### PR TITLE
[Easy] Removed post_hook from `cow_protocol_ethereum_trades.sql` to not have double columns

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -5,11 +5,7 @@
         unique_key = ['tx_hash', 'order_uid', 'evt_index'],
         on_schema_change='sync_all_columns',
         file_format ='delta',
-        incremental_strategy='merge',
-        post_hook='{{ expose_spells(\'["ethereum"]\',
-                                    "project",
-                                    "cow_protocol",
-                                    \'["bh2smith", "gentrexha"]\') }}'
+        incremental_strategy='merge'
     )
 }}
 


### PR DESCRIPTION
Removed post_hook from `cow_protocol_ethereum_trades.sql` to not have double columns in `cow_protocol.trades`. E.g.: 
![image](https://user-images.githubusercontent.com/21241380/192306516-35792e1e-e212-41dc-a95b-831eacb76f60.png)

cc @bh2smith for internal review
