### PR TITLE
[Bug] select LOWER missing on token tables

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -7,7 +7,7 @@
                                     \'["aalan3", "jeff-dude"]\') }}'
         )
 }}
-SELECT token_id, blockchain, symbol, contract_address, decimals from (
+SELECT token_id, blockchain, symbol, LOWER(contract_address) as contract_address, decimals from (
 VALUES
     ("ada-cardano", null, "ADA", null, null),
     ("ae-aeternity", null, "AE", null, null),

--- a/models/tokens/ethereum/tokens_ethereum_erc20.sql
+++ b/models/tokens/ethereum/tokens_ethereum_erc20.sql
@@ -1,6 +1,6 @@
 {{ config( alias='erc20')}}
 
-SELECT contract_address, symbol, decimals
+SELECT LOWER(contract_address) as contract_address, symbol, decimals
 FROM (VALUES
           ('0x3106a0a076bedae847652f42ef07fd58589e001f', '$ADS', 18),
           ('0xa48F7A48BDAFf54587A1C4e4B2f35459a2328E29', '$BATTLE', 9),

--- a/models/tokens/gnosis/tokens_gnosis_erc20.sql
+++ b/models/tokens/gnosis/tokens_gnosis_erc20.sql
@@ -1,6 +1,6 @@
 {{ config( alias='erc20')}}
 
-SELECT contract_address, symbol, decimals
+SELECT LOWER(contract_address) as contract_address, symbol, decimals
 FROM (VALUES
           ('0x3f9463bdb502ec2079bf39da6c924d4022ff9f4c', 'biubiu.tools', 18)
           ,('0xdbf3ea6f5bee45c02255b2c26a16f300502f68da', 'BZZ', 16)


### PR DESCRIPTION
[This query](https://dune.com/queries/1317291)  shows that there are hundreds of erc20 tokens with mixed case addresses (making integrity of token data inconsistent). This makes it consistent with the other token tables.