### PR TITLE
[Dune v1] Fix Seaport price amount error

### DIFF
--- a/deprecated-dune-v1-abstractions/ethereum/nft/trades/insert_seaport.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/nft/trades/insert_seaport.sql
@@ -304,11 +304,11 @@ with p1_call as (
           ,offer_item_type as offer_item_type
           ,offer_order_type as offer_order_type
           ,offer_identifier as nft_token_id_dcnt
-          ,price_token as price_token
-          ,price_item_type as price_item_type
-          ,price_amount as price_amount
-          ,fee_amount as fee_amount
-          ,royalty_amount as royalty_amount
+          ,evt_price_token as price_token
+          ,evt_price_item_type as price_item_type
+          ,evt_price_amount as price_amount
+          ,evt_fee_amount as fee_amount
+          ,evt_royalty_amount as royalty_amount
           ,evt_token_amount as evt_token_amount
           ,evt_price_amount as evt_price_amount
           ,evt_fee_amount as evt_fee_amount
@@ -317,9 +317,9 @@ with p1_call as (
           ,evt_royalty_token as evt_royalty_token
           ,evt_fee_recipient as evt_fee_recipient
           ,evt_royalty_recipient as evt_royalty_recipient
-          ,coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) as attempt_amount
-          ,case when evt_tx_hash is not null then coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) end as trade_amount
-          ,case when evt_tx_hash is null then coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) else 0 end as revert_amount
+          ,coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) as attempt_amount
+          ,case when evt_tx_hash is not null then coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) end as trade_amount
+          ,case when evt_tx_hash is null then coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) else 0 end as revert_amount
           ,case when evt_tx_hash is null then true else false end as reverted
           ,'Bulk Purchase' as trade_type
           ,'Bulk Purchase' as order_type

--- a/deprecated-dune-v1-abstractions/ethereum/seaport/insert_transactions.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/seaport/insert_transactions.sql
@@ -350,7 +350,7 @@ with p1_call as (
           ,'Buy Now' as purchase_method
       from p2_evt a
      group by 1,2,3,4,5
-     having count(distinct evt_price_token) > 1 -- execlude more than 2 currencies used in single txns
+     having count(distinct evt_price_token) = 1 -- execlude more than 2 currencies used in single txns
 )
 ,p2_nft_trades as ( 
     select a.block_time

--- a/deprecated-dune-v1-abstractions/ethereum/seaport/insert_transactions.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/seaport/insert_transactions.sql
@@ -313,11 +313,11 @@ with p1_call as (
           ,max(offer_order_type) as offer_order_type
           ,max(offer_identifier) as nft_token_id
           ,count(evt_tx_hash) as nft_transfer_cnt
-          ,max(price_token) as price_token
-          ,max(price_item_type) as price_item_type
-          ,sum(price_amount) as price_amount
-          ,sum(fee_amount) as fee_amount
-          ,sum(royalty_amount) as royalty_amount
+          ,max(evt_price_token) as price_token
+          ,max(evt_price_item_type) as price_item_type
+          ,sum(evt_price_amount) as price_amount
+          ,sum(evt_fee_amount) as fee_amount
+          ,sum(evt_royalty_amount) as royalty_amount
           ,sum(evt_price_amount) as evt_price_amount
           ,sum(evt_fee_amount) as evt_fee_amount
           ,sum(evt_royalty_amount) as evt_royalty_amount
@@ -335,9 +335,9 @@ with p1_call as (
           ,count(1) as attempt_cnt
           ,count(evt_tx_hash) as trade_cnt
           ,count(1) - count(evt_tx_hash) as revert_cnt
-          ,coalesce(sum(coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0)),0) as attempt_amount
-          ,coalesce(sum(case when evt_tx_hash is not null then coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) end),0) as trade_amount
-          ,coalesce(sum(case when evt_tx_hash is null then coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) end),0) as revert_amount
+          ,coalesce(sum(coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0)),0) as attempt_amount
+          ,coalesce(sum(case when evt_tx_hash is not null then coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) end),0) as trade_amount
+          ,coalesce(sum(case when evt_tx_hash is null then coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) end),0) as revert_amount
           ,count(case when offer_item_type = '2' then evt_token_amount end) as erc721_transfer_count 
           ,count(case when offer_item_type = '3' then evt_token_amount end) as erc1155_transfer_count 
           ,count(case when offer_item_type in ('2','3') then evt_token_amount end) as nft_transfer_count 

--- a/deprecated-dune-v1-abstractions/ethereum/seaport/insert_transactions.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/seaport/insert_transactions.sql
@@ -143,6 +143,7 @@ with p1_call as (
           ,max(purchase_method) as purchase_method
       from p1_evt_add a
      group by 1,2,3,4,5,6
+     having count(distinct price_token) = 1  -- execlude more than 2 currencies used in single txns
 )
 ,p1_nft_trades as ( 
     select a.block_time
@@ -349,6 +350,7 @@ with p1_call as (
           ,'Buy Now' as purchase_method
       from p2_evt a
      group by 1,2,3,4,5
+     having count(distinct evt_price_token) > 1 -- execlude more than 2 currencies used in single txns
 )
 ,p2_nft_trades as ( 
     select a.block_time
@@ -554,6 +556,9 @@ with p1_call as (
           ,max(order_type_id) as order_type_id
       from p3_add_rn a
      group by 1,2,3,4,5
+     having count(distinct case when purchase_method = 'Offer Accepted' and sub_type = 'offer' and sub_idx = 1 then token_contract_address::text
+                                when purchase_method = 'Buy Now' and sub_type = 'consideration' then token_contract_address::text
+                           end) = 1  -- execlude more than 2 currencies used in single txns
 )
 ,p3_nft_trades as (
     select a.block_time
@@ -759,6 +764,7 @@ with p1_call as (
       from p4_add_rn a
      where offer_item_type in ('2','3')
      group by 1,2,3,4,5,6
+     having count(distinct price_token) = 1  -- execlude more than 2 currencies used in single txns
 )
 ,p4_nft_trades as ( 
     select a.block_time

--- a/deprecated-dune-v1-abstractions/ethereum/seaport/insert_transfers.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/seaport/insert_transfers.sql
@@ -313,11 +313,11 @@ with p1_call as (
           ,offer_item_type as offer_item_type
           ,offer_order_type as offer_order_type
           ,offer_identifier as nft_token_id_dcnt
-          ,price_token as price_token
-          ,price_item_type as price_item_type
-          ,price_amount as price_amount
-          ,fee_amount as fee_amount
-          ,royalty_amount as royalty_amount
+          ,evt_price_token as price_token
+          ,evt_price_item_type as price_item_type
+          ,evt_price_amount as price_amount
+          ,evt_fee_amount as fee_amount
+          ,evt_royalty_amount as royalty_amount
           ,evt_token_amount as evt_token_amount
           ,evt_price_amount as evt_price_amount
           ,evt_fee_amount as evt_fee_amount
@@ -326,9 +326,9 @@ with p1_call as (
           ,evt_royalty_token as evt_royalty_token
           ,evt_fee_recipient as evt_fee_recipient
           ,evt_royalty_recipient as evt_royalty_recipient
-          ,coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) as attempt_amount
-          ,case when evt_tx_hash is not null then coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) end as trade_amount
-          ,case when evt_tx_hash is null then coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) else 0 end as revert_amount
+          ,coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) as attempt_amount
+          ,case when evt_tx_hash is not null then coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) end as trade_amount
+          ,case when evt_tx_hash is null then coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) else 0 end as revert_amount
           ,case when evt_tx_hash is null then true else false end as reverted
           ,'Bulk Purchase' as trade_type
           ,'Bulk Purchase' as order_type

--- a/deprecated-dune-v1-abstractions/polygon/seaport/insert_transactions.sql
+++ b/deprecated-dune-v1-abstractions/polygon/seaport/insert_transactions.sql
@@ -153,6 +153,7 @@ with p1_call as (
           ,max(purchase_method) as purchase_method
       from p1_evt_add a
      group by 1,2,3,4,5,6
+     having count(distinct price_token) = 1  -- execlude more than 2 currencies used in single txns
 )
 ,p1_nft_trades as ( 
     select a.block_time
@@ -351,6 +352,7 @@ with p1_call as (
           ,'Buy Now' as purchase_method
       from p2_evt a
      group by 1,2,3,4,5
+     having count(distinct evt_price_token) = 1 -- execlude more than 2 currencies used in single txns
 )
 ,p2_nft_trades as ( 
     select a.block_time
@@ -548,6 +550,9 @@ with p1_call as (
           ,max(order_type_id) as order_type_id
       from p3_add_rn a
      group by 1,2,3,4,5
+     having count(distinct case when purchase_method = 'Offer Accepted' and sub_type = 'offer' and sub_idx = 1 then token_contract_address::text
+                                when purchase_method = 'Buy Now' and sub_type = 'consideration' then token_contract_address::text
+                           end) = 1  -- execlude more than 2 currencies used in single txns
 )
 ,p3_nft_trades as (
     select a.block_time
@@ -745,6 +750,7 @@ with p1_call as (
       from p4_add_rn a
      where offer_item_type in ('2','3')
      group by 1,2,3,4,5,6
+     having count(distinct price_token) = 1  -- execlude more than 2 currencies used in single txns
 )
 ,p4_nft_trades as ( 
     select a.block_time


### PR DESCRIPTION
Brief comments on the purpose of your changes:

[Dune v1] Fix seaport error

1. Get the price from `evt` table rather than `call` table.
    - Actual price is written on evt table. most are the same to call table but sometimes it is different.
    - Target: (Dune v1 / Ethereum) `seaport.transfers`, `nft.trades`

2. Excluding txns when multiple currencies are used in a single transaction
    - There is no problem with the `seaport.transfer` table, but in `seaport.transactions` table, column `currency_contract` cannot represent both.
    - Recommend using `seaport.transfers` for accurate values
    - Target: (Dune v1 / Ethereum, polygon) `seaport.transactions`

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
