### PR TITLE
Fix duplicate SNX price feed

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -403,7 +403,6 @@ VALUES
     ("gtc-gitcoin", "ethereum", "GTC", "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f", 18),
     ("gto-gifto", "ethereum", "GTO", "0xc5bbae50781be1669306b9e001eff57a2957b09d", 5),
     ("gusd-gemini-dollar", "ethereum", "GUSD", "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd", 2),
-    ("hav-havven", "ethereum", "SNX", "0xc011a72400e58ecd99ee497cf89e3775d4bd732f", 18),
     ("hav-havven", "ethereum", "SNX", "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f", 18),
     ("hedg-hedgetrade", "ethereum", "HEDG", "0xf1290473e210b2108a85237fbcd7b6eb42cc654f", 18),
     ("hegic-hegic", "ethereum", "HEGIC", "0x584bc13c7d411c00c01a62e8019472de68768430", 18),

--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -403,7 +403,7 @@ VALUES
     ("gtc-gitcoin", "ethereum", "GTC", "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f", 18),
     ("gto-gifto", "ethereum", "GTO", "0xc5bbae50781be1669306b9e001eff57a2957b09d", 5),
     ("gusd-gemini-dollar", "ethereum", "GUSD", "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd", 2),
-    ("hav-havven", "ethereum", "SNX", "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f", 18),
+    ("snx-synthetix-network-token", "ethereum", "SNX", "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f", 18),
     ("hedg-hedgetrade", "ethereum", "HEDG", "0xf1290473e210b2108a85237fbcd7b6eb42cc654f", 18),
     ("hegic-hegic", "ethereum", "HEGIC", "0x584bc13c7d411c00c01a62e8019472de68768430", 18),
     ("hex-hex", "ethereum", "HEX", "0x2b591e99afe9f32eaa6214f7b7629768c40eeb39", 8),


### PR DESCRIPTION
Brief comments on the purpose of your changes:


*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
