### PR TITLE
fix arbitrum magic token address

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -44,7 +44,7 @@ VALUES
     ("usdc-usd-coin", "arbitrum", "USDC", "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8", 6),
     ("usdt-tether", "arbitrum", "USDT", "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9", 6),
     ("wbtc-wrapped-bitcoin", "arbitrum", "WBTC", "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f", 8),
-    ("magic-magic-arbitrum", "arbitrum", "MAGIC", "0xb0c7a3ba49c7a6eaba6cd4a96c55a1391070ac9a", 18),
+    ("magic-magic-arbitrum", "arbitrum", "MAGIC", "0x539bde0d7dbd336b79148aa742883198bbf60342", 18),
 
     ("dai-dai", "avalanche_c", "DAI", "0xd586e7f844cea2f87f50152665bcbc2c279d8d70", 18),
     ("usdc-usd-coin", "avalanche_c", "USDC", "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e", 6),


### PR DESCRIPTION
Fixes the MAGIC (Arbitrum) token address for prices (see on [Arbiscan](https://arbiscan.io/address/0x539bde0d7dbd336b79148aa742883198bbf60342)).
The previously merged contract address is the L1 address.

cc @antonio-mendes 