### PR TITLE
Add ENS resolver records + ENS labels

### DIFF
--- a/models/ens/ens_ethereum_schema.yml
+++ b/models/ens/ens_ethereum_schema.yml
@@ -128,32 +128,6 @@ models:
       - name: latest_tx_block_time
         description: "Block time of the latest transaction hash setting the reverse ENS"
 
-
-  - name: ens_reverse_latest
-    meta:
-      blockchain: ethereum
-      project: ethereum_name_service
-      contributors: 0xRob
-    config:
-      tags: [ 'ethereum','ens','ethereum_name_service','ethereumnameservice','reverse','latest','0xRob']
-    description: >
-      View the latest ENS reverse records
-    columns:
-      - name: address
-        description: "The ETH address"
-        tests:
-          - unique
-      - name: name
-        description: "The reverse ENS name"
-      - name: address_node
-        description: "The node (namehash) of the address reverse record"
-        tests:
-          - unique
-      - name: latest_tx_hash
-        description: "Latest transaction hash setting the reverse ENS"
-      - name: latest_tx_block_time
-        description: "Block time of the latest transaction hash setting the reverse ENS"
-
   - name: ens_node_names
     meta:
       blockchain: ethereum

--- a/models/ens/ens_ethereum_schema.yml
+++ b/models/ens/ens_ethereum_schema.yml
@@ -159,6 +159,29 @@ models:
       - name: evt_index
         description: "event index of the registration event"
 
+  - name: ens_resolver_records
+    meta:
+      blockchain: ethereum
+      project: ethereum_name_service
+      contributors: 0xRob
+    config:
+      tags: [ 'ethereum','ens','ethereum_name_service','ethereumnameservice','resolver_records','0xRob' ]
+    description: >
+      A table that shows the resolver addresses for known ENS names.
+    columns:
+      - name: name
+        description: "The ENS name"
+      - name: node
+        description: "The node, the namehash of the ENS name"
+      - name: address
+        description: "The resolver address of the ENS name"
+      - name: block_time
+        description: "block time of update"
+      - name: tx_hash
+        description: "transaction hash update"
+      - name: evt_index
+        description: "event index of node record update"
+
   - name: ens_resolver_latest
     meta:
       blockchain: ethereum
@@ -179,7 +202,9 @@ models:
           - unique
       - name: address
         description: "The resolver address of the ENS name"
-      - name: latest_tx_block_time
+      - name: block_time
         description: "block time of last update"
-      - name: latest_tx_hash
+      - name: tx_hash
         description: "transaction hash of last update"
+      - name: evt_index
+        description: "event index of node record update"

--- a/models/ens/ens_ethereum_schema.yml
+++ b/models/ens/ens_ethereum_schema.yml
@@ -205,7 +205,7 @@ models:
           - unique
       - name: address
         description: "The resolver address of the ENS name"
-      - name: block_time
+      - name: latest_tx_block_time
         description: "block time of last update"
-      - name: tx_hash
+      - name: latest_tx_hash
         description: "transaction hash of last update"

--- a/models/ens/ens_ethereum_schema.yml
+++ b/models/ens/ens_ethereum_schema.yml
@@ -127,3 +127,85 @@ models:
         description: "Latest transaction hash setting the reverse ENS"
       - name: latest_tx_block_time
         description: "Block time of the latest transaction hash setting the reverse ENS"
+
+
+  - name: ens_reverse_latest
+    meta:
+      blockchain: ethereum
+      project: ethereum_name_service
+      contributors: 0xRob
+    config:
+      tags: [ 'ethereum','ens','ethereum_name_service','ethereumnameservice','reverse','latest','0xRob']
+    description: >
+      View the latest ENS reverse records
+    columns:
+      - name: address
+        description: "The ETH address"
+        tests:
+          - unique
+      - name: name
+        description: "The reverse ENS name"
+      - name: address_node
+        description: "The node (namehash) of the address reverse record"
+        tests:
+          - unique
+      - name: latest_tx_hash
+        description: "Latest transaction hash setting the reverse ENS"
+      - name: latest_tx_block_time
+        description: "Block time of the latest transaction hash setting the reverse ENS"
+
+  - name: ens_node_names
+    meta:
+      blockchain: ethereum
+      project: ethereum_name_service
+      contributors: 0xRob
+    config:
+      tags: [ 'ethereum','ens','ethereum_name_service','ethereumnameservice','node_names','0xRob' ]
+    description: >
+      A table that links a node (namehash) to a readable ENS name.
+    columns:
+      - name: node
+        description: "The node, the namehash of the ENS name"
+        tests:
+          - unique
+      - name: name
+        description: "The ENS name"
+      - name: label_name
+        description: "The name of the ENS label"
+      - name: label_hash
+        description: "The namehash of the ENS label"
+      - name: initial_address
+        description: "The initial resolver address when registering the ENS"
+      - name: tx_hash
+        description: "transaction hash"
+      - name: block_number
+        description: "block number"
+      - name: block_time
+        description: "block time"
+      - name: evt_index
+        description: "event index of the registration event"
+
+  - name: ens_resolver_latest
+    meta:
+      blockchain: ethereum
+      project: ethereum_name_service
+      contributors: 0xRob
+    config:
+      tags: [ 'ethereum','ens','ethereum_name_service','ethereumnameservice','resolver_latest','0xRob' ]
+    description: >
+      A table that shows the latest resolver addresses for known ENS names.
+    columns:
+      - name: name
+        description: "The ENS name"
+        tests:
+          - unique
+      - name: node
+        description: "The node, the namehash of the ENS name"
+        tests:
+          - unique
+      - name: address
+        description: "The resolver address of the ENS name"
+      - name: block_time
+        description: "block time of last update"
+      - name: tx_hash
+        description: "transaction hash of last update"

--- a/models/ens/ens_ethereum_sources.yml
+++ b/models/ens/ens_ethereum_sources.yml
@@ -13,40 +13,30 @@ sources:
           warn_after: { count: 12, period: hour }
         loaded_at_field: evt_block_time
       - name: ETHRegistrarController_1_evt_NameRegistered
-        loaded_at_field: evt_block_time
       - name: ETHRegistrarController_2_evt_NameRegistered
-        loaded_at_field: evt_block_time
       - name: ETHRegistrarController_3_evt_NameRegistered
         freshness:
           warn_after: { count: 12, period: hour }
         loaded_at_field: evt_block_time
       - name: ENSRegistry_evt_NewOwner
-        loaded_at_field: evt_block_time
       - name: ENSRegistryWithFallback_evt_NewOwner
         freshness:
           warn_after: { count: 12, period: hour }
         loaded_at_field: evt_block_time
       - name: ETHRegistrarController_1_evt_NameRenewed
-        loaded_at_field: evt_block_time
       - name: ETHRegistrarController_2_evt_NameRenewed
-        loaded_at_field: evt_block_time
       - name: ETHRegistrarController_3_evt_NameRenewed
         freshness:
           warn_after: { count: 12, period: hour }
         loaded_at_field: evt_block_time
       - name: DefaultReverseResolver_call_setName
-        loaded_at_field: call_block_time
       - name: ReverseRegistrar_v2_call_setName
-        loaded_at_field: call_block_time
       - name: PublicResolver_call_setName
-        loaded_at_field: call_block_time
       - name: ReverseRegistrar_v1_call_setName
-        loaded_at_field: call_block_time
       - name: BaseRegistrarImplementation_call_reclaim
-        loaded_at_field: call_block_time
       - name: PublicResolver_evt_AddrChanged
+        freshness:
+          warn_after: { count: 12, period: hour }
         loaded_at_field: evt_block_time
       - name: PublicResolver_evt_AddressChanged
-        loaded_at_field: evt_block_time
       - name: OldBaseRegistrar_evt_NameRegistered
-        loaded_at_field: evt_block_time

--- a/models/ens/ens_node_names.sql
+++ b/models/ens/ens_node_names.sql
@@ -71,7 +71,7 @@ select
     ,concat(label_name,'.eth') as name
     ,label_name
     ,label_hash
-    ,initial_address
+    ,address as initial_address
     ,tx_hash
     ,block_number
     ,block_time

--- a/models/ens/ens_node_names.sql
+++ b/models/ens/ens_node_names.sql
@@ -61,16 +61,19 @@ with registrations as (
     where ordering = 1
 )
 
+,window as (partition by node order by block_time asc,evt_index asc)
+
 select
     node
     ,concat(label_name,'.eth') as name
     ,label_name
     ,label_hash
-    ,address as initial_address
-    ,tx_hash
-    ,block_number
-    ,block_time
-    ,evt_index
+    ,last(address,true) over window as initial_address
+    ,last(tx_hash,true) over window as tx_hash
+    ,last(block_number,true) over window as block_number
+    ,last(block_time,true) over window as block_time
+    ,last(evt_index,true) over window as evt_index
 from matching
+group by 1,2,3,4
 
 

--- a/models/ens/ens_node_names.sql
+++ b/models/ens/ens_node_names.sql
@@ -1,0 +1,76 @@
+{{ config(
+    alias = 'node_names',
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['node'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                            "project",
+                            "ens",
+                            \'["0xRob"]\') }}'
+    )
+}}
+
+-- because we don't have the keccak namehash function available in v2
+-- we do a little sketchy event matching to get the node <> name relationships
+-- basically this takes the last AddrChanged event in the same tx preceding a NameRegistred event to link the node and the name
+-- ONLY works for base ENS names (.eth , no subdomains)
+with registrations as (
+    select
+        label as label_hash
+        ,name as label_name
+        ,evt_block_number as block_number
+        ,evt_block_time as block_time
+        ,evt_tx_hash as tx_hash
+        ,evt_index
+    from {{ ref('ens_view_registrations') }}
+    {% if is_incremental() %}
+    WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
+)
+
+,node_info as (
+    select
+        a as address
+        ,node
+        ,evt_block_number as block_number
+        ,evt_block_time as block_time
+        ,evt_tx_hash as tx_hash
+        ,evt_index
+    from {{ source('ethereumnameservice_ethereum','PublicResolver_evt_AddrChanged') }}
+    {% if is_incremental() %}
+    WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
+)
+
+-- here's the sketchy matching
+, matching as (
+    select *
+    from (
+        select
+        r.*
+        ,n.address
+        ,n.node
+        ,row_number() over (partition by r.tx_hash order by (r.evt_index - n.evt_index) asc) as ordering
+        from registrations r
+        inner join node_info n
+        ON r.block_number = n.block_number
+        AND r.tx_hash = n.tx_hash
+        AND r.evt_index > n.evt_index --register event comes after node event
+    )
+    where ordering = 1
+)
+
+select
+    node
+    ,concat(label_name,'.eth') as name
+    ,label_name
+    ,label_hash
+    ,address as initial_address
+    ,tx_hash
+    ,block_number
+    ,block_time
+    ,evt_index
+from matching
+
+

--- a/models/ens/ens_node_names.sql
+++ b/models/ens/ens_node_names.sql
@@ -52,28 +52,26 @@ with registrations as (
         ,n.address
         ,n.node
         ,row_number() over (partition by r.tx_hash order by (r.evt_index - n.evt_index) asc) as ordering
+        ,row_number() over (partition by n.node order by r.block_time desc, r.evt_index desc) as ordering2
         from registrations r
         inner join node_info n
         ON r.block_number = n.block_number
         AND r.tx_hash = n.tx_hash
         AND r.evt_index > n.evt_index --register event comes after node event
     )
-    where ordering = 1
+    where ordering = 1 and ordering2 = 1
 )
-
-,window as (partition by node order by block_time asc,evt_index asc)
 
 select
     node
     ,concat(label_name,'.eth') as name
     ,label_name
     ,label_hash
-    ,last(address,true) over window as initial_address
-    ,last(tx_hash,true) over window as tx_hash
-    ,last(block_number,true) over window as block_number
-    ,last(block_time,true) over window as block_time
-    ,last(evt_index,true) over window as evt_index
+    ,initial_address
+    ,tx_hash
+    ,block_number
+    ,block_time
+    ,evt_index
 from matching
-group by 1,2,3,4
 
 

--- a/models/ens/ens_resolver_latest.sql
+++ b/models/ens/ens_resolver_latest.sql
@@ -15,6 +15,7 @@ select
     ,tx_hash
     ,evt_index
 from(
+     select
      *
     ,row_number() over (partition by node order by block_time desc, evt_index desc) as ordering
     from {{ ref('ens_resolver_records')}}

--- a/models/ens/ens_resolver_latest.sql
+++ b/models/ens/ens_resolver_latest.sql
@@ -1,0 +1,44 @@
+{{ config(
+    alias = 'resolver_latest',
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['node'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                            "project",
+                            "ens",
+                            \'["0xRob"]\') }}'
+    )
+}}
+
+with latest_resolver_records as (
+select
+    node
+    ,address
+    ,block_time
+    ,tx_hash
+    from(
+        select
+        a as address
+        ,node
+        ,evt_block_time as block_time
+        ,evt_tx_hash as tx_hash
+        ,evt_index
+        ,row_number() over (partition by node order by block_time desc, evt_index desc) as ordering
+        from {{ source('ethereumnameservice_ethereum','PublicResolver_evt_AddrChanged') }}
+        {% if is_incremental() %}
+        WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
+    ) foo
+    where ordering = 1
+   )
+
+select
+    ,n.name
+    ,r.address
+    ,r.node
+    ,r.block_time
+    ,r.tx_hash
+from latest_resolver_records r
+inner join {{ ref('ens_node_names')}} n
+ON r.node = n.node

--- a/models/ens/ens_resolver_latest.sql
+++ b/models/ens/ens_resolver_latest.sql
@@ -34,7 +34,7 @@ select
    )
 
 select
-    ,n.name
+    n.name
     ,r.address
     ,r.node
     ,r.block_time as latest_tx_block_time

--- a/models/ens/ens_resolver_latest.sql
+++ b/models/ens/ens_resolver_latest.sql
@@ -1,9 +1,5 @@
 {{ config(
     alias = 'resolver_latest',
-    materialized = 'incremental',
-    file_format = 'delta',
-    incremental_strategy = 'merge',
-    unique_key = ['node'],
     post_hook='{{ expose_spells(\'["ethereum"]\',
                             "project",
                             "ens",
@@ -11,34 +7,16 @@
     )
 }}
 
-with latest_resolver_records as (
 select
-    node
+    name
     ,address
+    ,node
     ,block_time
     ,tx_hash
-    from(
-        select
-        a as address
-        ,node
-        ,evt_block_time as block_time
-        ,evt_tx_hash as tx_hash
-        ,evt_index
-        ,row_number() over (partition by node order by evt_block_time desc, evt_index desc) as ordering
-        from {{ source('ethereumnameservice_ethereum','PublicResolver_evt_AddrChanged') }}
-        {% if is_incremental() %}
-        WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')
-        {% endif %}
-    ) foo
-    where ordering = 1
-   )
-
-select
-    n.name
-    ,r.address
-    ,r.node
-    ,r.block_time as latest_tx_block_time
-    ,r.tx_hash as latest_tx_hash
-from latest_resolver_records r
-inner join {{ ref('ens_node_names')}} n
-ON r.node = n.node
+    ,evt_index
+from(
+     *
+    ,row_number() over (partition by node order by block_time desc, evt_index desc) as ordering
+    from {{ ref('ens_resolver_records')}}
+) f
+where ordering = 1

--- a/models/ens/ens_resolver_latest.sql
+++ b/models/ens/ens_resolver_latest.sql
@@ -24,7 +24,7 @@ select
         ,evt_block_time as block_time
         ,evt_tx_hash as tx_hash
         ,evt_index
-        ,row_number() over (partition by node order by block_time desc, evt_index desc) as ordering
+        ,row_number() over (partition by node order by evt_block_time desc, evt_index desc) as ordering
         from {{ source('ethereumnameservice_ethereum','PublicResolver_evt_AddrChanged') }}
         {% if is_incremental() %}
         WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')

--- a/models/ens/ens_resolver_latest.sql
+++ b/models/ens/ens_resolver_latest.sql
@@ -37,8 +37,8 @@ select
     ,n.name
     ,r.address
     ,r.node
-    ,r.block_time
-    ,r.tx_hash
+    ,r.block_time as latest_tx_block_time
+    ,r.tx_hash as latest_tx_hash
 from latest_resolver_records r
 inner join {{ ref('ens_node_names')}} n
 ON r.node = n.node

--- a/models/ens/ens_resolver_records.sql
+++ b/models/ens/ens_resolver_records.sql
@@ -31,6 +31,6 @@ select
     ,r.block_time
     ,r.tx_hash
     ,r.evt_index
-from latest_resolver_records r
+from resolver_records r
 inner join {{ ref('ens_node_names')}} n
 ON r.node = n.node

--- a/models/ens/ens_resolver_records.sql
+++ b/models/ens/ens_resolver_records.sql
@@ -1,0 +1,36 @@
+{{ config(
+    alias = 'resolver_records',
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['node','block_time','evt_index'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                            "project",
+                            "ens",
+                            \'["0xRob"]\') }}'
+    )
+}}
+
+with resolver_records as (
+    select
+    a as address
+    ,node
+    ,evt_block_time as block_time
+    ,evt_tx_hash as tx_hash
+    ,evt_index
+    from {{ source('ethereumnameservice_ethereum','PublicResolver_evt_AddrChanged') }}
+    {% if is_incremental() %}
+    WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
+   )
+
+select
+    n.name
+    ,r.address
+    ,r.node
+    ,r.block_time
+    ,r.tx_hash
+    ,r.evt_index
+from latest_resolver_records r
+inner join {{ ref('ens_node_names')}} n
+ON r.node = n.node

--- a/models/labels/ens/labels_ens.sql
+++ b/models/labels/ens/labels_ens.sql
@@ -11,8 +11,8 @@ SELECT *
 FROM (
        SELECT
        array('ethereum') as blockchain,
-       coalesce(rev.address, res.address) as address
-       coalesce(rev.name, last(res.name,true) over (order by res.latest_tx_block_time asc)) as name
+       coalesce(rev.address, res.address) as address,
+       coalesce(rev.name, last(res.name,true) over (order by res.latest_tx_block_time asc)) as name,
        'ENS' as category,
        '0xRob' as contributor,
        'query' AS source,
@@ -22,6 +22,7 @@ FROM (
     OUTER JOIN {{ ref('ens_reverse_latest') }} rev
     ON res.address = rev.address
 ) ens
+UNION
 SELECT array('ethereum') as blockchain,
        address,
        name,

--- a/models/labels/ens/labels_ens.sql
+++ b/models/labels/ens/labels_ens.sql
@@ -12,7 +12,7 @@ FROM (
        SELECT
        array('ethereum') as blockchain,
        coalesce(rev.address, res.address) as address,
-       coalesce(rev.name, last(res.name,true) over (order by res.latest_tx_block_time asc)) as name,
+       coalesce(rev.name, last(res.name,true) over (order by res.block_time asc)) as name,
        'ENS' as category,
        '0xRob' as contributor,
        'query' AS source,

--- a/models/labels/ens/labels_ens.sql
+++ b/models/labels/ens/labels_ens.sql
@@ -6,7 +6,22 @@
 }}
 
 
-
+-- as default label, take the ENS reverse record or the latest resolver record
+SELECT *
+FROM (
+       SELECT
+       array('ethereum') as blockchain,
+       coalesce(rev.address, res.address) as address
+       coalesce(rev.name, last(res.name,true) over (order by res.latest_tx_block_time asc)) as name
+       'ENS' as category,
+       '0xRob' as contributor,
+       'query' AS source,
+       date('2022-10-06') as created_at,
+       now() as modified_at
+    FROM {{ ref('ens_resolver_latest') }} res
+    OUTER JOIN {{ ref('ens_reverse_latest') }} rev
+    ON res.address = rev.address
+) ens
 SELECT array('ethereum') as blockchain,
        address,
        name,
@@ -25,4 +40,7 @@ SELECT array('ethereum') as blockchain,
        'query' AS source,
        date('2022-10-06') as created_at,
        now() as modified_at
-FROM {{ ref('ens_resolver_latest') }}
+FROM {{ ref('ens_reverse_latest') }}
+UNION
+
+

--- a/models/labels/ens/labels_ens.sql
+++ b/models/labels/ens/labels_ens.sql
@@ -1,0 +1,28 @@
+{{config(alias='ens',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "sector",
+                                    "labels",
+                                    \'["0xRob"]\') }}')
+}}
+
+
+
+SELECT array('ethereum') as blockchain,
+       address,
+       name,
+       'ENS resolver' as category,
+       '0xRob' as contributor,
+       'query' AS source,
+       date('2022-10-06') as created_at,
+       now() as modified_at
+FROM {{ ref('ens_resolver_latest') }}
+UNION
+SELECT array('ethereum') as blockchain,
+       address,
+       name,
+       'ENS reverse' as category,
+       '0xRob' as contributor,
+       'query' AS source,
+       date('2022-10-06') as created_at,
+       now() as modified_at
+FROM {{ ref('ens_resolver_latest') }}

--- a/models/labels/ens/labels_ens.sql
+++ b/models/labels/ens/labels_ens.sql
@@ -19,7 +19,7 @@ FROM (
        date('2022-10-06') as created_at,
        now() as modified_at
     FROM {{ ref('ens_resolver_latest') }} res
-    OUTER JOIN {{ ref('ens_reverse_latest') }} rev
+    FULL OUTER JOIN {{ ref('ens_reverse_latest') }} rev
     ON res.address = rev.address
 ) ens
 UNION

--- a/models/labels/ens/labels_ens.sql
+++ b/models/labels/ens/labels_ens.sql
@@ -42,6 +42,4 @@ SELECT array('ethereum') as blockchain,
        date('2022-10-06') as created_at,
        now() as modified_at
 FROM {{ ref('ens_reverse_latest') }}
-UNION
-
 

--- a/models/labels/ens/labels_ens_schema.yml
+++ b/models/labels/ens/labels_ens_schema.yml
@@ -1,29 +1,22 @@
 version: 2
 
 models:
-  - name: labels_all
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - address
-            - name
-            - category
-            - blockchain
+  - name: labels_ens
     meta:
-      blockchain: ethereum, solana
+      blockchain: ethereum
       sector: labels
-      category: cex, nft
-      contibutors: hildobby, soispoke
+      category: ens
+      contibutors:  0xRob
     config:
-      tags: ['labels', 'ethereum', 'solana', 'cex', 'nft']
-    description: "All labels across chains and categories"
+      tags: ['query','labels', 'ethereum', 'ens', 'ENS resolver', 'ENS reverse']
+    description: "ENS labels"
     columns:
       - name: blockchain
         description: "Blockchain"
       - name: address
         description: "Label address"
       - name: name
-        description: "Label name"
+        description: "Label name (ENS name)"
       - name: category
         description: "Label category"
       - name: contributor

--- a/models/labels/labels_all.sql
+++ b/models/labels/labels_all.sql
@@ -35,3 +35,5 @@ UNION
 SELECT * FROM {{ ref('labels_miners') }}
 UNION
 SELECT * FROM {{ ref('labels_airdrop_1_receivers_optimism') }}
+UNION
+SELECT * FROM {{ ref('labels_ens') }}


### PR DESCRIPTION
1) Adds new tables for the resolver addresses of ENS names.
For now only baisc (.eth, no subdomains) ENS names are supported.
2) Adds the ENS name models to the label model

ENS main issue: https://github.com/duneanalytics/spellbook/issues/1666

---
*For Dune Engine V2*
I've checked that:
General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
