### PR TITLE
Use inner joins instead of left joins on transactions 

### DIFF
--- a/models/opensea/ethereum/opensea_v1_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v1_ethereum_events.sql
@@ -177,7 +177,7 @@ SELECT DISTINCT
   wa.fee_currency_symbol as royalty_fee_currency_symbol,
   'opensea' || '-' || wa.call_tx_hash || '-' || coalesce(wa.token_id, token_id_erc, '') || '-' ||  wa.seller || '-' || coalesce(evt_index::string, '') || '-' || coalesce(wa.call_trace_address::string,'') as unique_trade_id
 FROM wyvern_all wa
-LEFT JOIN {{ source('ethereum','transactions') }} tx ON wa.call_tx_hash = tx.hash
+INNER JOIN {{ source('ethereum','transactions') }} tx ON wa.call_tx_hash = tx.hash
     {% if is_incremental() %}
     and tx.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}

--- a/models/opensea/ethereum/opensea_v1_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v1_ethereum_events.sql
@@ -59,6 +59,9 @@ WHERE
 (addrs[3] = '0x5b3256965e7c3cf26e11fcaf296dfc8807c01073'
         OR addrs[10] = '0x5b3256965e7c3cf26e11fcaf296dfc8807c01073')
 AND call_success = true
+{% if is_incremental() %}
+AND call_block_time >= date_trunc("day", now() - interval '1 week')
+{% endif %}
 ),
 
 wyvern_all as

--- a/models/opensea/ethereum/opensea_v1_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v1_ethereum_events.sql
@@ -88,7 +88,8 @@ SELECT
     AND fees.trace_address = wc.call_trace_address
     {% if is_incremental() %}
     AND fees.block_time >= date_trunc("day", now() - interval '1 week')
-    {% endif %}
+  WHERE wc.call_block_time >= date_trunc("day", now() - interval '1 week')
+  {% endif %}
 ),
 
 erc_transfers as

--- a/models/seaport/ethereum/seaport_ethereum_transfers.sql
+++ b/models/seaport/ethereum/seaport_ethereum_transfers.sql
@@ -210,7 +210,7 @@ with p1_call as (
           string) as unique_trade_id,
           a.zone
       from p1_txn_level a
-        left join {{ source('ethereum','transactions') }} tx
+        inner join {{ source('ethereum','transactions') }} tx
             on tx.hash = a.tx_hash
             {% if not is_incremental() %}
             and tx.block_number > 14801608
@@ -415,7 +415,7 @@ with p1_call as (
           string) as unique_trade_id,
           a.zone
       from p2_transfer_level a
-        left join {{ source('ethereum','transactions') }} tx
+        inner join {{ source('ethereum','transactions') }} tx
             on tx.hash = a.tx_hash
             {% if not is_incremental() %}
             and tx.block_number > 14801608
@@ -645,7 +645,7 @@ with p1_call as (
           string) as unique_trade_id,
           a.zone
       from p3_txn_level a
-        left join {{ source('ethereum','transactions') }} tx
+        inner join {{ source('ethereum','transactions') }} tx
             on tx.hash = a.tx_hash
             {% if not is_incremental() %}
             and tx.block_number > 14801608
@@ -850,7 +850,7 @@ with p1_call as (
           string) as unique_trade_id,
           a.zone
     from p4_transfer_level a
-    left join {{ source('ethereum','transactions') }} tx
+    inner join {{ source('ethereum','transactions') }} tx
         on tx.hash = a.tx_hash
         {% if not is_incremental() %}
         and tx.block_number > 14801608

--- a/models/sudoswap/ethereum/sudoswap_ethereum_events.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_events.sql
@@ -237,6 +237,14 @@ WITH
             , tx.from as tx_from
             , tx.to as tx_to
         FROM swaps_cleaned sc
+        INNER JOIN {{ source('ethereum', 'transactions') }} tx
+            ON tx.hash=sc.tx_hash
+            {% if is_incremental() %}
+            AND tx.block_time >= date_trunc("day", now() - interval '1 week')
+            {% endif %}
+            {% if not is_incremental() %}
+            AND tx.block_time >= '2022-4-1'
+            {% endif %}
         LEFT JOIN {{ source('prices', 'usd') }} pu ON pu.blockchain='ethereum'
             AND date_trunc('minute', pu.minute)=date_trunc('minute', sc.block_time)
             AND symbol = 'WETH'
@@ -247,14 +255,6 @@ WITH
             AND pu.minute >= '2022-4-1'
             {% endif %}
             --add in `pu.contract_address = sc.currency_address` in the future when ERC20 pairs are added in.
-        LEFT JOIN {{ source('ethereum', 'transactions') }} tx
-            ON tx.hash=sc.tx_hash
-            {% if is_incremental() %}
-            AND tx.block_time >= date_trunc("day", now() - interval '1 week')
-            {% endif %}
-            {% if not is_incremental() %}
-            AND tx.block_time >= '2022-4-1'
-            {% endif %}
         LEFT JOIN nft_ethereum_aggregators agg ON agg.contract_address = tx.to --assumes aggregator is the top level call. Will need to change this to check for agg calls in internal traces later on.
         LEFT JOIN tokens_ethereum_nft tokens ON nft_contract_address = tokens.contract_address
     ),

--- a/models/sudoswap/ethereum/sudoswap_ethereum_events.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_events.sql
@@ -155,7 +155,7 @@ WITH
             , sb.ownerfee
             , sb.protocolfee
         FROM swaps_w_fees sb
-        LEFT JOIN {{ source('ethereum', 'traces') }} tr
+        INNER JOIN {{ source('ethereum', 'traces') }} tr
             ON tr.type = 'call'
             AND tr.call_type = 'call'
             AND tr.tx_hash = sb.call_tx_hash

--- a/models/x2y2/ethereum/x2y2_ethereum_events.sql
+++ b/models/x2y2/ethereum/x2y2_ethereum_events.sql
@@ -189,16 +189,16 @@ SELECT 'ethereum' AS blockchain
     END AS royalty_fee_currency_symbol
 , 'x2y2-' || txs.tx_hash || '-' || txs.nft_contract_address || txs.token_id || '-' || txs.seller || '-' || txs.evt_index || 'Trade' AS unique_trade_id
 FROM all_x2y2_txs txs
+INNER JOIN {{ source('ethereum','transactions') }} et ON et.hash=txs.tx_hash
+    {% if is_incremental() %}
+    AND et.block_time >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
 LEFT JOIN {{ source('prices','usd') }} pu ON pu.blockchain='ethereum'
     AND date_trunc('minute', pu.minute)=date_trunc('minute', txs.block_time)
     AND (pu.contract_address=txs.currency_contract
         OR (pu.contract_address='0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AND txs.currency_contract='0x0000000000000000000000000000000000000000'))
     {% if is_incremental() %}
     AND pu.minute >= date_trunc("day", now() - interval '1 week')
-    {% endif %}
-LEFT JOIN {{ source('ethereum','transactions') }} et ON et.hash=txs.tx_hash
-    {% if is_incremental() %}
-    AND et.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
 LEFT JOIN {{ source('erc721_ethereum','evt_transfer') }} erct ON txs.project_contract_address=erct.contract_address
     AND erct.evt_tx_hash=txs.tx_hash


### PR DESCRIPTION
This fixes a bug that I introduced with the performance fixes. 

On incremental runs we still select all of the decoded data in some cases. When we then `left join` instead of `inner join` the data that is more than 1 week old will have empty transaction data. To fix this we should use `inner join`. This should not be a problem because all decoded data has a transaction.

In the cases where we already filter decoded data on `where evt_block_time >= (select max(block_time) from {{ this }})` for incremental runs, this should not have caused any issue. But for opensea which doesn't have that for example it did.

If we still have to do a `left join` like we seemingly do on opensea fees, we can add the filter in the where statement as well to make sure we don't get any extra data.

Looksrare doesn't have this problem because it already uses an `inner join`.

I've verified the following:
- [x] Opensea inner join vs left join count is the same
- [x] Opensea join on fees needs to be left join so added a `where` statement as well
- [x] Opensea no null values for `block_time`
- [x] Opensea incremental update contains no null values for `block_time` like before
- [x] x2y2 inner join vs left join count is the same
- [x] seaport inner join vs left join count is the same
- [x] sudoswap inner join vs left join count is the same for join on transactions
- [x] sudoswap inner join vs left join count is the same for join on traces
