### PR TITLE
Nft performance 2

### DIFF
--- a/models/magiceden/solana/magiceden_solana_events.sql
+++ b/models/magiceden/solana/magiceden_solana_events.sql
@@ -95,7 +95,11 @@ SELECT
 FROM {{ source('solana','transactions') }}
 LEFT JOIN prices.usd p
   ON p.minute = date_trunc('minute', block_time)
+  AND p.blockchain is NULL
   AND p.symbol = 'SOL'
+  {% if is_incremental() %}
+  AND p.minute >= date_trunc("day", now() - interval '1 week')
+  {% endif %}
 WHERE (
      array_contains(account_keys, 'M2mx93ekt1fmXSVkTrUL9xVFHkmME8HTUi5Cyc5aF7K') -- magic eden v2
      OR array_contains(account_keys, 'CMZYPASGWeTz7RNGHaRJfCq2XQ5pYK6nDvVQxzkH51zb')
@@ -107,5 +111,5 @@ WHERE (
      {% endif %}
      {% if is_incremental() %}
      -- this filter will only be applied on an incremental run
-     AND block_date >= (select max(block_date) from {{ this }})
+     AND block_date >= date_trunc("day", now() - interval '1 week')
      {% endif %}

--- a/models/sudoswap/ethereum/sudoswap_ethereum_events.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_events.sql
@@ -166,7 +166,7 @@ WITH
             AND tr.to != '0xb16c1342e617a5b6e4b631eb114483fdb289c0a4' --we don't want duplicates from protocol fee transfer to show up in table. This needs to be most up to date funding recipient in the future, but should just be pair address for now.
             AND tr.to != asset_recip --we don't want duplicates where eth is transferred to asset recipient instead of pool in the case it isn't a trade pool
             {% if is_incremental() %}
-            AND tr.block_time >= (select max(block_time) from {{ this }})
+            AND tr.block_time >= date_trunc("day", now() - interval '1 week')
             {% endif %}
             {% if not is_incremental() %}
             AND tr.block_time >= '2022-4-1'
@@ -241,7 +241,7 @@ WITH
             AND date_trunc('minute', pu.minute)=date_trunc('minute', sc.block_time)
             AND symbol = 'WETH'
             {% if is_incremental() %}
-            AND pu.minute >= (select max(block_time) from {{ this }})
+            AND pu.minute >= date_trunc("day", now() - interval '1 week')
             {% endif %}
             {% if not is_incremental() %}
             AND pu.minute >= '2022-4-1'
@@ -250,7 +250,7 @@ WITH
         LEFT JOIN {{ source('ethereum', 'transactions') }} tx
             ON tx.hash=sc.tx_hash
             {% if is_incremental() %}
-            AND tx.block_time >= (select max(block_time) from {{ this }})
+            AND tx.block_time >= date_trunc("day", now() - interval '1 week')
             {% endif %}
             {% if not is_incremental() %}
             AND tx.block_time >= '2022-4-1'


### PR DESCRIPTION
This PR adds more time filters on incremental updates on the nft trades tables, for the ethereum.transactions and prices.usd tables. It's a follow up of https://github.com/duneanalytics/spellbook/pull/1444

A lot of the changed rows are just whitespace, these files have previously been saved without stripping whitespace.