### PR TITLE
Rewrote native mints abstraction

### DIFF
--- a/models/nft/ethereum/nft_ethereum_native_mints.sql
+++ b/models/nft/ethereum/nft_ethereum_native_mints.sql
@@ -7,164 +7,131 @@
         post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "sector",
                                     "nft",
-                                    \'["umer_h_adil"]\') }}')
+                                    \'["umer_h_adil", "hildobby"]\') }}')
 }}
 
-with 
--- ethereum.contracts can contain duplicates, i.e., for one address there might be multiple names
--- This is a bug and will be fixed. 
--- In the meanwhile, to prevent duplicate mints in our table, we implement a temporary fix by taking the most recent entry in ethereum.contracts
--- This fix can be removed as soon as ethereum.contracts is fixed.
-contract_names_without_duplicates as (
-	select
-		address,
-		first(namespace) as namespace
-	from {{ source('ethereum','contracts') }}
-	group by
-		address
-),
-ercs as (
-select
-  evt_block_time,
-  evt_block_number,
-  evt_tx_hash,
-  evt_index,
-  tokenId,
-  from,
-  to,
-  contract_address,
-  'erc721' as token_standard,
-  'Single Item Trade' as trade_type,
-  1 as number_of_items
-from {{ source('erc721_ethereum','evt_transfer') }}
-where from = '0x0000000000000000000000000000000000000000'
-	union
-select
-  evt_block_time,
-  evt_block_number,
-  evt_tx_hash,
-  evt_index,
-  id as tokenId,
-  from,
-  to,
-  contract_address,
-  'erc1155' as token_standard,
-  -- with an TransferSingle event only one item type is traded
-  'Single Item Trade' as trade_type,
-  -- of that item type any number of items can be traded
-  value as number_of_items
-from {{ source('erc1155_ethereum','evt_transfersingle') }}
-where from = '0x0000000000000000000000000000000000000000'
-	union
-select
-  evt_block_time,
-  evt_block_number,
-  evt_tx_hash,
-  evt_index,
-  case
-    -- if only one item type was traded: use it's id
-	when size(ids) = 1 then ids[0]
-    -- otherwise there's no meaningful id to display
-	when size(ids) > 1 then ''
-	else null
-  end as tokenId,
-  from,
-  to,
-  contract_address,
-  'erc1155' as token_standard,
-  case
-	when size(ids) > 1 then 'Bundle Trade'
-	when size(ids) = 1 then 'Single Item Trade'
-	else null
-  end as trade_type,
-  -- take the number of unique items as number_of_items
-  -- -- example:
-  -- -- --   ids = ["id_1", "id_2", "id_3"], values = ["1", "1", "2"] => number_of_items = 3
-  -- technically, it should be the sum of values (e.g. 4 in the example),
-  -- but in almost all erc1155 bundle transactions only one of each item type is transferred
-  -- so this implementation almost always be correct 
-  size(values) as number_of_items
-from {{ source('erc1155_ethereum','evt_transferbatch') }}
-where from = '0x0000000000000000000000000000000000000000'
-)
-select
-  'ethereum' as blockchain,
-  ec.namespace as project,
-  '' as version,
-  ercs.evt_block_time as block_time,
-  ercs.tokenId as token_id,
-  tokens_nft.name as collection,
-  prc.price * tx.value / sum(
-    case
-        when ercs.`from` = '0x0000000000000000000000000000000000000000' then 1
-        else 0
-    end
-  ) over (
-    partition by
-      ercs.contract_address,
-      ercs.evt_tx_hash
-  ) / power(10, prc.decimals) as amount_usd,
-  token_standard,
-  trade_type,
-  sum(
-    case
-        when ercs.`from` = '0x0000000000000000000000000000000000000000' then 1
-        else 0
-    end
-  ) over (
-    partition by
-      ercs.contract_address,
-      ercs.evt_tx_hash
-  ) as number_of_items,
-  'Buy' as trade_category,
-  'Mint' as evt_type,
-  ercs.`from` as seller,
-  ercs.`to` as buyer,
-  tx.value / sum(
-    case
-        when ercs.`from` = '0x0000000000000000000000000000000000000000' then 1
-        else 0
-    end
-  ) over (
-    partition by
-      ercs.contract_address,
-      ercs.evt_tx_hash
-  ) / power(10, prc.decimals) as amount_original,
-  tx.value / sum(
-    case
-        when ercs.`from` = '0x0000000000000000000000000000000000000000' then 1
-        else 0
-    end
-  ) over (
-    partition by
-      ercs.contract_address,
-      ercs.evt_tx_hash
-  )  as amount_raw,
-  'ETH' as currency_symbol,
-  '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as currency_contract,
-  ercs.contract_address as nft_contract_address,
-  ercs.to as project_contract_address,
-  '' as aggregator_name,
-  '' as aggregator_address,
-  ercs.evt_tx_hash as tx_hash,
-  ercs.evt_block_number as block_number,
-  ercs.`from` as tx_from,
-  ercs.`to` as tx_to,
-  ercs.contract_address || '-' || ercs.evt_tx_hash || '-' || coalesce(ercs.tokenId, '') || '-' || ercs.`from` || '-' || ercs.evt_index
-  as unique_trade_id
-from
-  ercs
-  left join {{ ref('tokens_nft') }} tokens_nft on ercs.contract_address = tokens_nft.contract_address and tokens_nft.blockchain = 'ethereum'
-  inner join {{ source('ethereum','transactions') }} tx on ercs.evt_tx_hash = tx.hash
-  left join {{ source('prices','usd') }} prc on prc.contract_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-  and prc.minute = date_trunc('minute', ercs.evt_block_time)
-  and prc.blockchain = 'ethereum'
-  left join contract_names_without_duplicates ec ON ec.address = ercs.to
-where
-  -- We're interested in collectible NFTs (e.g. BAYC), not functional NFTs (e.g. Uniswap LP), so we exclude NFTs originated in DeFi 
-  ercs.to not in (select address from {{ ref('addresses_ethereum_defi') }})
-  {% if is_incremental() %}
-  and ercs.evt_block_time >= date_trunc("day", now() - interval '1 week')
-  and tx.block_time >= date_trunc("day", now() - interval '1 week')
-  and prc.minute >= date_trunc("day", now() - interval '1 week')
-  {% endif %}
+
+WITH nft_mints AS (
+    SELECT evt_block_time, evt_block_number, evt_tx_hash, contract_address, from, to, tokenId AS token_id, 'erc721' AS standard
+    , 1 AS amount
+    FROM {{ source('erc721_ethereum','evt_transfer') }}
+    WHERE from='0x0000000000000000000000000000000000000000'
+    AND to NOT IN (SELECT address FROM addresses_ethereum.defi) -- We're interested in collectible NFTs (e.g. BAYC), not functional NFTs (e.g. Uniswap LP), so we exclude NFTs originated in DeFi
+    {% if is_incremental() %}
+    AND evt_block_time >= date_trunc("day", NOW() - interval '1 week')
+    {% endif %}
+    UNION
+    SELECT evt_block_time, evt_block_number, evt_tx_hash, contract_address, from, to, id AS token_id, 'erc1155' AS standard
+    , value AS amount
+    FROM {{ source('erc1155_ethereum','evt_transfersingle') }}
+    WHERE from='0x0000000000000000000000000000000000000000'
+    AND to NOT IN (SELECT address FROM addresses_ethereum.defi) -- We're interested in collectible NFTs (e.g. BAYC), not functional NFTs (e.g. Uniswap LP), so we exclude NFTs originated in DeFi
+    {% if is_incremental() %}
+    AND evt_block_time >= date_trunc("day", NOW() - interval '1 week')
+    {% endif %}
+    UNION
+    SELECT evt_block_time, evt_block_number, evt_tx_hash, contract_address, from, to
+    , ids_and_count.ids AS token_id
+    , 'erc1155' AS standard
+    , ids_and_count.values AS amount
+    FROM (
+        SELECT evt_block_time, evt_block_number, evt_tx_hash, contract_address, from, to, evt_index
+        , explode(arrays_zip(values, ids)) AS ids_and_count
+        FROM {{ source('erc1155_ethereum','evt_transferbatch') }}
+        WHERE from='0x0000000000000000000000000000000000000000'
+        AND to NOT IN (SELECT address FROM addresses_ethereum.defi) -- We're interested in collectible NFTs (e.g. BAYC), not functional NFTs (e.g. Uniswap LP), so we exclude NFTs originated in DeFi
+      {% if is_incremental() %}
+      AND evt_block_time >= date_trunc("day", NOW() - interval '1 week')
+      {% endif %}
+        GROUP BY evt_block_time, evt_block_number, evt_tx_hash, contract_address, from, to, evt_index, values, ids
+        )
+    WHERE ids_and_count.values > 0
+    GROUP BY evt_block_time, evt_block_number, evt_tx_hash, contract_address, from, to, evt_index, token_id, amount
+    )
+
+, namespaces AS (
+    SELECT address,
+    , FIRST(namespace) AS namespace
+	FROM {{ source('ethereum','contracts') }}
+	GROUP BY address
+	)
+
+, nfts_per_tx AS (
+    SELECT evt_tx_hash
+    , COUNT(*) AS nfts_minted_in_tx
+    FROM nft_mints
+    GROUP BY evt_tx_hash
+    )
+
+SELECT 'ethereum' AS blockchain
+, COALESCE(ec.namespace, 'Unknown') AS project
+, NULL AS version
+, nft_mints.evt_block_time AS block_time
+, date_trunc('day', nft_mints.evt_block_time) AS block_date
+, nft_mints.evt_block_number AS block_number
+, nft_mints.token_id AS token_id
+, tok.name AS collection
+, nft_mints.standard AS token_standard
+, CASE WHEN nft_mints.amount=1 THEN 'Single Item Mint'
+    ELSE 'Bundle Mint'
+    END AS trade_type
+, nft_mints.amount AS number_of_items
+, 'Mint' AS trade_category
+, 'Mint' AS evt_type
+, nft_mints.from AS seller
+, nft_mints.to AS buyer
+, COALESCE(SUM(et.value), SUM(erc20s.value), 0)*(nft_mints.amount/nft_count.nfts_minted_in_tx) AS amount_raw
+, COALESCE(SUM(et.value)/POWER(10, 18), SUM(erc20s.value)/POWER(10, pu_erc20s.decimals))*(nft_mints.amount/nft_count.nfts_minted_in_tx) AS amount_original
+, COALESCE(pu_eth.price*SUM(et.value)/POWER(10, 18), pu_erc20s.price*SUM(erc20s.value)/POWER(10, pu_erc20s.decimals))*(nft_mints.amount/nft_count.nfts_minted_in_tx) AS amount_usd
+, CASE WHEN et.success THEN 'ETH' ELSE pu_erc20s.symbol END AS currency_symbol
+, CASE WHEN et.success THEN '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' ELSE erc20s.contract_address END AS currency_contract
+, nft_mints.contract_address AS nft_contract_address
+, etxs.to AS project_contract_address
+, agg.name AS aggregator_name
+, agg.contract_address AS aggregator_address
+, nft_mints.evt_tx_hash AS tx_hash
+, etxs.from AS tx_from
+, etxs.to AS tx_to
+, 0 AS platform_fee_amount_raw
+, 0 AS platform_fee_amount
+, 0 AS platform_fee_amount_usd
+, 0 AS platform_fee_percentage
+, NULL AS royalty_fee_receive_address
+, 0 AS royalty_fee_currency_symbol
+, 0 AS royalty_fee_amount_raw
+, 0 AS royalty_fee_amount
+, 0 AS royalty_fee_amount_usd
+, 0 AS royalty_fee_percentage
+, 'ethereum' || '-' || COALESCE(ec.namespace, 'Unknown') || '-Mint-' || nft_mints.evt_tx_hash || '-' || nft_mints.to || '-' ||  nft_mints.contract_address || '-' || nft_mints.token_id AS unique_trade_id
+FROM nft_mints nft_mints
+LEFT JOIN nfts_per_tx nft_count ON nft_count.evt_tx_hash=nft_mints.evt_tx_hash
+LEFT JOIN {{ source('ethereum','traces') }} et ON et.block_time=nft_mints.evt_block_time
+    AND et.tx_hash=nft_mints.evt_tx_hash
+    AND et.from=nft_mints.to
+    AND (et.call_type NOT IN ('delegatecall', 'callcode', 'staticcall') OR et.call_type IS NULL)
+    AND et.success
+    AND et.value > 0
+LEFT JOIN {{ source('prices','usd') }} pu_eth ON pu_eth.blockchain='ethereum'
+    AND pu_eth.minute=date_trunc('minute', et.block_time)
+    AND pu_eth.contract_address='0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+LEFT JOIN erc20_ethereum.evt_Transfer erc20s ON erc20s.evt_block_time=nft_mints.evt_block_time
+    AND erc20s.from=nft_mints.to
+LEFT JOIN {{ source('prices','usd') }} pu_erc20s ON pu_erc20s.blockchain='ethereum'
+    AND pu_erc20s.minute=date_trunc('minute', erc20s.evt_block_time)
+    AND erc20s.contract_address=pu_erc20s.contract_address
+LEFT JOIN {{ source('ethereum','transactions') }} etxs ON etxs.block_time=nft_mints.evt_block_time
+    AND etxs.hash=nft_mints.evt_tx_hash
+LEFT JOIN {{ ref('nft_ethereum_aggregators') }} agg ON etxs.to=agg.contract_address
+LEFT JOIN {{ ref('tokens_nft') }} tok ON tok.contract_address=nft_mints.contract_address
+LEFT JOIN namespaces ec ON etxs.to=ec.address
+{% if is_incremental() %}
+WHERE nft_mints.evt_block_time >= date_trunc("day", now() - interval '1 week')
+AND  et.block_time >= date_trunc("day", now() - interval '1 week')
+AND  pu_eth.minute >= date_trunc("day", now() - interval '1 week')
+AND  pu_erc20s.minute >= date_trunc("day", now() - interval '1 week')
+AND  etxs.block_time >= date_trunc("day", now() - interval '1 week')
+{% endif %}
+GROUP BY nft_mints.evt_block_time, nft_mints.evt_block_number, nft_mints.token_id, nft_mints.standard
+, nft_mints.amount, nft_mints.from, nft_mints.to, nft_mints.contract_address, etxs.to
+, nft_mints.evt_tx_hash, etxs.from, ec.namespace, tok.name, pu_erc20s.decimals, pu_eth.price, pu_erc20s.price
+, agg.name, agg.contract_address, nft_count.nfts_minted_in_tx, pu_erc20s.symbol, erc20s.contract_address, et.success

--- a/models/nft/ethereum/nft_ethereum_schema.yml
+++ b/models/nft/ethereum/nft_ethereum_schema.yml
@@ -20,7 +20,7 @@ models:
     meta:
       blockchain: ethereum
       sector: nft
-      contributors: umer_h_adil
+      contributors: umer_h_adil, hildobby
     config:
       tags: ['nft','ethereum']
     description: >
@@ -35,6 +35,8 @@ models:
         description: "Project version"
       - name: block_time
         description: "UTC event block time"
+      - name: block_date
+        description: "Date in which the transaction was executed"
       - name: token_id
         description: "NFT Token ID"
       - name: collection
@@ -74,7 +76,7 @@ models:
       - name: tx_hash
         description:  "Transaction hash"
       - name: block_number
-        description: "Block number in which the transaction was executed "
+        description: "Block number in which the transaction was executed"
       - name: tx_from
         description:  "Address that initiated the transaction"
       - name: tx_to

--- a/models/nft/nft_mints.sql
+++ b/models/nft/nft_mints.sql
@@ -3,7 +3,7 @@
         post_hook='{{ expose_spells(\'["ethereum","solana"]\',
                     "sector",
                     "nft",
-                    \'["soispoke","umer_h_adil"]\') }}')
+                    \'["soispoke","umer_h_adil","hildobby"]\') }}')
 }}
 
 WITH project_mints AS (


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Native mints abstraction was causing some issues to nft.events and nft.mints, this hopefully fixes those.

*For Dune Engine V2*
I've checked that:
General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
