### PR TITLE
Fix Pool Source OP Uni Trades

### DIFF
--- a/models/uniswap/optimism/uniswap_v3_optimism_trades.sql
+++ b/models/uniswap/optimism/uniswap_v3_optimism_trades.sql
@@ -34,7 +34,7 @@ WITH dexs AS
         ,t.evt_index
     FROM
         {{ source('uniswap_v3_optimism', 'Pair_evt_Swap') }} t
-    INNER JOIN {{ source('uniswap_v3_optimism', 'factory_evt_poolcreated') }} f
+    INNER JOIN {{ source('uniswap_v3_optimism', 'pools') }} f
         ON f.pool = t.contract_address
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')

--- a/models/uniswap/optimism/uniswap_v3_optimism_trades.sql
+++ b/models/uniswap/optimism/uniswap_v3_optimism_trades.sql
@@ -34,7 +34,7 @@ WITH dexs AS
         ,t.evt_index
     FROM
         {{ source('uniswap_v3_optimism', 'Pair_evt_Swap') }} t
-    INNER JOIN {{ ref('uniswap_v3_optimism', 'pools') }} f
+    INNER JOIN {{ ref('uniswap_optimism_pools') }} f
         ON f.pool = t.contract_address
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')

--- a/models/uniswap/optimism/uniswap_v3_optimism_trades.sql
+++ b/models/uniswap/optimism/uniswap_v3_optimism_trades.sql
@@ -34,7 +34,7 @@ WITH dexs AS
         ,t.evt_index
     FROM
         {{ source('uniswap_v3_optimism', 'Pair_evt_Swap') }} t
-    INNER JOIN {{ source('uniswap_v3_optimism', 'pools') }} f
+    INNER JOIN {{ ref('uniswap_v3_optimism', 'pools') }} f
         ON f.pool = t.contract_address
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Fixing the pool source for Optimism Uniswap trades. Pools created after the chain regenesis won't have pool creation events, so instead changing the pool info source to read from the uniswap pools spell.

Still catching up on dbt, but I ~believe the table should be dropped and re-added

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
