### PR TITLE
Add spell for sudoswap pool stats

### DIFF
--- a/macros/optimize_tables.sql
+++ b/macros/optimize_tables.sql
@@ -111,6 +111,14 @@ OPTIMIZE cow_protocol_ethereum.trades;
 OPTIMIZE cow_protocol_ethereum.batches;
 {% endset %}
 
+{% set sudoswap_ethereum_pool_balance_changes %}
+OPTIMIZE sudoswap_ethereum.pool_balance_changes;
+{% endset %}
+
+{% set sudoswap_ethereum_pool_trades %}
+OPTIMIZE sudoswap_ethereum.pool_trades;
+{% endset %}
+
 
 {% do run_query(looksrare_ethereum_events) %}
 {% do run_query(magiceden_solana_events) %}
@@ -138,5 +146,7 @@ OPTIMIZE cow_protocol_ethereum.batches;
 {% do run_query(labels_all) %}
 {% do run_query(cow_protocol_ethereum_trades) %}
 {% do run_query(cow_protocol_ethereum_batches) %}
+{% do run_query(sudoswap_ethereum_pool_balance_changes) %}
+{% do run_query(sudoswap_ethereum_pool_trades) %}
 {% do log("Tables Optimized", info=True) %}
 {% endmacro %}

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pool_balance_changes.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pool_balance_changes.sql
@@ -1,0 +1,171 @@
+{{ config(
+        alias = 'pool_balance_changes',
+        partition_by = ['day'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'pool_address', 'nft_contract_address'],
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "project",
+                                    "sudoswap",
+                                    \'["niftytable"]\') }}'
+        )
+}}
+
+{% set project_start_date = '2022-04-23' %}
+
+WITH
+  pairs_created AS (
+    SELECT
+      CASE
+        WHEN _bondingCurve = '0x5b6ac51d9b1cede0068a1b26533cace807f883ee' THEN 'linear_bonding'
+        ELSE 'exp_bonding'
+      END as pricing_type,
+      _delta / 1e18 as delta,
+      CASE
+        WHEN _poolType = 0 THEN 'token'
+        WHEN _poolType = 1 THEN 'nft'
+        WHEN _poolType = 2 THEN 'trade'
+      END AS pool_type,
+      _spotPrice / 1e18 AS spot_price,
+      _nft AS nft_contract_address,
+      _initialNFTIDs AS nft_ids,
+      _fee AS initial_fee,
+      output_pair AS pair_address,
+      tx.FROM AS creator_address,
+      date_trunc('day', call_block_time) AS day_created,
+      cardinality(_initialNFTIDs) AS initial_nft_count,
+      tx.value / 1e18 AS initial_eth
+    FROM
+      {{ source('sudo_amm_ethereum','LSSVMPairFactory_call_createPairETH') }} cre
+      INNER JOIN {{ source('ethereum','transactions') }} tx ON tx.hash = cre.call_tx_hash
+    WHERE
+      call_success
+  ),
+
+  most_recent_spot_delta AS (
+    SELECT
+      COALESCE(del.contract_address, spot.contract_address) AS pair_address,
+      del.delta,
+      spot.spot_price
+    FROM
+      (
+        SELECT
+          *
+        FROM
+          (
+            SELECT
+              contract_address,
+              newDelta / 1e18 AS delta,
+              row_number() over (
+                PARTITION BY
+                  contract_address
+                ORDER BY
+                  evt_block_number DESC,
+                  evt_index DESC
+              ) as most_recent
+            FROM
+              {{ source('sudo_amm_ethereum','LSSVMPair_general_evt_DeltaUpdate') }}
+          ) a
+        WHERE
+          most_recent = 1
+      ) del
+      FULL OUTER JOIN (
+        SELECT
+          *
+        FROM
+          (
+            SELECT
+              contract_address,
+              newSpotPrice / 1e18 AS spot_price,
+              row_number() over (
+                PARTITION BY
+                  contract_address
+                ORDER BY
+                  evt_block_number DESC,
+                  evt_index DESC
+              ) AS most_recent
+            FROM
+              {{ source('sudo_amm_ethereum','LSSVMPair_general_evt_SpotPriceUpdate') }}
+          ) a
+        WHERE
+          most_recent = 1
+      ) spot ON del.contract_address = spot.contract_address
+  ),
+
+  erc721_balances AS (
+    SELECT
+      date_trunc('day', et.evt_block_time) AS day,
+      pair_address,
+      SUM(CASE WHEN et.to = p.pair_address THEN 1 ELSE -1 END) AS nft_balance_change,
+      0 AS eth_balance_change
+    FROM
+      {{ source('erc721_ethereum','evt_transfer') }} et
+      INNER JOIN pairs_created p ON p.nft_contract_address = et.contract_address
+      AND (et.to = p.pair_address OR et.from = p.pair_address)
+      {% if is_incremental() %}
+      -- this filter will only be applied on an incremental run. We only want to update with new transfers.
+      WHERE et.evt_block_time >= date_trunc("day", now() - interval '1 week')
+      {% endif %}
+    GROUP BY
+      1,2
+  ),
+
+  eth_balances AS (
+    SELECT
+      date_trunc('day',tr.block_time) AS day,
+      pair_address,
+      SUM(CASE WHEN tr.to = pc.pair_address THEN tr.value/1e18 ELSE -1*tr.value/1e18 END) AS eth_balance_change,
+      0 AS nft_balance_change
+    FROM
+      {{ source('ethereum','traces') }} tr
+      INNER JOIN pairs_created pc ON (pc.pair_address = tr.to OR pc.pair_address = tr.from)
+    WHERE
+      AND tr.success = true
+      AND tr.type = 'call'
+      AND (
+        tr.call_type NOT IN ('delegatecall', 'callcode', 'staticcall')
+        OR tr.call_type IS null
+      )
+      {% if not is_incremental() %}
+      tr.block_time > '{{project_start_date}}'
+      {% endif %}
+      {% if is_incremental() %}
+      -- this filter will only be applied on an incremental run. We only want to update with new transfers.
+      AND tr.block_time >= date_trunc("day", now() - interval '1 week')
+      {% endif %}
+    GROUP BY
+      1,2
+  )
+
+  SELECT
+    bal.day AS day,
+    bal.pair_address AS pool_address,
+    COALESCE(bal.eth_balance_change, 0) AS eth_balance_change,
+    COALESCE(bal.nft_balance_change, 0) AS nft_balance_change,
+    pc.pricing_type AS pricing_type,
+    pc.pool_type AS pool_type,
+    pc.nft_contract_address AS nft_contract_address,
+    pc.creator_address AS creator_address,
+    pc.spot_price AS initial_price,
+    pc.initial_nft_count AS initial_nft_count,
+    pc.initial_eth AS initial_eth,
+    pc.day_created AS day_created,
+    COALESCE(mr.delta, pc.delta) AS delta, --if delta was never updated, just keep original deploy delta
+    round(COALESCE(mr.spot_price, pc.spot_price), 4) as spot_price --same logic as above
+  FROM
+    (
+      SELECT
+        day,
+        pair_address,
+        COALESCE(SUM(eth_balance_change), 0) as eth_balance_change,
+        COALESCE(SUM(nft_balance_change),0) as nft_balance_change
+      FROM (
+      SELECT * FROM erc721_balances
+      UNION ALL
+      SELECT * FROM eth_balances
+      )
+      GROUP BY 1,2
+    ) bal
+  INNER JOIN pairs_created pc ON pc.pair_address = bal.pair_address
+  LEFT JOIN most_recent_spot_delta mr ON mr.pair_address = bal.pair_address

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pool_balance_changes.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pool_balance_changes.sql
@@ -120,8 +120,7 @@ WITH
     FROM
       {{ source('ethereum','traces') }} tr
       INNER JOIN pairs_created pc ON (pc.pair_address = tr.to OR pc.pair_address = tr.from)
-    WHERE
-      AND tr.success = true
+    WHERE tr.success = true
       AND tr.type = 'call'
       AND (
         tr.call_type NOT IN ('delegatecall', 'callcode', 'staticcall')

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pool_balance_changes.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pool_balance_changes.sql
@@ -127,7 +127,7 @@ WITH
         OR tr.call_type IS null
       )
       {% if not is_incremental() %}
-      tr.block_time > '{{project_start_date}}'
+      AND tr.block_time > '{{project_start_date}}'
       {% endif %}
       {% if is_incremental() %}
       -- this filter will only be applied on an incremental run. We only want to update with new transfers.

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pool_trades.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pool_trades.sql
@@ -1,0 +1,73 @@
+{{ config(
+        alias = 'pool_trades',
+        partition_by = ['day'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'pool_address'],
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "project",
+                                    "sudoswap",
+                                    \'["niftytable"]\') }}'
+        )
+}}
+
+{% set project_start_date = '2022-04-23' %}
+
+WITH
+  pairs_created AS (
+    SELECT
+      _nft AS nft_contract_address,
+      output_pair AS pair_address
+    FROM
+      {{ source('sudo_amm_ethereum','LSSVMPairFactory_call_createPairETH') }} cre
+    WHERE
+      call_success
+  ),
+
+  SELECT
+    day,
+    CASE
+      WHEN trade_category = 'Sell' THEN buyer
+      ELSE seller
+    END AS pool_address,
+    sum(amount_original) AS eth_volume,
+    sum(amount_usd) AS usd_volume,
+    sum(number_of_items) AS nfts_traded,
+    sum(pool_fee_amount) AS owner_fee_volume_eth,
+    sum(platform_fee_amount) AS platform_fee_volume_eth,
+    sum(
+      CASE
+        WHEN trade_category = 'Sell' THEN -1 * amount_original
+        ELSE (amount_original-platform_fee_amount)
+      END
+    ) AS eth_change_trading,
+    sum(
+      CASE
+        WHEN trade_category = 'Sell' THEN number_of_items
+        ELSE -1 * number_of_items
+      END
+    ) AS nft_change_trading
+  FROM
+    (
+      SELECT
+        block_date AS day,
+        trade_category,
+        buyer,
+        seller,
+        amount_original,
+        amount_usd,
+        number_of_items,
+        pool_fee_amount,
+        platform_fee_amount
+      FROM
+        {{ ref('sudoswap_ethereum_events') }} se
+      INNER JOIN pairs_created p ON ((p.nftcontractaddress = se.nft_contract_address)
+      AND (se.buyer = p.pair_address OR se.seller = p.pair_address))
+      {% if is_incremental() %}
+      -- this filter will only be applied on an incremental run. We only want to update with new swaps.
+      WHERE block_date >= date_trunc("day", now() - interval '1 week')
+      {% endif %}
+    ) a
+  GROUP BY
+    1,2

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pool_trades.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pool_trades.sql
@@ -63,11 +63,14 @@ WITH
       FROM
         {{ ref('sudoswap_ethereum_events') }} se
       INNER JOIN pairs_created p ON ((p.nft_contract_address = se.nft_contract_address)
-      AND (se.buyer = p.pair_address OR se.seller = p.pair_address))
+        AND (se.buyer = p.pair_address OR se.seller = p.pair_address))
+      {% if not is_incremental() %}
+      WHERE se.block_date >= '{{project_start_date}}'
+      {% endif %}
       {% if is_incremental() %}
-      -- this filter will only be applied on an incremental run. We only want to update with new swaps.
-      WHERE block_date >= date_trunc("day", now() - interval '1 week')
+      WHERE se.block_date >= date_trunc("day", now() - interval '1 week')
       {% endif %}
     ) a
   GROUP BY
     1,2
+    ;

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pool_trades.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pool_trades.sql
@@ -62,7 +62,7 @@ WITH
         platform_fee_amount
       FROM
         {{ ref('sudoswap_ethereum_events') }} se
-      INNER JOIN pairs_created p ON ((p.nftcontractaddress = se.nft_contract_address)
+      INNER JOIN pairs_created p ON ((p.nft_contract_address = se.nft_contract_address)
       AND (se.buyer = p.pair_address OR se.seller = p.pair_address))
       {% if is_incremental() %}
       -- this filter will only be applied on an incremental run. We only want to update with new swaps.

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pool_trades.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pool_trades.sql
@@ -23,7 +23,7 @@ WITH
       {{ source('sudo_amm_ethereum','LSSVMPairFactory_call_createPairETH') }} cre
     WHERE
       call_success
-  ),
+  )
 
   SELECT
     day,

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
@@ -76,3 +76,4 @@ FROM
   pool_stats ps
 INNER JOIN pool_balance pb ON pb.pool_address = ps.pool_address
 INNER JOIN pool_trades pt ON pt.pool_address = ps.pool_address
+;

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
@@ -1,0 +1,275 @@
+{{
+ config(
+       alias='pools',
+       post_hook='{{ expose_spells(\'["ethereum"]\',
+                                   "project",
+                                   "sudoswap",
+                                   \'["niftytable"]\') }}')
+}}
+
+WITH
+  pairs_created AS (
+    SELECT
+      CASE
+        WHEN _bondingCurve = '0x5b6ac51d9b1cede0068a1b26533cace807f883ee' THEN 'linear_bonding'
+        ELSE 'exp_bonding'
+      END as pricing_type,
+      _delta / 1e18 as delta,
+      CASE
+        WHEN _poolType = 0 THEN 'token'
+        WHEN _poolType = 1 THEN 'nft'
+        WHEN _poolType = 2 THEN 'trade'
+      END AS pooltype,
+      _spotPrice / 1e18 AS spotprice,
+      _nft AS nftcontractaddress,
+      _initialNFTIDs AS nft_ids,
+      _fee AS initialfee,
+      output_pair AS pair_address,
+      call_block_time AS block_time,
+      tx.FROM AS creator_address,
+      date_trunc('day', now()) - date_trunc('day', call_block_time) AS days_passed,
+      cardinality(_initialNFTIDs) AS initial_nft_count,
+      tx.value / 1e18 AS initial_eth
+    FROM
+      {{ source('sudo_amm_ethereum','LSSVMPairFactory_call_createPairETH') }} cre
+      LEFT JOIN {{ source('ethereum','transactions') }} tx ON tx.hash = cre.call_tx_hash
+    WHERE
+      call_success
+  ),
+  most_recent_spot_delta AS (
+    SELECT
+      COALESCE(del.contract_address, spot.contract_address) AS pair_address,
+      del.delta,
+      spot.spotprice
+    FROM
+      (
+        SELECT
+          *
+        FROM
+          (
+            SELECT
+              contract_address,
+              newDelta / 1e18 AS delta,
+              row_number() over (
+                PARTITION BY
+                  contract_address
+                ORDER BY
+                  evt_block_number DESC,
+                  evt_index DESC
+              ) as most_recent
+            FROM
+              {{ source('sudo_amm_ethereum','LSSVMPair_general_evt_DeltaUpdate') }}
+          ) a
+        WHERE
+          most_recent = 1
+      ) del
+      FULL OUTER JOIN (
+        SELECT
+          *
+        FROM
+          (
+            SELECT
+              contract_address,
+              newSpotPrice / 1e18 AS spotprice,
+              row_number() over (
+                PARTITION BY
+                  contract_address
+                ORDER BY
+                  evt_block_number DESC,
+                  evt_index DESC
+              ) AS most_recent
+            FROM
+              {{ source('sudo_amm_ethereum','LSSVMPair_general_evt_SpotPriceUpdate') }}
+          ) a
+        WHERE
+          most_recent = 1
+      ) spot ON del.contract_address = spot.contract_address
+  ),
+  erc721_balances AS (
+    SELECT
+      holder_address,
+      sum(value) AS tokens_held
+    FROM
+      (
+        SELECT
+          to AS holder_address,
+          count(evt_tx_hash) AS value
+        FROM
+          {{ source('erc721_ethereum','evt_transfer') }}
+        WHERE
+          to IN (
+            SELECT
+              pair_address
+            FROM
+              pairs_created
+          )
+        GROUP BY
+          1
+        union all
+        SELECT
+        FROM
+          AS holder_address,
+          count(evt_tx_hash) * -1 as value
+        FROM
+          {{ source('erc721_ethereum','evt_transfer') }}
+        WHERE
+        FROM
+          IN (
+            SELECT
+              pair_address
+            FROM
+              pairs_created
+          )
+        GROUP BY
+          1
+      ) a
+    GROUP BY
+      1
+  ),
+  eth_balances AS (
+    WITH
+      eth_in AS (
+        SELECT
+          tr.to AS holder_address,
+          SUM(tr.value / 1e18) AS eth_funded
+        FROM
+          {{ source('ethereum','traces') }} tr
+          JOIN pairs_created pc ON pc.pair_address = tr.to
+        WHERE
+          tr.block_time > '2022-04-23'
+          AND tr.success = true
+          AND tr.type = 'call'
+          AND (
+            tr.call_type NOT IN ('delegatecall', 'callcode', 'staticcall')
+            OR tr.call_type IS null
+          )
+        GROUP BY
+          1
+      ),
+      eth_out AS (
+        SELECT
+          tr.FROM AS holder_address,
+          SUM(tr.value / 1e18) AS eth_spent
+        FROM
+          {{ source('ethereum','traces') }} tr
+          JOIN pairs_created pc ON pc.pair_address = tr.FROM
+        WHERE
+          tr.block_time > '2022-04-23'
+          AND tr.success = true
+          AND tr.type = 'call'
+          AND (
+            tr.call_type NOT IN ('delegatecall', 'callcode', 'staticcall')
+            OR tr.call_type IS null
+          )
+        GROUP BY
+          1
+      )
+    SELECT
+      eth_in.holder_address,
+      eth_in.eth_funded,
+      eth_out.eth_spent,
+      COALESCE(eth_funded, 0) - COALESCE(eth_spent, 0) as eth_balance
+    FROM
+      eth_in
+      LEFT JOIN eth_out ON eth_in.holder_address = eth_out.holder_address
+  ),
+  all_pairs_cleaned AS (
+    SELECT
+      pricing_type,
+      pooltype,
+      nftcontractaddress,
+      creator_address,
+      COALESCE(mr.delta, pc.delta) AS delta --if delta was never updated, just keep original deploy delta
+,
+      round(COALESCE(mr.spotprice, pc.spotprice), 4) as spotprice --same logic as above
+,
+      nft_bal.tokens_held,
+      round(COALESCE(eth_bal.eth_balance, 0), 4) as eth_balance,
+      pc.pair_address AS raw_pair_address,
+      days_passed,
+      pc.spotprice AS initial_price,
+      pc.initial_nft_count,
+      pc.initial_eth
+    FROM
+      pairs_created pc
+      LEFT JOIN most_recent_spot_delta mr ON pc.pair_address = mr.pair_address
+      LEFT JOIN erc721_balances nft_bal ON nft_bal.holder_address = pc.pair_address
+      LEFT JOIN eth_balances eth_bal ON eth_bal.holder_address = pc.pair_address
+  ),
+  trading_totals as (
+    SELECT
+      CASE
+        WHEN trade_category = 'Sell' THEN buyer
+        ELSE seller
+      END AS pair_address,
+      sum(amount_original) AS eth_volume,
+      sum(amount_usd) AS usd_volume,
+      sum(number_of_items) AS nfts_traded,
+      sum(pool_fee_amount) AS owner_fee_volume_eth,
+      sum(platform_fee_amount) AS platform_fee_volume_eth,
+      sum(
+        CASE
+          WHEN trade_category = 'Sell' THEN -1 * amount_original
+          ELSE amount_original
+        END
+      ) AS eth_change_trading,
+      sum(
+        CASE
+          WHEN trade_category = 'Sell' THEN number_of_items
+          ELSE -1 * number_of_items
+        END
+      ) AS nft_change_trading
+    FROM
+      (
+        SELECT
+          trade_category,
+          buyer,
+          seller,
+          amount_original,
+          amount_usd,
+          number_of_items,
+          pool_fee_amount,
+          platform_fee_amount
+        FROM
+          ({{ ref('sudoswap_ethereum_events') }})
+        WHERE
+          buyer IN (
+            SELECT
+              pair_address
+            FROM
+              pairs_created
+          )
+          OR seller IN (
+            SELECT
+              pair_address
+            FROM
+              pairs_created
+          )
+      ) a
+    GROUP BY
+      1
+  )
+SELECT
+  acc.raw_pair_address AS pool_address,
+  nftcontractaddress,
+  creator_address,
+  spotprice,
+  COALESCE(tokens_held, 0) AS nft_balance,
+  COALESCE(eth_balance, 0) AS eth_balance,
+  COALESCE(trade.eth_volume, 0) AS eth_volume,
+  COALESCE(trade.nfts_traded, 0) AS nfts_traded,
+  COALESCE(trade.usd_volume, 0) AS usd_volume,
+  COALESCE(trade.owner_fee_volume_eth, 0) AS owner_fee_volume_eth,
+  COALESCE(trade.platform_fee_volume_eth, 0) as platform_fee_volume_eth,
+  pooltype,
+  pricing_type,
+  delta,
+  days_passed,
+  initial_price,
+  initial_nft_count,
+  initial_eth,
+  COALESCE(trade.eth_change_trading, 0) AS eth_change_trading,
+  COALESCE(trade.nft_change_trading, 0) AS nft_change_trading
+FROM
+  all_pairs_cleaned acc
+  LEFT JOIN trading_totals trade ON trade.pair_address = acc.raw_pair_address

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
@@ -97,9 +97,10 @@ WITH
         FROM
           {{ source('erc721_ethereum','evt_transfer') }}
         WHERE
-          to IN (
+          evt_block_time > '2022-04-23'
+        AND (contract_address, to) IN (
             SELECT
-              pair_address
+              (nftcontractaddress, pair_address)
             FROM
               pairs_created
           )
@@ -113,10 +114,11 @@ WITH
         FROM
           {{ source('erc721_ethereum','evt_transfer') }}
         WHERE
-        FROM
+          evt_block_time > '2022-04-23'
+        AND (contract_address, from)
           IN (
             SELECT
-              pair_address
+              (nftcontractaddress, pair_address)
             FROM
               pairs_created
           )

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
@@ -212,7 +212,7 @@ WITH
       sum(
         CASE
           WHEN trade_category = 'Sell' THEN -1 * amount_original
-          ELSE amount_original
+          ELSE (amount_original-platform_fee_amount)
         END
       ) AS eth_change_trading,
       sum(

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
@@ -32,7 +32,7 @@ WITH
       tx.value / 1e18 AS initial_eth
     FROM
       {{ source('sudo_amm_ethereum','LSSVMPairFactory_call_createPairETH') }} cre
-      LEFT JOIN {{ source('ethereum','transactions') }} tx ON tx.hash = cre.call_tx_hash
+      INNER JOIN {{ source('ethereum','transactions') }} tx ON tx.hash = cre.call_tx_hash
     WHERE
       call_success
   ),

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
@@ -1,279 +1,78 @@
 {{
- config(
-       alias='pools',
-       partition_by = ['pool_address'],
-       materialized = 'incremental',
-       file_format = 'delta',
-       incremental_strategy = 'merge',
-       unique_key = ['pool_address', 'nft_contract_address', 'creator_address'],
-       post_hook='{{ expose_spells(\'["ethereum"]\',
-                                   "project",
-                                   "sudoswap",
-                                   \'["niftytable"]\') }}'
-      )
+config(
+      alias='pools',
+      post_hook='{{ expose_spells(\'["ethereum"]\',
+                                  "project",
+                                  "sudoswap",
+                                  \'["niftytable"]\') }}')
 }}
 
-{% set project_start_date = '2022-04-23' %}
-
-WITH
-  pairs_created AS (
-    SELECT
-      CASE
-        WHEN _bondingCurve = '0x5b6ac51d9b1cede0068a1b26533cace807f883ee' THEN 'linear_bonding'
-        ELSE 'exp_bonding'
-      END as pricing_type,
-      _delta / 1e18 as delta,
-      CASE
-        WHEN _poolType = 0 THEN 'token'
-        WHEN _poolType = 1 THEN 'nft'
-        WHEN _poolType = 2 THEN 'trade'
-      END AS pool_type,
-      _spotPrice / 1e18 AS spot_price,
-      _nft AS nft_contract_address,
-      _initialNFTIDs AS nft_ids,
-      _fee AS initialfee,
-      output_pair AS pair_address,
-      call_block_time AS block_time,
-      tx.FROM AS creator_address,
-      date_trunc('day', now()) - date_trunc('day', call_block_time) AS days_passed,
-      cardinality(_initialNFTIDs) AS initial_nft_count,
-      tx.value / 1e18 AS initial_eth
-    FROM
-      {{ source('sudo_amm_ethereum','LSSVMPairFactory_call_createPairETH') }} cre
-      INNER JOIN {{ source('ethereum','transactions') }} tx ON tx.hash = cre.call_tx_hash
-    WHERE
-      call_success
-  ),
-  most_recent_spot_delta AS (
-    SELECT
-      COALESCE(del.contract_address, spot.contract_address) AS pair_address,
-      del.delta,
-      spot.spot_price
-    FROM
-      (
-        SELECT
-          *
-        FROM
-          (
-            SELECT
-              contract_address,
-              newDelta / 1e18 AS delta,
-              row_number() over (
-                PARTITION BY
-                  contract_address
-                ORDER BY
-                  evt_block_number DESC,
-                  evt_index DESC
-              ) as most_recent
-            FROM
-              {{ source('sudo_amm_ethereum','LSSVMPair_general_evt_DeltaUpdate') }}
-          ) a
-        WHERE
-          most_recent = 1
-      ) del
-      FULL OUTER JOIN (
-        SELECT
-          *
-        FROM
-          (
-            SELECT
-              contract_address,
-              newSpotPrice / 1e18 AS spot_price,
-              row_number() over (
-                PARTITION BY
-                  contract_address
-                ORDER BY
-                  evt_block_number DESC,
-                  evt_index DESC
-              ) AS most_recent
-            FROM
-              {{ source('sudo_amm_ethereum','LSSVMPair_general_evt_SpotPriceUpdate') }}
-          ) a
-        WHERE
-          most_recent = 1
-      ) spot ON del.contract_address = spot.contract_address
-  ),
-  erc721_balances AS (
-    SELECT
-      pair_address AS holder_address,
-      SUM(
-        CASE
-          WHEN et.to = p.pair_address THEN 1
-          ELSE -1
-        END
-      ) AS tokens_held
-    FROM
-      {{ source('erc721_ethereum','evt_transfer') }} et
-      INNER JOIN pairs_created p ON p.nft_contract_address = et.contract_address
-      AND (
-        et.to = p.pair_address
-        OR et.from = p.pair_address
-      )
-    {% if is_incremental() %}
-    -- this filter will only be applied on an incremental run. We only want to update with new transfers.
-    WHERE et.evt_block_time >= date_trunc("day", now() - interval '1 week')
-    {% endif %}
-    GROUP BY
-      1
-  ),
-  eth_balances AS (
-    WITH
-      eth_in AS (
-        SELECT
-          tr.to AS holder_address,
-          SUM(tr.value / 1e18) AS eth_funded
-        FROM
-          {{ source('ethereum','traces') }} tr
-          JOIN pairs_created pc ON pc.pair_address = tr.to
-        WHERE tr.success = true
-          AND tr.type = 'call'
-          AND (
-            tr.call_type NOT IN ('delegatecall', 'callcode', 'staticcall')
-            OR tr.call_type IS null
-          )
-          {% if not is_incremental() %}
-          AND tr.block_time > '{{project_start_date}}'
-          {% endif %}
-          {% if is_incremental() %}
-          -- this filter will only be applied on an incremental run. We only want to update with new traces.
-          AND tr.block_time >= date_trunc("day", now() - interval '1 week')
-          {% endif %}
-        GROUP BY
-          1
-      ),
-      eth_out AS (
-        SELECT
-          tr.FROM AS holder_address,
-          SUM(tr.value / 1e18) AS eth_spent
-        FROM
-          {{ source('ethereum','traces') }} tr
-          JOIN pairs_created pc ON pc.pair_address = tr.FROM
-        WHERE tr.success = true
-          AND tr.type = 'call'
-          AND (
-            tr.call_type NOT IN ('delegatecall', 'callcode', 'staticcall')
-            OR tr.call_type IS null
-          )
-          {% if not is_incremental() %}
-          AND tr.block_time > '{{project_start_date}}'
-          {% endif %}
-          {% if is_incremental() %}
-          -- this filter will only be applied on an incremental run. We only want to update with new traces.
-          AND tr.block_time >= date_trunc("day", now() - interval '1 week')
-          {% endif %}
-        GROUP BY
-          1
-      )
-    SELECT
-      eth_in.holder_address,
-      eth_in.eth_funded,
-      eth_out.eth_spent,
-      COALESCE(eth_funded, 0) - COALESCE(eth_spent, 0) as eth_balance
-    FROM
-      eth_in
-      LEFT JOIN eth_out ON eth_in.holder_address = eth_out.holder_address
-  ),
-  all_pairs_cleaned AS (
-    SELECT
-      pricing_type,
-      pool_type,
-      nft_contract_address,
-      creator_address,
-      COALESCE(mr.delta, pc.delta) AS delta --if delta was never updated, just keep original deploy delta
-,
-      round(COALESCE(mr.spot_price, pc.spot_price), 4) as spot_price --same logic as above
-,
-      nft_bal.tokens_held,
-      round(COALESCE(eth_bal.eth_balance, 0), 4) as eth_balance,
-      pc.pair_address AS raw_pair_address,
-      days_passed,
-      pc.spot_price AS initial_price,
-      pc.initial_nft_count,
-      pc.initial_eth
-    FROM
-      pairs_created pc
-      LEFT JOIN most_recent_spot_delta mr ON pc.pair_address = mr.pair_address
-      LEFT JOIN erc721_balances nft_bal ON nft_bal.holder_address = pc.pair_address
-      LEFT JOIN eth_balances eth_bal ON eth_bal.holder_address = pc.pair_address
-  ),
-  trading_totals as (
-    SELECT
-      CASE
-        WHEN trade_category = 'Sell' THEN buyer
-        ELSE seller
-      END AS pair_address,
-      sum(amount_original) AS eth_volume,
-      sum(amount_usd) AS usd_volume,
-      sum(number_of_items) AS nfts_traded,
-      sum(pool_fee_amount) AS owner_fee_volume_eth,
-      sum(platform_fee_amount) AS platform_fee_volume_eth,
-      sum(
-        CASE
-          WHEN trade_category = 'Sell' THEN -1 * amount_original
-          ELSE (amount_original-platform_fee_amount)
-        END
-      ) AS eth_change_trading,
-      sum(
-        CASE
-          WHEN trade_category = 'Sell' THEN number_of_items
-          ELSE -1 * number_of_items
-        END
-      ) AS nft_change_trading
-    FROM
-      (
-        SELECT
-          trade_category,
-          buyer,
-          seller,
-          amount_original,
-          amount_usd,
-          number_of_items,
-          pool_fee_amount,
-          platform_fee_amount
-        FROM
-          ({{ ref('sudoswap_ethereum_events') }})
-        WHERE
-          buyer IN (
-            SELECT
-              pair_address
-            FROM
-              pairs_created
-          )
-          OR seller IN (
-            SELECT
-              pair_address
-            FROM
-              pairs_created
-          )
-          {% if is_incremental() %}
-          -- this filter will only be applied on an incremental run. We only want to update with new traces.
-          AND block_time >= date_trunc("day", now() - interval '1 week')
-          {% endif %}
-      ) a
-    GROUP BY
-      1
-  )
+WITH pool_stats AS (
 SELECT
-  acc.raw_pair_address AS pool_address,
+  pool_address,
   nft_contract_address,
   creator_address,
-  spot_price,
-  COALESCE(tokens_held, 0) AS nft_balance,
-  COALESCE(eth_balance, 0) AS eth_balance,
-  COALESCE(trade.eth_volume, 0) AS eth_volume,
-  COALESCE(trade.nfts_traded, 0) AS nfts_traded,
-  COALESCE(trade.usd_volume, 0) AS usd_volume,
-  COALESCE(trade.owner_fee_volume_eth, 0) AS owner_fee_volume_eth,
-  COALESCE(trade.platform_fee_volume_eth, 0) as platform_fee_volume_eth,
   pool_type,
   pricing_type,
-  delta,
-  days_passed,
   initial_price,
   initial_nft_count,
   initial_eth,
-  COALESCE(trade.eth_change_trading, 0) AS eth_change_trading,
-  COALESCE(trade.nft_change_trading, 0) AS nft_change_trading
+  day_created,
+  delta,
+  spot_price
 FROM
-  all_pairs_cleaned acc
-  LEFT JOIN trading_totals trade ON trade.pair_address = acc.raw_pair_address
+  {{ ref('sudoswap_ethereum_pool_balance_changes') }}
+ORDER BY DAY DESC
+LIMIT 1 -- To get the most recent delta and spot price
+),
+
+pool_balance AS (
+SELECT
+  pool_address,
+  SUM(nft_balance_change) AS nft_balance,
+  SUM(eth_balance_change) AS eth_balance
+FROM
+  {{ ref('sudoswap_ethereum_pool_balance_changes') }}
+GROUP BY 1
+),
+
+pool_trades AS (
+SELECT
+  pool_address,
+  SUM(eth_volume) AS eth_volume,
+  SUM(nfts_traded) AS nfts_traded,
+  SUM(usd_volume) AS usd_volume,
+  SUM(owner_fee_volume_eth) AS owner_fee_volume_eth,
+  SUM(platform_fee_volume_eth) as platform_fee_volume_eth,
+  SUM(eth_change_trading) AS eth_change_trading,
+  SUM(nft_change_trading) AS nft_change_trading
+FROM
+  {{ ref('sudoswap_ethereum_pool_trades') }}
+GROUP BY 1
+)
+
+SELECT
+  ps.pool_address AS pool_address,
+  nft_contract_address,
+  creator_address,
+  spot_price,
+  pool_type,
+  pricing_type,
+  delta,
+  day_created,
+  initial_price,
+  initial_nft_count,
+  initial_eth,
+  nft_balance,
+  eth_balance,
+  eth_volume,
+  nfts_traded,
+  usd_volume,
+  owner_fee_volume_eth,
+  platform_fee_volume_eth,
+  eth_change_trading,
+  nft_change_trading
+FROM
+  pool_stats ps
+INNER JOIN pool_balance pb ON pb.pair_address = ps.pair_address
+INNER JOIN pool_trades pt ON pt.pair_address = ps.pair_address

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pools.sql
@@ -74,5 +74,5 @@ SELECT
   nft_change_trading
 FROM
   pool_stats ps
-INNER JOIN pool_balance pb ON pb.pair_address = ps.pair_address
-INNER JOIN pool_trades pt ON pt.pair_address = ps.pair_address
+INNER JOIN pool_balance pb ON pb.pool_address = ps.pool_address
+INNER JOIN pool_trades pt ON pt.pool_address = ps.pool_address

--- a/models/sudoswap/ethereum/sudoswap_ethereum_schema.yml
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_schema.yml
@@ -233,6 +233,12 @@ models:
       tags: ['ethereum','sudoswap','pools']
     description: >
         sudoswap pools on Ethereum
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - pool_address
+            - nft_contract_address
+            - creator_address
     columns:
       - name: pool_address
         description: "Address of the pool"

--- a/models/sudoswap/ethereum/sudoswap_ethereum_schema.yml
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_schema.yml
@@ -236,11 +236,11 @@ models:
     columns:
       - name: pool_address
         description: "Address of the pool"
-      - name: nftcontractaddress
+      - name: nft_contract_address
         description: "Contract of the NFT collection"
       - name: creator_address
         description: "Address of the pool creator"
-      - name: spotprice
+      - name: spot_price
         description: "Current price of a swap"
       - name: nft_balance
         description: "Number of NFTs in the pool"
@@ -256,7 +256,7 @@ models:
         description: "Fees collected by pool owner"
       - name: platform_fee_volume_eth
         description: "Fees collected by the protocol"
-      - name: pooltype
+      - name: pool_type
         description: "Type of pool"
       - name: pricing_type
         description: "Type of pricing"

--- a/models/sudoswap/ethereum/sudoswap_ethereum_schema.yml
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_schema.yml
@@ -232,7 +232,7 @@ models:
     config:
       tags: ['ethereum','sudoswap','pools']
     description: >
-        sudoswap pools on Ethereum
+        sudoswap pool stats on Ethereum
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -240,43 +240,123 @@ models:
             - nft_contract_address
             - creator_address
     columns:
-      - name: pool_address
+      - &pool_address
+        name: pool_address
         description: "Address of the pool"
-      - name: nft_contract_address
-        description: "Contract of the NFT collection"
-      - name: creator_address
+      - *nft_contract_address
+      - &creator_address
+        name: creator_address
         description: "Address of the pool creator"
-      - name: spot_price
+      - &spot_price
+        name: spot_price
         description: "Current price of a swap"
-      - name: nft_balance
+      - &nft_balance
+        name: nft_balance
         description: "Number of NFTs in the pool"
-      - name: eth_balance
+      - &eth_balance
+        name: eth_balance
         description: "Amount of ETH in the pool"
-      - name: eth_volume
+      - &eth_volume
+        name: eth_volume
         description: "ETH trading volume of the pool"
-      - name: nfts_traded
+      - &nfts_traded
+        name: nfts_traded
         description: "Number of NFTs traded by the pool"
-      - name: usd_volume
+      - &usd_volume
+        name: usd_volume
         description: "USD trading volume of the pool"
-      - name: owner_fee_volume_eth
+      - &owner_fee_volume_eth
+        name: owner_fee_volume_eth
         description: "Fees collected by pool owner"
-      - name: platform_fee_volume_eth
+      - &platform_fee_volume_eth
+        name: platform_fee_volume_eth
         description: "Fees collected by the protocol"
-      - name: pool_type
+      - &pool_type
+        name: pool_type
         description: "Type of pool"
-      - name: pricing_type
+      - &pricing_type
+        name: pricing_type
         description: "Type of pricing"
-      - name: delta
+      - &delta
+        name: delta
         description: "Change in price caused by one trade"
-      - name: days_passed
-        description: "Days since pool was created"
-      - name: initial_price
+      - &day_created
+        name: day_created
+        description: "Day the pool was created"
+      - &initial_price
+        name: initial_price
         description: "Initial spot price of the pool"
-      - name: initial_nft_count
+      - &initial_nft_count
+        name: initial_nft_count
         description: "Initial NFT balance of the pool"
-      - name: initial_eth
+      - &initial_eth
+        name: initial_eth
         description: "Initial ETH balance of the pool"
-      - name: eth_change_trading
+      - &eth_change_trading
+        name: eth_change_trading
         description: "Change in ETH balance caused by trading"
-      - name: nft_change_trading
+      - &nft_change_trading
+        name: nft_change_trading
         description: "Change in NFT balance caused by trading"
+
+  - name: sudoswap_ethereum_pool_trades
+    meta:
+      blockchain: ethereum
+      project: sudoswap
+      contributors: [niftytable]
+    config:
+      tags: ['ethereum','sudoswap','pool_trades']
+    description: >
+        sudoswap pool trades on Ethereum
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - pool_address
+    columns:
+      - &day
+        name: day
+        description: "Day"
+      - *pool_address
+      - *eth_volume
+      - *usd_volume
+      - *nfts_traded
+      - *owner_fee_volume_eth
+      - *platform_fee_volume_eth
+      - *eth_change_trading
+      - *nft_change_trading
+
+  - name: sudoswap_ethereum_pool_balance_changes
+    meta:
+      blockchain: ethereum
+      project: sudoswap
+      contributors: [niftytable]
+    config:
+      tags: ['ethereum','sudoswap','pool_balance_changes']
+    description: >
+        sudoswap pool balance changes on Ethereum
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - nft_contract_address
+            - pool_address
+    columns:
+      - *day
+      - *pool_address
+      - &eth_balance_change
+        name: eth_balance_change
+        description: "Change in eth balance of the pool"
+      - &nft_balance_change
+        name: nft_balance_change
+        description: "Change in nft balance of the pool"
+      - *pricing_type
+      - *pool_type
+      - *nft_contract_address
+      - *creator_address
+      - *initial_price
+      - *initial_nft_count
+      - *initial_eth
+      - *day_created
+      - *delta
+      - *spot_price

--- a/models/sudoswap/ethereum/sudoswap_ethereum_schema.yml
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_schema.yml
@@ -223,3 +223,54 @@ models:
       - *tx_from
       - *tx_to
       - *unique_trade_id
+
+  - name: sudoswap_ethereum_pools
+    meta:
+      blockchain: ethereum
+      project: sudoswap
+      contributors: [niftytable]
+    config:
+      tags: ['ethereum','sudoswap','pools']
+    description: >
+        sudoswap pools on Ethereum
+    columns:
+      - name: pool_address
+        description: "Address of the pool"
+      - name: nftcontractaddress
+        description: "Contract of the NFT collection"
+      - name: creator_address
+        description: "Address of the pool creator"
+      - name: spotprice
+        description: "Current price of a swap"
+      - name: nft_balance
+        description: "Number of NFTs in the pool"
+      - name: eth_balance
+        description: "Amount of ETH in the pool"
+      - name: eth_volume
+        description: "ETH trading volume of the pool"
+      - name: nfts_traded
+        description: "Number of NFTs traded by the pool"
+      - name: usd_volume
+        description: "USD trading volume of the pool"
+      - name: owner_fee_volume_eth
+        description: "Fees collected by pool owner"
+      - name: platform_fee_volume_eth
+        description: "Fees collected by the protocol"
+      - name: pooltype
+        description: "Type of pool"
+      - name: pricing_type
+        description: "Type of pricing"
+      - name: delta
+        description: "Change in price caused by one trade"
+      - name: days_passed
+        description: "Days since pool was created"
+      - name: initial_price
+        description: "Initial spot price of the pool"
+      - name: initial_nft_count
+        description: "Initial NFT balance of the pool"
+      - name: initial_eth
+        description: "Initial ETH balance of the pool"
+      - name: eth_change_trading
+        description: "Change in ETH balance caused by trading"
+      - name: nft_change_trading
+        description: "Change in NFT balance caused by trading"

--- a/models/sudoswap/ethereum/sudoswap_ethereum_sources.yml
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_sources.yml
@@ -26,3 +26,11 @@ sources:
         loaded_at_field: evt_block_time
       - name: LSSVMPairFactory_evt_ProtocolFeeMultiplierUpdate
         loaded_at_field: evt_block_time
+      - name: LSSVMPair_general_evt_DeltaUpdate
+        freshness:
+          warn_after: { count: 12, period: hour }
+        loaded_at_field: evt_block_time
+      - name: LSSVMPair_general_evt_SpotPriceUpdate
+        freshness:
+          warn_after: { count: 12, period: hour }
+        loaded_at_field: evt_block_time


### PR DESCRIPTION
Adding a spell that provides stats on all sudoswap poola


*For Dune Engine V2*
I've checked that:
General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)
* [x] if adding a new materialized table, I edited the optimize table macro

Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
