### PR TITLE
Change sector to dex_aggregator

### DIFF
--- a/models/dex/aggregator/dex_aggregator_schema.yml
+++ b/models/dex/aggregator/dex_aggregator_schema.yml
@@ -4,7 +4,7 @@ models:
   - name: dex_aggregator_trades
     meta:
       blockchain: ethereum
-      sector: dex
+      sector: dex_aggregator
       contributors: bh2smith
     config:
       tags: ['ethereum', 'aggregator', 'dex', 'trades', 'cross-chain']

--- a/models/dex/aggregator/dex_aggregator_trades.sql
+++ b/models/dex/aggregator/dex_aggregator_trades.sql
@@ -2,7 +2,7 @@
         alias ='trades',
         post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "sector",
-                                "dex",
+                                "dex_aggregator",
                                 \'["bh2smith"]\') }}'
         )
 }}


### PR DESCRIPTION
In response to suggestion made in https://github.com/duneanalytics/spellbook/pull/1600#discussion_r979634669

we change the sector to `dex_aggregator`