### PR TITLE
[Dune v1] opensea zeroex patch for bytea converting

### DIFF
--- a/deprecated-dune-v1-abstractions/polygon/opensea/insert_trades.sql
+++ b/deprecated-dune-v1-abstractions/polygon/opensea/insert_trades.sql
@@ -13,14 +13,14 @@ with iv_raw as (
                 else 'erc721' -- 138
            end as erc_standard
           ,'Single Item Trade' as trade_type
-          ,(a."rightOrder"->>'makerAddress')::bytea as seller
-          ,(a."leftOrder"->>'makerAddress')::bytea as buyer
+          ,concat('\x',substr(a."rightOrder"->>'makerAddress',3,40))::bytea as seller
+          ,concat('\x',substr(a."leftOrder"->>'makerAddress',3,40))::bytea as buyer
           ,"paymentTokenAddress" as currency_contract
-          ,least("output_matchedFillResults"->'left'->'takerFeePaid', "output_matchedFillResults"->'right'->'makerFeePaid')::numeric as nft_item_count
-          ,least("output_matchedFillResults"->'left'->'makerFeePaid', "output_matchedFillResults"->'right'->'takerFeePaid')::numeric as original_amount_raw
-          ,("feeData"->0->>'recipient')::bytea as fee_receive_address
+          ,least("output_matchedFillResults"->'left'->>'takerFeePaid', "output_matchedFillResults"->'right'->>'makerFeePaid')::numeric as nft_item_count
+          ,least("output_matchedFillResults"->'left'->>'makerFeePaid', "output_matchedFillResults"->'right'->>'takerFeePaid')::numeric as original_amount_raw
+          ,concat('\x',substr("feeData"->0->>'recipient',3,40))::bytea as fee_receive_address
           ,("feeData"->0->>'paymentTokenAmount')::numeric as fee_amount_raw
-          ,("feeData"->1->>'recipient')::bytea as royalty_receive_address
+          ,concat('\x',substr("feeData"->1->>'recipient',3,40))::bytea as royalty_receive_address
           ,("feeData"->1->>'paymentTokenAmount')::numeric as royalty_amount_raw
           ,a.call_tx_hash as tx_hash
           ,a.call_block_number as block_number


### PR DESCRIPTION
Brief comments on the purpose of your changes:

for Dune v1
OpenSea Zeroex contract patch for `bytea` converting

Below columns are not converted properly
- `seller`, `buyer`, `fee_receive_address`, `royalty_receive_address`

FYI:
- Zeroex contract were terminated after Seaport contract launch, but want to correct and backfill for data consistency. (entire period)
- requested by [cbrown#3077](https://discord.com/channels/757637422384283659/757893948428517376/1031272142702129282)

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
