### PR TITLE
[Easy] Add block_date to both trades and batches

### DIFF
--- a/models/cow_protocol/cow_protocol_trades.sql
+++ b/models/cow_protocol/cow_protocol_trades.sql
@@ -13,7 +13,7 @@ FROM
             'ethereum' AS blockchain,
             'CoW Protocol' AS project,
             '1' AS version,
-            TRY_CAST(date_trunc('DAY', block_time) AS date) AS block_date,
+            block_date,
             block_time,
             buy_token AS token_bought_symbol,
             sell_token AS token_sold_symbol,

--- a/models/cow_protocol/cow_protocol_trades_schema.yml
+++ b/models/cow_protocol/cow_protocol_trades_schema.yml
@@ -14,28 +14,28 @@ models:
     columns:
       - &blockchain
         name: blockchain
-        description: "Blockchain which the DEX is deployed"
+        description: "Blockchain which the project is deployed"
       - &project 
         name: project
-        description: "Project name of the DEX"  
+        description: "Project name"
       - &version
         name: version
-        description: "Version of the contract built and deployed by the DEX project"  
+        description: "Version of the contract built and deployed by the project"
       - &block_date
         name: block_date
-        description: "UTC event block date of each DEX trade"
+        description: "UTC event block date of each trade"
       - &block_time
         name: block_time
-        description: "UTC event block time of each DEX trade"
+        description: "UTC event block time of each trade"
       - &token_bought_symbol
         name: token_bought_symbol
-        description: "Token symbol for token bought in the transaction"
+        description: "Token symbol for token bought in the trade"
       - &token_sold_symbol
         name: token_sold_symbol
-        description: "Token symbol for token sold in the transaction"
+        description: "Token symbol for token sold in the trade"
       - &token_pair
         name: token_pair
-        description: "Token symbol pair for each token involved in the transaction"
+        description: "Token symbol pair for each token involved in the trade"
       - &token_bought_amount
         name: token_bought_amount
         description: "Value of the token bought at time of execution in the original currency"
@@ -80,7 +80,7 @@ models:
         description: ""
       - &evt_index
         name: evt_index
-        description: ""
+        description: "Index of the corresponding trade event"
       - &unique_trade_id
         name: unique_trade_id
         description: "Unique trade ID built to track merge incremental strategy in the model"

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql
@@ -1,6 +1,7 @@
 {{  config(
         alias='batches',
         materialized='incremental',
+        partition_by = ['block_date'],
         unique_key = ['tx_hash'],
         on_schema_change='sync_all_columns',
         file_format ='delta',
@@ -15,7 +16,8 @@
 WITH
 -- Find the PoC Query here: https://dune.com/queries/1290518
 batch_counts as (
-    select s.evt_block_time,
+    select try_cast(date_trunc('day', s.evt_block_time) as date) as block_date,
+           s.evt_block_time,
            s.evt_tx_hash,
            solver,
            name,

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql
@@ -62,6 +62,7 @@ batch_values as (
 
 combined_batch_info as (
     select
+        block_date,
         evt_block_time                                 as block_time,
         num_trades,
         CASE

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -33,12 +33,18 @@ models:
     description: >
       CoW Protocol enriched trades list on Ethereum
     columns:
+      - &block_date
+        name: block_date
+        description: "UTC event block date of each trade"
       - &block_time
         name: block_time
         description: "Timestamp for block event time in UTC"
       - &tx_hash
         name: tx_hash
         description: "Transaction hash of trade"
+      - &evt_index
+        name: evt_index
+        description: "Index of the corresponding trade event"
       - &order_uid
         name: order_uid
         description: "Unique identifier of order involved in trade. Note that partially fillable orders can be touched multiple times so this is not a unique ID for trade events."
@@ -112,6 +118,7 @@ models:
     description: >
       CoW Protocol enriched batches table on Ethereum
     columns:
+      - *block_date
       - *block_time
       - &num_trades
         name: num_trades

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -1,6 +1,7 @@
 {{  config(
         alias='trades',
         materialized='incremental',
+        partition_by = ['block_date'],
         unique_key = ['tx_hash', 'order_uid', 'evt_index'],
         on_schema_change='sync_all_columns',
         file_format ='delta',
@@ -17,7 +18,8 @@ WITH
 -- First subquery joins buy and sell token prices from prices.usd.
 -- Also deducts fee from sell amount.
 trades_with_prices AS (
-    SELECT evt_block_time            as block_time,
+    SELECT try_cast(date_trunc('day', evt_block_time) as date) as block_date,
+           evt_block_time            as block_time,
            evt_tx_hash               as tx_hash,
            evt_index,
            settlement.contract_address          as project_contract_address,

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -58,7 +58,8 @@ trades_with_prices AS (
 ),
 -- Second subquery gets token symbol and decimals from tokens.erc20 (to display units bought and sold)
 trades_with_token_units as (
-    SELECT block_time,
+    SELECT block_date,
+           block_time,
            tx_hash,
            evt_index,
            project_contract_address,
@@ -146,7 +147,8 @@ uid_to_app_id as (
 ),
 
 valued_trades as (
-    SELECT block_time,
+    SELECT block_date,
+           block_time,
            tx_hash,
            evt_index,
            project_contract_address,


### PR DESCRIPTION
As suggested by @jeff-dude in https://github.com/duneanalytics/spellbook/pull/1591#discussion_r978801896

We add `block_date` to both the cow trades and batches table. 

Not sure why `try_cast` is used here, but I am willing to stick with the pattern.

Also fixed the schemas, and noticed `evt_index` was missing from one.