### PR TITLE
Fix volume_usd for synthetix on optimism

### DIFF
--- a/models/synthetix/optimism/synthetix_optimism_trades.sql
+++ b/models/synthetix/optimism/synthetix_optimism_trades.sql
@@ -65,7 +65,7 @@ perps AS (
 				), 'UTF-8'
 			) AS market
 		,s.contract_address AS market_address
-		,ABS(s.tradeSize)/1e18 * p.price AS volume_usd
+		,ABS(s.tradeSize) * p.price AS volume_usd
 		,s.fee/1e18 AS fee_usd
 		,s.margin/1e18 AS margin_usd
 		,(ABS(s.tradeSize)/1e18 * p.price) / (s.margin/1e18) AS leverage_ratio


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Fixes the USD volume of Synthetix/Kwenta perpetual swaps on Optimism.

*For Dune Engine V2*
I've checked that:
General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)
* [ ] if adding a new materialized table, I edited the optimize table macro

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
* [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
