### PR TITLE
Edit location name syntax

### DIFF
--- a/macros/dune/create_seed_as.sql
+++ b/macros/dune/create_seed_as.sql
@@ -13,7 +13,7 @@
         {%- endfor -%}
     )
     {% if s3_bucket != 'local' %}
-        {{ file_format_clause() }} location "{{ 's3a://'+ s3_bucket + '/' +  this.render() | replace(".","/") | replace("_","-") }}"
+        {{ file_format_clause() }} location "{{ 's3a://'+ s3_bucket + '/' +  this.render() | replace(".","/") }}"
     {% else %}
         {{ file_format_clause() }}
     {% endif %}
@@ -46,7 +46,7 @@
         {%- endfor -%}
     )
     {% if s3_bucket != 'local' %}
-        {{ file_format_clause() }} location "{{ 's3a://'+ s3_bucket + '/' +  this.render() | replace(".","/") | replace("_","-") }}"
+        {{ file_format_clause() }} location "{{ 's3a://'+ s3_bucket + '/' +  this.render() | replace(".","/") }}"
     {% else %}
         {{ file_format_clause() }}
     {% endif %}    {{ partition_cols(label="partitioned by") }}

--- a/macros/dune/create_table_as.sql
+++ b/macros/dune/create_table_as.sql
@@ -12,7 +12,7 @@
         create table {{ relation }}
       {% endif %}
             {% if s3_bucket != 'local' %}
-                {{ file_format_clause() }} location "{{ 's3a://'+ s3_bucket + '/' +  relation | replace(".","/") | replace("_","-") }}"
+                {{ file_format_clause() }} location "{{ 's3a://'+ s3_bucket + '/' +  relation | replace(".","/") }}"
              {% else %}
                 {{ file_format_clause() }}
             {% endif %}
@@ -49,7 +49,7 @@
         create table {{ relation }}
       {% endif %}
         {% if s3_bucket != 'local' %}
-            {{ file_format_clause() }} location "{{ 's3a://'+ s3_bucket + '/' +  relation | replace(".","/") | replace("_","-") }}"
+            {{ file_format_clause() }} location "{{ 's3a://'+ s3_bucket + '/' +  relation | replace(".","/") }}"
          {% else %}
             {{ file_format_clause() }}
         {% endif %}


### PR DESCRIPTION
Script-generated s3 paths for migration did not replace '_' with '-' but the macros do. I am removing the replace statement from the macro to alleviate this. 