### PR TITLE
Fix typo in time filter for uniswap_v2

### DIFF
--- a/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
+++ b/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
@@ -77,7 +77,7 @@ INNER JOIN {{ source('ethereum', 'transactions') }} tx
     AND tx.block_time >= "2020-05-05 00:00:00"
     {% endif %}
     {% if is_incremental() %}
-    AND tx.block_time = date_trunc("day", now() - interval '1 week')
+    AND tx.block_time => date_trunc("day", now() - interval '1 week')
     {% endif %}
 LEFT JOIN {{ ref('tokens_erc20') }} erc20a ON erc20a.contract_address = dexs.token_bought_address AND erc20a.blockchain = 'ethereum'
 LEFT JOIN {{ ref('tokens_erc20') }} erc20b ON erc20b.contract_address = dexs.token_sold_address  AND erc20b.blockchain = 'ethereum'


### PR DESCRIPTION
There's a typo here so we don't actually insert any data. We should do a full refresh on this table once deployed.