### PR TITLE
Exclude Tests From some Hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,6 @@ repos:
   - id: dbt-compile
   - id: check-script-ref-and-source
   - id: check-model-has-description
+    exclude: ^tests/
   - id: check-model-has-properties-file
+    exclude: ^tests/


### PR DESCRIPTION
Extending on https://github.com/duneanalytics/spellbook/pull/1761/files

I have noticed that these hooks fail in many cases on the test directory (a place model properties and description aren't relevant - or at least -  aren't used)

See also [this failing run](https://github.com/duneanalytics/spellbook/actions/runs/3409911862/jobs/5672249882):where only test files were changed.

This is related to a comment made [here](https://github.com/duneanalytics/spellbook/pull/1761#issuecomment-1305483882)