### PR TITLE
Add pricing for WBNB & WAVAX

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -46,11 +46,13 @@ VALUES
     ("wbtc-wrapped-bitcoin", "arbitrum", "WBTC", "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f", 8),
     ("magic-magic-arbitrum", "arbitrum", "MAGIC", "0x539bde0d7dbd336b79148aa742883198bbf60342", 18),
 
+    ("wavax-wavax", "avalanche_c", "WAVAX", "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7", 18),
     ("dai-dai", "avalanche_c", "DAI", "0xd586e7f844cea2f87f50152665bcbc2c279d8d70", 18),
     ("usdc-usd-coin", "avalanche_c", "USDC", "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e", 6),
     ("usdt-tether", "avalanche_c", "USDT", "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7", 6),
     ("wbtc-wrapped-bitcoin", "avalanche_c", "WBTC", "0x50b7545627a5162f82a992c33b87adc75187b218", 8),
 
+    ("wbnb-wbnb", "bnb", "WBNB", "0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c", 18),
     ("1inch-1inch", "bnb", "1INCH", "0x111111111117dc0aa78b770fa6a738034120c302", 18),
     ("aave-aave-token", "bnb", "AAVE", "0xfb6115445bff7b52feb98650c87f44907e58f802", 18),
     ("abnbc-abnbc", "bnb", "ABNBC", "0xe85afccdafbe7f2b096f268e31cce3da8da2990a", 18),


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Add pricing data for WBNB (on BNB) and WAVAX (on AVAX)

*For Dune Engine V2*
I've checked that:

* [X] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [X] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [X] if adding a new model, I added a test
* [X] the filename is unique and ends with .sql
* [X] each sql file is a select statement and has only one view, table or function defined  
* [X] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
