### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,5 +8,5 @@ repos:
   - id: check-script-ref-and-source
   - id: check-model-has-description
   - id: check-model-has-meta-keys
-    args: ['--meta-keys', 'blockchain', 'project', 'contributors', '--']
+    args: ['--meta-keys', 'blockchain', 'contributors', '--']
   - id: check-model-has-properties-file


### PR DESCRIPTION
Pre commit hook is looking for required keys under meta. But a spell can be project or sector. Removing that required key. 