### PR TITLE
Ethereum gas spell

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -126,6 +126,13 @@ models:
       ethereum:
         +schema: foundation_ethereum
         +materialized: view
+        
+    gas:
+      +schema: gas
+      +materialized: view
+      ethereum:
+        +schema: gas_ethereum
+        +materialized: view
     
     gmx:
       +schema: gmx

--- a/models/gas/ethereum/gas_ethereum_fees.sql
+++ b/models/gas/ethereum/gas_ethereum_fees.sql
@@ -1,0 +1,58 @@
+{{ config(
+    alias = 'fees',
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_time','tx_hash','tx_amount_eth']
+    )
+}}
+
+SELECT 
+     block_time,
+     block_number,
+     txns.hash AS tx_hash,
+     value/1e18 AS tx_amount_eth,
+     value/1e18 * p.price AS tx_amount_usd,
+     CASE WHEN type = 'Legacy' THEN (gas_price * txns.gas_used)/1e18
+          WHEN type = 'DynamicFee' THEN ((base_fee_per_gas + priority_fee_per_gas) * txns.gas_used)/1e18 
+          END AS tx_fee_eth, 
+     CASE WHEN type = 'Legacy' THEN (gas_price * txns.gas_used)/1e18 * p.price 
+          WHEN type = 'DynamicFee' THEN ((base_fee_per_gas + priority_fee_per_gas) * txns.gas_used)/1e18 * p.price 
+          END AS tx_fee_usd,
+     CASE WHEN type = 'Legacy' THEN NULL::double 
+          WHEN type = 'DynamicFee' THEN ((base_fee_per_gas) * txns.gas_used)/1e18 
+          END AS burned_eth, 
+     CASE WHEN type = 'Legacy' THEN NULL::double 
+          WHEN type = 'DynamicFee' THEN (((base_fee_per_gas) * txns.gas_used)/1e18) * p.price 
+          END AS burned_usd,
+     CASE WHEN type = 'Legacy' THEN NULL::double 
+          WHEN type = 'DynamicFee' THEN ((max_fee_per_gas - priority_fee_per_gas - base_fee_per_gas) * txns.gas_used)/1e18 
+          END AS tx_savings_eth,
+     CASE WHEN type = 'Legacy' THEN NULL::double 
+          WHEN type = 'DynamicFee' THEN (((max_fee_per_gas - priority_fee_per_gas - base_fee_per_gas) * txns.gas_used)/1e18) * p.price 
+          END AS tx_savings_usd,
+     miner AS validator, -- or block_proposer since Proposer Builder Separation (PBS) happened ?
+     max_fee_per_gas / 1e9 AS max_fee_gwei,
+     max_fee_per_gas / 1e18 * p.price AS max_fee_usd,
+     base_fee_per_gas / 1e9 AS base_fee_gwei,
+     base_fee_per_gas / 1e18 * p.price AS base_fee_usd,
+     priority_fee_per_gas / 1e9 AS priority_fee_gwei,
+     priority_fee_per_gas / 1e18 * p.price AS priority_fee_usd,
+     gas_price /1e9 AS gas_price_gwei,
+     gas_price / 1e18 * p.price AS gas_price_usd,
+     txns.gas_used,
+     txns.gas_limit,
+     txns.gas_used / txns.gas_limit * 100 AS gas_usage_percent,
+     difficulty,
+     type AS transaction_type
+FROM ethereum.transactions txns
+JOIN ethereum.blocks blocks ON blocks.number = txns.block_number
+{% if is_incremental() %}
+AND txns.block_time >= date_trunc("day", now() - interval '1 week')
+{% endif %}
+LEFT JOIN prices.usd p ON p.minute = date_trunc('minute', block_time)
+AND p.blockchain = 'ethereum'
+AND p.symbol = 'WETH'
+{% if is_incremental() %}
+AND p.minute >= date_trunc("day", now() - interval '1 week')
+{% endif %}

--- a/models/gas/ethereum/gas_ethereum_fees.sql
+++ b/models/gas/ethereum/gas_ethereum_fees.sql
@@ -21,18 +21,10 @@ SELECT
      CASE WHEN type = 'Legacy' THEN (gas_price * txns.gas_used)/1e18 * p.price 
           WHEN type = 'DynamicFee' THEN ((base_fee_per_gas + priority_fee_per_gas) * txns.gas_used)/1e18 * p.price 
           END AS tx_fee_usd,
-     CASE WHEN type = 'Legacy' THEN NULL::double 
-          WHEN type = 'DynamicFee' THEN ((base_fee_per_gas) * txns.gas_used)/1e18 
-          END AS burned_eth, 
-     CASE WHEN type = 'Legacy' THEN NULL::double 
-          WHEN type = 'DynamicFee' THEN (((base_fee_per_gas) * txns.gas_used)/1e18) * p.price 
-          END AS burned_usd,
-     CASE WHEN type = 'Legacy' THEN NULL::double 
-          WHEN type = 'DynamicFee' THEN ((max_fee_per_gas - priority_fee_per_gas - base_fee_per_gas) * txns.gas_used)/1e18 
-          END AS tx_savings_eth,
-     CASE WHEN type = 'Legacy' THEN NULL::double 
-          WHEN type = 'DynamicFee' THEN (((max_fee_per_gas - priority_fee_per_gas - base_fee_per_gas) * txns.gas_used)/1e18) * p.price 
-          END AS tx_savings_usd,
+     ((base_fee_per_gas) * txns.gas_used)/1e18 AS burned_eth, 
+     (((base_fee_per_gas) * txns.gas_used)/1e18) * p.price AS burned_usd,
+     ((max_fee_per_gas - priority_fee_per_gas - base_fee_per_gas) * txns.gas_used)/1e18 AS tx_savings_eth,
+     (((max_fee_per_gas - priority_fee_per_gas - base_fee_per_gas) * txns.gas_used)/1e18) * p.price AS tx_savings_usd,
      miner AS validator, -- or block_proposer since Proposer Builder Separation (PBS) happened ?
      max_fee_per_gas / 1e9 AS max_fee_gwei,
      max_fee_per_gas / 1e18 * p.price AS max_fee_usd,

--- a/models/gas/ethereum/gas_ethereum_fees.sql
+++ b/models/gas/ethereum/gas_ethereum_fees.sql
@@ -9,7 +9,7 @@
 }}
 
 SELECT 
-     date_trunc('week', block_time) AS block_date,
+     date_trunc('day', block_time) AS block_date,
      block_time,
      block_number,
      txns.hash AS tx_hash,

--- a/models/gas/ethereum/gas_ethereum_fees.sql
+++ b/models/gas/ethereum/gas_ethereum_fees.sql
@@ -9,6 +9,7 @@
 }}
 
 SELECT 
+     'ethereum' as blockchain,
      date_trunc('day', block_time) AS block_date,
      block_time,
      block_number,

--- a/models/gas/ethereum/gas_ethereum_fees.sql
+++ b/models/gas/ethereum/gas_ethereum_fees.sql
@@ -4,7 +4,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_time','tx_hash','tx_amount_eth']
+    unique_key = ['block_time','tx_hash','tx_amount_native']
     )
 }}
 
@@ -13,17 +13,18 @@ SELECT
      block_time,
      block_number,
      txns.hash AS tx_hash,
-     value/1e18 AS tx_amount_eth,
+     'ETH' as native_token_symbol,
+     value/1e18 AS tx_amount_native,
      value/1e18 * p.price AS tx_amount_usd,
      CASE WHEN type = 'Legacy' THEN (gas_price * txns.gas_used)/1e18
           WHEN type = 'DynamicFee' THEN ((base_fee_per_gas + priority_fee_per_gas) * txns.gas_used)/1e18 
-          END AS tx_fee_eth, 
+          END AS tx_fee_native, 
      CASE WHEN type = 'Legacy' THEN (gas_price * txns.gas_used)/1e18 * p.price 
           WHEN type = 'DynamicFee' THEN ((base_fee_per_gas + priority_fee_per_gas) * txns.gas_used)/1e18 * p.price 
           END AS tx_fee_usd,
-     ((base_fee_per_gas) * txns.gas_used)/1e18 AS burned_eth, 
+     ((base_fee_per_gas) * txns.gas_used)/1e18 AS burned_native, 
      (((base_fee_per_gas) * txns.gas_used)/1e18) * p.price AS burned_usd,
-     ((max_fee_per_gas - priority_fee_per_gas - base_fee_per_gas) * txns.gas_used)/1e18 AS tx_savings_eth,
+     ((max_fee_per_gas - priority_fee_per_gas - base_fee_per_gas) * txns.gas_used)/1e18 AS tx_savings_native,
      (((max_fee_per_gas - priority_fee_per_gas - base_fee_per_gas) * txns.gas_used)/1e18) * p.price AS tx_savings_usd,
      miner AS validator, -- or block_proposer since Proposer Builder Separation (PBS) happened ?
      max_fee_per_gas / 1e9 AS max_fee_gwei,

--- a/models/gas/ethereum/gas_ethereum_fees.sql
+++ b/models/gas/ethereum/gas_ethereum_fees.sql
@@ -1,5 +1,6 @@
 {{ config(
     alias = 'fees',
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -8,6 +9,7 @@
 }}
 
 SELECT 
+     date_trunc('week', block_time) AS block_date,
      block_time,
      block_number,
      txns.hash AS tx_hash,

--- a/models/gas/ethereum/gas_ethereum_fees.sql
+++ b/models/gas/ethereum/gas_ethereum_fees.sql
@@ -60,4 +60,5 @@ AND p.symbol = 'WETH'
 AND p.minute >= date_trunc("day", now() - interval '1 week')
 WHERE block_time >= date_trunc("day", now() - interval '1 week')
 AND blocks.time >= date_trunc("day", now() - interval '1 week')
+AND p.minute >= date_trunc("day", now() - interval '1 week')
 {% endif %}

--- a/models/gas/ethereum/gas_ethereum_fees.sql
+++ b/models/gas/ethereum/gas_ethereum_fees.sql
@@ -48,11 +48,14 @@ SELECT
 FROM ethereum.transactions txns
 JOIN ethereum.blocks blocks ON blocks.number = txns.block_number
 {% if is_incremental() %}
-AND txns.block_time >= date_trunc("day", now() - interval '1 week')
+AND block_time >= date_trunc("day", now() - interval '1 week')
+AND blocks.time >= date_trunc("day", now() - interval '1 week')
 {% endif %}
 LEFT JOIN prices.usd p ON p.minute = date_trunc('minute', block_time)
 AND p.blockchain = 'ethereum'
 AND p.symbol = 'WETH'
 {% if is_incremental() %}
 AND p.minute >= date_trunc("day", now() - interval '1 week')
+WHERE block_time >= date_trunc("day", now() - interval '1 week')
+AND blocks.time >= date_trunc("day", now() - interval '1 week')
 {% endif %}

--- a/models/gas/ethereum/gas_ethereum_schema.yml
+++ b/models/gas/ethereum/gas_ethereum_schema.yml
@@ -1,0 +1,90 @@
+version: 2
+
+models:
+  - name: gas_ethereum_fees
+    meta:
+      blockchain: ethereum
+      sector: gas
+      contributors: soispoke
+    config:
+      tags: ['ethereum', 'gas', 'fees']
+    description: >
+        Gas Fees on Ethereum
+    columns:
+      - &block_time
+        name: block_time
+        description: "Timestamp for block event time in UTC"
+      - &block_number
+        name: block_number
+        description: "Block number"
+      - name: tx_hash
+        description: "Primary key of the transaction"
+        tests:
+          - unique
+          - not_null
+      - &tx_amount_eth
+        name: tx_amount_eth
+        description: "Amount of ETH transferred from sender to recipient"
+      - &tx_amount_usd
+        name: tx_amount_usd
+        description: "Amount of $USD transferred from sender to recipient"
+      - &tx_fee_eth
+        name: tx_fee_eth
+        description: "Total amount of ETH paid in gas fees -- Pre EIP 1559: Gas Price * Gas Used; Post EIP 1559: Gas Price * Gas Used ; Base fee + Priority fee) * Gas used"
+      - &tx_fee_usd
+        name: tx_fee_usd
+        description: "Total amount of $USD paid in gas fees"
+      - &burned_eth
+        name: burned_eth
+        description: "Total amount of ETH burned for this transaction, Post EIP 1559: Is equal to the Base Fee"
+      - &burned_usd
+        name: burned_usd
+        description: "Total amount of $USD burned for this transaction"   
+      - &tx_savings_eth
+        name: tx_savings_eth
+        description: "Total amount of ETH refunded to the user if the max fee exceeded the total transaction fee after the transaction execution"
+      - &tx_savings_usd
+        name: tx_savings_usd
+        description: "Total amount of $USD refunded to the user"  
+      - &validator
+        name: validator
+        description: "Address of blockchain validator for this transaction within the block, also referred to as miner before the Merge when Ethereum's consensus mechanism was PoW"  
+      - &max_fee_gwei
+        name: max_fee_gwei
+        description: "Maximum amount of gas (in Gwei) willing to be paid for the transaction: Is refunded if exceeds the total transaction fee once the transaction is executed"
+      - &max_fee_usd
+        name: max_fee_usd
+        description: "Maximum amount of gas (in $USD) willing to be paid for the transaction: Is refunded if exceeds the total transaction fee once the transaction is executed"
+      - &base_fee_gwei
+        name: base_fee_gwei
+        description: "Market price for gas (in Gwei)"
+      - &base_fee_usd
+        name: base_fee_usd
+        description: "Market price for gas (in $USD)"
+      - &priority_fee_gwei
+        name: priority_fee_gwei
+        description: "Maximum amount of gas (in Gwei) to be included as a tip to the miner/validator"
+      - &priority_fee_usd
+        name: priority_fee_usd
+        description: "Maximum amount of gas (in $USD) to be included as a tip to the miner/validator"
+      - &gas_price_gwei
+        name: gas_price_gwei
+        description: "Gas price (per gas unit) denoted in gwei"
+      - &gas_price_usd
+        name: gas_price_usd
+        description: "Gas price (per gas unit) denoted in $USD"
+      - &gas_used
+        name: gas_used
+        description: "Amount of gas units consumed by the transaction"
+      - &gas_limit
+        name: gas_limit
+        description: "Maximum amount of gas units that can be consumed by the transaction"
+      - &gas_usage_percent
+        name: gas_usage_percent
+        description: "Percentage of Gas Used relative to the gas limit"
+      - &difficulty
+        name: difficulty
+        description: "Maximum amount of gas units that can be consumed by the transaction"
+      - &type
+        name: type
+        description: "Transaction type: Legacy (Pre EIP 1559) or DynamicFee (Post EIP-1559)"


### PR DESCRIPTION
Brief comments on the purpose of your changes:
This Spell is the first of Gas Spells across all blockchains indexed by Dune
Would love to have your feedback @augustog about what you think should be included in there as well (even though this might evolve anyways when trying to standardize this across blockchains)

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
