### PR TITLE
Opensea incremental update performance fix

### DIFF
--- a/models/opensea/ethereum/opensea_ethereum_schema.yml
+++ b/models/opensea/ethereum/opensea_ethereum_schema.yml
@@ -22,6 +22,8 @@ models:
       tags: ['ethereum','opensea','v1','fees']
     description: OpenSea v1 fees on Ethereum
     columns:
+      - name: block_time
+        description: "Block time of transaction"
       - name: trace_address
         description: "Trace address for fees"
       - name: tx_hash

--- a/models/opensea/ethereum/opensea_v1_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v1_ethereum_events.sql
@@ -83,7 +83,13 @@ SELECT
   fees.fee_currency_symbol,
   call_trace_address
   FROM wyvern_call_data wc
-  LEFT JOIN {{ ref('opensea_v1_ethereum_fees') }} fees ON fees.tx_hash = wc.call_tx_hash AND fees.trace_address = wc.call_trace_address),
+  LEFT JOIN {{ ref('opensea_v1_ethereum_fees') }} fees ON
+    fees.tx_hash = wc.call_tx_hash
+    AND fees.trace_address = wc.call_trace_address
+    {% if is_incremental() %}
+    AND fees.block_time >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
+),
 
 erc_transfers as
 (SELECT evt_tx_hash,

--- a/models/opensea/ethereum/opensea_v1_ethereum_fees.sql
+++ b/models/opensea/ethereum/opensea_v1_ethereum_fees.sql
@@ -1,8 +1,10 @@
 
- {{ config(schema = 'opensea_v1_ethereum',
+SELECT
+{{ config(schema = 'opensea_v1_ethereum',
 alias='fees') }}
 
 SELECT
+    block_time,
     CASE WHEN size(trace_address) = 1 then array(3::bigint) -- for single row join
     WHEN size(trace_address) = 2 then array(trace_address[0])
     WHEN size(trace_address) = 3 then array(trace_address[0], trace_address[1])
@@ -15,9 +17,12 @@ FROM  {{ source('ethereum', 'traces') }} source_fees
 WHERE
 FROM IN ('0x7be8076f4ea4a4ad08075c2508e481d6c946d12b','0x7f268357a8c2552623316e2562d90e642bb538e5')
 AND to = '0x5b3256965e7c3cf26e11fcaf296dfc8807c01073' -- OpenSea Wallet
-GROUP BY 1,2,4,5
-                UNION ALL
+GROUP BY 1,2,3,5,6
+
+UNION ALL
+
 SELECT
+    evt_block_time as block_time,
     array(3::bigint) as trace_address,
     evt_tx_hash as tx_hash,
     SUM(value) AS fees,
@@ -27,4 +32,5 @@ SELECT
    LEFT JOIN  {{ ref('tokens_ethereum_erc20') }} erc20 ON erc20.contract_address =  erc.contract_address
    WHERE to = '0x5b3256965e7c3cf26e11fcaf296dfc8807c01073'
    AND evt_tx_hash = '0xaa68c271a72a2a280eb06d89506d1feb3de6a84f6f19d1aa001885d783d5b9c7'
-   GROUP BY 1,2,4,5
+GROUP BY 1,2,3,5,6
+

--- a/models/opensea/ethereum/opensea_v1_ethereum_fees.sql
+++ b/models/opensea/ethereum/opensea_v1_ethereum_fees.sql
@@ -1,5 +1,3 @@
-
-SELECT
 {{ config(schema = 'opensea_v1_ethereum',
 alias='fees') }}
 


### PR DESCRIPTION
This PR speeds up the opensea spell on incremental updates. It does so by pusing down a `block_time` filter on `ethereum.traces`.  

Since the `ethereum.transactions` table is now filtered on this query, the slowest part is a full scan on `ethereum.traces`. This happens because to get the fees (via the opensea fees view), we do a query on `ethereum.traces` by `tx_hash` and `trace_address` which results in a full scan.

By `block_time` is added the fees table, we can then use a filter on we join on fees in the main query which prevents a full scan on incremental updates