### PR TITLE
Dex trades performance

### DIFF
--- a/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
+++ b/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
@@ -72,10 +72,12 @@ FROM dexs
 INNER JOIN {{ source('ethereum', 'transactions') }} tx
     ON tx.hash = dexs.tx_hash
     {% if not is_incremental() %}
-    AND tx.block_time >= (SELECT MIN(block_time) FROM dexs)
+    -- The date below is derrived from `select min(evt_block_time) from uniswap_v2_ethereum.Factory_evt_PairCreated;`
+    -- If dexs above is changed then this will also need to be changed.
+    AND tx.block_time >= "2020-05-05 00:00:00"
     {% endif %}
     {% if is_incremental() %}
-    AND TRY_CAST(date_trunc('DAY', tx.block_time) AS date) = TRY_CAST(date_trunc('DAY', dexs.block_time) AS date)
+    AND tx.block_time = date_trunc("day", now() - interval '1 week')
     {% endif %}
 LEFT JOIN {{ ref('tokens_ethereum_erc20') }} erc20a ON erc20a.contract_address = dexs.token_bought_address
 LEFT JOIN {{ ref('tokens_ethereum_erc20') }} erc20b ON erc20b.contract_address = dexs.token_sold_address
@@ -83,17 +85,21 @@ LEFT JOIN {{ source('prices', 'usd') }} p_bought ON p_bought.minute = date_trunc
     AND p_bought.contract_address = dexs.token_bought_address
     AND p_bought.blockchain = 'ethereum'
     {% if not is_incremental() %}
-    AND p_bought.minute >= (SELECT MIN(block_time) FROM dexs)
+    -- The date below is derrived from `select min(evt_block_time) from uniswap_v2_ethereum.Factory_evt_PairCreated;`
+    -- If dexs above is changed then this will also need to be changed.
+    AND p_bought.minute >= "2020-05-05 00:00:00"
     {% endif %}
     {% if is_incremental() %}
-    AND p_bought.minute >= (SELECT MAX(block_time) FROM {{ this }})
+    AND p_bought.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
 LEFT JOIN {{ source('prices', 'usd') }} p_sold ON p_sold.minute = date_trunc('minute', dexs.block_time)
     AND p_sold.contract_address = dexs.token_sold_address
     AND p_sold.blockchain = 'ethereum'
     {% if not is_incremental() %}
-    AND p_sold.minute >= (SELECT MIN(block_time) FROM dexs)
+    -- The date below is derrived from `select min(evt_block_time) from uniswap_v2_ethereum.Factory_evt_PairCreated;`
+    -- If dexs above is changed then this will also need to be changed.
+    AND p_sold.minute >= "2020-05-05 00:00:00"
     {% endif %}
     {% if is_incremental() %}
-    AND p_sold.minute >= (SELECT MAX(block_time) FROM {{ this }})
+    AND p_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}


### PR DESCRIPTION
This is a follow up on https://github.com/duneanalytics/spellbook/pull/1444 and https://github.com/duneanalytics/spellbook/pull/1449.

This PR adds the date filters to the uniswap queries. 

It also adds the static dates for the first uniswap transactions in each version, for when we are not doing an incremental update. Before this was using `min(block_time)` from the `dexs` query. It's a value that doesn't change and hardcoding it will give some performance gain when redoing the whole table.