### PR TITLE
All new Seaport Trades

### DIFF
--- a/models/seaport/ethereum/seaport_ethereum_base_pairs.sql
+++ b/models/seaport/ethereum/seaport_ethereum_base_pairs.sql
@@ -1,7 +1,6 @@
 {{ config(
-    alias = 'base_pairs',
-    materialized = 'view'
-   )
+     alias = 'base_pairs'
+     )
 }}
 
 with iv_offer_consideration as (

--- a/models/seaport/ethereum/seaport_ethereum_base_pairs.sql
+++ b/models/seaport/ethereum/seaport_ethereum_base_pairs.sql
@@ -3,7 +3,12 @@
      )
 }}
 
-with iv_offer_consideration as (
+with decode_Seaport_evt_OrderFulfilled as (
+    select *
+    --   from seaport_ethereum.Seaport_evt_OrderFulfilled
+      from {{ source('seaport_ethereum','Seaport_evt_OrderFulfilled') }} 
+)
+,iv_offer_consideration as (
     select evt_block_time as block_time
           ,evt_block_number as block_number
           ,evt_tx_hash as tx_hash
@@ -37,7 +42,7 @@ with iv_offer_consideration as (
                 else 'etc' 
            end as item_type
           ,offer_item:identifier as token_id
-          ,contract_address as exchange_contract_address
+          ,contract_address as platform_contract_address
           ,size(offer) as offer_cnt
           ,size(consideration) as consideration_cnt
           ,case when recipient = '0x0000000000000000000000000000000000000000' then true
@@ -45,8 +50,8 @@ with iv_offer_consideration as (
            end as is_private
       from (select *
                   ,posexplode(offer) as (offer_idx, offer_item)
-              from {{ source('seaport_ethereum','Seaport_evt_OrderFulfilled') }} 
-           )          
+              from decode_Seaport_evt_OrderFulfilled   
+           )
     union all
     select evt_block_time as block_time
           ,evt_block_number as block_number
@@ -89,7 +94,7 @@ with iv_offer_consideration as (
            end as is_private
       from (select *
                   ,posexplode(consideration) as (consideration_idx, consideration_item)
-              from {{ source('seaport_ethereum','Seaport_evt_OrderFulfilled') }} 
+              from decode_Seaport_evt_OrderFulfilled
            )
 )
 ,iv_base_pairs as (

--- a/models/seaport/ethereum/seaport_ethereum_schema.yml
+++ b/models/seaport/ethereum/seaport_ethereum_schema.yml
@@ -246,7 +246,7 @@ models:
       - name: consideration_cnt
         description: "Total number of consideration items"
       - name: is_private
-        description: "If trade is private sale then boolean `true` else `false`"
+        description: "If trade is private sale then `true` else `false` (boolean)"
       - name: eth_erc_idx
         description: "Sequencial number of native or erc20 tokens only"
       - name: nft_cnt
@@ -280,10 +280,77 @@ models:
     config:
       tags: ['ethereum','seaport','base_pairs','sohwak']
     description: >
-        Exploded table from Seaport trade events with `offer` and `consideration` array columns
+        Seaport trades on Ethereum
     columns:
-      - name: block_time
-        description: "Block time in UTC"
-      - name: block_number
-        description: "Block number of transaction"
-
+      - *blockchain
+      - *project
+      - *version
+      - name: block_date
+        description:  "block date"
+      - *block_time
+      - *seller
+      - *buyer
+      - *trade_type
+      - *trade_category
+      - *evt_type
+      - *nft_contract_address
+      - *collection
+      - *token_id
+      - *number_of_items
+      - *token_standard
+      - *amount_raw
+      - *amount_original
+      - *amount_usd
+      - *currency_symbol
+      - *currency_contract
+      - name:  original_currency_contract
+        description: "original currency"
+      - name:  currency_decimal
+        description:  "Token Decimal"
+      - *project_contract_address
+      - name: platform_fee_receive_address
+        description:  "Platform fee receive address"
+      - *platform_fee_amount_raw
+      - *platform_fee_amount
+      - *platform_fee_amount_usd
+      - name: royalty_fee_receive_address
+        description:  "Wallet addresses receiving fees from the transaction"
+      - *royalty_fee_amount_raw
+      - *royalty_fee_amount
+      - *royalty_fee_amount_usd
+      - name: royalty_fee_receive_address_1
+        description:  "Wallet addresses receiving fees from the transaction"
+      - name: royalty_fee_receive_address_2
+        description:  "Wallet addresses receiving fees from the transaction"
+      - name: royalty_fee_receive_address_3
+        description:  "Wallet addresses receiving fees from the transaction"
+      - name: royalty_fee_receive_address_4
+        description:  "Wallet addresses receiving fees from the transaction"
+      - name: royalty_fee_amount_raw_1
+        description:  "Wallet addresses receiving fees from the transaction"
+      - name: royalty_fee_amount_raw_2
+        description:  "Wallet addresses receiving fees from the transaction"
+      - name: royalty_fee_amount_raw_3
+        description:  "Wallet addresses receiving fees from the transaction"
+      - name: royalty_fee_amount_raw_4
+        description:  "Wallet addresses receiving fees from the transaction"
+      - *aggregator_name
+      - *aggregator_address
+      - *block_number
+      - *tx_hash
+      - name: evt_index
+        description: "Event index of transaction event"
+      - *tx_from
+      - *tx_to
+      - name: right_hash
+        description: "right 8 character of data column on Transaction"
+      - name: zone_address
+        description: "zone address of Seaport transaction"
+      - name: estimated_price
+        description: "True if it is bundle trade and dividened price"
+      - name: is_private
+        description: "True if it is private sale"
+      - name : unique_trade_id
+        description:  "Unique trade ID"
+        tests:
+          - unique

--- a/models/seaport/ethereum/seaport_ethereum_schema.yml
+++ b/models/seaport/ethereum/seaport_ethereum_schema.yml
@@ -197,3 +197,79 @@ models:
         description:  "Unique trade ID"
         tests:
           - unique
+
+  - name: seaport_ethereum_base_pairs
+    meta:
+      blockchain: ethereum
+      project: seaport
+      contributors: sohwak
+    config:
+      tags: ['ethereum','seaport','opensea','base_pair']
+    description: >
+        Seaport transactions on Ethereum
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain"
+      - name: block_time
+        description: "UTC event block time"
+      - name: block_number
+        description: 
+      - name: tx_hash
+        description: 
+      - name: evt_index
+        description: 
+      - name: sub_type
+        description: 
+      - name: sub_idx
+        description: 
+      - name: offer_first_item_type
+        description: 
+      - name: consideration_first_item_type
+        description: 
+      - name: sender
+        description: 
+      - name: receiver
+        description: 
+      - name: zone
+        description: 
+      - name: token_contract_address
+        description: 
+      - name: original_amount
+        description: 
+      - name: item_type
+        description: 
+      - name: token_id
+        description: 
+      - name: exchange_contract_address
+        description: 
+      - name: offer_cnt
+        description: 
+      - name: consideration_cnt
+        description: 
+      - name: is_private
+        description: 
+      - name: eth_erc_idx
+        description: 
+      - name: nft_cnt
+        description: 
+      - name: erc721_cnt
+        description: 
+      - name: erc1155_cnt
+        description: 
+      - name: order_type
+        description: 
+      - name: is_price
+        description: 
+      - name: is_netprice
+        description: 
+      - name: is_platform_fee
+        description: 
+      - name: is_creator_fee
+        description: 
+      - name: creator_fee_idx
+        description: 
+      - name: is_traded_nft
+        description: 
+      - name: is_moved_nft
+        description: 

--- a/models/seaport/ethereum/seaport_ethereum_schema.yml
+++ b/models/seaport/ethereum/seaport_ethereum_schema.yml
@@ -272,4 +272,18 @@ models:
       - name: is_moved_nft
         description: "Transferred NFT if `true`, because it is traded or just transferred."
 
+  - name: seaport_ethereum_trades
+    meta:
+      blockchain: ethereum
+      project: seaport
+      contributors: sohwak
+    config:
+      tags: ['ethereum','seaport','base_pairs','sohwak']
+    description: >
+        Exploded table from Seaport trade events with `offer` and `consideration` array columns
+    columns:
+      - name: block_time
+        description: "Block time in UTC"
+      - name: block_number
+        description: "Block number of transaction"
 

--- a/models/seaport/ethereum/seaport_ethereum_schema.yml
+++ b/models/seaport/ethereum/seaport_ethereum_schema.yml
@@ -11,8 +11,7 @@ models:
     description: >
         Seaport transactions on Ethereum
     columns:
-      - &blockchain
-        name: blockchain
+      - name: blockchain
         description: "Blockchain"
       - name: block_time
         description: "UTC event block time"
@@ -87,7 +86,9 @@ models:
     description: >
         Seaport transfers on Ethereum
     columns:
-      - *blockchain
+      - &blockchain
+        name: blockchain
+        description: "Blockchain"
       - &project
         name: project
         description: "Project"
@@ -204,72 +205,71 @@ models:
       project: seaport
       contributors: sohwak
     config:
-      tags: ['ethereum','seaport','opensea','base_pair']
+      tags: ['ethereum','seaport','base_pairs','sohwak']
     description: >
-        Seaport transactions on Ethereum
+        Exploded table from Seaport trade events with `offer` and `consideration` array columns
     columns:
-      - &blockchain
-        name: blockchain
-        description: "Blockchain"
       - name: block_time
-        description: "UTC event block time"
+        description: "Block time in UTC"
       - name: block_number
-        description: 
+        description: "Block number of transaction"
       - name: tx_hash
-        description: 
+        description: "Hash ID of transaction" 
       - name: evt_index
-        description: 
+        description: "Event log index"
       - name: sub_type
-        description: 
+        description: "Exploded column : `offer`|`consideration`"
       - name: sub_idx
-        description: 
+        description: "Index number of `sub_type`" 
       - name: offer_first_item_type
-        description: 
+        description: "First item_type of offer in this trade : `native`|`erc20`|`erc721`|`erc1155`"
       - name: consideration_first_item_type
-        description: 
+        description: "First item_type of consideration in this trade : `native`|`erc20`|`erc721`|`erc1155`"
       - name: sender
-        description: 
+        description: "Item sender"
       - name: receiver
-        description: 
+        description: "Item receiver"
       - name: zone
-        description: 
+        description: "Zone address"
       - name: token_contract_address
-        description: 
+        description: "Item contract address"
       - name: original_amount
-        description: 
+        description: "Number of Items"
       - name: item_type
-        description: 
+        description: "`native`|`erc20`|`erc721`|`erc1155`"
       - name: token_id
-        description: 
-      - name: exchange_contract_address
-        description: 
+        description: "Item token_id"
+      - name: platform_contract_address
+        description: "platform's contract_address"
       - name: offer_cnt
-        description: 
+        description: "Total number of offer items"
       - name: consideration_cnt
-        description: 
+        description: "Total number of consideration items"
       - name: is_private
-        description: 
+        description: "If trade is private sale then boolean `true` else `false`"
       - name: eth_erc_idx
-        description: 
+        description: "Sequencial number of native or erc20 tokens only"
       - name: nft_cnt
-        description: 
+        description: "Total number of traded NFT in this trade"
       - name: erc721_cnt
-        description: 
+        description: "Total number of traded erc721 in this trade"
       - name: erc1155_cnt
-        description: 
+        description: "Total number of traded erc1155 in this trade"
       - name: order_type
-        description: 
+        description: "Direction of trade. `buy` or `offer accepted` only (lowercase)"
       - name: is_price
-        description: 
+        description: "Part of volume or not. `true` makes volume of this trade"
       - name: is_netprice
-        description: 
+        description: "Change of `price - platform_fee - creator_fee`, (but might not be used)"
       - name: is_platform_fee
-        description: 
+        description: "Platform fee if `true`"
       - name: is_creator_fee
-        description: 
+        description: "Creator fee if `true`"
       - name: creator_fee_idx
-        description: 
+        description: "Sequencial number only for creator fee"
       - name: is_traded_nft
-        description: 
+        description: "Traded NFT if `true`, because it is traded or just transferred."
       - name: is_moved_nft
-        description: 
+        description: "Transferred NFT if `true`, because it is traded or just transferred."
+
+

--- a/models/seaport/ethereum/seaport_ethereum_trades.sql
+++ b/models/seaport/ethereum/seaport_ethereum_trades.sql
@@ -12,7 +12,51 @@
     )
 }}
 
-with iv_base_pairs_priv as (
+{% set c_native_token_address = "0x0000000000000000000000000000000000000000" %}
+{% set c_alternative_token_address = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2" %}
+{% set c_native_symbol = "ETH" %}
+{% set c_seaport_first_date = "2022-06-01" %}
+
+with source_ethereum_transactions as (
+    select *
+    --   from ethereum.transactions 
+      from {{ source('ethereum','transactions') }}
+     where block_time > date '{{c_seaport_first_date}}'  -- seaport first txn
+    {% if is_incremental() %}
+      and t.block_time >= date_trunc('day', current_date - interval '1 week')
+    {% endif %}
+)
+,ref_seaport_ethereum_base_pairs as (
+    select *
+    --   from seaport_ethereum_base_pairs
+      from {{ ref('seaport_ethereum_base_pairs') }}
+     where 1=1
+     {% if is_incremental() %}
+      and block_time >= date_trunc('day', current_date - interval '1 week')
+     {% endif %}     
+)
+,ref_tokens_nft as (
+    select *
+    --   from tokens.nft
+      from {{ ref('tokens_nft') }}
+     where blockchain = 'ethereum'
+)
+,ref_tokens_erc20 as (
+    select *
+    --   from tokens.erc20
+      from {{ ref('tokens_erc20') }}
+     where blockchain = 'ethereum'
+)
+,source_prices_usd as (
+    select *
+    --   from prices.usd
+      from {{ source('prices', 'usd') }}
+     where blockchain = 'ethereum'
+     {% if is_incremental() %} 
+      and minute >= date_trunc('day', current_date - interval '1 week')
+     {% endif %}
+)
+,iv_base_pairs_priv as (
     select a.block_time
           ,a.block_number
           ,a.tx_hash
@@ -44,11 +88,8 @@ with iv_base_pairs_priv as (
           ,a.creator_fee_idx
           ,a.is_traded_nft
           ,a.is_moved_nft
-      from {{ ref('seaport_ethereum_base_pairs') }} a
+      from ref_seaport_ethereum_base_pairs a
      where 1=1 
-       {% if is_incremental() %}
-       and block_time >= (select max(block_time) from {{ this }})
-       {% endif %}     
        and not a.is_private
     union all
     select a.block_time
@@ -84,8 +125,8 @@ with iv_base_pairs_priv as (
           ,a.creator_fee_idx
           ,a.is_traded_nft
           ,a.is_moved_nft
-      from {{ ref('seaport_ethereum_base_pairs') }} a
-           left join {{ ref('seaport_ethereum_base_pairs') }} b on b.tx_hash = a.tx_hash
+      from ref_seaport_ethereum_base_pairs a
+           left join ref_seaport_ethereum_base_pairs b on b.tx_hash = a.tx_hash
                                   and b.evt_index = a.evt_index
                                   and b.block_time = a.block_time -- for performance
                                   and b.token_contract_address = a.token_contract_address
@@ -93,9 +134,6 @@ with iv_base_pairs_priv as (
                                   and b.original_amount = a.original_amount
                                   and b.is_moved_nft
      where 1=1
-       {% if is_incremental() %}
-       and block_time >= (select max(block_time) from {{ this }})
-       {% endif %}     
        and a.is_private
        and not a.is_moved_nft
        and a.consideration_cnt > 0
@@ -137,7 +175,7 @@ with iv_base_pairs_priv as (
           ,a.token_id as nft_token_id
           ,a.item_type as nft_token_standard
           ,a.zone
-          ,a.exchange_contract_address
+          ,a.platform_contract_address
           ,b.token_contract_address 
           ,round(price_amount_raw / nft_cnt) as price_amount_raw  -- to truncate the odd number of decimal places 
           ,round(platform_fee_amount_raw / nft_cnt) as platform_fee_amount_raw
@@ -167,7 +205,7 @@ with iv_base_pairs_priv as (
           ,t.`from` as tx_from
           ,t.`to` as tx_to
           ,right(t.data,8) as right_hash
-          ,case when a.token_contract_address = '0x0000000000000000000000000000000000000000' then 'ETH'
+          ,case when a.token_contract_address = '{{c_native_token_address}}' then '{{c_native_symbol}}'
                 else e.symbol
            end as token_symbol
           ,a.price_amount_raw / power(10, e.decimals) as price_amount
@@ -178,26 +216,13 @@ with iv_base_pairs_priv as (
           ,a.creator_fee_amount_raw / power(10, e.decimals) * p.price as creator_fee_amount_usd
           ,tx_hash || '-' || evt_index as unique_trade_id
       from iv_nfts a
-           inner join {{ source('ethereum','transactions') }} t on t.hash = a.tx_hash
-                                                        {% if not is_incremental() %}
-                                                        and t.block_number > 14801608
-                                                        {% endif %}
-                                                        {% if is_incremental() %}
-                                                        and t.block_time >= date_trunc("day", now() - interval '1 week')
-                                                        {% endif %}
-           left join {{ ref('tokens_nft') }} n on n.contract_address = nft_contract_address 
-                                               and n.blockchain = 'ethereum'
-           left join {{ ref('tokens_erc20') }} e on e.contract_address = a.token_contract_address
-                                                 and e.blockchain = 'ethereum'
-           left join {{ source('prices', 'usd') }} p on p.contract_address = case when a.token_contract_address = '0x0000000000000000000000000000000000000000' then '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-                                                                                  else a.token_contract_address
-                                                                             end
-                                                    and p.minute = date_trunc('minute', a.block_time)
-                                                    and p.blockchain = 'ethereum'
-                                                    {% if is_incremental() %} 
-                                                    and p1.minute >= date_trunc("day", now() - interval '1 week')
-                                                    {% endif %}       
+           inner join source_ethereum_transactions t on t.hash = a.tx_hash
+           left join ref_tokens_nft n on n.contract_address = nft_contract_address 
+           left join ref_tokens_erc20 e on e.contract_address = a.token_contract_address
+           left join source_prices_usd p on p.contract_address = case when a.token_contract_address = '{{c_native_token_address}}' then '{{c_alternative_token_address}}'
+                                                                      else a.token_contract_address
+                                                                 end
+                                         and p.minute = date_trunc('minute', a.block_time)
 )
 select *
   from iv_trades
-   

--- a/models/seaport/ethereum/seaport_ethereum_trades.sql
+++ b/models/seaport/ethereum/seaport_ethereum_trades.sql
@@ -1,0 +1,131 @@
+{{ config(
+    alias = 'trades',
+    partition_by = ['block_date'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'unique_trade_id'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                            "project",
+                            "seaport",
+                            \'["sohawk"]\') }}'
+    )
+}}
+
+-- base페어에 price, platform, creator를 붙여봅시다.
+with iv_volume as (
+    select block_time
+          ,tx_hash
+          ,evt_index
+          ,max(token_contract_address::text) as token_contract_address 
+          ,sum(case when is_price then original_amount end) as price_amount_raw
+          ,sum(case when is_platform_fee then original_amount end) as platform_fee_amount_raw
+          ,max(case when is_platform_fee then receiver::text end) as platform_fee_receiver
+          ,sum(case when is_creator_fee then original_amount end) as creator_fee_amount_raw
+          ,sum(case when is_creator_fee and creator_fee_idx = 1 then original_amount end) as creator_fee_amount_1_raw
+          ,sum(case when is_creator_fee and creator_fee_idx = 2 then original_amount end) as creator_fee_amount_2_raw
+          ,sum(case when is_creator_fee and creator_fee_idx = 3 then original_amount end) as creator_fee_amount_3_raw
+          ,sum(case when is_creator_fee and creator_fee_idx = 4 then original_amount end) as creator_fee_amount_4_raw
+          ,max(case when is_creator_fee and creator_fee_idx = 1 then receiver::text end) as creator_fee_receiver_1_raw
+          ,max(case when is_creator_fee and creator_fee_idx = 2 then receiver::text end) as creator_fee_receiver_2_raw
+          ,max(case when is_creator_fee and creator_fee_idx = 3 then receiver::text end) as creator_fee_receiver_3_raw
+          ,max(case when is_creator_fee and creator_fee_idx = 4 then receiver::text end) as creator_fee_receiver_4_raw
+      from dune_user_generated.sohwak_os_s10_base_pair_3 a
+     where 1=1
+       and eth_erc_idx > 0
+    --   and tx_hash = '\xa9cb862c5a172319dd403f72e5ba806708d7bb8774a2f61d55ea169d27923a19' -- multi buy
+    --   and tx_hash = '\x067494c3c2e1dfc68d4806e51ebb76d89f7be369f752fcaa1df4e7d91acbbda8' -- bundle trade
+    --   and tx_hash = '\x08eba6fac7c403068b8ed13bd2fc37e9717a29929581a66c9e88ca88fa206a3d' -- multitrade
+    --   and tx_hash = '\x0001e6fd67badfda25f85364215572173b1eff29ff11362987562b23b730fb47' -- offer_accepted, 1 nft
+    --   and tx_hash = '\x8cd79572bb14ee10a07a149644b4e5f37f62cb5d029ea23713107094f53ff68c' -- offer_accepted, 20 nft, weth
+    --   and tx_hash = '\x0b836ca871e15048c48c4143c243d7c7f35323fd20ecd394ce004fe48101edc6' -- offer_accepted, 2x creator fee 
+    --   and tx_hash = '\xd95bfa3251c5971ca7dec1b1cbde9ffb8637074810fafbdda4cfacf32e2698c9' -- TOWNSTAR + ETH
+    --   and tx_hash = '\xa9cb862c5a172319dd403f72e5ba806708d7bb8774a2f61d55ea169d27923a19' -- same seller, token_contract, token_id but 4 transfers 
+    --   and tx_hash = '\x3c86aa7172ff0971b3d2450f2aa09e2aa99492b774403bfd036113accaccdcc2' -- MEV
+    --   and tx_hash = '\x4ac895a0975574084899a93496b08e2d05808d39189d3a27ce8ac3935679aa15' -- 2nft, buy and move, and no price
+    --   and tx_hash = '\x287ee2e4dfa7feee4b7c3c54f74013088fd7fe87c382103c45562e050019cc20' -- 3 erc1155, buy, move item so erc20->erc1155 
+    --  and tx_hash = '\x698024deef22eace175e3a5fe81ec7219970aa13af1efada75df8813d9c06f4e' -- self wash trade -- very rare and bad case
+    --  and tx_hash =  '\x79f2ca6153e03b186cd6ec1d7bc96f50309f0e8a86cc302de48d805d076c3fe2' -- buy 1 simul and send them all to another wallet
+    --  and tx_hash = '\x5022f60c36cb85b777f4e0ce5768465234b496030a1909d17ab5a6b8f514d759' -- buy 3 simul and send them all to another wallet
+     group by 1,2,3
+)
+-- select *
+--   from iv_volume
+--  order by 
+--  block_time, tx_hash, evt_index 
+,iv_nfts as (
+    select a.block_time
+          ,a.tx_hash
+          ,a.evt_index
+          ,a.sender as seller
+          ,a.receiver as buyer
+          ,case when nft_cnt > 1 then 'bundle trade' 
+                else 'single trade'
+           end as trade_type
+          ,a.order_type
+          ,a.token_contract_address as nft_contract_address
+          ,a.original_amount as nft_token_amount
+          ,a.token_id as nft_token_id
+          ,a.item_type as nft_token_standard
+          ,a.zone
+          ,a.exchange_contract_address
+          ,b.token_contract_address 
+          ,price_amount_raw / nft_cnt as price_amount_raw
+          ,platform_fee_amount_raw / nft_cnt as platform_fee_amount_raw
+          ,platform_fee_receiver
+          ,creator_fee_amount_raw / nft_cnt as creator_fee_amount_raw
+          ,creator_fee_amount_1_raw / nft_cnt as creator_fee_amount_1_raw
+          ,creator_fee_amount_2_raw / nft_cnt as creator_fee_amount_2_raw
+          ,creator_fee_amount_3_raw / nft_cnt as creator_fee_amount_3_raw
+          ,creator_fee_amount_4_raw / nft_cnt as creator_fee_amount_4_raw
+          ,creator_fee_receiver_1_raw
+          ,creator_fee_receiver_2_raw
+          ,creator_fee_receiver_3_raw
+          ,creator_fee_receiver_4_raw
+          ,case when nft_cnt > 1 then true
+                else false
+           end as estimated_price
+      from dune_user_generated.sohwak_os_s10_base_pair_3 a
+           left join iv_volume b on b.block_time = a.block_time  -- tx_hash and evt_index is PK, but for performance, block_time is included
+                                 and b.tx_hash = a.tx_hash
+                                 and b.evt_index = a.evt_index
+     where 1=1
+       and a.is_traded_nft
+    --   and a.tx_hash = '\xa9cb862c5a172319dd403f72e5ba806708d7bb8774a2f61d55ea169d27923a19' -- multi buy
+    --   and a.tx_hash = '\x067494c3c2e1dfc68d4806e51ebb76d89f7be369f752fcaa1df4e7d91acbbda8' -- bundle trade
+    --   and a.tx_hash = '\x08eba6fac7c403068b8ed13bd2fc37e9717a29929581a66c9e88ca88fa206a3d' -- multitrade, different zone so different platform fees
+    --   and a.tx_hash = '\x0001e6fd67badfda25f85364215572173b1eff29ff11362987562b23b730fb47' -- offer_accepted, 1 nft
+    --   and a.tx_hash = '\x8cd79572bb14ee10a07a149644b4e5f37f62cb5d029ea23713107094f53ff68c' -- offer_accepted, 20 nft, weth
+    --   and a.tx_hash = '\x0b836ca871e15048c48c4143c243d7c7f35323fd20ecd394ce004fe48101edc6' -- offer_accepted, 2x creator fee 
+    --   and a.tx_hash = '\xd95bfa3251c5971ca7dec1b1cbde9ffb8637074810fafbdda4cfacf32e2698c9' -- TOWNSTAR + ETH
+    --   and a.tx_hash = '\xa9cb862c5a172319dd403f72e5ba806708d7bb8774a2f61d55ea169d27923a19' -- same seller, token_contract, token_id but 4 transfers 
+    --   and a.tx_hash = '\x3c86aa7172ff0971b3d2450f2aa09e2aa99492b774403bfd036113accaccdcc2' -- MEV arbitrage, but self?
+    --   and a.tx_hash = '\x4ac895a0975574084899a93496b08e2d05808d39189d3a27ce8ac3935679aa15' -- 2nft, buy and move, and no price
+    --   and a.tx_hash = '\x287ee2e4dfa7feee4b7c3c54f74013088fd7fe87c382103c45562e050019cc20' -- 3 erc1155, buy, move item so erc20->erc1155 
+    --  and a.tx_hash = '\x698024deef22eace175e3a5fe81ec7219970aa13af1efada75df8813d9c06f4e' -- self wash trade -- very rare and bad case
+    --  and a.tx_hash =  '\x79f2ca6153e03b186cd6ec1d7bc96f50309f0e8a86cc302de48d805d076c3fe2' -- buy 1 simul and send them all to another wallet
+    --  and a.tx_hash = '\x5022f60c36cb85b777f4e0ce5768465234b496030a1909d17ab5a6b8f514d759' -- buy 3 simul and send them all to another wallet
+    --  and a.tx_hash = '\xe1efb363d1d6a726c033d902da2e9ed3330486e9544086bb24c5315d5660b2f0' -- private1
+    --  and a.tx_hash = '\xe1efb363d1d6a726c033d902da2e9ed3330486e9544086bb24c5315d5660b2f0' -- private2 -- no cost
+    --  and a.tx_hash = '\x69a51f105786c9aa4afa15fcb91148c52e97cd1a3a87065c0d5b7b7f3f8eae1c' -- private3
+    --  group by 1,2,3
+)
+select 
+    --   sum(price_amount_raw)
+    --   ,sum(platform_fee_amount_raw)
+       *
+  from iv_nfts
+ limit 1000
+
+
+-- select block_time
+--       ,tx_hash
+--       ,evt_index
+--       ,token_contract_address
+--       ,
+--   from dune_user_generated.sohwak_os_s10_base_pair a
+--  where 1=1
+--   and is_traded_nft 
+--   and tx_hash = '\xa9cb862c5a172319dd403f72e5ba806708d7bb8774a2f61d55ea169d27923a19' -- multi buy
+   
+   

--- a/models/seaport/ethereum/seaport_etheruem_base_pairs.sql
+++ b/models/seaport/ethereum/seaport_etheruem_base_pairs.sql
@@ -1,0 +1,144 @@
+{{ config(
+    alias = 'base_pairs',
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                            "project",
+                            "seaport",
+                            \'["sohawk"]\') }}'
+    )
+}}
+
+with iv_base_pair as (
+    select evt_block_time as block_time
+          ,evt_block_number as block_number
+          ,evt_tx_hash as tx_hash
+          ,evt_index
+          ,'offer' as sub_type
+          ,offer_idx as sub_idx
+          ,case offer->0->>'itemType' 
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc'
+           end as offer_first_item_type
+          ,case consideration->0->>'itemType'
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc' 
+           end as consideration_first_item_type          
+          ,offerer as sender
+          ,recipient as receiver
+          ,zone
+          ,concat('\x',substr(offer_item->>'token',3,40))::bytea as token_contract_address 
+          ,(offer_item->>'amount')::numeric as original_amount
+          ,case offer_item->>'itemType'
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc' 
+           end as item_type
+          ,(offer_item->>'identifier') as token_id
+          ,contract_address as exchange_contract_address
+          ,jsonb_array_length(offer) as offer_cnt
+          ,jsonb_array_length(consideration) as consideration_cnt
+          ,case when recipient = '\x0000000000000000000000000000000000000000'::bytea then true
+                else false
+           end as is_private
+      from seaport."Seaport_evt_OrderFulfilled" a
+          ,jsonb_array_elements(offer) with ordinality as t (offer_item, offer_idx)
+    union all
+    select evt_block_time as block_time
+          ,evt_block_number as block_number
+          ,evt_tx_hash as tx_hash
+          ,evt_index
+          ,'consideration' as sub_type
+          ,consideration_idx as sub_idx
+          ,case offer->0->>'itemType' 
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc'
+           end as offer_first_item_type
+          ,case consideration->0->>'itemType'
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc' 
+           end as consideration_first_item_type          
+          ,recipient as sender
+          ,concat('\x',substr(consideration_item->>'recipient',3,40))::bytea as receiver
+          ,zone
+          ,concat('\x',substr(consideration_item->>'token',3,40))::bytea as token_contract_address
+          ,(consideration_item->>'amount')::numeric as original_amount
+          ,case consideration_item->>'itemType'
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc' -- actually not exists
+           end as item_type
+          ,(consideration_item->>'identifier') as token_id
+          ,contract_address as exchange_contract_address
+          ,jsonb_array_length(offer) as offer_cnt
+          ,jsonb_array_length(consideration) as consideration_cnt
+          ,case when recipient = '\x0000000000000000000000000000000000000000'::bytea then true
+                else false
+           end as is_private
+      from seaport."Seaport_evt_OrderFulfilled" a
+          ,jsonb_array_elements(consideration) with ordinality as t (consideration_item, consideration_idx)
+)       
+,iv_base_pair_add as (
+    select a.*
+          ,case when offer_first_item_type = 'erc20' then 'offer accepted'
+                when offer_first_item_type in ('erc721','erc1155') then 'buy'
+                else 'etc' -- some txns has no nfts
+           end as order_type
+          ,case when offer_first_item_type = 'erc20' and sub_type = 'offer' and item_type = 'erc20' then true
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and item_type in ('native','erc20') then true
+                else false
+           end is_price
+          ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and eth_erc_idx = 0 then true  -- offer accepted has no price at all. it has to be calculated.
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and eth_erc_idx = 1 then true
+                else false
+           end is_netprice
+          ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and eth_erc_idx = 1 then true
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and eth_erc_idx = 2 then true
+                else false
+           end is_platform_fee
+          ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and eth_erc_idx > 1 then true
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and eth_erc_idx > 2 then true
+                else false
+           end is_creator_fee
+          ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and eth_erc_idx > 1 then eth_erc_idx - 1
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and eth_erc_idx > 2 then eth_erc_idx - 2
+           end creator_fee_idx
+          ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and item_type in ('erc721','erc1155') then true
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'offer' and item_type in ('erc721','erc1155') then true
+                else false
+           end is_traded_nft
+          ,case when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and item_type in ('erc721','erc1155') then true
+                else false
+           end is_moved_nft
+      from (select 
+                   a.*
+                  ,case when item_type in ('native','erc20') then sum(case when item_type in ('native','erc20') then 1 end) over (partition by tx_hash, evt_index, sub_type order by sub_idx) end as eth_erc_idx
+                  ,sum(case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and item_type in ('erc721','erc1155') then 1
+                            when offer_first_item_type in ('erc721','erc1155') and sub_type = 'offer' and item_type in ('erc721','erc1155') then 1
+                       end) over (partition by tx_hash, evt_index) as nft_cnt
+                  ,sum(case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and item_type in ('erc721') then 1
+                            when offer_first_item_type in ('erc721','erc1155') and sub_type = 'offer' and item_type in ('erc721') then 1
+                       end) over (partition by tx_hash, evt_index) as erc721_cnt
+                  ,sum(case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and item_type in ('erc1155') then 1
+                            when offer_first_item_type in ('erc721','erc1155') and sub_type = 'offer' and item_type in ('erc1155') then 1
+                       end) over (partition by tx_hash, evt_index) as erc1155_cnt
+              from iv_base_pair a
+           ) a
+)
+select *
+  from iv_base_pair_add
+;


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Fully newly created `seaport.trades` spell table with increased accuracy

Feature: 
- Only event table is used to increase accuracy and reduce error probability

Next plans:
- When data integrity is verified then integrate into the following data:
  - `nft.trades`
  - `seaport.transfers` (refer to `seaport.trades`, and remain for backward-compatibility)
  - `seaport.transactions` (refer to `seaport.trades`, and remain for backward-compatibility)
- Create and deploy other chains as well including Avalanche, Arbitrum, Polygon, Optimism, etc.


*For Dune Engine V2*
I've checked that:
General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
