### PR TITLE
T 15666 fix dbt source snapshot freshness warn instead of error

### DIFF
--- a/models/base_sources/arbitrum_base_sources.yml
+++ b/models/base_sources/arbitrum_base_sources.yml
@@ -6,7 +6,6 @@ sources:
     description: "Arbitrum raw tables"
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: transactions
         loaded_at_field: block_time

--- a/models/base_sources/avalanche_c_base_sources.yml
+++ b/models/base_sources/avalanche_c_base_sources.yml
@@ -6,7 +6,6 @@ sources:
     description: "avalanche_c raw tables"
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: transactions
         loaded_at_field: block_time

--- a/models/base_sources/bnb_base_sources.yml
+++ b/models/base_sources/bnb_base_sources.yml
@@ -6,7 +6,6 @@ sources:
     description: "bnb raw tables"
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: transactions
         loaded_at_field: block_time

--- a/models/base_sources/ethereum_base_sources.yml
+++ b/models/base_sources/ethereum_base_sources.yml
@@ -6,7 +6,6 @@ sources:
     description: "Ethereum raw tables including transactions, traces and logs."
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: transactions_0006
         description: "underlying transactions table. ethereum.transactions is an exposed view of this table."

--- a/models/base_sources/gnosis_base_sources.yml
+++ b/models/base_sources/gnosis_base_sources.yml
@@ -6,7 +6,6 @@ sources:
     description: "gnosis raw tables"
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: transactions
         loaded_at_field: block_time

--- a/models/base_sources/optimism_base_sources.yml
+++ b/models/base_sources/optimism_base_sources.yml
@@ -6,7 +6,6 @@ sources:
     description: "Optimism raw tables including transactions, traces and logs."
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: transactions
         loaded_at_field: block_time

--- a/models/base_sources/solana_base_sources.yml
+++ b/models/base_sources/solana_base_sources.yml
@@ -6,7 +6,6 @@ sources:
     description: "Solana raw tables including transactions, traces and logs."
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: transactions
         loaded_at_field: block_time

--- a/models/ens/ens_ethereum_sources.yml
+++ b/models/ens/ens_ethereum_sources.yml
@@ -7,12 +7,10 @@ sources:
       - name: BaseRegistrarImplementation_evt_NameRegistered
         freshness:
           warn_after: { count: 12, period: hour }
-          error_after: { count: 24, period: hour }
         loaded_at_field: evt_block_time
       - name: BaseRegistrarImplementation_evt_NameRenewed
         freshness:
           warn_after: { count: 12, period: hour }
-          error_after: { count: 24, period: hour }
         loaded_at_field: evt_block_time
       - name: ETHRegistrarController_1_evt_NameRegistered
         loaded_at_field: evt_block_time
@@ -21,14 +19,12 @@ sources:
       - name: ETHRegistrarController_3_evt_NameRegistered
         freshness:
           warn_after: { count: 12, period: hour }
-          error_after: { count: 24, period: hour }
         loaded_at_field: evt_block_time
       - name: ENSRegistry_evt_NewOwner
         loaded_at_field: evt_block_time
       - name: ENSRegistryWithFallback_evt_NewOwner
         freshness:
           warn_after: { count: 12, period: hour }
-          error_after: { count: 24, period: hour }
         loaded_at_field: evt_block_time
       - name: ETHRegistrarController_1_evt_NameRenewed
         loaded_at_field: evt_block_time
@@ -37,5 +33,4 @@ sources:
       - name: ETHRegistrarController_3_evt_NameRenewed
         freshness:
           warn_after: { count: 12, period: hour }
-          error_after: { count: 24, period: hour }
         loaded_at_field: evt_block_time

--- a/models/looksrare/ethereum/looksrare_ethereum_sources.yml
+++ b/models/looksrare/ethereum/looksrare_ethereum_sources.yml
@@ -4,7 +4,6 @@ sources:
   - name: looksrare_ethereum
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: looksrareexchange_evt_takerask
         loaded_at_field: evt_block_time

--- a/models/prices/prices_sources.yml
+++ b/models/prices/prices_sources.yml
@@ -6,7 +6,6 @@ sources:
     description: "Prices tables across blockchains"
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: usd
         loaded_at_field: minute

--- a/models/safe/ethereum/safe_ethereum_sources.yml
+++ b/models/safe/ethereum/safe_ethereum_sources.yml
@@ -4,7 +4,6 @@ sources:
   - name: gnosis_safe_ethereum
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: GnosisSafev1_3_0_evt_SafeSetup
         loaded_at_field: evt_block_time

--- a/models/seaport/ethereum/seaport_ethereum_sources.yml
+++ b/models/seaport/ethereum/seaport_ethereum_sources.yml
@@ -4,7 +4,6 @@ sources:
   - name: seaport_ethereum
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: Seaport_call_fulfillAvailableAdvancedOrders
         loaded_at_field: call_block_time

--- a/models/sudoswap/ethereum/sudoswap_ethereum_sources.yml
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_sources.yml
@@ -6,25 +6,21 @@ sources:
       - name: LSSVMPairFactory_call_createPairETH
         freshness:
           warn_after: { count: 12, period: hour }
-          error_after: { count: 24, period: hour }
         description: "As of 8/9/22, only ETH pairs have been created. Will need ERC20 logic in the future."
         loaded_at_field: call_block_time
       - name: LSSVMPair_general_call_swapNFTsForToken
         freshness:
           warn_after: { count: 12, period: hour }
-          error_after: { count: 24, period: hour }
         loaded_at_field: call_block_time
       - name: LSSVMPair_general_call_swapTokenForAnyNFTs
         loaded_at_field: call_block_time
       - name: LSSVMPair_general_call_swapTokenForSpecificNFTs
         freshness:
           warn_after: { count: 12, period: hour }
-          error_after: { count: 24, period: hour }
         loaded_at_field: call_block_time
       - name: LSSVMPair_general_evt_FeeUpdate
         freshness:
           warn_after: { count: 12, period: hour }
-          error_after: { count: 24, period: hour }
         loaded_at_field: evt_block_time
       - name: LSSVMPair_general_evt_AssetRecipientChange
         loaded_at_field: evt_block_time

--- a/models/tornado_cash/tornado_cash_sources.yml
+++ b/models/tornado_cash/tornado_cash_sources.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: tornado_cash_bnb
     freshness:
-      warn_after: { count: 12, period: hour }
+      warn_after: { count: 7, period: day }
     tables:
       - name: TornadoCashBNB_evt_Deposit
         loaded_at_field: evt_block_time
@@ -30,7 +30,7 @@ sources:
 
   - name: tornado_cash_arbitrum
     freshness:
-      warn_after: { count: 12, period: hour }
+      warn_after: { count: 7, period: day }
     tables:
       - name: ETHTornado_evt_Deposit
         loaded_at_field: evt_block_time
@@ -58,7 +58,7 @@ sources:
 
   - name: tornado_cash_optimism
     freshness:
-      warn_after: { count: 12, period: hour }
+      warn_after: { count: 7, period: day }
     tables:
       - name: ETHTornado_evt_Deposit
         loaded_at_field: evt_block_time
@@ -86,7 +86,7 @@ sources:
 
   - name: tornado_cash_avalanche_c
     freshness:
-      warn_after: { count: 12, period: hour }
+      warn_after: { count: 7, period: day }
     tables:
       - name: ETHTornado_evt_Deposit
         loaded_at_field: evt_block_time
@@ -114,7 +114,7 @@ sources:
 
   - name: tornado_cash_ethereum
     freshness:
-      warn_after: { count: 12, period: hour }
+      warn_after: { count: 7, period: day }
     tables:
       - name: erc20_evt_Deposit
         loaded_at_field: evt_block_time
@@ -161,7 +161,7 @@ sources:
 
   - name: tornado_cash_gnosis
     freshness:
-      warn_after: { count: 12, period: hour }
+      warn_after: { count: 7, period: day }
     tables:
       - name: eth_evt_Deposit
         loaded_at_field: evt_block_time

--- a/models/transfers/ethereum/transfers_ethereum_sources.yml
+++ b/models/transfers/ethereum/transfers_ethereum_sources.yml
@@ -4,7 +4,6 @@ sources:
   - name: zeroex_ethereum
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: weth9_evt_deposit
         loaded_at_field: evt_block_time

--- a/models/uniswap/ethereum/uniswap_ethereum_sources.yml
+++ b/models/uniswap/ethereum/uniswap_ethereum_sources.yml
@@ -7,7 +7,6 @@ sources:
       - name: Exchange_evt_TokenPurchase
         freshness:
           warn_after: { count: 12, period: hour }
-          error_after: { count: 24, period: hour }
         loaded_at_field: evt_block_time
         description: "" # to-do
         columns:
@@ -74,7 +73,6 @@ sources:
     description: "Ethereum decoded tables related to Uniswap v2 contract"
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: Pair_evt_Swap
         loaded_at_field: evt_block_time

--- a/models/x2y2/ethereum/x2y2_ethereum_sources.yml
+++ b/models/x2y2/ethereum/x2y2_ethereum_sources.yml
@@ -4,7 +4,6 @@ sources:
   - name: x2y2_ethereum
     freshness:
       warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     tables:
       - name: X2Y2_r1_evt_EvProfit
         loaded_at_field: evt_block_time


### PR DESCRIPTION
Brief comments on the purpose of your changes:
This PR aims to use the source freshness utility better. Since the DX team doesn't ultimately errors/delays on base and decoded tables, I propose to have the source freshness command attached to our daily job to check if everything looks good, but instead of throwing errors (that ultimately end up in failed jobs), throwing warnings so we can alert the data platform team without having to worry about failed jobs on our end

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if adding a new model, I edited the alter table macro to display new database object (table or view) in UI explorer
* [ ] if adding a new materialized table, I edited the optimize table macro

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
