### PR TITLE
Replace OpenSea's `Buy Now` with `Buy` for consistency with other marketplaces

### DIFF
--- a/models/seaport/ethereum/seaport_ethereum_schema.yml
+++ b/models/seaport/ethereum/seaport_ethereum_schema.yml
@@ -5,7 +5,7 @@ models:
     meta:
       blockchain: ethereum
       project: seaport
-      contributors: sohwak, soispoke
+      contributors: sohwak, soispoke, hildobby
     config:
       tags: ['ethereum','seaport','opensea','transaction']
     description: >
@@ -81,7 +81,7 @@ models:
     meta:
       blockchain: ethereum
       project: seaport
-      contributors: soispoke, sohwak
+      contributors: soispoke, sohwak, hildobby
     config:
       tags: ['ethereum','seaport','transfers']
     description: >

--- a/models/seaport/ethereum/seaport_ethereum_transfers.sql
+++ b/models/seaport/ethereum/seaport_ethereum_transfers.sql
@@ -82,10 +82,10 @@ with p1_call as (
 
 
 ,p1_add_rn as (select (max(case when purchase_method = 'Offer Accepted' and sub_type = 'offer' and sub_idx = 0 then token_contract_address
-                     when purchase_method = 'Buy Now' and sub_type = 'consideration' then token_contract_address
+                     when purchase_method = 'Buy' and sub_type = 'consideration' then token_contract_address
                 end) over (partition by tx_hash, evt_index)) as avg_original_currency_contract
           ,sum(case when purchase_method = 'Offer Accepted' and sub_type = 'offer' and sub_idx = 0 then original_amount
-                    when purchase_method = 'Buy Now' and sub_type = 'consideration' then original_amount
+                    when purchase_method = 'Buy' and sub_type = 'consideration' then original_amount
                end) over (partition by tx_hash, evt_index)
            / nft_transfer_count as avg_original_amount
           ,sum(case when fee_royalty_yn = 'fee' then original_amount end) over (partition by tx_hash, evt_index) / nft_transfer_count as avg_fee_amount
@@ -95,19 +95,19 @@ with p1_call as (
           ,a.*
       from (select case when purchase_method = 'Offer Accepted' and sub_type = 'consideration' and fee_royalty_idx = 1 then 'fee'
                         when purchase_method = 'Offer Accepted' and sub_type = 'consideration' and fee_royalty_idx = 2 then 'royalty'
-                        when purchase_method = 'Buy Now' and sub_type = 'consideration' and fee_royalty_idx = 2 then 'fee'
-                        when purchase_method = 'Buy Now' and sub_type = 'consideration' and fee_royalty_idx = 3 then 'royalty'
+                        when purchase_method = 'Buy' and sub_type = 'consideration' and fee_royalty_idx = 2 then 'fee'
+                        when purchase_method = 'Buy' and sub_type = 'consideration' and fee_royalty_idx = 3 then 'royalty'
                    end as fee_royalty_yn
                   ,case when purchase_method = 'Offer Accepted' and main_type = 'order' then 'Individual Offer'
                         when purchase_method = 'Offer Accepted' and main_type = 'basic_order' then 'Individual Offer'
                         when purchase_method = 'Offer Accepted' and main_type = 'advanced_order' then 'Collection/Trait Offers'
-                        else 'Buy Now'
+                        else 'Buy'
                    end as order_type
                   ,a.*
               from (select (count(case when item_type in ('2','3') then 1 end) over (partition by tx_hash, evt_index)) as nft_transfer_count
                           ,(sum(case when item_type in ('0','1') then 1 end) over (partition by tx_hash, evt_index, sub_type order by sub_idx)) as fee_royalty_idx
                           ,case when max(case when (sub_type,sub_idx,item_type) in (('offer',0,'1')) then 1 else 0 end) over (partition by tx_hash) = 1 then 'Offer Accepted'
-                                else 'Buy Now'
+                                else 'Buy'
                            end as purchase_method
                           ,a.*
                       from p1_evt a
@@ -356,7 +356,7 @@ with p1_call as (
           ,case when evt_tx_hash is null then true else false end as reverted
           ,'Bulk Purchase' as trade_type
           ,'Bulk Purchase' as order_type
-          ,'Buy Now' as purchase_method
+          ,'Buy' as purchase_method
       from p2_evt a
 )
 
@@ -519,10 +519,10 @@ with p1_call as (
 
 
 ,p3_add_rn as (select (max(case when purchase_method = 'Offer Accepted' and sub_type = 'offer' and sub_idx = 0 then token_contract_address::string
-                     when purchase_method = 'Buy Now' and sub_type = 'consideration' then token_contract_address::string
+                     when purchase_method = 'Buy' and sub_type = 'consideration' then token_contract_address::string
                 end) over (partition by tx_hash, evt_index)) as avg_original_currency_contract
           ,sum(case when purchase_method = 'Offer Accepted' and sub_type = 'offer' and sub_idx = 0 then original_amount
-                    when purchase_method = 'Buy Now' and sub_type = 'consideration' then original_amount
+                    when purchase_method = 'Buy' and sub_type = 'consideration' then original_amount
                end) over (partition by tx_hash, evt_index)
            / nft_transfer_count as avg_original_amount
           ,sum(case when fee_royalty_yn = 'fee' then original_amount end) over (partition by tx_hash, evt_index) / nft_transfer_count as avg_fee_amount
@@ -532,19 +532,19 @@ with p1_call as (
           ,a.*
       from (select case when purchase_method = 'Offer Accepted' and sub_type = 'consideration' and fee_royalty_idx = 1 then 'fee'
                         when purchase_method = 'Offer Accepted' and sub_type = 'consideration' and fee_royalty_idx = 2 then 'royalty'
-                        when purchase_method = 'Buy Now' and sub_type = 'consideration' and fee_royalty_idx = 2 then 'fee'
-                        when purchase_method = 'Buy Now' and sub_type = 'consideration' and fee_royalty_idx = 3 then 'royalty'
+                        when purchase_method = 'Buy' and sub_type = 'consideration' and fee_royalty_idx = 2 then 'fee'
+                        when purchase_method = 'Buy' and sub_type = 'consideration' and fee_royalty_idx = 3 then 'royalty'
                    end as fee_royalty_yn
                   ,case when purchase_method = 'Offer Accepted' and main_type = 'order' then 'Individual Offer'
                         when purchase_method = 'Offer Accepted' and main_type = 'basic_order' then 'Individual Offer'
                         when purchase_method = 'Offer Accepted' and main_type = 'advanced_order' then 'Collection/Trait Offers'
-                        else 'Buy Now'
+                        else 'Buy'
                    end as order_type
                   ,a.*
               from (select count(case when item_type in ('2','3') then 1 end) over (partition by tx_hash, evt_index) as nft_transfer_count
                           ,sum(case when item_type in ('0','1') then 1 end) over (partition by tx_hash, evt_index, sub_type order by sub_idx) as fee_royalty_idx
                           ,case when max(case when (sub_type,sub_idx,item_type) in (('offer',0,'1')) then 1 else 0 end) over (partition by tx_hash) = 1 then 'Offer Accepted'
-                                else 'Buy Now'
+                                else 'Buy'
                            end as purchase_method
                           ,a.*
                       from p3_evt a
@@ -786,7 +786,7 @@ with p1_call as (
           ,false as reverted
           ,'' as offer_order_type
           ,'Private Sales' as order_type
-          ,'Buy Now' as purchase_method
+          ,'Buy' as purchase_method
           ,nft_transfer_count
       from p4_add_rn a
      where offer_item_type in ('2','3')

--- a/models/seaport/ethereum/seaport_ethereum_view_transactions.sql
+++ b/models/seaport/ethereum/seaport_ethereum_view_transactions.sql
@@ -244,22 +244,22 @@ with iv_availadv as (
           ,a.zone as zone_address
           ,case when spc1.call_tx_hash is not null then 'Auction'
                 when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 16 and 23 then 'Auction'
-                when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 0 and 7 then 'Buy Now'
-                when spc2.call_tx_hash is not null then 'Buy Now'
+                when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 0 and 7 then 'Buy'
+                when spc2.call_tx_hash is not null then 'Buy'
                 when spc3.call_tx_hash is not null and spc3.advancedOrder:parameters:consideration[0]:identifierOrCriteria > '0' then 'Trait Offer'
                 when spc3.call_tx_hash is not null then 'Collection Offer'
                 else 'Private Sales'
            end as category          
           ,case when spc1.call_tx_hash is not null then 'Collection/Trait Offers' -- include English Auction and Dutch Auction
-                when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 0 and 15 then 'Buy Now' -- Buy it directly
+                when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 0 and 15 then 'Buy' -- Buy it directly
                 when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 16 and 23 and spc2.parameters:considerationIdentifier = a.nft_token_id then 'Individual Offer'
-                when spc2.call_tx_hash is not null then 'Buy Now'
-                when spc3.call_tx_hash is not null and a.original_currency_contract = '0x0000000000000000000000000000000000000000' then 'Buy Now'
+                when spc2.call_tx_hash is not null then 'Buy'
+                when spc3.call_tx_hash is not null and a.original_currency_contract = '0x0000000000000000000000000000000000000000' then 'Buy'
                 when spc3.call_tx_hash is not null then 'Collection/Trait Offers' -- offer for collection
                 when spc4.call_tx_hash is not null then 'Bulk Purchase' -- bundles of NFTs are purchased through aggregators or in a cart 
                 when spc5.call_tx_hash is not null then 'Bulk Purchase' -- bundles of NFTs are purchased through aggregators or in a cart 
                 when spc6.call_tx_hash is not null then 'Private Sales' -- sales for designated address
-                else 'Buy Now'
+                else 'Buy'
            end as order_type  
 
       from iv_txn_level a


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Replacing Seaport's abstraction's "Buy Now" with "Buy".

*For Dune Engine V2*
I've checked that:
General checks:
* [X] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [X] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [X] if adding a new model, I added a test
* [X] the filename is unique and ends with .sql
* [X] each sql file is a select statement and has only one view, table or function defined  
* [X] column names are `lowercase_snake_cased`
* [X] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [X] if adding a new model, I edited the alter table macro to display new database object (table or view) in UI explorer
* [X] if adding a new materialized table, I edited the optimize table macro

Join logic:
* [X] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [X] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [X] where block_time >= date_trunc("day", now() - interval '1 week')
* [X] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [X] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
