### PR TITLE
update cron schedules

### DIFF
--- a/deprecated-dune-v1-abstractions/README.md
+++ b/deprecated-dune-v1-abstractions/README.md
@@ -21,7 +21,7 @@ Materialized view names should be prefxied by `view_`, same as normal views.
 Additionally, a materialized view must specify at what interval it should be refreshed. This is done by adding the following block to the end of the declaration:
 ```sql
 INSERT INTO cron.job(schedule, command)
-VALUES ('* 1 * * *', $$REFRESH MATERIALIZED VIEW CONCURRENTLY x.view_y$$)
+VALUES ('0 * * * *', $$REFRESH MATERIALIZED VIEW CONCURRENTLY x.view_y$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
 ```
 Note that the preferred way to refresh a materialized view is using the `CONCURRENTLY` keyword, and that this mandates the existence of a `UNIQUE` index on the materialized view. See more info [here](https://www.postgresql.org/docs/12/sql-refreshmaterializedview.html).
@@ -30,7 +30,7 @@ Note that the preferred way to refresh a materialized view is using the `CONCURR
 Tables are declared without any prefix in the name. If the table `x.y` needs to be periodically updated, the convention is to create a companion function `x.insert_y(from timestamptz, to timestamptz=now())`. It is then customary to do
 ```sql
 INSERT INTO cron.job (schedule, command)
-VALUES ('* 1 * * *', $$SELECT x.insert_y((SELECT max(block_time) - interval '1 days' FROM x.y));$$)
+VALUES ('0 * * * *', $$SELECT x.insert_y((SELECT max(block_time) - interval '1 days' FROM x.y));$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
 ```
 

--- a/deprecated-dune-v1-abstractions/ethereum/balancer_v2/view_bpt_prices.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/balancer_v2/view_bpt_prices.sql
@@ -61,6 +61,6 @@ CREATE MATERIALIZED VIEW balancer_v2.view_bpt_prices AS (
 CREATE UNIQUE INDEX IF NOT EXISTS dex_token_prices_unique ON balancer_v2.view_bpt_prices (hour, contract_address);
 
 INSERT INTO cron.job(schedule, command)
-VALUES ('* 1 * * *', $$REFRESH MATERIALIZED VIEW CONCURRENTLY balancer_v2.view_bpt_prices$$)
+VALUES ('0 * * * *', $$REFRESH MATERIALIZED VIEW CONCURRENTLY balancer_v2.view_bpt_prices$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
 COMMIT;

--- a/deprecated-dune-v1-abstractions/ethereum/dex/view_token_prices.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/dex/view_token_prices.sql
@@ -47,6 +47,6 @@ CREATE MATERIALIZED VIEW dex.view_token_prices AS (
 CREATE UNIQUE INDEX IF NOT EXISTS dex_token_prices_unique ON dex.view_token_prices (hour, contract_address);
 
 INSERT INTO cron.job(schedule, command)
-VALUES ('* 1 * * *', $$REFRESH MATERIALIZED VIEW CONCURRENTLY dex.view_token_prices$$)
+VALUES ('0 * * * *', $$REFRESH MATERIALIZED VIEW CONCURRENTLY dex.view_token_prices$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
 COMMIT;

--- a/deprecated-dune-v1-abstractions/ethereum/olympus/view_olympus_hourly_rebase.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/olympus/view_olympus_hourly_rebase.sql
@@ -128,5 +128,5 @@ CREATE INDEX IF NOT EXISTS "timestamp" ON olympus.olympus_hourly_rebase ("timest
 COMMIT;
 
 INSERT INTO cron.job(schedule, command)
-VALUES ('* 1 * * *', $$REFRESH MATERIALIZED VIEW CONCURRENTLY olympus.olympus_hourly_rebase$$)
+VALUES ('0 * * * *', $$REFRESH MATERIALIZED VIEW CONCURRENTLY olympus.olympus_hourly_rebase$$)
 ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;


### PR DESCRIPTION
We just realized that we blindly copied the sample `INSERT INTO cron.job` from the readme, but that example is a schedule that doesn't make much sense for the purposes of `view_bpt_prices` and `view_token_prices` ('* 1 * * *' = [“At every minute past hour 1”](https://crontab.guru/#*_1_*_*_*)). A more meaningful schedule is to perform hourly updates.

I believe someone made the same mistake when they created `view_olympus_hourly_rebase`, so I'm proposing to change the schedule there too.

And to avoid future mistakes like this, I'm proposing we apply the same change to the readme.