### PR TITLE
Identify Gem-routed Sudoswap NFT trades

### DIFF
--- a/models/sudoswap/ethereum/sudoswap_ethereum_events.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_events.sql
@@ -291,7 +291,7 @@ WITH
         SELECT
             sc.*
             , tokens.name AS collection
-            , agg.name as aggregator_name
+            , case when right(ett.input, 8)='72db8c0b' then 'Gem' else agg.name end as aggregator_name
             , agg.contract_address as aggregator_address
             , sc.amount_original*pu.price as amount_usd
             , sc.pool_fee_amount*pu.price as pool_fee_amount_usd
@@ -307,6 +307,8 @@ WITH
             {% if not is_incremental() %}
             AND tx.block_time >= '2022-4-1'
             {% endif %}
+        LEFT JOIN {{ source('ethereum','traces') }} ett
+            ON sc.block_number = ett.block_number AND sc.tx_hash = ett.tx_hash AND right(ett.input, 8)='72db8c0b'
         LEFT JOIN {{ source('prices', 'usd') }} pu ON pu.blockchain='ethereum'
             AND date_trunc('minute', pu.minute)=date_trunc('minute', sc.block_time)
             AND symbol = 'WETH'


### PR DESCRIPTION
Brief comments on the purpose of your changes:

See here from vasa from gem.xyz: https://twitter.com/vasa_develop/status/1579830106067202049?s=20&t=HiJh9TmZmceCklyV8xbyQg

*For Dune Engine V2*
I've checked that:
General checks:
* [X] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [X] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [X] if adding a new model, I added a test
* [X] the filename is unique and ends with .sql
* [X] each sql file is a select statement and has only one view, table or function defined  
* [X] column names are `lowercase_snake_cased`
* [X] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [X] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [X] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [X] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [X] where block_time >= date_trunc("day", now() - interval '1 week')
* [X] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [X] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
