### PR TITLE
Fix mango markets symbol typo

### DIFF
--- a/prices/solana/coinpaprika.yaml
+++ b/prices/solana/coinpaprika.yaml
@@ -14,7 +14,7 @@
   decimals: 6
 - name: mngo-mango-markets
   id: mngo-mango-markets
-  symbol: SRM
+  symbol: MNGO
   address: MangoCzJ36AjZyKwVj3VnYU4GTonjfVEnJmvvWaxLac
   decimals: 6
 - name: samo-samoyedcoin


### PR DESCRIPTION
Small typo fix. Will manually update db via a query to fix this.