### PR TITLE
changed UNION to UNION ALL

### DIFF
--- a/models/dex/dex_trades.sql
+++ b/models/dex/dex_trades.sql
@@ -51,7 +51,7 @@ FROM (
         evt_index
     FROM {{ ref(dex_model) }}
     {% if not loop.last %}
-    UNION
+    UNION ALL
     {% endif %}
     {% endfor %}
 )

--- a/models/element/avalanche_c/element_avalanche_c_events.sql
+++ b/models/element/avalanche_c/element_avalanche_c_events.sql
@@ -35,7 +35,7 @@ WITH element_txs AS (
         WHERE ee.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
         
-        UNION
+        UNION ALL
         
         -- Avalanche ERC721 Buys
         SELECT 'avalanche_c' AS blockchain
@@ -62,7 +62,7 @@ WITH element_txs AS (
         WHERE ee.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
         
-        UNION
+        UNION ALL
         
         -- Avalanche ERC1155 Sells
         SELECT 'avalanche_c' AS blockchain
@@ -89,7 +89,7 @@ WITH element_txs AS (
         WHERE ee.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
         
-        UNION
+        UNION ALL
         
         -- Avalanche ERC1155 Buys
         SELECT 'avalanche_c' AS blockchain

--- a/models/element/bnb/element_bnb_events.sql
+++ b/models/element/bnb/element_bnb_events.sql
@@ -35,7 +35,7 @@ WITH element_txs AS (
         WHERE ee.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
         
-        UNION
+        UNION ALL
         
         -- BNB ERC721 Buys
         SELECT 'bnb' AS blockchain
@@ -62,7 +62,7 @@ WITH element_txs AS (
         WHERE ee.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
         
-        UNION
+        UNION ALL
         
         -- BNB ERC1155 Sells
         SELECT 'bnb' AS blockchain
@@ -89,7 +89,7 @@ WITH element_txs AS (
         WHERE ee.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
         
-        UNION
+        UNION ALL
         
         -- BNB ERC1155 Buys
         SELECT 'bnb' AS blockchain

--- a/models/element/element_burns.sql
+++ b/models/element/element_burns.sql
@@ -36,7 +36,7 @@ SELECT * FROM (
         tx_to,
         unique_trade_id
         FROM {{ ref('element_ethereum_burns') }}
-        UNION
+        UNION ALL
         SELECT blockchain,
         project,
         version,
@@ -65,7 +65,7 @@ SELECT * FROM (
         tx_to,
         unique_trade_id
         FROM {{ ref('element_avalanche_c_burns') }}
-        UNION
+        UNION ALL
         SELECT blockchain,
         project,
         version,

--- a/models/element/element_events.sql
+++ b/models/element/element_events.sql
@@ -49,7 +49,7 @@ FROM
                 royalty_fee_currency_symbol,
                 unique_trade_id
         FROM {{ ref('element_ethereum_events') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -89,7 +89,7 @@ FROM
                 royalty_fee_currency_symbol,
                 unique_trade_id
         FROM {{ ref('element_bnb_events') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,

--- a/models/element/element_fees.sql
+++ b/models/element/element_fees.sql
@@ -41,7 +41,7 @@ SELECT * FROM (
         tx_to,
         unique_trade_id
         FROM {{ ref('element_ethereum_fees') }}
-        UNION
+        UNION ALL
         SELECT blockchain,
         project,
         version,
@@ -75,7 +75,7 @@ SELECT * FROM (
         tx_to,
         unique_trade_id
         FROM {{ ref('element_avalanche_c_fees') }}
-        UNION
+        UNION ALL
         SELECT blockchain,
         project,
         version,

--- a/models/element/element_mints.sql
+++ b/models/element/element_mints.sql
@@ -36,7 +36,7 @@ SELECT * FROM (
         tx_to,
         unique_trade_id
         FROM {{ ref('element_ethereum_mints') }}
-        UNION
+        UNION ALL
         SELECT blockchain,
         project,
         version,
@@ -65,7 +65,7 @@ SELECT * FROM (
         tx_to,
         unique_trade_id
         FROM {{ ref('element_avalanche_c_mints') }}
-        UNION
+        UNION ALL
         SELECT blockchain,
         project,
         version,

--- a/models/element/element_trades.sql
+++ b/models/element/element_trades.sql
@@ -36,7 +36,7 @@ SELECT * FROM (
         tx_to,
         unique_trade_id
         FROM {{ ref('element_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT blockchain,
         project,
         version,
@@ -65,7 +65,7 @@ SELECT * FROM (
         tx_to,
         unique_trade_id
         FROM {{ ref('element_avalanche_c_trades') }}
-        UNION
+        UNION ALL
         SELECT blockchain,
         project,
         version,

--- a/models/element/ethereum/element_ethereum_events.sql
+++ b/models/element/ethereum/element_ethereum_events.sql
@@ -35,7 +35,7 @@ WITH element_txs AS (
         WHERE ee.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
         
-        UNION
+        UNION ALL
         
         -- Ethereum ERC721 Buys
         SELECT 'ethereum' AS blockchain
@@ -62,7 +62,7 @@ WITH element_txs AS (
         WHERE ee.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
         
-        UNION
+        UNION ALL
         
         -- Ethereum ERC1155 Sells
         SELECT 'ethereum' AS blockchain
@@ -89,7 +89,7 @@ WITH element_txs AS (
         WHERE ee.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
         
-        UNION
+        UNION ALL
         
         -- Ethereum ERC1155 Buys
         SELECT 'ethereum' AS blockchain

--- a/models/foundation/ethereum/foundation_ethereum_events.sql
+++ b/models/foundation/ethereum/foundation_ethereum_events.sql
@@ -40,7 +40,7 @@ WITH all_foundation_trades AS (
      {% if is_incremental() %} -- this filter will only be applied on an incremental run
      WHERE f.evt_block_time >= (select max(block_time) from {{ this }})
      {% endif %}
-    UNION
+    UNION ALL
     SELECT 'ethereum' AS blockchain
     , 'foundation' AS project
     , 'v1' AS version
@@ -67,7 +67,7 @@ WITH all_foundation_trades AS (
      {% if is_incremental() %} -- this filter will only be applied on an incremental run
      WHERE f.evt_block_time >= (select max(block_time) from {{ this }})
      {% endif %}
-    UNION
+    UNION ALL
     SELECT 'ethereum' AS blockchain
     , 'foundation' AS project
     , 'v1' AS version
@@ -94,7 +94,7 @@ WITH all_foundation_trades AS (
      {% if is_incremental() %} -- this filter will only be applied on an incremental run
      WHERE f.evt_block_time >= (select max(block_time) from {{ this }})
      {% endif %}
-    UNION
+    UNION ALL
     SELECT 'ethereum' AS blockchain
     , 'foundation' AS project
     , 'v1' AS version

--- a/models/gas/gas_fees.sql
+++ b/models/gas/gas_fees.sql
@@ -41,7 +41,7 @@ FROM (
         transaction_type
     FROM {{ ref(gas_model) }}
     {% if not loop.last %}
-    UNION
+    UNION ALL
     {% endif %}
     {% endfor %}
 )

--- a/models/labels/contracts/labels_contracts.sql
+++ b/models/labels/contracts/labels_contracts.sql
@@ -14,7 +14,7 @@ SELECT array('ethereum') as blockchain,
        date('2022-09-26') as created_at,
        now() as modified_at
 FROM {{ source('ethereum','contracts') }} 
-UNION 
+UNION ALL
 SELECT array('gnosis') as blockchain,
        address, 
        concat(upper(substring(namespace,1,1)),substring(namespace,2)) || ': ' || name as name,
@@ -24,7 +24,7 @@ SELECT array('gnosis') as blockchain,
        date('2022-09-26') as created_at,
        now() as modified_at
 FROM {{ source('gnosis','contracts') }} 
-UNION 
+UNION ALL
 SELECT array('avalanche_c') as blockchain,
        address, 
        concat(upper(substring(namespace,1,1)),substring(namespace,2)) || ': ' || name as name,
@@ -34,7 +34,7 @@ SELECT array('avalanche_c') as blockchain,
        date('2022-09-26') as created_at,
        now() as modified_at
 FROM {{ source('avalanche_c','contracts') }} 
-UNION 
+UNION ALL
 SELECT array('arbitrum') as blockchain,
        address, 
        concat(upper(substring(namespace,1,1)),substring(namespace,2)) || ': ' || name as name,
@@ -44,7 +44,7 @@ SELECT array('arbitrum') as blockchain,
        date('2022-09-26') as created_at,
        now() as modified_at
 FROM {{ source('arbitrum','contracts') }} 
-UNION 
+UNION ALL
 SELECT array('bnb') as blockchain,
        address, 
        concat(upper(substring(namespace,1,1)),substring(namespace,2)) || ': ' || name as name,
@@ -54,7 +54,7 @@ SELECT array('bnb') as blockchain,
        date('2022-09-26') as created_at,
        now() as modified_at
 FROM {{ source('bnb','contracts') }} 
-UNION 
+UNION ALL
 SELECT array('optimism') as blockchain,
        address, 
        concat(upper(substring(namespace,1,1)),substring(namespace,2)) || ': ' || name as name,

--- a/models/labels/labels_all.sql
+++ b/models/labels/labels_all.sql
@@ -10,40 +10,40 @@
 
 -- Static Labels
 SELECT * FROM {{ ref('labels_cex') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_funds') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_bridges') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_ofac_sanctionned_ethereum') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_multisig_ethereum') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_hackers_ethereum') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_mev_ethereum') }}
-UNION
+UNION ALL
 SELECT blockchain, address, name, category, contributor, source, created_at, updated_at FROM {{ ref('labels_aztec_v2_contracts_ethereum') }}
-UNION
+UNION ALL
 -- Query Labels
 SELECT * FROM {{ ref('labels_nft') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_safe_ethereum') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_tornado_cash') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_contracts') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_miners') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_airdrop_1_receivers_optimism') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_arbitrage_traders')}}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_flashbots_ethereum') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_ens') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_validators') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_sandwich_attackers') }}

--- a/models/labels/miners/labels_miners.sql
+++ b/models/labels/miners/labels_miners.sql
@@ -14,7 +14,7 @@ SELECT DISTINCT array('ethereum') as blockchain,
        date('2022-09-28') as created_at,
        now() as modified_at
 FROM {{ source('ethereum','blocks') }} 
-UNION 
+UNION ALL
 SELECT DISTINCT array('gnosis') as blockchain,
        miner, 
        'Gnosis Miner' as name,
@@ -24,7 +24,7 @@ SELECT DISTINCT array('gnosis') as blockchain,
        date('2022-09-28') as created_at,
        now() as modified_at
 FROM {{ source('gnosis','blocks') }} 
-UNION 
+UNION ALL
 SELECT DISTINCT array('avalanche_c') as blockchain,
        miner, 
        'Avalanche Miner' as name,
@@ -34,7 +34,7 @@ SELECT DISTINCT array('avalanche_c') as blockchain,
        date('2022-09-28') as created_at,
        now() as modified_at
 FROM {{ source('avalanche_c','blocks') }} 
-UNION 
+UNION ALL
 SELECT DISTINCT array('arbitrum') as blockchain,
        miner, 
        'Arbitrum Miner' as name,
@@ -44,7 +44,7 @@ SELECT DISTINCT array('arbitrum') as blockchain,
        date('2022-09-28') as created_at,
        now() as modified_at
 FROM {{ source('arbitrum','blocks') }} 
-UNION 
+UNION ALL
 SELECT DISTINCT array('bnb') as blockchain,
        miner, 
        'BNB Chain Miner' as name,
@@ -54,7 +54,7 @@ SELECT DISTINCT array('bnb') as blockchain,
        date('2022-09-28') as created_at,
        now() as modified_at
 FROM {{ source('bnb','blocks') }} 
-UNION 
+UNION ALL
 SELECT DISTINCT array('optimism') as blockchain,
        miner, 
        'Optimism Miner' as name,

--- a/models/labels/nft/labels_nft.sql
+++ b/models/labels/nft/labels_nft.sql
@@ -6,7 +6,7 @@
 )}}
 
 SELECT * FROM {{ ref('labels_nft_traders_transactions') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_nft_traders_volume_usd') }}
-UNION
+UNION ALL
 SELECT * FROM {{ ref('labels_nft_users_platforms') }}

--- a/models/labels/nft/labels_nft_traders_transactions.sql
+++ b/models/labels/nft/labels_nft_traders_transactions.sql
@@ -7,7 +7,7 @@ SELECT
     tx_hash,
     buyer AS address
 FROM {{ ref('nft_trades') }}
-        UNION
+        UNION ALL
 SELECT
     blockchain,
     tx_hash,

--- a/models/labels/nft/labels_nft_traders_volume_usd.sql
+++ b/models/labels/nft/labels_nft_traders_volume_usd.sql
@@ -6,7 +6,7 @@ SELECT
     amount_usd,
     buyer AS address
 FROM {{ ref('nft_trades') }}
-        UNION
+        UNION ALL
 SELECT
     blockchain,
     amount_usd,

--- a/models/labels/nft/labels_nft_users_platforms.sql
+++ b/models/labels/nft/labels_nft_users_platforms.sql
@@ -6,7 +6,7 @@ SELECT
     project,
     buyer AS address
 FROM {{ ref('nft_trades') }}
-        UNION
+        UNION ALL
 SELECT
     blockchain,
     project,

--- a/models/labels/tornado_cash/labels_tornado_cash.sql
+++ b/models/labels/tornado_cash/labels_tornado_cash.sql
@@ -12,7 +12,7 @@ SELECT
     depositor AS address,
     'Depositor' as name
 FROM {{ ref('tornado_cash_deposits') }}
-UNION
+UNION ALL
 SELECT
     lower(blockchain) as blockchain,
     tx_hash,

--- a/models/labels/validators/labels_validators.sql
+++ b/models/labels/validators/labels_validators.sql
@@ -5,7 +5,7 @@
                                     \'["soispoke"]\') }}')}}
 
 SELECT * FROM  {{ ref('labels_validators_ethereum') }}
-UNION
+UNION ALL
 SELECT * FROM  {{ ref('labels_validators_bnb') }}
-UNION
+UNION ALL
 SELECT * FROM  {{ ref('labels_validators_solana') }}

--- a/models/looksrare/ethereum/looksrare_ethereum_events.sql
+++ b/models/looksrare/ethereum/looksrare_ethereum_events.sql
@@ -44,7 +44,7 @@ WITH looks_rare AS (
      {% if is_incremental() %} -- this filter will only be applied on an incremental run
      WHERE ask.evt_block_time >= date_trunc("day", now() - interval '1 week')
      {% endif %}
-                            UNION
+    UNION ALL
     SELECT
         bid.evt_block_time AS block_time,
         bid.tokenId::string AS token_id,
@@ -95,7 +95,7 @@ erc_transfers as
         WHERE erc1155.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
         GROUP BY evt_tx_hash,value,id,evt_index, erc1155.from, erc1155.to, erc1155.contract_address
-            UNION
+UNION ALL
 SELECT evt_tx_hash,
         contract_address,
         tokenId::string as token_id_erc,

--- a/models/looksrare/ethereum/looksrare_ethereum_events.sql
+++ b/models/looksrare/ethereum/looksrare_ethereum_events.sql
@@ -44,7 +44,7 @@ WITH looks_rare AS (
      {% if is_incremental() %} -- this filter will only be applied on an incremental run
      WHERE ask.evt_block_time >= date_trunc("day", now() - interval '1 week')
      {% endif %}
-    UNION ALL
+    UNION
     SELECT
         bid.evt_block_time AS block_time,
         bid.tokenId::string AS token_id,
@@ -95,7 +95,7 @@ erc_transfers as
         WHERE erc1155.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
         GROUP BY evt_tx_hash,value,id,evt_index, erc1155.from, erc1155.to, erc1155.contract_address
-UNION ALL
+UNION
 SELECT evt_tx_hash,
         contract_address,
         tokenId::string as token_id_erc,

--- a/models/nft/ethereum/metadata/nft_ethereum_metadata_art_platform_collections.sql
+++ b/models/nft/ethereum/metadata/nft_ethereum_metadata_art_platform_collections.sql
@@ -14,7 +14,7 @@ FROM
                  artist_name, 
                  art_collection_unique_id
         FROM {{ ref('nft_ethereum_metadata_art_blocks_collections') }}
-        UNION
+        UNION ALL
         SELECT
                  contract_address, 
                  project_id, 
@@ -23,7 +23,7 @@ FROM
                  artist_name, 
                  art_collection_unique_id
         FROM {{ ref('nft_ethereum_metadata_braindrops') }}
-        UNION
+        UNION ALL
         SELECT
                  contract_address, 
                  project_id, 
@@ -32,7 +32,7 @@ FROM
                  artist_name, 
                  art_collection_unique_id
         FROM {{ ref('nft_ethereum_metadata_bright_moments') }}
-        UNION
+        UNION ALL
         SELECT
                  contract_address, 
                  project_id, 
@@ -41,7 +41,7 @@ FROM
                  artist_name, 
                  art_collection_unique_id
         FROM {{ ref('nft_ethereum_metadata_mirage_gallery_curated') }}        
-        UNION
+        UNION ALL
         SELECT
                  contract_address, 
                  project_id, 
@@ -50,7 +50,7 @@ FROM
                  artist_name, 
                  art_collection_unique_id
         FROM {{ ref('nft_ethereum_metadata_proof_grails_i') }}              
-        UNION
+        UNION ALL
         SELECT
                  contract_address, 
                  project_id, 

--- a/models/nft/ethereum/nft_ethereum_native_mints.sql
+++ b/models/nft/ethereum/nft_ethereum_native_mints.sql
@@ -38,7 +38,7 @@ select
   1 as number_of_items
 from {{ source('erc721_ethereum','evt_transfer') }}
 where from = '0x0000000000000000000000000000000000000000'
-	union
+	union all
 select
   evt_block_time,
   evt_block_number,
@@ -55,7 +55,7 @@ select
   value as number_of_items
 from {{ source('erc1155_ethereum','evt_transfersingle') }}
 where from = '0x0000000000000000000000000000000000000000'
-	union
+	union all
 select
   evt_block_time,
   evt_block_number,

--- a/models/nft/nft_aggregators.sql
+++ b/models/nft/nft_aggregators.sql
@@ -7,9 +7,9 @@
 }}
 
 SELECT 'avalanche_c' as blockchain, * FROM  {{ ref('nft_avalanche_c_aggregators') }}
-UNION
+UNION ALL
 SELECT 'bnb' as blockchain, * FROM  {{ ref('nft_bnb_aggregators') }}
-UNION
+UNION ALL
 SELECT 'ethereum' as blockchain, * FROM  {{ ref('nft_ethereum_aggregators') }}
-UNION
+UNION ALL
 SELECT 'polygon' as blockchain, * FROM  {{ ref('nft_polygon_aggregators') }}

--- a/models/nft/nft_burns.sql
+++ b/models/nft/nft_burns.sql
@@ -38,7 +38,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('opensea_burns') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -68,7 +68,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('looksrare_ethereum_burns') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -98,7 +98,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('x2y2_ethereum_burns') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -128,7 +128,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('element_burns') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -158,7 +158,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('foundation_ethereum_burns') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -188,7 +188,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('zora_ethereum_burns') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,

--- a/models/nft/nft_events.sql
+++ b/models/nft/nft_events.sql
@@ -46,7 +46,7 @@ WITH project_events AS (
         royalty_fee_percentage,
         unique_trade_id
     FROM {{ ref('opensea_events') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -86,7 +86,7 @@ WITH project_events AS (
         royalty_fee_percentage,
         unique_trade_id
     FROM {{ ref('magiceden_events') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -126,7 +126,7 @@ WITH project_events AS (
         royalty_fee_percentage,
         unique_trade_id
     FROM {{ ref('looksrare_ethereum_events') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -166,7 +166,7 @@ WITH project_events AS (
         royalty_fee_percentage,
         unique_trade_id
     FROM {{ ref('x2y2_ethereum_events') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -206,7 +206,7 @@ WITH project_events AS (
         royalty_fee_percentage,
         unique_trade_id
     FROM {{ ref('sudoswap_ethereum_events') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -246,7 +246,7 @@ WITH project_events AS (
         royalty_fee_percentage,
         unique_trade_id
     FROM {{ ref('foundation_ethereum_events') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -286,7 +286,7 @@ WITH project_events AS (
         royalty_fee_percentage,
         unique_trade_id
     FROM {{ ref('archipelago_ethereum_events') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -326,7 +326,7 @@ WITH project_events AS (
         royalty_fee_percentage,
         unique_trade_id
     FROM {{ ref('cryptopunks_ethereum_events') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -366,7 +366,7 @@ WITH project_events AS (
         royalty_fee_percentage,
         unique_trade_id
     FROM {{ ref('element_events') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -406,7 +406,7 @@ WITH project_events AS (
         royalty_fee_percentage,
         unique_trade_id
     FROM {{ ref('superrare_ethereum_events') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -446,7 +446,7 @@ WITH project_events AS (
         royalty_fee_percentage,
         unique_trade_id
     FROM {{ ref('zora_ethereum_events') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -530,5 +530,5 @@ native_mints AS (
 	WHERE tx_hash NOT IN (SELECT tx_hash FROM project_events)
 )
 SELECT * FROM project_events
-UNION
+UNION ALL
 SELECT * FROM native_mints

--- a/models/nft/nft_fees.sql
+++ b/models/nft/nft_fees.sql
@@ -43,7 +43,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('opensea_fees') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -78,7 +78,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('looksrare_ethereum_fees') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -113,7 +113,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('x2y2_ethereum_fees') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -148,7 +148,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('sudoswap_ethereum_fees') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -183,7 +183,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('foundation_ethereum_fees') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -218,7 +218,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('archipelago_ethereum_fees') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -253,7 +253,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('element_fees') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -288,7 +288,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('superrare_ethereum_fees') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -323,7 +323,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('zora_ethereum_fees') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,

--- a/models/nft/nft_mints.sql
+++ b/models/nft/nft_mints.sql
@@ -36,7 +36,7 @@ WITH project_mints AS (
         tx_to,
         unique_trade_id
     FROM {{ ref('opensea_mints') }} 
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -66,7 +66,7 @@ WITH project_mints AS (
         tx_to,
         unique_trade_id
     FROM {{ ref('magiceden_mints') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -96,7 +96,7 @@ WITH project_mints AS (
         tx_to,
         unique_trade_id
     FROM {{ ref('looksrare_ethereum_mints') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -126,7 +126,7 @@ WITH project_mints AS (
         tx_to,
         unique_trade_id
     FROM {{ ref('x2y2_ethereum_mints') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -156,7 +156,7 @@ WITH project_mints AS (
         tx_to,
         unique_trade_id
     FROM {{ ref('element_mints') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -186,7 +186,7 @@ WITH project_mints AS (
         tx_to,
         unique_trade_id
     FROM {{ ref('foundation_ethereum_mints') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -216,7 +216,7 @@ WITH project_mints AS (
         tx_to,
         unique_trade_id
     FROM {{ ref('zora_ethereum_mints') }}
-    UNION
+    UNION ALL
     SELECT
         blockchain,
         project,
@@ -280,5 +280,5 @@ native_mints AS (
 	WHERE tx_hash NOT IN (SELECT tx_hash FROM project_mints)
 )
 SELECT * FROM project_mints
-UNION
+UNION ALL
 SELECT * FROM native_mints

--- a/models/nft/nft_trades.sql
+++ b/models/nft/nft_trades.sql
@@ -38,7 +38,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('opensea_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -68,7 +68,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('magiceden_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -98,7 +98,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('looksrare_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -128,7 +128,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('x2y2_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -158,7 +158,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('sudoswap_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -188,7 +188,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('foundation_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -218,7 +218,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('archipelago_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -248,7 +248,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('cryptopunks_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -278,7 +278,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('element_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -308,7 +308,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('superrare_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -338,7 +338,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('zora_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,

--- a/models/opensea/ethereum/opensea_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_ethereum_events.sql
@@ -45,7 +45,7 @@ FROM
                 royalty_fee_currency_symbol,
                 unique_trade_id
         FROM {{ ref('opensea_v1_ethereum_events') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 'opensea' as project,

--- a/models/opensea/opensea_events.sql
+++ b/models/opensea/opensea_events.sql
@@ -49,7 +49,7 @@ FROM
                 royalty_fee_currency_symbol,
                 unique_trade_id
         FROM {{ ref('opensea_ethereum_events') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,

--- a/models/opensea/opensea_trades.sql
+++ b/models/opensea/opensea_trades.sql
@@ -36,7 +36,7 @@ tx_to,
 unique_trade_id
 FROM {{ ref('opensea_ethereum_trades') }}
 
-            UNION
+            UNION ALL
 
 SELECT blockchain,
 project,

--- a/models/tokens/tokens_erc20.sql
+++ b/models/tokens/tokens_erc20.sql
@@ -5,13 +5,13 @@
                                     \'["0xManny","hildobby","soispoke","dot2dotseurat","mtitus6"]\') }}')}}
 
 SELECT 'arbitrum' as blockchain, * FROM  {{ ref('tokens_arbitrum_erc20') }}
-UNION
+UNION ALL
 SELECT 'avalanche_c' as blockchain, * FROM  {{ ref('tokens_avalanche_c_erc20') }}
-UNION
+UNION ALL
 SELECT 'bnb' as blockchain, * FROM  {{ ref('tokens_bnb_bep20') }}
-UNION
+UNION ALL
 SELECT 'ethereum' as blockchain, * FROM  {{ ref('tokens_ethereum_erc20') }}
-UNION
+UNION ALL
 SELECT 'gnosis' as blockchain, * FROM  {{ ref('tokens_gnosis_erc20') }}
-UNION
+UNION ALL
 SELECT 'optimism' as blockchain, * FROM  {{ ref('tokens_optimism_erc20') }}

--- a/models/tokens/tokens_nft.sql
+++ b/models/tokens/tokens_nft.sql
@@ -12,7 +12,7 @@ symbol,
 standard, 
 category 
 FROM  {{ ref('tokens_avalanche_c_nft') }}
-            UNION
+            UNION ALL
 SELECT
 'ethereum' as blockchain, 
 contract_address, 
@@ -21,7 +21,7 @@ symbol,
 standard, 
 category 
 FROM  {{ ref('tokens_ethereum_nft') }}
-            UNION
+            UNION ALL
 SELECT
 'gnosis' as blockchain, 
 contract_address, 
@@ -30,7 +30,7 @@ symbol,
 standard, 
 CAST(NULL as STRING) as category 
 FROM  {{ ref('tokens_gnosis_nft') }}
-            UNION
+            UNION ALL
 SELECT
 'optimism' as blockchain, 
 contract_address, 
@@ -39,7 +39,7 @@ CAST(NULL as STRING) as symbol,
 CAST(NULL as STRING) as standard, 
 CAST(NULL as STRING) as category 
 FROM  {{ ref('tokens_optimism_nft') }}
-            UNION
+            UNION ALL
 SELECT
 'bnb' as blockchain, 
 contract_address, 

--- a/models/x2y2/ethereum/x2y2_ethereum_events.sql
+++ b/models/x2y2/ethereum/x2y2_ethereum_events.sql
@@ -142,7 +142,7 @@ WITH aggregator_routed_x2y2_txs AS (
 
 , all_x2y2_txs AS (
     SELECT * FROM aggregator_routed_x2y2_txs_formatted
-    UNION ALL
+    UNION
     SELECT * FROM direct_x2y2_txs_formated
     )
 

--- a/models/x2y2/ethereum/x2y2_ethereum_events.sql
+++ b/models/x2y2/ethereum/x2y2_ethereum_events.sql
@@ -142,7 +142,7 @@ WITH aggregator_routed_x2y2_txs AS (
 
 , all_x2y2_txs AS (
     SELECT * FROM aggregator_routed_x2y2_txs_formatted
-    UNION
+    UNION ALL
     SELECT * FROM direct_x2y2_txs_formated
     )
 

--- a/models/zora/ethereum/zora_ethereum_events.sql
+++ b/models/zora/ethereum/zora_ethereum_events.sql
@@ -35,7 +35,7 @@ WITH zora_trades AS (
         {% if is_incremental() %}
         AND z3_o1_rp.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    UNION
+    UNION ALL
     SELECT 'v3' AS version
     , z3_a0_ee.evt_block_time AS block_time
     , z3_a0_ee.evt_block_number AS block_number
@@ -58,7 +58,7 @@ WITH zora_trades AS (
         {% if is_incremental() %}
         AND z3_a0_rp.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    UNION
+    UNION ALL
     SELECT 'v3' AS version
     , z3_a1_ee.evt_block_time AS block_time
     , z3_a1_ee.evt_block_number AS block_number
@@ -81,7 +81,7 @@ WITH zora_trades AS (
         {% if is_incremental() %}
         AND z3_a1_rp.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    UNION
+    UNION ALL
     SELECT 'v3' AS version
     , z3_rafe_ae.evt_block_time AS block_time
     , z3_rafe_ae.evt_block_number AS block_number
@@ -104,7 +104,7 @@ WITH zora_trades AS (
         {% if is_incremental() %}
         AND z3_rafe_rp.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    UNION
+    UNION ALL
     SELECT 'v3' AS version
     , z3_ape_af.evt_block_time AS block_time
     , z3_ape_af.evt_block_number AS block_number
@@ -127,7 +127,7 @@ WITH zora_trades AS (
         {% if is_incremental() %}
         AND z3_ape_rp.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    UNION
+    UNION ALL
     SELECT 'v3' AS version
     , z3_ace_af.evt_block_time AS block_time
     , z3_ace_af.evt_block_number AS block_number
@@ -150,7 +150,7 @@ WITH zora_trades AS (
         {% if is_incremental() %}
         AND z3_ace_rp.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    UNION
+    UNION ALL
     SELECT 'v3' AS version
     , z3_race_ae.evt_block_time AS block_time
     , z3_race_ae.evt_block_number AS block_number
@@ -173,7 +173,7 @@ WITH zora_trades AS (
         {% if is_incremental() %}
         AND z3_race_rp.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    UNION
+    UNION ALL
     SELECT 'v3' AS version
     , z3_racerc_ae.evt_block_time AS block_time
     , z3_racerc_ae.evt_block_number AS block_number
@@ -196,7 +196,7 @@ WITH zora_trades AS (
         {% if is_incremental() %}
         AND z3_racerc_rp.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    UNION
+    UNION ALL
     SELECT 'v3' AS version
     , z3_raferc_ae.evt_block_time AS block_time
     , z3_raferc_ae.evt_block_number AS block_number
@@ -219,7 +219,7 @@ WITH zora_trades AS (
         {% if is_incremental() %}
         AND z3_raferc_rp.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    UNION
+    UNION ALL
     SELECT 'v3' AS version
     , z3_rale_ae.evt_block_time AS block_time
     , z3_rale_ae.evt_block_number AS block_number
@@ -242,7 +242,7 @@ WITH zora_trades AS (
         {% if is_incremental() %}
         AND z3_rale_rp.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    UNION
+    UNION ALL
     SELECT 'v3' AS version
     , z3_rale_ae.evt_block_time AS block_time
     , z3_rale_ae.evt_block_number AS block_number
@@ -265,7 +265,7 @@ WITH zora_trades AS (
         {% if is_incremental() %}
         AND z3_rale_rp.evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    UNION
+    UNION ALL
     SELECT 'v2' AS version
     , z2_ae.evt_block_time AS block_time
     , z2_ae.evt_block_number AS block_number
@@ -284,7 +284,7 @@ WITH zora_trades AS (
     {% if is_incremental() %}
     WHERE z2_ae.evt_block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-    UNION
+    UNION ALL
     SELECT 'v1' AS version
     , z1_bf.evt_block_time AS block_time
     , z1_bf.evt_block_number AS block_number


### PR DESCRIPTION
Brief comments on the purpose of your changes:

I checked the current scripts, `UNION` is used too much. I think this will significantly impact the performance aspect of the current DB.

In most cases, using `UNION ALL` is highly recommended rather than using `UNION` except in some cases on purpose.

`UNION ALL` simply merges two tables. So, it checks whether only the number of columns and data type are the same then merges them immediately.
On the other hand, `UNION` looks similar but additionally, it removes all duplicated rows. To this, DB performs sorting or something equivalent to find a duplicate value. All volumes (columns * rows) are included in this heavy operation.

This is a SQL grammar, so I think there is no exception regardless of DB type or architecture. At least every DB I used did.

For this PR, I have modified only the parts where the logic is clear and most large performance degradation is expected.


*For Dune Engine V2*
I've checked that:
General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
