### PR TITLE
Correctly trunc date for transfers

### DIFF
--- a/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_day.sql
+++ b/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_day.sql
@@ -20,6 +20,6 @@ from {{ ref('transfers_ethereum_erc20') }} tr
 left join {{ ref('tokens_ethereum_erc20') }} t on t.contract_address = tr.token_address
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-where tr.evt_block_time > now() - interval '1 week'
+where tr.evt_block_time >= date_trunc('day', now() - interval '1 week')
 {% endif %}
 group by 1, 2, 3, 4, 5, 6

--- a/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_hour.sql
+++ b/models/transfers/ethereum/erc20/transfers_ethereum_erc20_agg_hour.sql
@@ -20,6 +20,6 @@ from {{ ref('transfers_ethereum_erc20') }} tr
 left join {{ ref('tokens_ethereum_erc20') }} t on t.contract_address = tr.token_address
 {% if is_incremental() %}
 -- this filter will only be applied on an incremental run
-where tr.evt_block_time > now() - interval '1 week'
+where tr.evt_block_time >= date_trunc('hour', now() - interval '1 week')
 {% endif %}
 group by 1, 2, 3, 4, 5, 6


### PR DESCRIPTION
I may have made a mistake in the previous PR. Without truncating the date, we risk losing some events that happened in between the truncated date and when the query is running. This is also a problem because the `merge into` updates records, so currently rows from a week ago might be updated when they shouldn't. 

We should do either do a full refresh of transfers after this is deployed or delete data from today to 7 days ago and refill.