### PR TITLE
Fix x2y2's trade_id

### DIFF
--- a/models/x2y2/ethereum/x2y2_ethereum_events.sql
+++ b/models/x2y2/ethereum/x2y2_ethereum_events.sql
@@ -208,7 +208,7 @@ SELECT 'ethereum' AS blockchain
 , CASE WHEN currency_contract='0x0000000000000000000000000000000000000000' THEN 'ETH'
     ELSE pu.symbol
     END AS royalty_fee_currency_symbol
-, 'x2y2-' || txs.tx_hash || '-' || txs.nft_contract_address || txs.token_id || '-' || txs.seller || '-' || txs.evt_index || erct.evt_index || 'Trade' AS unique_trade_id
+, 'x2y2-' || COALESCE(txs.tx_hash, -1) || '-' || COALESCE(txs.nft_contract_address, -1) || COALESCE(txs.token_id, -1) || '-' || COALESCE(txs.seller, -1) || '-' || COALESCE(txs.evt_index, -1) || COALESCE(erct.evt_index, -1) || 'Trade' AS unique_trade_id
 FROM all_x2y2_txs txs
 INNER JOIN {{ source('ethereum','transactions') }} et ON et.block_time=txs.block_time
     AND et.hash=txs.tx_hash


### PR DESCRIPTION
Brief comments on the purpose of your changes:


*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
