### PR TITLE
Blur - Fix for when buyer or seller is aggregator 

### DIFF
--- a/models/blur/ethereum/blur_ethereum_events.sql
+++ b/models/blur/ethereum/blur_ethereum_events.sql
@@ -27,10 +27,10 @@ SELECT 'ethereum' AS blockchain
     END AS trade_type
 , get_json_object(bm.buy, '$.amount') AS number_of_items
 , 'Trade' AS evt_type
-, get_json_object(bm.sell, '$.trader') AS seller
-, get_json_object(bm.buy, '$.trader') AS buyer
-, CASE WHEN et.from=get_json_object(bm.sell, '$.trader') THEN 'Offer Accepted'
-    ELSE 'Buy'
+, COALESCE(taker_fix.from, get_json_object(bm.sell, '$.trader')) AS seller
+, COALESCE(maker_fix.to, get_json_object(bm.buy, '$.trader')) AS buyer
+, CASE WHEN et.from=maker_fix.to OR et.from=get_json_object(bm.buy, '$.trader') THEN 'Buy'
+    ELSE 'Offer Accepted'
     END AS trade_category
 , get_json_object(bm.buy, '$.price') AS amount_raw
 , CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN get_json_object(bm.buy, '$.price')/POWER(10, 18)
@@ -68,7 +68,7 @@ SELECT 'ethereum' AS blockchain
 , CASE WHEN get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.recipient') IS NOT NULL AND get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN 'ETH'
     WHEN get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.recipient') IS NOT NULL THEN pu.symbol
     END AS royalty_fee_currency_symbol
-,  'ethereum-blur-v1' || bm.evt_tx_hash || '-' || get_json_object(bm.sell, '$.trader') || '-' || get_json_object(bm.buy, '$.trader') || '-' || get_json_object(bm.buy, '$.collection') || '-' || get_json_object(bm.buy, '$.tokenId') AS unique_trade_id
+,  'ethereum-blur-v1' || bm.evt_tx_hash || '-' || COALESCE(taker_fix.from, get_json_object(bm.sell, '$.trader')) || '-' || COALESCE(maker_fix.to, get_json_object(bm.buy, '$.trader')) || '-' || get_json_object(bm.buy, '$.collection') || '-' || get_json_object(bm.buy, '$.tokenId') AS unique_trade_id
 FROM {{ source('blur_ethereum','BlurExchange_evt_OrdersMatched') }} bm
 LEFT JOIN {{ source('ethereum','transactions') }} et ON et.block_time=bm.evt_block_time
     AND et.hash=bm.evt_tx_hash
@@ -91,6 +91,22 @@ LEFT JOIN {{ source('erc721_ethereum','evt_transfer') }} erct ON erct.evt_block_
     AND erct.from=get_json_object(bm.sell, '$.trader')
     {% if is_incremental() %}
     AND erct.evt_block_time >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
+LEFT JOIN {{ source('erc721_ethereum','evt_transfer') }} maker_fix ON maker_fix.evt_block_time=bm.evt_block_time
+    AND get_json_object(bm.buy, '$.collection')=maker_fix.contract_address
+    AND maker_fix.evt_tx_hash=bm.evt_tx_hash
+    AND get_json_object(bm.buy, '$.tokenId')=maker_fix.tokenId
+    AND maker_fix.from=agg.contract_address
+    {% if is_incremental() %}
+    AND maker_fix.evt_block_time >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
+LEFT JOIN {{ source('erc721_ethereum','evt_transfer') }} taker_fix ON taker_fix.evt_block_time=bm.evt_block_time
+    AND get_json_object(bm.buy, '$.collection')=taker_fix.contract_address
+    AND taker_fix.evt_tx_hash=bm.evt_tx_hash
+    AND get_json_object(bm.buy, '$.tokenId')=taker_fix.tokenId
+    AND taker_fix.to=agg.contract_address
+    {% if is_incremental() %}
+    AND taker_fix.evt_block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
 {% if is_incremental() %}
 WHERE bm.evt_block_time >= date_trunc("day", now() - interval '1 week')


### PR DESCRIPTION
Brief comments on the purpose of your changes:
 
Buyer/seller is sometimes the address of the aggregator used for routing, this PR fixes this issue. Same fix as this one from 2d ago for OpenSea, LooksRare & X2Y2: https://github.com/duneanalytics/spellbook/pull/1536

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
