### PR TITLE
Fix shrink manifest for dbt v1.3

### DIFF
--- a/scripts/docs_shrink_manifest.py
+++ b/scripts/docs_shrink_manifest.py
@@ -10,16 +10,16 @@ class ManifestEditor:
 
     @staticmethod
     def filter_large_raw_sql(node, max_lines=500):
-        raw_sql = node.get('raw_sql', '')
-        compiled_sql = node.get('compiled_sql', '')
+        raw_code = node.get('raw_code', '')
+        compiled_code = node.get('compiled_code', '')
 
-        if raw_sql.count('\n') > max_lines:
-            node['raw_sql'] = ''.join(
-                raw_sql.split('\n')[0:max_lines])
+        if raw_code.count('\n') > max_lines:
+            node['raw_code'] = ''.join(
+                raw_code.split('\n')[0:max_lines])
 
-        if compiled_sql.count('\n') > max_lines:
-            node['compiled_sql'] = ''.join(
-                compiled_sql.split('\n')[0:max_lines])
+        if compiled_code.count('\n') > max_lines:
+            node['compiled_code'] = ''.join(
+                compiled_code.split('\n')[0:max_lines])
 
         return node
 


### PR DESCRIPTION
Brief comments on the purpose of your changes:

[dbt v1.3](https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.3) has made a breaking change to mainfest.json:

> If you have custom code accessing the `raw_sql` property of [model](https://docs.getdbt.com/reference/dbt-jinja-functions/model)s (with the model or [graph](https://docs.getdbt.com/reference/dbt-jinja-functions/graph) objects), it has been renamed to `raw_code`. This is a change to the manifest contract, described in more detail below.

This updates our shrink manifest logic accordingly. Tested locally, new manifest.json is 8.6M.
