### PR TITLE
remove STARL due to bad price feed

### DIFF
--- a/deprecated-dune-v1-abstractions/prices/ethereum/coinpaprika.yaml
+++ b/deprecated-dune-v1-abstractions/prices/ethereum/coinpaprika.yaml
@@ -1780,11 +1780,6 @@
   symbol: ARCH
   address: 0x1f3f9d3068568f8040775be2e8c03c103c61f3af
   decimals: 18
-- name: starl_starlink
-  id: starl-starlink
-  symbol: STARL
-  address: 0x8e6cd950ad6ba651f6dd608dc70e5886b1aa6b24
-  decimals: 18
 - name: torn_tornado_cash
   id: torn-tornado-cash
   symbol: TORN

--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -568,7 +568,6 @@ VALUES
     ("srm-serum", "ethereum", "SRM", "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff", 6),
     ("srn-sirin-labs-token", "ethereum", "SRN", "0x68d57c9a1c35f63e2c83ee8e49a64e9d70528d25", 18),
     ("stake-xdai-stake", "ethereum", "STAKE", "0x0ae055097c6d159879521c384f1d2123d1f195e6", 18),
-    ("starl-starlink", "ethereum", "STARL", "0x8e6cd950ad6ba651f6dd608dc70e5886b1aa6b24", 18),
     ("steth-lido-staked-ether", "ethereum", "stETH", "0xae7ab96520de3a18e5e111b5eaab095312d7fe84", 18),
     ("storj-storj", "ethereum", "STORJ", "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac", 8),
     ("stpt-stpt", "ethereum", "STPT", "0xde7d85157d9714eadf595045cc12ca4a5f3e2adb", 18),


### PR DESCRIPTION
This Price is WAY OFF on coin Paprika for the date October 17 (and continuing today).

CP is quoting 2.44$ but its far below 0.000

https://coinpaprika.com/coin/starl-starlink/

https://etherscan.io/token/0x8e6cd950ad6ba651f6dd608dc70e5886b1aa6b24

Here is an example trade from yesterday

https://etherscan.io/tx/0xaba68eef58a89ae4d740281d7565951488a38c633415e246cff645e63ffc75af


This is affecting Dex trades and all other exchange related metrics!

Should probably also run some script to purge the prices from the tables as well.
