### PR TITLE
[Easy] Add avalanche_c.logs and avalanche_c.traces to avalanche base sources

### DIFF
--- a/models/base_sources/avalanche_c_base_sources.yml
+++ b/models/base_sources/avalanche_c_base_sources.yml
@@ -35,6 +35,9 @@ sources:
             description: "Any binary data payload"
           - name: hash
             description: "Primary key of the transaction"
+            tests:
+              - unique
+              - not_null
           - name: type
           - name: access_list
           
@@ -115,3 +118,47 @@ sources:
           - &tx_index
             name: tx_index
             description: "Transaction index"
+
+      - name: traces
+        loaded_at_field: block_time
+        description: "An Avalanche C-Chain trace is a small atomic action that modify the internal state of the Avalanche's Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
+        columns:
+          - name: address
+            description: "Address of the trace creator"
+          - *block_hash
+          - *block_number
+          - *block_time
+          - name: call_type
+            description: "Hexadecimal representations of the trace's call type"
+          - name: code
+            description: "Raw EVM code for the trace"
+          - name: error
+            description: "Error log"
+          - name: from
+            description: "Wallet address that initiated the trace"
+          - name: gas
+            description: "Amount of gas consumed by the trace"
+          - name: gas_used
+            description: "Number of gas units used by the trace"
+          - name: input
+            description: "Input data for the trace"
+          - name: output
+            description: "Output data for the trace"
+          - name: refund_address
+            description: "Refund Address"
+          - name: sub_traces
+            description: "Number of subtraces (i.e, number of calls at a particular level within a transaction)"
+          - name: success
+            description: "Whether the trace was completed successfully"
+          - name: to
+            description: "Wallet address that received the trace"
+          - name: trace_address
+            description: "All returned traces, gives the exact location in the call trace"
+          - *tx_hash
+          - *tx_index
+          - name: tx_success
+            description: "Whether the transaction was completed sucessfully"
+          - name: type
+            description: "Type of trace (e.g., call, create, suicide)"
+          - name: value
+            description: "Raw amount of ERC20 token transferred"

--- a/models/base_sources/avalanche_c_base_sources.yml
+++ b/models/base_sources/avalanche_c_base_sources.yml
@@ -10,9 +10,13 @@ sources:
       - name: transactions
         loaded_at_field: block_time
         columns:
-          - name: block_time
+          - &block_time
+            name: block_time
+            description: "Timestamp for block event time in UTC"
           - name: value
-          - name: block_number
+          - &block_number
+            name: block_number
+            description: "Block number"
           - name: gas_limit
           - name: gas_price
           - name: gas_used
@@ -24,9 +28,13 @@ sources:
           - name: success
           - name: from
           - name: to
-          - name: block_hash
+          - &block_hash
+            name: block_hash
+            description: "Primary key of the block"
           - name: data
+            description: "Any binary data payload"
           - name: hash
+            description: "Primary key of the transaction"
           - name: type
           - name: access_list
           
@@ -79,3 +87,31 @@ sources:
               - accepted_values:
                   values: ["factory", "base", "dynamic"]
           - name: created_at
+
+      - name: logs
+        loaded_at_field: block_time
+        description: "An Avalanche C-Chain log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
+        columns:
+          - *block_hash
+          - *block_number
+          - *block_time
+          - name: contract_address
+            description: "Address of the avalanche c-chain smart contract generating the log"
+          - name: data
+            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings."
+          - name: index
+            description: "Log index"
+          - name: topic1
+            description: "Topics are 32-byte (256 bit) “words” that are used to describe what’s going on in an event. The first topic usually consists of the signature of the name of the event that occurred, including the types (uint256, string, etc.) of its parameters."
+          - name: topic2
+            description: "Second topic"
+          - name: topic3
+            description: "Third topic"
+          - name: topic4
+            description: "Fourth topic"
+          - &tx_hash
+            name: tx_hash
+            description: "Primary key of the transaction"
+          - &tx_index
+            name: tx_index
+            description: "Transaction index"


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Adding avlanche_c.logs and avalanche_c.traces tables to V2 base sources.
This will make the development of avalanche_c dex.trades easier for contributors.