### PR TITLE
modify seaport column to avoid integer overflow (Dune v1)

### DIFF
--- a/deprecated-dune-v1-abstractions/polygon/seaport/transactions.sql
+++ b/deprecated-dune-v1-abstractions/polygon/seaport/transactions.sql
@@ -6,8 +6,8 @@ CREATE TABLE IF NOT EXISTS seaport.transactions (
     ,order_type text  
     ,purchase_method text  
     ,trade_type text  
-    ,nft_transfer_count int8  
-    ,nft_item_count int8  
+    ,nft_transfer_count numeric  
+    ,nft_item_count numeric  
     ,seller bytea  
     ,buyer bytea  
     ,original_currency_contract bytea  
@@ -24,10 +24,10 @@ CREATE TABLE IF NOT EXISTS seaport.transactions (
     ,royalty_amount numeric  
     ,royalty_amount_raw numeric  
     ,royalty_usd_amount numeric  
-    ,erc721_transfer_count int8  
-    ,erc1155_transfer_count int8  
-    ,erc721_item_count int8  
-    ,erc1155_item_count int8  
+    ,erc721_transfer_count numeric  
+    ,erc1155_transfer_count numeric  
+    ,erc721_item_count numeric  
+    ,erc1155_item_count numeric  
     ,exchange_contract_address bytea  
     ,zone_address bytea  
     ,platform text  

--- a/deprecated-dune-v1-abstractions/polygon/seaport/transfers.sql
+++ b/deprecated-dune-v1-abstractions/polygon/seaport/transfers.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS seaport.transfers (
    ,order_type text
    ,purchase_method text
    ,trade_type text
-   ,nft_item_count int8
+   ,nft_item_count numeric
    ,seller bytea
    ,buyer bytea
    ,original_currency_contract bytea


### PR DESCRIPTION
Brief comments on the purpose of your changes:

(Dune v1) Currently, an integer overflow is occurring in the seaport table on Polygon so altering columns datatype is needed.

*For Dune Engine V2*
I've checked that:

* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`

When you are ready for a review, tag duneanalytics/data-experience. We will re-open your forked pull request as an internal pull request. Then your spells will run in dbt and the logs will be avaiable in Github Actions DBT Slim CI. This job will only run the models and tests changed by your PR compared to the production project. 
