### PR TITLE
OP2 contracts remove mismapped opensea contract creator

### DIFF
--- a/deprecated-dune-v1-abstractions/optimism2/ovm2/get_contracts/contract_creator_address_list.sql
+++ b/deprecated-dune-v1-abstractions/optimism2/ovm2/get_contracts/contract_creator_address_list.sql
@@ -278,7 +278,6 @@ COPY ovm2.contract_creator_address_list (creator_address,project) FROM stdin;
 \\x0c36A5b01E1668C867A5e58f23bb6cb4d83a4cc8	Rainbow
 \\x3A893A7525C4263052c3C04f9C32d919c75cb8e0	Symphony Finance
 \\x939c8d89ebc11fa45e576215e2353673ad0ba18a	OpenSea
-\\x0000000000FFe8B47B3e2130213B802212439497	OpenSea
 \\x7c9c773e41a3b68924b3b4924df8fffcf7ae7e18	Naga DAO
 \\x24bD918b03dB3f16557942A15c92b6859510c4dc	Diamond Protocol
 \\x9143743c4a54fdCF81f38e2370A4e9819E98797c	Diamond Protocol

--- a/deprecated-dune-v1-abstractions/optimism2/ovm2/get_contracts/update_queries/update_mismapped_os_creator.sql
+++ b/deprecated-dune-v1-abstractions/optimism2/ovm2/get_contracts/update_queries/update_mismapped_os_creator.sql
@@ -1,4 +1,5 @@
 --unmap contracts linked to this creator to help us overwrite them now.
+--this should only be run once as an ad-hoc update
 
 UPDATE ovm2.get_contracts
 SET contract_project = NULL

--- a/deprecated-dune-v1-abstractions/optimism2/ovm2/get_contracts/update_queries/update_mismapped_os_creator.sql
+++ b/deprecated-dune-v1-abstractions/optimism2/ovm2/get_contracts/update_queries/update_mismapped_os_creator.sql
@@ -1,0 +1,5 @@
+--unmap contracts linked to this creator to help us overwrite them now.
+
+UPDATE ovm2.get_contracts
+SET contract_project = NULL
+WHERE creator_address = '\x0000000000ffe8b47b3e2130213b802212439497';


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Updating a mismapped contract creator.

*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
