### PR TITLE
Remove MALT and TITAN from Polygon prices

### DIFF
--- a/prices/polygon/coingecko.yaml
+++ b/prices/polygon/coingecko.yaml
@@ -152,7 +152,6 @@
 - id: iota
 - id: iron-finance
 - id: iron-stablecoin
-- id: iron-titanium-token
 - id: jpyc
 - id: kenny-token
 - id: kin
@@ -170,7 +169,6 @@
 - id: loser-coin
 - id: l-pesa
 - id: mahadao
-- id: malt-stablecoin
 - id: mantra-dao
 - id: mask-network
 - id: matic-aave-aave


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
