### PR TITLE
Added loot_attributes to nft_traits.

### DIFF
--- a/ethereum/nft_traits/loot_attributes.sql
+++ b/ethereum/nft_traits/loot_attributes.sql
@@ -8013,4 +8013,4 @@ VALUES
 ('1980','Grave Wand','Linen Robe','Divine Hood','Plated Belt','Chain Boots','Heavy Gloves','Pendant','Bronze Ring'),
 ('1039','Grave Wand','Chain Mail','Hood','Silk Sash','Chain Boots','Wool Gloves','Pendant','Bronze Ring');
 
-CREATE INDEX IF NOT EXISTS loot.loot_attributes_idx ON loot.loot_attributes USING BRIN (token_id);
+CREATE INDEX IF NOT EXISTS loot_loot_attributes_idx ON loot.loot_attributes USING BRIN (token_id);


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
