### PR TITLE
[easy] make ENS labels show emoji's

### DIFF
--- a/models/labels/ens/labels_ens.sql
+++ b/models/labels/ens/labels_ens.sql
@@ -15,7 +15,7 @@ FROM (
        SELECT
        array('ethereum') as blockchain,
        coalesce(rev.address, res.address) as address,
-       coalesce(rev.name, res.name) as name,
+       encode(coalesce(rev.name, res.name),'utf8') as name,
        'ENS' as category,
        '0xRob' as contributor,
        'query' AS source,


### PR DESCRIPTION
Encode ENS labels in 'utf8' so they show emoji's. :smile: 
This change is only done in the labels as we don't really want to change the internal datastring encodings of the ENS models.