### PR TITLE
Fix nonzero perpetual trade filter for Synthetix/Kwenta on Optimism.

### DIFF
--- a/models/perpetual_protocol/optimism/perpetual_protocol_v2_optimism_trades.sql
+++ b/models/perpetual_protocol/optimism/perpetual_protocol_v2_optimism_trades.sql
@@ -53,7 +53,7 @@ WITH perps AS (
 
 SELECT
 	'optimism' AS blockchain
-    ,TRY_CAST(date_trunc('DAY', perps.block_time) AS date) AS block_date
+	,TRY_CAST(date_trunc('DAY', perps.block_time) AS date) AS block_date
 	,perps.block_time
 	,COALESCE(e.symbol, CAST(perps.baseToken AS STRING)) AS virtual_asset
 	,SUBSTRING(e.symbol, 2) AS underlying_asset

--- a/models/pika/optimism/pika_v1_optimism_trades.sql
+++ b/models/pika/optimism/pika_v1_optimism_trades.sql
@@ -135,7 +135,7 @@ perps AS (
 
 SELECT
 	'optimism' AS blockchain
-    ,TRY_CAST(date_trunc('DAY', perps.block_time) AS date) AS block_date
+	,TRY_CAST(date_trunc('DAY', perps.block_time) AS date) AS block_date
 	,perps.block_time
 	,perps.virtual_asset
 	,perps.underlying_asset

--- a/models/pika/optimism/pika_v2_optimism_trades.sql
+++ b/models/pika/optimism/pika_v2_optimism_trades.sql
@@ -136,7 +136,7 @@ perps AS (
 
 SELECT
 	'optimism' AS blockchain
-    ,TRY_CAST(date_trunc('DAY', perps.block_time) AS date) AS block_date
+	,TRY_CAST(date_trunc('DAY', perps.block_time) AS date) AS block_date
 	,perps.block_time
 	,perps.virtual_asset
 	,perps.underlying_asset

--- a/models/pika/optimism/pika_v3_optimism_trades.sql
+++ b/models/pika/optimism/pika_v3_optimism_trades.sql
@@ -135,7 +135,7 @@ perps AS (
 
 SELECT
 	'optimism' AS blockchain
-    ,TRY_CAST(date_trunc('DAY', perps.block_time) AS date) AS block_date
+	,TRY_CAST(date_trunc('DAY', perps.block_time) AS date) AS block_date
 	,perps.block_time
 	,perps.virtual_asset
 	,perps.underlying_asset


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Fixes the nonzero perpetual trade filter for Synthetix/Kwenta on Optimism. Also make the (re)correction on volume_usd decimals for Synthetix.

*For Dune Engine V2*
I've checked that:
General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)
* [ ] if adding a new materialized table, I edited the optimize table macro

Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
* [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
