### PR TITLE
OP Contracts - Comment out Null

### DIFF
--- a/models/contracts/optimism/contracts_optimism_contract_creator_address_list.sql
+++ b/models/contracts/optimism/contracts_optimism_contract_creator_address_list.sql
@@ -137,7 +137,7 @@ from
     ,('0x8602ee2f8aaeb671e409b26d48e36dd8cc3b7ed7', 'ZipSwap')
     ,('0xf7c1daf7443d7307df13c81f5f0328d4c7803e7b', 'BoringDAO')
     ,('0x38e63793993ae54be374d129f34a3faf2c382e97', 'TokenFunder')
-    ,('0xbb6e024b9cffacb947a71991e386681b1cd1477d', 'NULL')
+--     ,('0xbb6e024b9cffacb947a71991e386681b1cd1477d', 'NULL')
     ,('0x512472840327530ea03cce6f58966b221f3a8b6a', 'Perpetual Protocol')
     ,('0x56cf1fa9185e42e90205e955e299f33b6204da59', 'DoraHacks')
     ,('0x6336cf6f9a7abb9efa86c04ac29541f015dd58b1', 'XmasBook')


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Small change, just commenting out one contract creator that was null, because we never want it mapped. But we don't want the project to show as "null."

Is there a good way to add a check to make sure that this address is never entered in the table? cc @chuxinh 

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
