### PR TITLE
Add arbitrage trader labels for ethereal

### DIFF
--- a/macros/alter_table_properties.sql
+++ b/macros/alter_table_properties.sql
@@ -308,7 +308,7 @@ ALTER TABLE labels.all SET TBLPROPERTIES('dune.public'='true',
 {% endset %}
 
 {% set labels_arb_traders %}
-ALTER VIEW labels.nft SET TBLPROPERTIES('dune.public'='true',
+ALTER VIEW labels.arb_traders SET TBLPROPERTIES('dune.public'='true',
                                         'dune.data_explorer.blockchains'='["ethereum"]',
                                         'dune.data_explorer.category'='abstraction',
                                         'dune.data_explorer.abstraction.type'='sector',

--- a/macros/alter_table_properties.sql
+++ b/macros/alter_table_properties.sql
@@ -307,6 +307,15 @@ ALTER TABLE labels.all SET TBLPROPERTIES('dune.public'='true',
                                         'dune.data_explorer.contributors'='["soispoke","hildobby"]');
 {% endset %}
 
+{% set labels_arb_traders %}
+ALTER VIEW labels.nft SET TBLPROPERTIES('dune.public'='true',
+                                        'dune.data_explorer.blockchains'='["ethereum"]',
+                                        'dune.data_explorer.category'='abstraction',
+                                        'dune.data_explorer.abstraction.type'='sector',
+                                        'dune.data_explorer.abstraction.name'='labels',
+                                        'dune.data_explorer.contributors'='["alexth"]');
+{% endset %}
+
 {% set labels_cex %}
 ALTER VIEW labels.cex SET TBLPROPERTIES('dune.public'='true',
                                         'dune.data_explorer.blockchains'='["ethereum"]',

--- a/models/labels/arb_traders/ethereum/labels_arb_traders_ethereum.sql
+++ b/models/labels/arb_traders/ethereum/labels_arb_traders_ethereum.sql
@@ -11,7 +11,7 @@ with
     WHERE
       t1.blockchain = 'ethereum'
       AND t2.blockchain = 'ethereum'
-      AND t1.block_date >= date_trunc('day', now() - interval '180 days')
+      -- AND t1.block_date >= date_trunc('day', now() - interval '180 days')
       AND t1.token_sold_address = t2.token_bought_address
       AND t1.token_bought_address = t2.token_sold_address
       AND t1.evt_index != t2.evt_index
@@ -23,7 +23,7 @@ with
 select
   "ethereum" as blockchain,
   address,
-  "arb trader" AS name,
+  "Arbitrage Trader" AS name,
   "arb_traders" AS category,
   "alexth" AS contributor,
   "query" AS source,

--- a/models/labels/arb_traders/labels_arb_traders.sql
+++ b/models/labels/arb_traders/labels_arb_traders.sql
@@ -1,0 +1,3 @@
+{{config(alias='arb_traders')}}
+
+SELECT * FROM {{ ref('labels_arb_traders_ethereum') }}

--- a/models/labels/arb_traders/labels_arb_traders_ethereum.sql
+++ b/models/labels/arb_traders/labels_arb_traders_ethereum.sql
@@ -1,0 +1,33 @@
+{{config(alias='arb_traders_ethereum')}}
+
+
+with
+  eth_arb_traders as (
+    SELECT
+      distinct t1.tx_from as address
+    FROM
+      {{ref('dex_trades')}} t1
+      INNER JOIN {{ref('dex_trades')}} t2 ON t1.tx_hash = t2.tx_hash
+    WHERE
+      t1.blockchain = 'ethereum'
+      AND t2.blockchain = 'ethereum'
+      AND t1.block_date >= date_trunc('day', now() - interval '180 days')
+      AND t1.token_sold_address = t2.token_bought_address
+      AND t1.token_bought_address = t2.token_sold_address
+      AND t1.evt_index != t2.evt_index
+    GROUP BY
+      t1.tx_from
+    ORDER BY
+      1
+  )
+select
+  "ethereum" as blockchain,
+  address,
+  "arb trader" AS name,
+  "arb_traders" AS category,
+  "alexth" AS contributor,
+  "query" AS source,
+  timestamp('2022-09-18') as created_at,
+  now() as updated_at
+from
+  eth_arb_traders

--- a/models/labels/arb_traders/labels_arb_traders_schema.yml
+++ b/models/labels/arb_traders/labels_arb_traders_schema.yml
@@ -8,7 +8,7 @@ models:
       category: arb_traders
       contibutors: alexth
     config:
-      tags: ['labels', 'ethereum', 'arbitrage', 'dex']
+      tags: ['labels', 'ethereum', 'arbitrage', 'dex', 'arb_traders']
     description: "Known arbitrage trader addresses across chains"
     columns:
       - &blockchain
@@ -17,6 +17,24 @@ models:
       - &address
         name: address
         description: "Address of known arbitrage trader"
+      - &name
+        name: name
+        description: "Label name (Arbitrage Trader)"
+      - &category
+        name: category
+        description: "Label category (arb_traders)"
+      - &contributor
+        name: contributor
+        description: "Wizard(s) contributing to labels"
+      - &source
+        name: source
+        description: "How were labels generated (could be static or query)"
+      - &created_at
+        name: created_at
+        description: "When were labels created"
+      - &updated_at
+        name: updated_at
+        description: "When were labels updated for the last time"
 
   - name: labels_arb_traders_ethereum
     meta:
@@ -25,8 +43,14 @@ models:
       category: arb_traders
       contibutors: alexth
     config:
-      tags: ['labels', 'ethereum', 'arbitrage', 'dex']
+      tags: ['labels', 'ethereum', 'arbitrage', 'dex', 'arb_traders']
     description: "Known arbitrage trader addresses on Ethereum"
     columns:
       - *blockchain
       - *address
+      - *name
+      - *category
+      - *contributor
+      - *source
+      - *created_at
+      - *updated_at

--- a/models/labels/arb_traders/labels_arb_traders_schema.yml
+++ b/models/labels/arb_traders/labels_arb_traders_schema.yml
@@ -1,0 +1,32 @@
+version: 2
+
+models:
+  - name: labels_arb_traders
+    meta:
+      blockchain: ethereum
+      sector: labels
+      category: arb_traders
+      contibutors: alexth
+    config:
+      tags: ['labels', 'ethereum', 'arbitrage', 'dex']
+    description: "Known arbitrage trader addresses across chains"
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain"   
+      - &address
+        name: address
+        description: "Address of known arbitrage trader"
+
+  - name: labels_arb_traders_ethereum
+    meta:
+      blockchain: ethereum
+      sector: labels
+      category: arb_traders
+      contibutors: alexth
+    config:
+      tags: ['labels', 'ethereum', 'arbitrage', 'dex']
+    description: "Known arbitrage trader addresses on Ethereum"
+    columns:
+      - *blockchain
+      - *address


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Add labels for all wallets engaging in arbitrage activity on ethereal

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if adding a new model, I edited the alter table macro to display new database object (table or view) in UI explorer
* [ ] if adding a new materialized table, I edited the optimize table macro

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
