### PR TITLE
Some X2Y2 fixes

### DIFF
--- a/models/seaport/ethereum/seaport_ethereum_schema.yml
+++ b/models/seaport/ethereum/seaport_ethereum_schema.yml
@@ -5,7 +5,7 @@ models:
     meta:
       blockchain: ethereum
       project: seaport
-      contributors: sohwak, soispoke
+      contributors: sohwak, soispoke, hildobby
     config:
       tags: ['ethereum','seaport','opensea','transaction']
     description: >
@@ -81,7 +81,7 @@ models:
     meta:
       blockchain: ethereum
       project: seaport
-      contributors: soispoke, sohwak
+      contributors: soispoke, sohwak, hildobby
     config:
       tags: ['ethereum','seaport','transfers']
     description: >

--- a/models/seaport/ethereum/seaport_ethereum_transfers.sql
+++ b/models/seaport/ethereum/seaport_ethereum_transfers.sql
@@ -82,10 +82,10 @@ with p1_call as (
 
 
 ,p1_add_rn as (select (max(case when purchase_method = 'Offer Accepted' and sub_type = 'offer' and sub_idx = 0 then token_contract_address
-                     when purchase_method = 'Buy Now' and sub_type = 'consideration' then token_contract_address
+                     when purchase_method = 'Buy' and sub_type = 'consideration' then token_contract_address
                 end) over (partition by tx_hash, evt_index)) as avg_original_currency_contract
           ,sum(case when purchase_method = 'Offer Accepted' and sub_type = 'offer' and sub_idx = 0 then original_amount
-                    when purchase_method = 'Buy Now' and sub_type = 'consideration' then original_amount
+                    when purchase_method = 'Buy' and sub_type = 'consideration' then original_amount
                end) over (partition by tx_hash, evt_index)
            / nft_transfer_count as avg_original_amount
           ,sum(case when fee_royalty_yn = 'fee' then original_amount end) over (partition by tx_hash, evt_index) / nft_transfer_count as avg_fee_amount
@@ -95,19 +95,19 @@ with p1_call as (
           ,a.*
       from (select case when purchase_method = 'Offer Accepted' and sub_type = 'consideration' and fee_royalty_idx = 1 then 'fee'
                         when purchase_method = 'Offer Accepted' and sub_type = 'consideration' and fee_royalty_idx = 2 then 'royalty'
-                        when purchase_method = 'Buy Now' and sub_type = 'consideration' and fee_royalty_idx = 2 then 'fee'
-                        when purchase_method = 'Buy Now' and sub_type = 'consideration' and fee_royalty_idx = 3 then 'royalty'
+                        when purchase_method = 'Buy' and sub_type = 'consideration' and fee_royalty_idx = 2 then 'fee'
+                        when purchase_method = 'Buy' and sub_type = 'consideration' and fee_royalty_idx = 3 then 'royalty'
                    end as fee_royalty_yn
                   ,case when purchase_method = 'Offer Accepted' and main_type = 'order' then 'Individual Offer'
                         when purchase_method = 'Offer Accepted' and main_type = 'basic_order' then 'Individual Offer'
                         when purchase_method = 'Offer Accepted' and main_type = 'advanced_order' then 'Collection/Trait Offers'
-                        else 'Buy Now'
+                        else 'Buy'
                    end as order_type
                   ,a.*
               from (select (count(case when item_type in ('2','3') then 1 end) over (partition by tx_hash, evt_index)) as nft_transfer_count
                           ,(sum(case when item_type in ('0','1') then 1 end) over (partition by tx_hash, evt_index, sub_type order by sub_idx)) as fee_royalty_idx
                           ,case when max(case when (sub_type,sub_idx,item_type) in (('offer',0,'1')) then 1 else 0 end) over (partition by tx_hash) = 1 then 'Offer Accepted'
-                                else 'Buy Now'
+                                else 'Buy'
                            end as purchase_method
                           ,a.*
                       from p1_evt a
@@ -356,7 +356,7 @@ with p1_call as (
           ,case when evt_tx_hash is null then true else false end as reverted
           ,'Bulk Purchase' as trade_type
           ,'Bulk Purchase' as order_type
-          ,'Buy Now' as purchase_method
+          ,'Buy' as purchase_method
       from p2_evt a
 )
 
@@ -519,10 +519,10 @@ with p1_call as (
 
 
 ,p3_add_rn as (select (max(case when purchase_method = 'Offer Accepted' and sub_type = 'offer' and sub_idx = 0 then token_contract_address::string
-                     when purchase_method = 'Buy Now' and sub_type = 'consideration' then token_contract_address::string
+                     when purchase_method = 'Buy' and sub_type = 'consideration' then token_contract_address::string
                 end) over (partition by tx_hash, evt_index)) as avg_original_currency_contract
           ,sum(case when purchase_method = 'Offer Accepted' and sub_type = 'offer' and sub_idx = 0 then original_amount
-                    when purchase_method = 'Buy Now' and sub_type = 'consideration' then original_amount
+                    when purchase_method = 'Buy' and sub_type = 'consideration' then original_amount
                end) over (partition by tx_hash, evt_index)
            / nft_transfer_count as avg_original_amount
           ,sum(case when fee_royalty_yn = 'fee' then original_amount end) over (partition by tx_hash, evt_index) / nft_transfer_count as avg_fee_amount
@@ -532,19 +532,19 @@ with p1_call as (
           ,a.*
       from (select case when purchase_method = 'Offer Accepted' and sub_type = 'consideration' and fee_royalty_idx = 1 then 'fee'
                         when purchase_method = 'Offer Accepted' and sub_type = 'consideration' and fee_royalty_idx = 2 then 'royalty'
-                        when purchase_method = 'Buy Now' and sub_type = 'consideration' and fee_royalty_idx = 2 then 'fee'
-                        when purchase_method = 'Buy Now' and sub_type = 'consideration' and fee_royalty_idx = 3 then 'royalty'
+                        when purchase_method = 'Buy' and sub_type = 'consideration' and fee_royalty_idx = 2 then 'fee'
+                        when purchase_method = 'Buy' and sub_type = 'consideration' and fee_royalty_idx = 3 then 'royalty'
                    end as fee_royalty_yn
                   ,case when purchase_method = 'Offer Accepted' and main_type = 'order' then 'Individual Offer'
                         when purchase_method = 'Offer Accepted' and main_type = 'basic_order' then 'Individual Offer'
                         when purchase_method = 'Offer Accepted' and main_type = 'advanced_order' then 'Collection/Trait Offers'
-                        else 'Buy Now'
+                        else 'Buy'
                    end as order_type
                   ,a.*
               from (select count(case when item_type in ('2','3') then 1 end) over (partition by tx_hash, evt_index) as nft_transfer_count
                           ,sum(case when item_type in ('0','1') then 1 end) over (partition by tx_hash, evt_index, sub_type order by sub_idx) as fee_royalty_idx
                           ,case when max(case when (sub_type,sub_idx,item_type) in (('offer',0,'1')) then 1 else 0 end) over (partition by tx_hash) = 1 then 'Offer Accepted'
-                                else 'Buy Now'
+                                else 'Buy'
                            end as purchase_method
                           ,a.*
                       from p3_evt a
@@ -786,7 +786,7 @@ with p1_call as (
           ,false as reverted
           ,'' as offer_order_type
           ,'Private Sales' as order_type
-          ,'Buy Now' as purchase_method
+          ,'Buy' as purchase_method
           ,nft_transfer_count
       from p4_add_rn a
      where offer_item_type in ('2','3')

--- a/models/seaport/ethereum/seaport_ethereum_view_transactions.sql
+++ b/models/seaport/ethereum/seaport_ethereum_view_transactions.sql
@@ -244,22 +244,22 @@ with iv_availadv as (
           ,a.zone as zone_address
           ,case when spc1.call_tx_hash is not null then 'Auction'
                 when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 16 and 23 then 'Auction'
-                when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 0 and 7 then 'Buy Now'
-                when spc2.call_tx_hash is not null then 'Buy Now'
+                when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 0 and 7 then 'Buy'
+                when spc2.call_tx_hash is not null then 'Buy'
                 when spc3.call_tx_hash is not null and spc3.advancedOrder:parameters:consideration[0]:identifierOrCriteria > '0' then 'Trait Offer'
                 when spc3.call_tx_hash is not null then 'Collection Offer'
                 else 'Private Sales'
            end as category          
           ,case when spc1.call_tx_hash is not null then 'Collection/Trait Offers' -- include English Auction and Dutch Auction
-                when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 0 and 15 then 'Buy Now' -- Buy it directly
+                when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 0 and 15 then 'Buy' -- Buy it directly
                 when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 16 and 23 and spc2.parameters:considerationIdentifier = a.nft_token_id then 'Individual Offer'
-                when spc2.call_tx_hash is not null then 'Buy Now'
-                when spc3.call_tx_hash is not null and a.original_currency_contract = '0x0000000000000000000000000000000000000000' then 'Buy Now'
+                when spc2.call_tx_hash is not null then 'Buy'
+                when spc3.call_tx_hash is not null and a.original_currency_contract = '0x0000000000000000000000000000000000000000' then 'Buy'
                 when spc3.call_tx_hash is not null then 'Collection/Trait Offers' -- offer for collection
                 when spc4.call_tx_hash is not null then 'Bulk Purchase' -- bundles of NFTs are purchased through aggregators or in a cart 
                 when spc5.call_tx_hash is not null then 'Bulk Purchase' -- bundles of NFTs are purchased through aggregators or in a cart 
                 when spc6.call_tx_hash is not null then 'Private Sales' -- sales for designated address
-                else 'Buy Now'
+                else 'Buy'
            end as order_type  
 
       from iv_txn_level a

--- a/models/x2y2/ethereum/x2y2_ethereum_events.sql
+++ b/models/x2y2/ethereum/x2y2_ethereum_events.sql
@@ -134,7 +134,7 @@ WITH aggregator_routed_x2y2_txs AS (
     )
 
 SELECT 'ethereum' AS blockchain
-, 'X2Y2' AS project
+, 'x2y2' AS project
 , 'v1' AS version
 , TRY_CAST(date_trunc('DAY', txs.block_time) AS date) AS block_date
 , txs.block_time

--- a/models/x2y2/ethereum/x2y2_ethereum_events.sql
+++ b/models/x2y2/ethereum/x2y2_ethereum_events.sql
@@ -95,7 +95,7 @@ WITH aggregator_routed_x2y2_txs AS (
     FROM aggregator_routed_x2y2_txs txs
     LEFT JOIN {{ source('erc721_ethereum','evt_transfer') }} e721 ON txs.block_time = e721.evt_block_time
         AND txs.tx_hash = e721.evt_tx_hash
-        AND ROUND(txs.token_id, 0) = e721.tokenId
+        AND CAST(txs.token_id AS int) = e721.tokenId
         AND e721.contract_address = txs.project_contract_address
         AND to NOT IN (SELECT contract_address FROM {{ ref('nft_ethereum_aggregators') }})
     {% if is_incremental() %}

--- a/models/x2y2/ethereum/x2y2_ethereum_events.sql
+++ b/models/x2y2/ethereum/x2y2_ethereum_events.sql
@@ -28,7 +28,8 @@ WITH aggregator_routed_x2y2_txs AS (
     , COALESCE(get_json_object(get_json_object(inv.detail, '$.fees[1]'), '$.percentage')/1e6, 0) AS royalty_fee_percentage
     , get_json_object(get_json_object(inv.detail, '$.fees[1]'), '$.to') AS royalty_fee_receive_address
     FROM {{ source('x2y2_ethereum','X2Y2_r1_evt_EvProfit') }} prof
-    INNER JOIN {{ source('x2y2_ethereum','X2Y2_r1_evt_EvInventory') }} inv ON inv.itemHash = prof.itemHash
+    INNER JOIN {{ source('x2y2_ethereum','X2Y2_r1_evt_EvInventory') }} inv  ON inv.evt_block_time=prof.evt_block_time
+        AND inv.itemHash = prof.itemHash
     LEFT JOIN {{ ref('tokens_ethereum_nft') }} tokens ON ('0x' || substring(get_json_object(inv.item, '$.data'), 155, 40)) = tokens.contract_address
     LEFT JOIN {{ ref('nft_ethereum_aggregators') }} agg ON agg.contract_address=taker
     WHERE taker IN (SELECT contract_address FROM {{ ref('nft_ethereum_aggregators') }})
@@ -59,7 +60,8 @@ WITH aggregator_routed_x2y2_txs AS (
     , COALESCE(get_json_object(get_json_object(inv.detail, '$.fees[1]'), '$.percentage')/1e6, 0) AS royalty_fee_percentage
     , get_json_object(get_json_object(inv.detail, '$.fees[1]'), '$.to') AS royalty_fee_receive_address
     FROM  {{ source('x2y2_ethereum','X2Y2_r1_evt_EvProfit') }} prof
-    INNER JOIN {{ source('x2y2_ethereum','X2Y2_r1_evt_EvInventory') }} inv ON inv.itemHash=prof.itemHash
+    INNER JOIN {{ source('x2y2_ethereum','X2Y2_r1_evt_EvInventory') }} inv  ON inv.evt_block_time=prof.evt_block_time
+        AND inv.itemHash=prof.itemHash
     LEFT JOIN {{ ref('tokens_ethereum_nft') }} tokens ON ('0x' || substring(get_json_object(inv.item, '$.data'), 155, 40)) = tokens.contract_address
     WHERE taker NOT IN (SELECT contract_address FROM {{ ref('nft_ethereum_aggregators') }})
     {% if is_incremental() %}
@@ -73,7 +75,7 @@ WITH aggregator_routed_x2y2_txs AS (
     , block_number
     , e721.to AS buyer
     , seller
-    , token_id
+    , ROUND(token_id, 0) AS token_id
     , amount_raw
     , currency_contract
     , project_contract_address
@@ -90,8 +92,9 @@ WITH aggregator_routed_x2y2_txs AS (
     , royalty_fee_percentage
     , royalty_fee_receive_address
     FROM aggregator_routed_x2y2_txs txs
-    LEFT JOIN {{ source('erc721_ethereum','evt_transfer') }} e721 ON txs.tx_hash = e721.evt_tx_hash
-        AND txs.token_id = e721.tokenId
+    LEFT JOIN {{ source('erc721_ethereum','evt_transfer') }} e721 ON txs.block_time = e721.evt_block_time
+        AND txs.tx_hash = e721.evt_tx_hash
+        AND ROUND(txs.token_id, 0) = e721.tokenId
         AND e721.contract_address = txs.project_contract_address
         AND to NOT IN (SELECT contract_address FROM {{ ref('nft_ethereum_aggregators') }})
     {% if is_incremental() %}
@@ -105,7 +108,7 @@ WITH aggregator_routed_x2y2_txs AS (
     , block_number
     , buyer
     , seller
-    , token_id
+    , ROUND(token_id, 0) AS token_id
     , amount_raw
     , currency_contract
     , project_contract_address
@@ -174,7 +177,7 @@ SELECT 'ethereum' AS blockchain
 , CASE WHEN currency_contract='0x0000000000000000000000000000000000000000' THEN pu.price*platform_fee_amount_raw/POWER(10, 18)
     ELSE pu.price*platform_fee_amount_raw/POWER(10, pu.decimals)
     END AS platform_fee_amount_usd
-, platform_fee_percentage
+, platform_fee_percentage*100 AS platform_fee_percentage
 , royalty_fee_amount_raw
 , CASE WHEN currency_contract='0x0000000000000000000000000000000000000000' THEN royalty_fee_amount_raw/POWER(10, 18)
     ELSE royalty_fee_amount_raw/POWER(10, pu.decimals)
@@ -182,14 +185,15 @@ SELECT 'ethereum' AS blockchain
 , CASE WHEN currency_contract='0x0000000000000000000000000000000000000000' THEN pu.price*royalty_fee_amount_raw/POWER(10, 18)
     ELSE pu.price*royalty_fee_amount_raw/POWER(10, pu.decimals)
     END AS royalty_fee_amount_usd
-, royalty_fee_percentage
+, royalty_fee_percentage*100 AS royalty_fee_percentage
 , royalty_fee_receive_address
 , CASE WHEN currency_contract='0x0000000000000000000000000000000000000000' THEN 'ETH'
     ELSE pu.symbol
     END AS royalty_fee_currency_symbol
 , 'x2y2-' || txs.tx_hash || '-' || txs.nft_contract_address || txs.token_id || '-' || txs.seller || '-' || txs.evt_index || 'Trade' AS unique_trade_id
 FROM all_x2y2_txs txs
-INNER JOIN {{ source('ethereum','transactions') }} et ON et.hash=txs.tx_hash
+INNER JOIN {{ source('ethereum','transactions') }} et ON et.block_time=txs.block_time
+    AND et.hash=txs.tx_hash
     {% if is_incremental() %}
     AND et.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
@@ -200,7 +204,8 @@ LEFT JOIN {{ source('prices','usd') }} pu ON pu.blockchain='ethereum'
     {% if is_incremental() %}
     AND pu.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ source('erc721_ethereum','evt_transfer') }} erct ON txs.project_contract_address=erct.contract_address
+LEFT JOIN {{ source('erc721_ethereum','evt_transfer') }} erct ON erct.evt_block_time=txs.block_time
+    AND txs.nft_contract_address=erct.contract_address
     AND erct.evt_tx_hash=txs.tx_hash
     AND erct.tokenId=txs.token_id
     AND erct.from=txs.seller

--- a/models/x2y2/ethereum/x2y2_ethereum_events.sql
+++ b/models/x2y2/ethereum/x2y2_ethereum_events.sql
@@ -76,7 +76,7 @@ WITH aggregator_routed_x2y2_txs AS (
     , block_number
     , buyer
     , seller
-    , ROUND(token_id, 0) AS token_id
+    , CAST(token_id AS int) AS token_id
     , amount_raw
     , currency_contract
     , project_contract_address
@@ -109,7 +109,7 @@ WITH aggregator_routed_x2y2_txs AS (
     , block_number
     , buyer
     , seller
-    , ROUND(token_id, 0) AS token_id
+    , CAST(token_id AS int) AS token_id
     , amount_raw
     , currency_contract
     , project_contract_address

--- a/models/x2y2/ethereum/x2y2_ethereum_events.sql
+++ b/models/x2y2/ethereum/x2y2_ethereum_events.sql
@@ -11,6 +11,7 @@
 WITH aggregator_routed_x2y2_txs AS (
     SELECT inv.evt_block_time AS block_time
     , inv.evt_block_number AS block_number
+    , inv.taker AS buyer
     , prof.to AS seller
     , ROUND(bytea2numeric_v2(substring(get_json_object(inv.item, '$.data'), 195,64)),0) AS token_id
     , get_json_object(inv.item, '$.price') AS amount_raw
@@ -42,7 +43,7 @@ WITH aggregator_routed_x2y2_txs AS (
 , direct_x2y2_txs AS (
     SELECT inv.evt_block_time AS block_time
     , inv.evt_block_number AS block_number
-    , CASE WHEN inv.currency = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' THEN maker ELSE taker END AS buyer
+    , inv.taker AS buyer
     , prof.to AS seller
     , ROUND(bytea2numeric_v2(substring(get_json_object(inv.item, '$.data'), 195,64)),0) AS token_id
     , get_json_object(inv.item, '$.price') AS amount_raw
@@ -73,7 +74,7 @@ WITH aggregator_routed_x2y2_txs AS (
 , aggregator_routed_x2y2_txs_formatted AS (
     SELECT block_time
     , block_number
-    , e721.to AS buyer
+    , buyer
     , seller
     , ROUND(token_id, 0) AS token_id
     , amount_raw


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Fixed X2Y2's `token_id`, `project`, `royalty_fee_percentage`, `platform_fee_percentage` and `token_standard` and make abstraction more efficient (added block_time on joins)

Probably needs a full rerun after merging due to project name change 🤔 

*For Dune Engine V2*
I've checked that:
General checks:
* [X] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [X] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [X] if adding a new model, I added a test
* [X] the filename is unique and ends with .sql
* [X] each sql file is a select statement and has only one view, table or function defined  
* [X] column names are `lowercase_snake_cased`
* [X] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [X] if adding a new model, I edited the alter table macro to display new database object (table or view) in UI explorer
* [X] if adding a new materialized table, I edited the optimize table macro

Join logic:
* [X] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [X] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [X] where block_time >= date_trunc("day", now() - interval '1 week')
* [X] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [X] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
