### PR TITLE
Making nft tables' trade_category more consistent

### DIFF
--- a/models/archipelago/ethereum/archipelago_ethereum_events.sql
+++ b/models/archipelago/ethereum/archipelago_ethereum_events.sql
@@ -202,7 +202,7 @@ SELECT
     , token_standard
     , 1 as number_of_items
     , 'Single Item Trade' as trade_type
-    , case when tx_from = seller then 'Sell' else 'Buy' end as trade_category
+    , case when tx_from = seller then 'Offer Accepted' else 'Buy' end as trade_category
     , 'Trade' as evt_type
     , seller
     , buyer

--- a/models/element/avalanche_c/element_avalanche_c_events.sql
+++ b/models/element/avalanche_c/element_avalanche_c_events.sql
@@ -19,7 +19,7 @@ WITH element_txs AS (
         , 'erc721' AS token_standard
         , 'Single Item Trade' AS trade_type
         , 1 AS number_of_items
-        , 'Sell' AS trade_category
+        , 'Offer Accepted' AS trade_category
         , ee.maker AS seller
         , ee.taker AS buyer
         , ee.erc20TokenAmount AS amount_raw
@@ -73,7 +73,7 @@ WITH element_txs AS (
         , 'erc1155' AS token_standard
         , 'Single Item Trade' AS trade_type
         , 1 AS number_of_items
-        , 'Sell' AS trade_category
+        , 'Offer Accepted' AS trade_category
         , ee.maker AS seller
         , ee.taker AS buyer
         , ee.erc20FillAmount AS amount_raw

--- a/models/element/bnb/element_bnb_events.sql
+++ b/models/element/bnb/element_bnb_events.sql
@@ -19,7 +19,7 @@ WITH element_txs AS (
         , 'erc721' AS token_standard
         , 'Single Item Trade' AS trade_type
         , 1 AS number_of_items
-        , 'Sell' AS trade_category
+        , 'Offer Accepted' AS trade_category
         , ee.maker AS seller
         , ee.taker AS buyer
         , ee.erc20TokenAmount AS amount_raw
@@ -73,7 +73,7 @@ WITH element_txs AS (
         , 'erc1155' AS token_standard
         , 'Single Item Trade' AS trade_type
         , 1 AS number_of_items
-        , 'Sell' AS trade_category
+        , 'Offer Accepted' AS trade_category
         , ee.maker AS seller
         , ee.taker AS buyer
         , ee.erc20FillAmount AS amount_raw

--- a/models/element/ethereum/element_ethereum_events.sql
+++ b/models/element/ethereum/element_ethereum_events.sql
@@ -19,7 +19,7 @@ WITH element_txs AS (
         , 'erc721' AS token_standard
         , 'Single Item Trade' AS trade_type
         , 1 AS number_of_items
-        , 'Sell' AS trade_category
+        , 'Offer Accepted' AS trade_category
         , ee.maker AS seller
         , ee.taker AS buyer
         , ee.erc20TokenAmount AS amount_raw
@@ -73,7 +73,7 @@ WITH element_txs AS (
         , 'erc1155' AS token_standard
         , 'Single Item Trade' AS trade_type
         , 1 AS number_of_items
-        , 'Sell' AS trade_category
+        , 'Offer Accepted' AS trade_category
         , ee.maker AS seller
         , ee.taker AS buyer
         , ee.erc20FillAmount AS amount_raw

--- a/models/seaport/ethereum/seaport_ethereum_view_transactions.sql
+++ b/models/seaport/ethereum/seaport_ethereum_view_transactions.sql
@@ -246,23 +246,23 @@ with iv_availadv as (
           ,a.fee_amount / power(10, e2.decimals) as fee_amount
           ,a.fee_amount / power(10, e2.decimals) * p2.price as fee_usd_amount
           ,a.zone as zone_address
-          ,case when spc1.call_tx_hash is not null then 'Auction'
-                when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 16 and 23 then 'Auction'
+          ,case when spc1.call_tx_hash is not null then 'Auction Settled'
+                when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 16 and 23 then 'Auction Settled'
                 when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 0 and 7 then 'Buy'
                 when spc2.call_tx_hash is not null then 'Buy'
-                when spc3.call_tx_hash is not null and spc3.advancedOrder:parameters:consideration[0]:identifierOrCriteria > '0' then 'Trait Offer'
-                when spc3.call_tx_hash is not null then 'Collection Offer'
-                else 'Private Sales'
+                when spc3.call_tx_hash is not null and spc3.advancedOrder:parameters:consideration[0]:identifierOrCriteria > '0' then 'Trait Offer Accepted'
+                when spc3.call_tx_hash is not null then 'Collection Offer Accepted'
+                else 'Private Sale'
            end as category          
-          ,case when spc1.call_tx_hash is not null then 'Collection/Trait Offers' -- include English Auction and Dutch Auction
+          ,case when spc1.call_tx_hash is not null then 'Collection/Trait Offer Accepted' -- include English Auction and Dutch Auction
                 when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 0 and 15 then 'Buy' -- Buy it directly
-                when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 16 and 23 and spc2.parameters:considerationIdentifier = a.nft_token_id then 'Individual Offer'
+                when spc2.call_tx_hash is not null and spc2.parameters:basicOrderType::integer between 16 and 23 and spc2.parameters:considerationIdentifier = a.nft_token_id then 'Individual Offer Accepted'
                 when spc2.call_tx_hash is not null then 'Buy'
                 when spc3.call_tx_hash is not null and a.original_currency_contract = '0x0000000000000000000000000000000000000000' then 'Buy'
-                when spc3.call_tx_hash is not null then 'Collection/Trait Offers' -- offer for collection
+                when spc3.call_tx_hash is not null then 'Collection/Trait Offer Accepted' -- offer for collection
                 when spc4.call_tx_hash is not null then 'Bulk Purchase' -- bundles of NFTs are purchased through aggregators or in a cart 
                 when spc5.call_tx_hash is not null then 'Bulk Purchase' -- bundles of NFTs are purchased through aggregators or in a cart 
-                when spc6.call_tx_hash is not null then 'Private Sales' -- sales for designated address
+                when spc6.call_tx_hash is not null then 'Private Sale' -- sales for designated address
                 else 'Buy'
            end as order_type  
 

--- a/models/zora/ethereum/zora_ethereum_events.sql
+++ b/models/zora/ethereum/zora_ethereum_events.sql
@@ -109,7 +109,7 @@ WITH zora_trades AS (
     , z3_ape_af.evt_block_time AS block_time
     , z3_ape_af.evt_block_number AS block_number
     , z3_ape_af.tokenId AS token_id
-    , 'Private Buy' AS trade_category
+    , 'Private Sale' AS trade_category
     , get_json_object(z3_ape_af.ask, '$.seller') AS seller
     , get_json_object(z3_ape_af.ask, '$.buyer') AS buyer
     , get_json_object(z3_ape_af.ask, '$.price') AS amount_raw


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Before this PR, we have: `Buy`, `Offer Accepted`, `Collection Offer Accepted`, `Sell`, `Auction Settled`, `Private Sale`, `Private Sales`, `Private Buy`, `Auction`, `Collection Offer`, `Collection/Trait` & `Trait Offer`.

This PR narrows it down to: `Buy`, `Offer Accepted`, `Collection Offer Accepted`, `Sell` (now only for sudoswap, other platforms were switched to `Offer Accepted`), `Auction Settled`, `Private Sale`, `Collection Offer Accepted`, `Trait Offer Accepted` & `Collection/Trait Offer Accepted` (couldn't tell how to split that one into `Collection Offer Accepted` and `Trait Offer Accepted`).

Those were overlaps with other names so I switched them to the more used name: `Private Sales`, `Private Buy`, `Auction`.

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
