### PR TITLE
materialize dex and nft meta spells as incremental tables tables

### DIFF
--- a/macros/alter_table_properties.sql
+++ b/macros/alter_table_properties.sql
@@ -263,7 +263,7 @@ ALTER VIEW nft.events SET TBLPROPERTIES('dune.public'='true',
 {% endset %}
 
 {% set nft_trades %}
-ALTER VIEW nft.trades SET TBLPROPERTIES('dune.public'='true',
+ALTER TABLE nft.trades SET TBLPROPERTIES('dune.public'='true',
                                         'dune.data_explorer.blockchains'='["ethereum","solana"]',
                                         'dune.data_explorer.category'='abstraction',
                                         'dune.data_explorer.abstraction.type'='sector',
@@ -272,7 +272,7 @@ ALTER VIEW nft.trades SET TBLPROPERTIES('dune.public'='true',
 {% endset %}
 
 {% set nft_mints %}
-ALTER VIEW nft.mints SET TBLPROPERTIES('dune.public'='true',
+ALTER TABLE nft.mints SET TBLPROPERTIES('dune.public'='true',
                                         'dune.data_explorer.blockchains'='["ethereum","solana"]',
                                         'dune.data_explorer.category'='abstraction',
                                         'dune.data_explorer.abstraction.type'='sector',
@@ -281,7 +281,7 @@ ALTER VIEW nft.mints SET TBLPROPERTIES('dune.public'='true',
 {% endset %}
 
 {% set nft_burns %}
-ALTER VIEW nft.burns SET TBLPROPERTIES('dune.public'='true',
+ALTER TABLE nft.burns SET TBLPROPERTIES('dune.public'='true',
                                         'dune.data_explorer.blockchains'='["ethereum","solana"]',
                                         'dune.data_explorer.category'='abstraction',
                                         'dune.data_explorer.abstraction.type'='sector',
@@ -290,7 +290,7 @@ ALTER VIEW nft.burns SET TBLPROPERTIES('dune.public'='true',
 {% endset %}
 
 {% set nft_fees %}
-ALTER VIEW nft.fees SET TBLPROPERTIES('dune.public'='true',
+ALTER TABLE nft.fees SET TBLPROPERTIES('dune.public'='true',
                                         'dune.data_explorer.blockchains'='["ethereum","solana"]',
                                         'dune.data_explorer.category'='abstraction',
                                         'dune.data_explorer.abstraction.type'='sector',
@@ -371,7 +371,7 @@ ALTER VIEW uniswap.trades SET TBLPROPERTIES('dune.public'='true',
 {% endset %}
 
 {% set dex_trades %}
-ALTER VIEW dex.trades SET TBLPROPERTIES('dune.public'='true',
+ALTER TABLE dex.trades SET TBLPROPERTIES('dune.public'='true',
                                             'dune.data_explorer.blockchains'='["ethereum"]',
                                             'dune.data_explorer.category'='abstraction',
                                             'dune.data_explorer.abstraction.type'='sector',

--- a/models/dex/dex_trades.sql
+++ b/models/dex/dex_trades.sql
@@ -1,7 +1,13 @@
 {{ config(
-        alias ='trades'
-        )
+    alias = 'trades',
+    partition_by = ['block_date'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'unique_trade_id']
+    )
 }}
+
 SELECT *
 FROM
 (
@@ -31,6 +37,9 @@ FROM
                 ,evt_index
                 ,unique_trade_id
         FROM {{ ref('uniswap_trades') }}
+        {% if is_incremental() %}
+        WHERE block_date >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         /*
         UNION
         <add future protocols here>

--- a/models/nft/nft_burns.sql
+++ b/models/nft/nft_burns.sql
@@ -1,6 +1,11 @@
 {{ config(
-        alias ='burns'
-)
+    alias = 'burns',
+    partition_by = ['block_time'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_time', 'unique_trade_id']
+    )
 }}
 
 SELECT *
@@ -35,6 +40,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('opensea_burns') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -65,6 +73,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('looksrare_ethereum_burns') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -95,4 +106,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('x2y2_ethereum_burns') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
 )

--- a/models/nft/nft_events.sql
+++ b/models/nft/nft_events.sql
@@ -1,6 +1,11 @@
 {{ config(
-        alias ='events'
-)
+    alias = 'events',
+    partition_by = ['block_time'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_time', 'unique_trade_id']
+    )
 }}
 
 SELECT *
@@ -45,6 +50,9 @@ FROM
                 royalty_fee_percentage,
                 unique_trade_id
         FROM {{ ref('opensea_events') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -85,6 +93,9 @@ FROM
                 royalty_fee_percentage,
                 unique_trade_id
         FROM {{ ref('magiceden_events') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -125,6 +136,9 @@ FROM
                 royalty_fee_percentage,
                 unique_trade_id
         FROM {{ ref('looksrare_ethereum_events') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -165,6 +179,9 @@ FROM
                 royalty_fee_percentage,
                 unique_trade_id
         FROM {{ ref('x2y2_ethereum_events') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -205,6 +222,9 @@ FROM
                 royalty_fee_percentage,
                 unique_trade_id
         FROM {{ ref('sudoswap_ethereum_events') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -245,4 +265,7 @@ FROM
                 royalty_fee_percentage,
                 unique_trade_id
         FROM {{ ref('archipelago_ethereum_events') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
 )

--- a/models/nft/nft_fees.sql
+++ b/models/nft/nft_fees.sql
@@ -1,6 +1,11 @@
 {{ config(
-        alias ='fees'
-)
+    alias = 'fees',
+    partition_by = ['block_time'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_time', 'unique_trade_id']
+    )
 }}
 
 SELECT *
@@ -40,6 +45,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('opensea_fees') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -75,6 +83,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('looksrare_ethereum_fees') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -110,6 +121,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('x2y2_ethereum_fees') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -145,6 +159,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('sudoswap_ethereum_fees') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -180,4 +197,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('archipelago_ethereum_fees') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
 )

--- a/models/nft/nft_mints.sql
+++ b/models/nft/nft_mints.sql
@@ -1,8 +1,12 @@
 {{ config(
-        alias ='mints'
-)
+    alias = 'mints',
+    partition_by = ['block_time'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_time', 'unique_trade_id']
+    )
 }}
-
 SELECT *
 FROM
 (
@@ -35,6 +39,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('opensea_mints') }} 
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -65,6 +72,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('magiceden_mints') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -95,6 +105,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('looksrare_ethereum_mints') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -125,4 +138,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('x2y2_ethereum_mints') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
 )

--- a/models/nft/nft_trades.sql
+++ b/models/nft/nft_trades.sql
@@ -1,6 +1,11 @@
 {{ config(
-        alias ='trades'
-        )
+    alias = 'trades',
+    partition_by = ['block_time'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_time', 'unique_trade_id']
+    )
 }}
 
 SELECT *
@@ -35,6 +40,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('opensea_trades') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -65,6 +73,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('magiceden_trades') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -95,6 +106,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('looksrare_ethereum_trades') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -125,6 +139,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('x2y2_ethereum_trades') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -155,6 +172,9 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('sudoswap_ethereum_trades') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
         UNION
         SELECT
                 blockchain,
@@ -185,4 +205,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('archipelago_ethereum_trades') }}
+        {% if is_incremental() %}
+        WHERE block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
 )


### PR DESCRIPTION
+ add filters

Brief comments on the purpose of your changes:
The idea of this PR is to materialize views that are exposed to users on the Dune App as incremental tables in order to improve the time it takes to query such tables.

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if adding a new model, I edited the alter table macro to display new database object (table or view) in UI explorer
* [ ] if adding a new materialized table, I edited the optimize table macro

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
