### PR TITLE
Seaportv1: Fix token_id and token_standard for events with token_id > 2**64

### DIFF
--- a/models/opensea/ethereum/opensea_v1_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v1_ethereum_events.sql
@@ -60,7 +60,6 @@ WHERE
 (addrs[3] = '0x5b3256965e7c3cf26e11fcaf296dfc8807c01073'
         OR addrs[10] = '0x5b3256965e7c3cf26e11fcaf296dfc8807c01073')
 AND call_success = true
--- AND call_block_number = 12395486 -- for debugging
 {% if is_incremental() %}
 AND call_block_time >= date_trunc("day", now() - interval '1 week')
 {% endif %}
@@ -111,7 +110,6 @@ erc_transfers as
         ELSE 'Trade' END AS evt_type,
         evt_index
         FROM {{ source('erc1155_ethereum','evt_transfersingle') }} erc1155
-		-- WHERE evt_block_number = 12395486 -- for debugging
         GROUP BY evt_tx_hash,value,id,evt_index, erc1155.from, erc1155.to
             UNION ALL
 SELECT evt_tx_hash,
@@ -127,7 +125,6 @@ SELECT evt_tx_hash,
         ELSE 'Trade' END AS evt_type,
         evt_index
         FROM {{ source('erc721_ethereum','evt_transfer') }} erc721
-		-- WHERE evt_block_number = 12395486 -- for debugging
         GROUP BY evt_tx_hash,tokenId,evt_index, erc721.from, erc721.to)
 
 SELECT DISTINCT
@@ -195,7 +192,6 @@ INNER JOIN {{ source('ethereum','transactions') }} tx ON wa.call_tx_hash = tx.ha
     {% if is_incremental() %}
     and tx.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-	-- and tx.block_number =  12395486 -- for debugging
 LEFT JOIN erc_transfers ON erc_transfers.evt_tx_hash = wa.call_tx_hash AND (wa.token_id = erc_transfers.token_id_erc
 OR wa.token_id = null)
 LEFT JOIN {{ ref('tokens_nft') }} tokens_nft ON tokens_nft.contract_address = wa.nft_contract_address and tokens_nft.blockchain = 'ethereum'


### PR DESCRIPTION
Brief comments on the purpose of your changes:
In seaport v1 for all events with token_id > 2**64 (including all Opensea Shared StoreFront events) the `token_id `and `token_standard` is wrong. This PR aims to fix that.

See chat with @soispoke: https://discord.com/channels/757637422384283659/757893948428517376/1031496427777576990 for more details, including detailed explaination.

*For Dune Engine V2*
I've checked that:
General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
