### PR TITLE
Add DOGE coin to Polygon prices

### DIFF
--- a/prices/polygon/coingecko.yaml
+++ b/prices/polygon/coingecko.yaml
@@ -407,3 +407,4 @@
 - id: gogocoin
 - id: milk
 - id: radar
+- id: dogecoin


### PR DESCRIPTION
Add dogecoin to track prices of DOGE in `prices.layer1_usd` table in Polygon.

DOGE is already present on Ethereum