### PR TITLE
Foundation: remove syntax error in unit tests

### DIFF
--- a/tests/foundation/ethereum/foundation_ethereum_assert_trades.sql
+++ b/tests/foundation/ethereum/foundation_ethereum_assert_trades.sql
@@ -6,7 +6,7 @@ WITH raw_events AS (
   , c.tokenId AS raw_token_id
   FROM {{ source('foundation_ethereum','market_evt_ReserveAuctionFinalized') }} f
   LEFT JOIN {{ source('foundation_ethereum','market_evt_ReserveAuctionCreated') }} c ON c.auctionId=f.auctionId AND c.evt_block_time<=f.evt_block_time
-  WHERE f.evt_block_time >= --'2022-04-15'
+  WHERE f.evt_block_time >= '2022-04-15'
   AND f.evt_block_time < NOW() - interval '1 day' -- allow some head desync
   UNION
   SELECT f.evt_block_time AS raw_block_time
@@ -14,7 +14,7 @@ WITH raw_events AS (
   , f.nftContract AS raw_nft_contract_address
   , f.tokenId AS raw_token_id
     FROM {{ source('foundation_ethereum','market_evt_BuyPriceAccepted') }} f
-  WHERE f.evt_block_time >= --'2022-04-15'
+  WHERE f.evt_block_time >= '2022-04-15'
   AND f.evt_block_time < NOW() - interval '1 day' -- allow some head desync
   UNION
   SELECT f.evt_block_time AS raw_block_time
@@ -22,7 +22,7 @@ WITH raw_events AS (
   , f.nftContract AS raw_nft_contract_address
   , f.tokenId AS raw_token_id
     FROM {{ source('foundation_ethereum','market_evt_OfferAccepted') }} f
-  WHERE f.evt_block_time >= --'2022-04-15'
+  WHERE f.evt_block_time >= '2022-04-15'
   AND f.evt_block_time < NOW() - interval '1 day' -- allow some head desync
   UNION
   SELECT f.evt_block_time AS raw_block_time
@@ -30,7 +30,7 @@ WITH raw_events AS (
   , f.nftContract AS raw_nft_contract_address
   , f.tokenId AS raw_token_id
     FROM {{ source('foundation_ethereum','market_evt_PrivateSaleFinalized') }} f
-  WHERE f.evt_block_time >= --'2022-04-15'
+  WHERE f.evt_block_time >= '2022-04-15'
   AND f.evt_block_time < NOW() - interval '1 day' -- allow some head desync
   )
 

--- a/tests/foundation/ethereum/foundation_ethereum_assert_trades.sql
+++ b/tests/foundation/ethereum/foundation_ethereum_assert_trades.sql
@@ -4,6 +4,7 @@ WITH raw_events AS (
   , f.evt_tx_hash AS raw_tx_hash
   , c.nftContract AS raw_nft_contract_address
   , c.tokenId AS raw_token_id
+  , f.evt_tx_hash || '-' || c.nftContract || '-' || c.tokenId AS raw_unique_trade_id
   FROM {{ source('foundation_ethereum','market_evt_ReserveAuctionFinalized') }} f
   LEFT JOIN {{ source('foundation_ethereum','market_evt_ReserveAuctionCreated') }} c ON c.auctionId=f.auctionId AND c.evt_block_time<=f.evt_block_time
   WHERE f.evt_block_time >= '2022-04-15'
@@ -13,6 +14,7 @@ WITH raw_events AS (
   , f.evt_tx_hash AS raw_tx_hash
   , f.nftContract AS raw_nft_contract_address
   , f.tokenId AS raw_token_id
+  , f.evt_tx_hash || '-' || f.nftContract || '-' || f.tokenId AS raw_unique_trade_id
     FROM {{ source('foundation_ethereum','market_evt_BuyPriceAccepted') }} f
   WHERE f.evt_block_time >= '2022-04-15'
   AND f.evt_block_time < NOW() - interval '1 day' -- allow some head desync
@@ -21,6 +23,7 @@ WITH raw_events AS (
   , f.evt_tx_hash AS raw_tx_hash
   , f.nftContract AS raw_nft_contract_address
   , f.tokenId AS raw_token_id
+  , f.evt_tx_hash || '-' || f.nftContract || '-' || f.tokenId AS raw_unique_trade_id
     FROM {{ source('foundation_ethereum','market_evt_OfferAccepted') }} f
   WHERE f.evt_block_time >= '2022-04-15'
   AND f.evt_block_time < NOW() - interval '1 day' -- allow some head desync
@@ -29,6 +32,7 @@ WITH raw_events AS (
   , f.evt_tx_hash AS raw_tx_hash
   , f.nftContract AS raw_nft_contract_address
   , f.tokenId AS raw_token_id
+  , f.evt_tx_hash || '-' || f.nftContract || '-' || f.tokenId AS raw_unique_trade_id
     FROM {{ source('foundation_ethereum','market_evt_PrivateSaleFinalized') }} f
   WHERE f.evt_block_time >= '2022-04-15'
   AND f.evt_block_time < NOW() - interval '1 day' -- allow some head desync
@@ -39,7 +43,8 @@ WITH raw_events AS (
   , tx_hash AS processed_tx_hash
   , nft_contract_address AS processed_nft_contract_address
   , token_id AS processed_token_id
-  FROM {{ ref('nft_trades') }}
+  , tx_hash || '-' || nft_contract_address || '-' || token_id AS processed_trade_id
+  FROM {{ ref('foundation_ethereum_events') }}
   WHERE blockchain = 'ethereum'
     AND project = 'foundation'
     AND version = 'v1'


### PR DESCRIPTION
Fixes syntax error in unit tests introduced in #1543 (hopefully)