### PR TITLE
sandwich attacker labels: add documentation remove uniswap v3 router from results

### DIFF
--- a/models/labels/sandwich_attackers/ethereum/labels_sandwich_attackers_ethereum.sql
+++ b/models/labels/sandwich_attackers/ethereum/labels_sandwich_attackers_ethereum.sql
@@ -23,7 +23,8 @@ with
         and sell.blockchain = 'ethereum'
         and (et_sell.index >= et_buy.index + 2 -- buy first
         or et_buy.index >= et_sell.index + 2) -- sell first
-        and buy.tx_to != '0x7a250d5630b4cf539739df2c5dacb4c659f2488d' -- uniswap v2 routers 
+        and buy.tx_to != '0x7a250d5630b4cf539739df2c5dacb4c659f2488d' -- uniswap v2 router 
+        and buy.tx_to != '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45' -- uniswap v3 router
   )
 select
   array("ethereum") as blockchain,

--- a/models/labels/sandwich_attackers/ethereum/labels_sandwich_attackers_schema.yml
+++ b/models/labels/sandwich_attackers/ethereum/labels_sandwich_attackers_schema.yml
@@ -44,7 +44,22 @@ models:
       contibutors: alexth
     config:
       tags: ['labels', 'ethereum', 'sandwich', 'bot','sandwich_attackers', 'dex']
-    description: "Known sandwich attacker addresses on Ethereum"
+    description: "Known sandwich attacker addresses on Ethereum
+
+      The logic to identify a sandwich attacker is as follows:
+
+        1. Two separate trades, t1 and t2 in no particular order, in the same block initiated by the same address
+        2. Both trades inititated on the same project
+        3. Token bought in t1 = token sold in t2
+        4. Token sold in t1 = token bought in t2
+        5. Amount bought in t1 = Amount sold in t2
+        6. Amount sold in t1 < amount bought in t2 (excluded)
+        7. (index of t1 >= index of t2 + 2) or (index of t2 >= index of t1 + 2)
+        8. Exclude uniswap v2 router address since this gets included as a false positive for some reason
+        
+      This logic should work to include both buy-first and less common sell-first sandwiches
+      By excluding point 6, we also include sandwich attacks that made a loss
+      By using '>=' instead of just '=' in point 7, we can also include sandwich attackers that are perhaps not using flashbots and not tightly bundling their transactions"
     columns:
       - *blockchain
       - *address


### PR DESCRIPTION
Brief comments on the purpose of your changes:

- 1 line addition to ethereum/labels_sandwich_attackers_ethereum.sql file to remove uniswap v3 router from results set. 
- also add documentation of process of identifying sandwich attackers

*For Dune Engine V2*
I've checked that:
General checks:
* [x ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x ] if adding a new model, I added a test
* [x ] the filename is unique and ends with .sql
* [x ] each sql file is a select statement and has only one view, table or function defined  
* [x ] column names are `lowercase_snake_cased`
* [x ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Pricing checks:
* [x ] `coin_id` represents the ID of the coin on coinpaprika.com
* [x ] all the coins are active on coinpaprika.com (please remove inactive ones)

Join logic:
* [ x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ x] where block_time >= date_trunc("day", now() - interval '1 week')
* [ x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
