### PR TITLE
Remove erc20 join that causes duplicate entries

### DIFF
--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_events.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_events.sql
@@ -86,7 +86,7 @@ SELECT
     NULL::string AS number_of_items,
     buys.trade_category,
     buys.from AS seller,
-    CASE WHEN buys.`enhanced_to`= agg.contract_address THEN erc.to
+    CASE WHEN buys.`enhanced_to`= agg.contract_address THEN NULL::string --erc.to
       ELSE buys.`enhanced_to` END AS buyer,
     "Trade" as evt_type,
     buys.enhanced_buy_value / power(10,18) AS amount_original,
@@ -124,11 +124,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p ON p.minute = date_trunc('minute', buy
 {% if is_incremental() %}
     AND p.minute >= date_trunc("day", now() - interval '1 week')
 {% endif %}
-LEFT JOIN {{ source('erc20_ethereum','evt_transfer') }} erc ON erc.evt_block_time=buys.evt_block_time
-    AND erc.contract_address="0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb"
-    AND erc.evt_tx_hash=buys.evt_tx_hash
-    AND erc.from=buys.`enhanced_to`
-    {% if is_incremental() %}
-    AND erc.evt_block_time >= date_trunc("day", now() - interval '1 week')
-    {% endif %}
 WHERE buys.type = "PunkBought"


### PR DESCRIPTION
Removed join on erc20 transfers for now as it results in duplication of buy events and duplicate `unique_trade_id` in some cases.

fyi @hildobby an example of a tx that results in duplication is [0x04f019f90a5afea8bdc72dddccdf5f7fb5ec5cdce69877497ad35bdabe07f9c5](https://etherscan.io/tx/0x04f019f90a5afea8bdc72dddccdf5f7fb5ec5cdce69877497ad35bdabe07f9c5#eventlog)

#1536 may very well be affected by this issue also.

