### PR TITLE
Remove overshooting price feed.

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -673,7 +673,7 @@ VALUES
     ("x2y2-x2y2token", "ethereum", "X2Y2", "0x1e4ede388cbc9f4b5c79681b7f94d36a11abebc9", 18),
     ("tcr-tracer-dao", "ethereum", "TCR", "0x9c4a4204b79dd291d6b6571c5be8bbcd0622f050", 18),
     ("tsuka-dejitaru-tsuka", "ethereum", "TSUKA", "0xc5fb36dd2fb59d3b98deff88425a3f425ee469ed", 9),
-    ("caw-a-hunters-dream", "ethereum", "CAW", "0xf3b9569f82b18aef890de263b84189bd33ebe452", 18),
+    -- ("caw-a-hunters-dream", "ethereum", "CAW", "0xf3b9569f82b18aef890de263b84189bd33ebe452", 18), Removed until feed fixed by cp
     ("inu-inu", "ethereum", "INU", "0x050d94685c6b0477e1fc555888af6e2bb8dfbda5", 18),
     ("metis-metis-token", "ethereum", "METIS", "0x9e32b13ce7f2e80a01932b42553652e053d6ed8e", 18),
     ("note-notional", "ethereum", "NOTE", "0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5", 8),


### PR DESCRIPTION
See T-19870

Brief comments on the purpose of your changes:


*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
