### PR TITLE
Add FXS to Token Prices

### DIFF
--- a/prices/ethereum/coinpaprika.yaml
+++ b/prices/ethereum/coinpaprika.yaml
@@ -1486,3 +1486,8 @@
   symbol: EDEN
   address: 0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559
   decimals: 18
+- name: fxs-frax-share
+  id: fxs-frax-share
+  symbol: FXS
+  address: 0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0
+  decimals: 18


### PR DESCRIPTION
I've checked that:

* [x] the query produces the intended results
* [x] the folder name matches the schema name
* [x] the schema name exists in Dune
* [x] views are prefixed with `view_`, functions with `fn_`.
* [x] the filename matches the defined view, table or function and ends with .sql
* [x] each file has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
