### PR TITLE
[Polygon Seaport] pull price from event table not call table

### DIFF
--- a/deprecated-dune-v1-abstractions/polygon/seaport/insert_transactions.sql
+++ b/deprecated-dune-v1-abstractions/polygon/seaport/insert_transactions.sql
@@ -316,11 +316,11 @@ with p1_call as (
           ,max(offer_order_type) as offer_order_type
           ,max(offer_identifier) as nft_token_id
           ,count(evt_tx_hash) as nft_transfer_cnt
-          ,max(price_token) as price_token
-          ,max(price_item_type) as price_item_type
-          ,sum(price_amount) as price_amount
-          ,sum(fee_amount) as fee_amount
-          ,sum(royalty_amount) as royalty_amount
+          ,max(evt_price_token) as price_token
+          ,max(evt_price_item_type) as price_item_type
+          ,sum(evt_price_amount) as price_amount
+          ,sum(evt_fee_amount) as fee_amount
+          ,sum(evt_royalty_amount) as royalty_amount
           ,sum(evt_price_amount) as evt_price_amount
           ,sum(evt_fee_amount) as evt_fee_amount
           ,sum(evt_royalty_amount) as evt_royalty_amount
@@ -338,9 +338,9 @@ with p1_call as (
           ,count(1) as attempt_cnt
           ,count(evt_tx_hash) as trade_cnt
           ,count(1) - count(evt_tx_hash) as revert_cnt
-          ,coalesce(sum(coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0)),0) as attempt_amount
-          ,coalesce(sum(case when evt_tx_hash is not null then coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) end),0) as trade_amount
-          ,coalesce(sum(case when evt_tx_hash is null then coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) end),0) as revert_amount
+          ,coalesce(sum(coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0)),0) as attempt_amount
+          ,coalesce(sum(case when evt_tx_hash is not null then coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) end),0) as trade_amount
+          ,coalesce(sum(case when evt_tx_hash is null then coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) end),0) as revert_amount
           ,count(case when offer_item_type = '2' then evt_token_amount end) as erc721_transfer_count 
           ,count(case when offer_item_type = '3' then evt_token_amount end) as erc1155_transfer_count 
           ,count(case when offer_item_type in ('2','3') then evt_token_amount end) as nft_transfer_count 

--- a/deprecated-dune-v1-abstractions/polygon/seaport/insert_transactions.sql
+++ b/deprecated-dune-v1-abstractions/polygon/seaport/insert_transactions.sql
@@ -848,13 +848,14 @@ $function$
 ;
 
 -- backfill
-SELECT seaport.insert_transactions('2022-07-01', (SELECT current_timestamp - interval '20 minutes'));
+delete from seaport.transactions where block_time >= '2022-10-01';
+SELECT seaport.insert_transactions('2022-10-01', (SELECT current_timestamp - interval '20 minutes'));
 
--- cronjob
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/20 * * * *', 
-$$SELECT seaport.insert_transactions((SELECT date_trunc('day',MAX(block_time)) FROM seaport.transactions)
-                                            ,(SELECT current_timestamp - interval '20 minutes'));$$
-       )
-ON CONFLICT (command) 
-DO UPDATE SET schedule=EXCLUDED.schedule;
+-- -- cronjob
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/20 * * * *', 
+-- $$SELECT seaport.insert_transactions((SELECT date_trunc('day',MAX(block_time)) FROM seaport.transactions)
+--                                             ,(SELECT current_timestamp - interval '20 minutes'));$$
+--        )
+-- ON CONFLICT (command) 
+-- DO UPDATE SET schedule=EXCLUDED.schedule;

--- a/deprecated-dune-v1-abstractions/polygon/seaport/insert_transfers.sql
+++ b/deprecated-dune-v1-abstractions/polygon/seaport/insert_transfers.sql
@@ -315,11 +315,11 @@ with p1_call as (
           ,offer_item_type as offer_item_type
           ,offer_order_type as offer_order_type
           ,offer_identifier as nft_token_id_dcnt
-          ,price_token as price_token
-          ,price_item_type as price_item_type
-          ,price_amount as price_amount
-          ,fee_amount as fee_amount
-          ,royalty_amount as royalty_amount
+          ,evt_price_token as price_token
+          ,evt_price_item_type as price_item_type
+          ,evt_price_amount as price_amount
+          ,evt_fee_amount as fee_amount
+          ,evt_royalty_amount as royalty_amount
           ,evt_token_amount as evt_token_amount
           ,evt_price_amount as evt_price_amount
           ,evt_fee_amount as evt_fee_amount
@@ -328,9 +328,9 @@ with p1_call as (
           ,evt_royalty_token as evt_royalty_token
           ,evt_fee_recipient as evt_fee_recipient
           ,evt_royalty_recipient as evt_royalty_recipient
-          ,coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) as attempt_amount
-          ,case when evt_tx_hash is not null then coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) end as trade_amount
-          ,case when evt_tx_hash is null then coalesce(price_amount,0) + coalesce(fee_amount,0) + coalesce(royalty_amount,0) else 0 end as revert_amount
+          ,coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) as attempt_amount
+          ,case when evt_tx_hash is not null then coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) end as trade_amount
+          ,case when evt_tx_hash is null then coalesce(evt_price_amount,0) + coalesce(evt_fee_amount,0) + coalesce(evt_royalty_amount,0) else 0 end as revert_amount
           ,case when evt_tx_hash is null then true else false end as reverted
           ,'Bulk Purchase' as trade_type
           ,'Bulk Purchase' as order_type

--- a/deprecated-dune-v1-abstractions/polygon/seaport/insert_transfers.sql
+++ b/deprecated-dune-v1-abstractions/polygon/seaport/insert_transfers.sql
@@ -822,13 +822,14 @@ $function$
 ;
 
 -- backfill
-SELECT seaport.insert_transfers('2022-07-01', (SELECT current_timestamp - interval '20 minutes'));
+delete from seaport.transfers where block_time >= '2022-10-01';
+SELECT seaport.insert_transfers('2022-10-01', (SELECT current_timestamp - interval '20 minutes'));
 
--- cronjob
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/20 * * * *', 
-$$SELECT seaport.insert_transfers((SELECT date_trunc('day',MAX(block_time)) FROM seaport.transfers)
-                                            ,(SELECT current_timestamp - interval '20 minutes'));$$
-       )
-ON CONFLICT (command) 
-DO UPDATE SET schedule=EXCLUDED.schedule;
+-- -- cronjob
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/20 * * * *', 
+-- $$SELECT seaport.insert_transfers((SELECT date_trunc('day',MAX(block_time)) FROM seaport.transfers)
+--                                             ,(SELECT current_timestamp - interval '20 minutes'));$$
+--        )
+-- ON CONFLICT (command) 
+-- DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
Brief comments on the purpose of your changes:

related PR : https://github.com/duneanalytics/spellbook/pull/1715
apply this patch to Seaport on polygon as well 

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
