### PR TITLE
Ethereum and BNB chain gas spell

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -136,6 +136,9 @@ models:
       ethereum:
         +schema: gas_ethereum
         +materialized: view
+      bnb:
+        +schema: gas_bnb
+        +materialized: view
     
     gmx:
       +schema: gmx

--- a/models/gas/bnb/gas_bnb_fees.sql
+++ b/models/gas/bnb/gas_bnb_fees.sql
@@ -1,0 +1,48 @@
+{{ config(
+    alias = 'fees',
+    partition_by = ['block_date'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_time','tx_hash','tx_amount_native']
+    )
+}}
+
+SELECT 
+    'bnb' as blockchain,
+     date_trunc('day', block_time) AS block_date,
+    block_number,
+    block_time,
+    txns.hash AS tx_hash,
+    'BNB' as native_token_symbol,
+    value/1e18 AS tx_amount_native,
+    value/1e18 * p.price AS tx_amount_usd,
+    (gas_price * txns.gas_used)/1e18 AS txn_fee_native, 
+    (gas_price * txns.gas_used)/1e18 * p.price  AS txn_fee_usd,
+    CASE WHEN block_number >= 13082000 THEN value/1e18 * 10 / 100 
+        ELSE NULL::double END AS burned_native, -- change after BEP95
+    CASE WHEN block_number >= 13082000 THEN value/1e18 * 10 / 100 * p.price 
+        ELSE NULL::double END AS burned_usd, -- change after BEP95
+    miner AS validator,
+    gas_price /1e9 AS gas_price_in_gwei,
+    gas_price / 1e18 * p.price AS gas_price_in_usd,
+    txns.gas_used,
+    txns.gas_used / txns.gas_limit * 100 AS gas_usage_percent,
+    txns.gas_limit,
+    difficulty,
+    type AS transaction_type
+FROM {{ source('bnb','transactions') }} txns
+JOIN {{ source('bnb','blocks') }} blocks ON blocks.number = txns.block_number
+{% if is_incremental() %}
+AND block_time >= date_trunc("day", now() - interval '1 week')
+AND blocks.time >= date_trunc("day", now() - interval '1 week')
+{% endif %}
+LEFT JOIN {{ source('prices', 'usd') }} p ON p.minute = date_trunc('minute', block_time)
+AND p.blockchain = 'ethereum'
+AND p.symbol = 'BNB'
+{% if is_incremental() %}
+AND p.minute >= date_trunc("day", now() - interval '1 week')
+WHERE block_time >= date_trunc("day", now() - interval '1 week')
+AND blocks.time >= date_trunc("day", now() - interval '1 week')
+AND p.minute >= date_trunc("day", now() - interval '1 week')
+{% endif %}

--- a/models/gas/bnb/gas_bnb_schema.yml
+++ b/models/gas/bnb/gas_bnb_schema.yml
@@ -1,0 +1,67 @@
+version: 2
+
+models:
+  - name: gas_bnb_fees
+    meta:
+      blockchain: bnb
+      sector: gas
+      contributors: soispoke
+    config:
+      tags: ['bnb', 'gas', 'fees']
+    description: >
+        Gas Fees on BNB chain
+    columns:
+      - &blokchain
+        name: blockchain
+        description: "Blockchain name"    
+      - &block_number
+        name: block_number
+        description: "Block number"
+      - &block_time
+        name: block_time
+        description: "Timestamp for block event time in UTC"
+      - &tx_hash
+        name: tx_hash
+        description: "Primary key of the transaction"
+        tests:
+          - unique
+          - not_null
+      - &tx_amount_native
+        name: tx_amount_native
+        description: "Amount of native tokens (BNB) transferred from sender to recipient"
+      - &tx_amount_usd
+        name: tx_amount_usd
+        description: "Amount of $USD transferred from sender to recipient"
+      - &tx_fee_native
+        name: tx_fee_native
+        description: "Total amount of native tokens (BNB) paid in gas fees -- Gas Price * Gas Used"
+      - &tx_fee_usd
+        name: tx_fee_usd
+        description: "Total amount of $USD paid in gas fees"
+      - &burned_native
+        name: burned_native
+        description: "Total amount of native tokens (BNB) burned for this transaction, Post BEP-95: 10% of transaction fee"
+      - &burned_usd
+        name: burned_usd
+        description: "Total amount of $USD burned for this transaction, Post BEP-95: 10% of transaction fee"   
+      - &validator
+        name: validator
+        description: "Address of blockchain validator for this transaction within the block"  
+      - &gas_price_gwei
+        name: gas_price_gwei
+        description: "Gas price (per gas unit) denoted in gwei"
+      - &gas_price_usd
+        name: gas_price_usd
+        description: "Gas price (per gas unit) denoted in $USD"
+      - &gas_used
+        name: gas_used
+        description: "Amount of gas units consumed by the transaction"
+      - &gas_limit
+        name: gas_limit
+        description: "Maximum amount of gas units that can be consumed by the transaction"
+      - &gas_usage_percent
+        name: gas_usage_percent
+        description: "Percentage of Gas Used relative to the gas limit"
+      - &transaction_type
+        name: transaction_type
+        description: "Transaction type"

--- a/models/gas/ethereum/gas_ethereum_fees.sql
+++ b/models/gas/ethereum/gas_ethereum_fees.sql
@@ -11,8 +11,8 @@
 SELECT 
      'ethereum' as blockchain,
      date_trunc('day', block_time) AS block_date,
-     block_time,
      block_number,
+     block_time,
      txns.hash AS tx_hash,
      'ETH' as native_token_symbol,
      value/1e18 AS tx_amount_native,
@@ -41,13 +41,13 @@ SELECT
      txns.gas_used / txns.gas_limit * 100 AS gas_usage_percent,
      difficulty,
      type AS transaction_type
-FROM ethereum.transactions txns
-JOIN ethereum.blocks blocks ON blocks.number = txns.block_number
+FROM {{ source('ethereum','transactions') }} txns
+JOIN {{ source('ethereum','blocks') }} blocks ON blocks.number = txns.block_number
 {% if is_incremental() %}
 AND block_time >= date_trunc("day", now() - interval '1 week')
 AND blocks.time >= date_trunc("day", now() - interval '1 week')
 {% endif %}
-LEFT JOIN prices.usd p ON p.minute = date_trunc('minute', block_time)
+LEFT JOIN {{ source('prices','usd') }} p ON p.minute = date_trunc('minute', block_time)
 AND p.blockchain = 'ethereum'
 AND p.symbol = 'WETH'
 {% if is_incremental() %}

--- a/models/gas/ethereum/gas_ethereum_schema.yml
+++ b/models/gas/ethereum/gas_ethereum_schema.yml
@@ -11,38 +11,42 @@ models:
     description: >
         Gas Fees on Ethereum
     columns:
+      - &blokchain
+        name: blockchain
+        description: "Blockchain name"    
       - &block_time
         name: block_time
         description: "Timestamp for block event time in UTC"
       - &block_number
         name: block_number
         description: "Block number"
-      - name: tx_hash
+      - &tx_hash
+        name: tx_hash
         description: "Primary key of the transaction"
         tests:
           - unique
           - not_null
-      - &tx_amount_eth
-        name: tx_amount_eth
-        description: "Amount of ETH transferred from sender to recipient"
+      - &tx_amount_native
+        name: tx_amount_native
+        description: "Amount of native tokens (ETH) transferred from sender to recipient"
       - &tx_amount_usd
         name: tx_amount_usd
         description: "Amount of $USD transferred from sender to recipient"
-      - &tx_fee_eth
-        name: tx_fee_eth
-        description: "Total amount of ETH paid in gas fees -- Pre EIP 1559: Gas Price * Gas Used; Post EIP 1559: Gas Price * Gas Used ; Base fee + Priority fee) * Gas used"
+      - &tx_fee_native
+        name: tx_fee_native
+        description: "Total amount of native tokens (ETH) paid in gas fees -- Pre EIP 1559: Gas Price * Gas Used; Post EIP 1559: Gas Price * Gas Used ; Base fee + Priority fee) * Gas used"
       - &tx_fee_usd
         name: tx_fee_usd
         description: "Total amount of $USD paid in gas fees"
-      - &burned_eth
-        name: burned_eth
-        description: "Total amount of ETH burned for this transaction, Post EIP 1559: Is equal to the Base Fee"
+      - &burned_native
+        name: burned_native
+        description: "Total amount of native tokens (ETH) burned for this transaction, Post EIP 1559: Is equal to the Base Fee"
       - &burned_usd
         name: burned_usd
         description: "Total amount of $USD burned for this transaction"   
-      - &tx_savings_eth
-        name: tx_savings_eth
-        description: "Total amount of ETH refunded to the user if the max fee exceeded the total transaction fee after the transaction execution"
+      - &tx_savings_native
+        name: tx_savings_native
+        description: "Total amount of native tokens (ETH) refunded to the user if the max fee exceeded the total transaction fee after the transaction execution"
       - &tx_savings_usd
         name: tx_savings_usd
         description: "Total amount of $USD refunded to the user"  

--- a/models/gas/gas_fees.sql
+++ b/models/gas/gas_fees.sql
@@ -1,0 +1,48 @@
+{{ config(
+        alias ='fees',
+        post_hook='{{ expose_spells(\'["ethereum","bnb"]\',
+                                "sector",
+                                "dex",
+                                \'["soispoke"]\') }}'
+        )
+}}
+SELECT *
+FROM
+    (
+        SELECT
+                blockchain,
+                block_number,
+                block_time,
+                tx_amount_native,
+                tx_amount_usd,
+                tx_fee_native,
+                tx_fee_usd,
+                burned_native,
+                burned_usd,
+                validator,
+                gas_price_gwei,
+                gas_price_usd,
+                gas_used,
+                gas_limit,
+                gas_usage_percent,
+                transaction_type
+        FROM {{ ref('gas_ethereum_fees') }}
+        UNION
+        SELECT
+                blockchain,
+                block_number,
+                block_time,
+                tx_amount_native,
+                tx_amount_usd,
+                tx_fee_native,
+                tx_fee_usd,
+                burned_native,
+                burned_usd,
+                validator,
+                gas_price_gwei,
+                gas_price_usd,
+                gas_used,
+                gas_limit,
+                gas_usage_percent,
+                transaction_type
+        FROM {{ ref('gas_bnb_fees') }})

--- a/models/gas/gas_fees_schema.yml
+++ b/models/gas/gas_fees_schema.yml
@@ -1,0 +1,67 @@
+version: 2
+
+models:
+  - name: gas_fees
+    meta:
+      blockchain: ethereum, bnb
+      sector: gas
+      contributors: soispoke
+    config:
+      tags: ['ethereum', 'bnb', 'gas', 'fees']
+    description: >
+        Gas Fees across chains
+    columns:
+      - &blokchain
+        name: blockchain
+        description: "Blockchain name"
+  - &block_time
+    name: block_time
+    description: "Timestamp for block event time in UTC"
+  - &block_number
+    name: block_number
+    description: "Block number"
+  - &tx_hash
+    name: tx_hash
+    description: "Primary key of the transaction"
+    tests:
+      - unique
+      - not_null
+  - &tx_amount_native
+    name: tx_amount_native
+    description: "Amount of native tokens transferred from sender to recipient"
+  - &tx_amount_usd
+    name: tx_amount_usd
+    description: "Amount of $USD transferred from sender to recipient"
+  - &tx_fee_native
+    name: tx_fee_native
+    description: "Total amount of native tokens paid in gas fees"
+  - &tx_fee_usd
+    name: tx_fee_usd
+    description: "Total amount of $USD paid in gas fees"
+  - &burned_native
+    name: burned_native
+    description: "Total amount of native tokens burned for this transaction"
+  - &burned_usd
+    name: burned_usd
+    description: "Total amount of $USD burned for this transaction"   
+  - &validator
+    name: validator
+    description: "Address of blockchain validator for this transaction within the block"  
+  - &gas_price_gwei
+    name: gas_price_gwei
+    description: "Gas price (per gas unit) denoted in gwei"
+  - &gas_price_usd
+    name: gas_price_usd
+    description: "Gas price (per gas unit) denoted in $USD"
+  - &gas_used
+    name: gas_used
+    description: "Amount of gas units consumed by the transaction"
+  - &gas_limit
+    name: gas_limit
+    description: "Maximum amount of gas units that can be consumed by the transaction"
+  - &gas_usage_percent
+    name: gas_usage_percent
+    description: "Percentage of Gas Used relative to the gas limit"
+  - &type
+    name: type
+    description: "Transaction type"


### PR DESCRIPTION
Brief comments on the purpose of your changes:
This Spell is the first of Gas Spells across all blockchains indexed by Dune
Would love to have your feedback @augustog about what you think should be included in there as well (even though this might evolve anyways when trying to standardize this across blockchains)

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
