### PR TITLE
Modify seaport.view_transactions to refer to seaport abstraction table

### DIFF
--- a/ethereum/seaport/view_transactions.sql
+++ b/ethereum/seaport/view_transactions.sql
@@ -1,6 +1,6 @@
 create schema if not exists seaport;
 
-drop view if exists seaport.view_transactions;
+drop view if exists seaport.view_transactions cascade;
 
 create or replace view seaport.view_transactions
 AS


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Modify `seaport.view_transactions` to refer to only `seaport.transactions` directly.

*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
