### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,4 @@ repos:
   - id: dbt-compile
   - id: check-script-ref-and-source
   - id: check-model-has-description
-  - id: check-model-has-meta-keys
-    args: ['--meta-keys', 'blockchain', 'contributors', '--']
   - id: check-model-has-properties-file


### PR DESCRIPTION
this rule, check-model-has-meta-keys, doesn't allow extra keys by default. lets drop it until we have a more robust solution.

check-model-has-meta-keys
Ensures that the model has a list of valid meta keys. (usually schema.yml).

By default, it does not allow the model to have any other meta keys other than the ones required. An optional argument can be used to allow for extra keys.

Arguments
--manifest: location of manifest.json file. Usually target/manifest.json. This file contains a full representation of dbt project. Default: target/manifest.json
--meta-keys: list of the required keys in the meta part of the model.
--allow-extra-keys: whether extra keys are allowed. Default: False.