### PR TITLE
Transfers optimize

### DIFF
--- a/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_day.sql
+++ b/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_day.sql
@@ -20,6 +20,6 @@ from {{ ref('transfers_ethereum_erc20') }} tr
 left join {{ ref('tokens_ethereum_erc20') }} t on t.contract_address = tr.token_address
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-where date_trunc('day', tr.evt_block_time) > now() - interval 2 days
+where tr.evt_block_time > now() - 'interval 1 week'
 {% endif %}
 group by 1, 2, 3, 4, 5, 6

--- a/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_day.sql
+++ b/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_day.sql
@@ -22,9 +22,4 @@ left join {{ ref('tokens_ethereum_erc20') }} t on t.contract_address = tr.token_
 -- this filter will only be applied on an incremental run
 where date_trunc('day', tr.evt_block_time) > now() - interval 2 days
 {% endif %}
-group by
-    date_trunc('day', tr.evt_block_time),
-  tr.wallet_address,
-  tr.token_address,
-  t.symbol,
-  tr.wallet_address || '-' || tr.token_address || '-' || date_trunc('day', tr.evt_block_time)
+group by 1, 2, 3, 4, 5, 6

--- a/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_hour.sql
+++ b/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_hour.sql
@@ -20,6 +20,6 @@ from {{ ref('transfers_ethereum_erc20') }} tr
 left join {{ ref('tokens_ethereum_erc20') }} t on t.contract_address = tr.token_address
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-where date_trunc('hour', tr.evt_block_time) > now() - interval 2 days
+where tr.evt_block_time > now() - 'interval 1 week'
 {% endif %}
 group by 1, 2, 3, 4, 5, 6

--- a/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_hour.sql
+++ b/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_hour.sql
@@ -1,5 +1,5 @@
 {{ config(
-        alias ='erc20_agg_hour', 
+        alias ='erc20_agg_hour',
         materialized ='incremental',
         file_format ='delta',
         incremental_strategy='merge',
@@ -22,9 +22,4 @@ left join {{ ref('tokens_ethereum_erc20') }} t on t.contract_address = tr.token_
 -- this filter will only be applied on an incremental run
 where date_trunc('hour', tr.evt_block_time) > now() - interval 2 days
 {% endif %}
-group by
-    date_trunc('hour', tr.evt_block_time),
-  tr.wallet_address,
-  tr.token_address,
-  t.symbol,
-  tr.wallet_address || '-' || tr.token_address || '-' || date_trunc('hour', tr.evt_block_time)
+group by 1, 2, 3, 4, 5, 6


### PR DESCRIPTION
This PR should bring transfers time filtering to the same speed as the rest of the tables.

The reason why it doesn't work atm is because there's a `date_trunc` in the `where`. We don't need to truncate the date there, we can just pass the value.

Thanks to @jkylling for pointing this out and solving this!