### PR TITLE
Add OP Bridges, CEXs, L2 Submitters to v2 Address Lists

### DIFF
--- a/models/addresses/ethereum/addresses_ethereum_bridges.sql
+++ b/models/addresses/ethereum/addresses_ethereum_bridges.sql
@@ -3,9 +3,9 @@
         post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "sector",
                                     "addresses",
-                                    \'["hildobby"]\') }}') }}
+                                    \'["hildobby","msilb7"]\') }}') }}
 
-SELECT address, bridge_name, description
+SELECT lower(address) AS address, bridge_name, description
 FROM (VALUES
       ('0x8ed95d1746bf1e4dab58d8ed4724f1ef95b20db0', '0x', 'Erc20 Bridge Proxy')
     , ('0x0ac2d6f5f5afc669d3ca38f830dad2b4f238ad3f', '0x', 'Eth2Dai Bridge')
@@ -114,4 +114,16 @@ FROM (VALUES
     , ('0x43298f9f91a4545df64748e78a2c777c580573d6', 'Across Protocol', 'Badger Bridge Pool')
     , ('0x30b44c676a05f1264d1de9cc31db5f2a945186b6', 'Across Protocol', 'Bridge Admin')
     , ('0xdfe0ec39291e3b60aca122908f86809c9ee64e90', 'Across Protocol', 'UMA Bridge Pool')
+    , ('0xcd9d4988c0ae61887b075ba77f08cbfad2b65068', 'Optimism', 'Synthetix: L2 Deposit')
+    , ('0x5fd79d46eba7f351fe49bff9e87cdea6c821ef9f', 'Optimism', 'Synthetix: L2 Deposit Escrow')
+    , ('0x99c9fc46f92e8a1c0dec1b1747d010903e884be1', 'Optimism', 'Optimism: Gateway')
+    , ('0xf20c38fcddf0c790319fd7431d17ea0c2bc9959c', 'Optimism', 'Optimism: Legacy Bridge')
+    , ('0xe681f80966a8b1ffadecf8068bd6f99034791c95', 'Optimism', 'Optimism: Legacy Bridge')
+    , ('0xc51f137e19f1ae6944887388fd12b2b6dfd12594', 'Optimism', 'Synthetix: Legacy Optimism Bridge')
+    , ('0x10e6593cdda8c58a1d0f14c5164b376352a55f2f', 'Optimism', 'Optimism: DAI Bridge')
+    , ('0xaba2c5f108f7e820c049d5af70b16ac266c8f128', 'Optimism', 'Optimism: BITANT Bridge')
+    , ('0xc5b1ec605738ef73a4efc562274c1c0b6609cf59', 'Optimism', 'Optimism: dForce Bridge')
+    , ('0x045e507925d2e05d114534d0810a1abd94aca8d6', 'Optimism', 'Synthetix: Legacy L2 Bridge')
+    , ('0x467194771dae2967aef3ecbedd3bf9a310c76c65', 'Optimism', 'Optimism: DAI L1 Escrow')
+
     ) AS x (address, bridge_name, description)

--- a/models/addresses/ethereum/addresses_ethereum_l2_batch_submitters.sql
+++ b/models/addresses/ethereum/addresses_ethereum_l2_batch_submitters.sql
@@ -15,12 +15,10 @@ FROM (VALUES
       ,('0x6887246668a3b87f54deb3b94ba47a6f63f32985', 'Optimism', 'Canonical Transaction Chain','from_address','','Optimism: Sequencer')
       ,('0xe969c2724d2448f1d1a6189d3e2aa1f37d5998c1', 'Optimism', 'State Commitment Chain','from_address','','Optimism: State Root Proposer')
    
-
       ,('0xa4b10ac61e79ea1e150df70b8dda53391928fd14', 'Arbitrum','SequencerInbox','from_address','','Arbitrum: Sequencer')
       ,('0xcce5c6cff61c49b4d53dd6024f8295f3c5230513', 'Arbitrum','SequencerInbox','from_address','','Arbitrum: Sequencer 2')
       ,('0x4c6f947ae67f572afa4ae0730947de7c874f95ef', 'Arbitrum','SequencerInbox','to_address','1','Arbitrum: Old Sequencer Inbox')
-      ,('0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6', 'Arbitrum','SequencerInbox','to_address','2','Arbitrum: Sequencer Inbox')
-
+      ,('0x1c479675ad559dc151f6ec7ed3fbf8cee79582b6', 'Arbitrum','SequencerInbox','to_address','2','Arbitrum: Sequencer Inbox')
 
       ,('0xfa46908b587f9102e81ce6c43b7b41b52881c57f', 'Boba', 'Canonical Transaction Chain','from_address','2','')
       ,('0x702ad5c5fb87aace54978143a707d565853d6fd5', 'Boba', 'Canonical Transaction Chain','from_address','','')
@@ -32,7 +30,5 @@ FROM (VALUES
       ,('0x56a76bcc92361f6df8d75476fed8843edc70e1c9', 'Metis', 'Canonical Transaction Chain','to_address','1','')
       ,('0x6a1db7d799fba381f2a518ca859ed30cb8e1d41a', 'Metis', 'Canonical Transaction Chain','to_address','2','')
       ,('0xf209815e595cdf3ed0aaf9665b1772e608ab9380', 'Metis', 'State Commitment Chain','to_address','','')
-
-      
 
     ) AS x (address, protocol_name, submitter_type, role_type, version, description)

--- a/models/addresses/ethereum/addresses_ethereum_l2_batch_submitters.sql
+++ b/models/addresses/ethereum/addresses_ethereum_l2_batch_submitters.sql
@@ -1,0 +1,38 @@
+{{ config(alias='l2_batch_submitters',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "sector",
+                                    "addresses",
+                                    \'["msilb7"]\') }}') }}
+
+SELECT lower(address) AS address, protocol_name, submitter_type, role_type, version, description
+FROM (VALUES
+--Sourced from decoded contracts - some submitters may be missing. Please add any you notice are missing!
+       ('0x5e4e65926ba27467555eb562121fac00d24e9dd2', 'Optimism', 'Canonical Transaction Chain','to_address','2','Optimism: Canonical Transaction Chain')
+      ,('0xbe5dab4a2e9cd0f27300db4ab94bee3a233aeb19', 'Optimism', 'State Commitment Chain','to_address','2','Optimism: State Commitment Chain')
+      ,('0x4bf681894abec828b212c906082b444ceb2f6cf6', 'Optimism', 'Canonical Transaction Chain','to_address','1','Optimism: OVM Canonical Transaction Chain')
+      ,('0x473300df21d047806a082244b417f96b32f13a33', 'Optimism', 'State Commitment Chain','to_address','1','Optimism: OVM State Commitment Chain')
+      
+      ,('0x6887246668a3b87f54deb3b94ba47a6f63f32985', 'Optimism', 'Canonical Transaction Chain','from_address','','Optimism: Sequencer')
+      ,('0xe969c2724d2448f1d1a6189d3e2aa1f37d5998c1', 'Optimism', 'State Commitment Chain','from_address','','Optimism: State Root Proposer')
+   
+
+      ,('0xa4b10ac61e79ea1e150df70b8dda53391928fd14', 'Arbitrum','SequencerInbox','from_address','','Arbitrum: Sequencer')
+      ,('0xcce5c6cff61c49b4d53dd6024f8295f3c5230513', 'Arbitrum','SequencerInbox','from_address','','Arbitrum: Sequencer 2')
+      ,('0x4c6f947ae67f572afa4ae0730947de7c874f95ef', 'Arbitrum','SequencerInbox','to_address','1','Arbitrum: Old Sequencer Inbox')
+      ,('0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6', 'Arbitrum','SequencerInbox','to_address','2','Arbitrum: Sequencer Inbox')
+
+
+      ,('0xfa46908b587f9102e81ce6c43b7b41b52881c57f', 'Boba', 'Canonical Transaction Chain','from_address','2','')
+      ,('0x702ad5c5fb87aace54978143a707d565853d6fd5', 'Boba', 'Canonical Transaction Chain','from_address','','')
+      ,('0xfbd2541e316948b259264c02f370ed088e04c3db', 'Boba', 'Canonical Transaction Chain','to_address','2','')
+      ,('0x4b5d9e5a6b1a514eba15a2f949531dccd7c272f2', 'Boba', 'Canonical Transaction Chain','to_address','1','')
+
+      ,('0xcdf02971871b7736874e20b8487c019d28090019', 'Metis', 'Canonical Transaction Chain','from_address','','')
+      ,('0x9cb01d516d930ef49591a05b09e0d33e6286689d', 'Metis', 'State Commitment Chain','from_address','','')
+      ,('0x56a76bcc92361f6df8d75476fed8843edc70e1c9', 'Metis', 'Canonical Transaction Chain','to_address','1','')
+      ,('0x6a1db7d799fba381f2a518ca859ed30cb8e1d41a', 'Metis', 'Canonical Transaction Chain','to_address','2','')
+      ,('0xf209815e595cdf3ed0aaf9665b1772e608ab9380', 'Metis', 'State Commitment Chain','to_address','','')
+
+      
+
+    ) AS x (address, protocol_name, submitter_type, role_type, version, description)

--- a/models/addresses/ethereum/addresses_ethereum_schema.yml
+++ b/models/addresses/ethereum/addresses_ethereum_schema.yml
@@ -68,7 +68,6 @@ models:
       tags: ['table', 'L2', 'batch submitters', 'addresses', 'ethereum']
     description: "Known L2 Batch Submitter Addresses"
     columns:
-      address, protocol_name, submitter_type, role_type, version, description
       - name: address
         description: "Address of known L2 Batch Submitter"
       - name: protocol_name

--- a/models/addresses/ethereum/addresses_ethereum_schema.yml
+++ b/models/addresses/ethereum/addresses_ethereum_schema.yml
@@ -57,3 +57,27 @@ models:
         description: "Contract address of OFAC sanctioned currency"
       - name: currency_name
         description: "Currency symbol of OFAC sanctioned currency"
+  
+  - name: addresses_ethereum_l2_batch_submitters
+    meta:
+      blockchain: ethereum
+      sector: l2_batch_submitters
+      project: addresses
+      contibutors: msilb7
+    config:
+      tags: ['table', 'L2', 'batch submitters', 'addresses', 'ethereum']
+    description: "Known L2 Batch Submitter Addresses"
+    columns:
+      address, protocol_name, submitter_type, role_type, version, description
+      - name: address
+        description: "Address of known L2 Batch Submitter"
+      - name: protocol_name
+        description: "Protocol Name"
+      - name: submitter_type
+        description: "Submitter Type (i.e. state vs transaction batch)"
+      - name: role_type
+        description: "Batch sender (from_address) or receiver (to_address)"
+      - name: version
+        description: "Version of the batch submitter"
+      - name: description
+        description: "Additional descriptiors of the address"

--- a/models/addresses/optimism/addresses_optimism_cex.sql
+++ b/models/addresses/optimism/addresses_optimism_cex.sql
@@ -1,0 +1,34 @@
+{{config(alias='cex',
+        post_hook='{{ expose_spells(\'["optimism"]\',
+                                    "sector",
+                                    "addresses",
+                                    \'["msilb7"]\') }}')}}
+
+SELECT LOWER(address) AS address, cex_name, distinct_name
+FROM (VALUES
+     ('0x88880809d6345119ccabe8a9015e4b1309456990','Juno','Juno 1')
+    ,('0x5122e9aa635c13afd2fc31de3953e0896bac7ab4','Coinbase','Coinbase 1') --from source
+    ,('0xf491d040110384dbcf7f241ffe2a546513fd873d','Coinbase','Coinbase 2') --from source
+    ,('0xd839c179a4606f46abd7a757f7bb77d7593ae249','Coinbase','Coinbase 3') --from source
+    ,('0xc8373edfad6d5c5f600b6b2507f78431c5271ff5','Coinbase','Coinbase 4') --from source
+    ,('0xdfd76bbfeb9eb8322f3696d3567e03f894c40d6c','Coinbase','Coinbase 5') --from source
+    ,('0xebb8ea128bbdff9a1780a4902a9380022371d466','KuCoin','KuCoin 1') --verified
+    ,('0xd6216fc19db775df9774a6e33526131da7d19a2c', 'KuCoin', 'KuCoin 2') -- verified
+    ,('0xf977814e90da44bfa03b6295a0616a897441acec','Binance','Binance 1')
+    ,('0x43c5b1c2be8ef194a509cf93eb1ab3dbd07b97ed','Binance','Binance 2') -- not confirmed. suspected via on-chain tracing
+    ,('0xacd03d601e5bb1b275bb94076ff46ed9d753435a','Binance','Binance 3') -- etherscan
+    ,('0x66f791456b82921cbc3f89a98c24ea21784973a1', 'Binance', 'Binance 4') -- verified
+    ,('0xf2de20dbf4b224af77aa4ff446f43318800bd6b4', 'Binance', 'Binance 5') -- verified
+    ,('0x7ab33ad1e91ddf6d5edf69a79d5d97a9c49015d4', 'Binance', 'Binance 6') -- verified
+    ,('0x4d072a68d0428a9a3054e03ad7ee61c557b537ab', 'Binance', 'Binance 7') -- verified
+    ,('0xc3c8e0a39769e2308869f7461364ca48155d1d9e', 'Binance', 'Binance 8') -- verified
+    ,('0x1763f1a93815ee6e6bc3c4475d31cc9570716db2', 'Binance', 'Binance 9') -- verified
+    ,('0x972bed5493f7e7bdc760265fbb4d8e73ea89e453', 'Binance', 'Binance 10') -- verified
+    ,('0x79fafb8ef911804ebedfd35ed888a69cd183f79c', 'Binance', 'Binance 11') -- verified
+    ,('0x36b06e0b929f40365eebaa81ef25edfcc624a0df', 'Binance', 'Binance 12') -- verified
+    ,('0x1bf7f994cf93c4eaab5f785d712668e2d6fff9d6', 'Binance', 'Binance 13') -- verified
+    ,('0xb22ffd456ab4efc3863be8299f4a404d813b92be', 'Binance', 'Binance 14') -- verified
+    ,('0xef7fb88f709ac6148c07d070bc71d252e8e13b92', 'Binance', 'Binance 15') --seems likely
+    
+   
+    ) AS x (address, cex_name, distinct_name)

--- a/models/addresses/optimism/addresses_optimism_schema.yml
+++ b/models/addresses/optimism/addresses_optimism_schema.yml
@@ -31,3 +31,20 @@ models:
         description: "Overlap Bonus"
       - name: total_op_eligible_to_claim
         description: "Total $OP tokens eligible to claim"
+        
+  - name: addresses_ethereum_cex
+    meta:
+      blockchain: optimism
+      sector: cex
+      project: addresses
+      contibutors: msilb7
+    config:
+      tags: ['table', 'cex', 'addresses', 'optimism']
+    description: "Known centralized exchange and on-ramp addresses"
+    columns:
+      - name: address
+        description: "Address of known CEX/On-Ramp"
+      - name: cex_name
+        description: "Name of centralized exchange/ on-ramp"
+      - name: distinct_name
+        description: "Distinct name of centralized exchange / on-ramp address"

--- a/models/addresses/optimism/addresses_optimism_schema.yml
+++ b/models/addresses/optimism/addresses_optimism_schema.yml
@@ -31,8 +31,8 @@ models:
         description: "Overlap Bonus"
       - name: total_op_eligible_to_claim
         description: "Total $OP tokens eligible to claim"
-        
-  - name: addresses_ethereum_cex
+
+  - name: addresses_optimism_cex
     meta:
       blockchain: optimism
       sector: cex

--- a/models/labels/cex/labels_cex.sql
+++ b/models/labels/cex/labels_cex.sql
@@ -6,5 +6,5 @@ UNION All
 
 -- add address list from CEXs
 SELECT 
-array("optimism"), address, distinct_name, 'cex', 'msilb7','2022-10-10'::timestamp,now()
+array("optimism"), address, distinct_name, 'cex', 'msilb7','static','2022-10-10'::timestamp,now()
 FROM {{ ref('addresses_optimism_cex') }}

--- a/models/labels/cex/labels_cex.sql
+++ b/models/labels/cex/labels_cex.sql
@@ -1,3 +1,10 @@
 {{config(alias='cex')}}
 
 SELECT * FROM {{ ref('labels_cex_ethereum') }}
+
+UNION All
+
+-- add address list from CEXs
+SELECT 
+array("optimism"), address, distinct_name, 'cex', 'msilb7','2022-10-10'::timestamp,now()
+FROM {{ ref('addresses_optimism_cex') }}


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Added Bridges and CEXs to the addresses folder

Did a union to get them in to the labels database, but may be weird. Want to avoid two difference lists / sources + the labels having "CEX + Number" feels unusable vs the CEX addresses table (i.e. I want to know if an address is Binance, I don't care if it's Binance 4).

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
