### PR TITLE
change deploy condition

### DIFF
--- a/.github/workflows/spellbook_deploy_trigger.yml
+++ b/.github/workflows/spellbook_deploy_trigger.yml
@@ -2,8 +2,8 @@ name: Trigger Spellbook Deploy to update the spellbook site
 
 on:
   push:
-    paths:
-      - 'spellbook/**'
+    branches:
+      - 'main'
 
 jobs:
   notify:


### PR DESCRIPTION
Brief comments on the purpose of your changes:
It looks like the spellbook docs at https://spellbook-docs.dune.com are out of date. 

We changed the structure of the directory when we moved v1 into the deprecated folder. I think that after we made that change, this workflow wasn't running because we no longer had a spellbook sub directory. 

@philippWassibauer can you take a look at this change and let me know if you think there is anything else we need to change to keep the docs up to date. 

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if adding a new model, I edited the alter table macro to display new database object (table or view) in UI explorer
* [ ] if adding a new materialized table, I edited the optimize table macro

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
