### PR TITLE
Add ETH Prices Table

### DIFF
--- a/models/prices/prices_eth.sql
+++ b/models/prices/prices_eth.sql
@@ -27,7 +27,6 @@ FROM (
     {% if is_incremental() %}
     WHERE minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-    GROUP BY blockchain, contract_address
     ) pusd
 INNER JOIN {{ source('prices', 'usd') }} peth
     ON peth.blockchain IS NULL

--- a/models/prices/prices_eth.sql
+++ b/models/prices/prices_eth.sql
@@ -1,0 +1,40 @@
+{{ config(
+        schema='prices',
+        alias ='prices_eth',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        post_hook='{{ expose_spells(\'["ethereum", "solana", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c"]\',
+                                    "sector",
+                                    "prices",
+                                    \'["msilb7"]\') }}'
+        )
+}}
+
+SELECT
+  pusd.blockchain
+, pusd.contract_address
+, pusd.decimals
+, pusd.minute
+, pusd.price / peth.price AS price_eth
+, pusd.symbol
+FROM (
+    SELECT blockchain
+    , contract_address
+    , minute
+    , price
+    FROM {{ source('prices', 'usd') }}
+    {% if is_incremental() %}
+    WHERE minute >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
+    GROUP BY blockchain, contract_address
+    ) pusd
+INNER JOIN {{ source('prices', 'usd') }} peth
+    ON peth.blockchain IS NULL
+    AND peth.symbol = 'ETH'
+    AND peth.minute= pusd.minute
+
+{% if is_incremental() %}
+WHERE peth.minute >= date_trunc("day", now() - interval '1 week')
+{% endif %}
+

--- a/models/prices/prices_eth.sql
+++ b/models/prices/prices_eth.sql
@@ -23,6 +23,8 @@ FROM (
     , contract_address
     , minute
     , price
+    , decimals
+    , symbol
     FROM {{ source('prices', 'usd') }}
     {% if is_incremental() %}
     WHERE minute >= date_trunc("day", now() - interval '1 week')

--- a/models/prices/prices_eth_latest.sql
+++ b/models/prices/prices_eth_latest.sql
@@ -1,0 +1,27 @@
+{{ config(
+        schema='prices',
+        alias ='eth_latest',
+        post_hook='{{ expose_spells(\'["ethereum", "solana", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c"]\',
+                                    "sector",
+                                    "prices",
+                                    \'["msilb7"]\') }}'
+        )
+}}
+
+SELECT pu.blockchain
+, pu.contract_address
+, pu.decimals
+, pu.minute
+, pu.price_eth
+, pu.symbol
+FROM (
+    SELECT blockchain
+    , contract_address
+    , MAX(minute) AS latest
+    FROM {{ ref('prices_eth') }}
+    GROUP BY blockchain, contract_address
+    ) latest
+LEFT JOIN {{ ref('prices_eth') }} pu ON pu.blockchain=latest.blockchain
+    AND pu.contract_address=latest.contract_address
+    AND pu.minute=latest.latest
+

--- a/models/prices/prices_schema.yml
+++ b/models/prices/prices_schema.yml
@@ -38,3 +38,39 @@ models:
         description: "Token symbol"
       - name: price
         description: "USD price of a token"
+  - name: prices_eth
+    meta:
+      sector: prices
+      contributors: msilb7
+    config:
+      tags: ['prices', 'eth', 'latest']
+    description: "Token prices in ETH"
+    columns:
+      - name: minute
+        description: "UTC event block time truncated to the minute mark"
+      - name: blockchain
+        description: "Native blockchain of the token"
+      - name: contract_address
+        description: "Contract address of the token"
+      - name: symbol
+        description: "Token symbol"
+      - name: price_eth
+        description: "ETH price of a token"
+  - name: prices_eth_latest
+    meta:
+      sector: prices
+      contributors: msilb7
+    config:
+      tags: ['prices', 'eth', 'latest']
+    description: "Latest prices table across blockchains in ETH"
+    columns:
+      - name: minute
+        description: "UTC event block time truncated to the minute mark"
+      - name: blockchain
+        description: "Native blockchain of the token"
+      - name: contract_address
+        description: "Contract address of the token"
+      - name: symbol
+        description: "Token symbol"
+      - name: price
+        description: "ETH price of a token"


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Adding a version of USD Prices table to include ETH Prices.

Open Q: Should ETH price be a column in prices.usd or its own table?

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
