### PR TITLE
Remove redundant brackets in some view definitions

### DIFF
--- a/models/element/avalanche_c/element_avalanche_c_burns.sql
+++ b/models/element/avalanche_c/element_avalanche_c_burns.sql
@@ -30,5 +30,5 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('element_avalanche_c_events') }})
+FROM {{ ref('element_avalanche_c_events') }}
 WHERE evt_type = 'Burn'

--- a/models/element/avalanche_c/element_avalanche_c_fees.sql
+++ b/models/element/avalanche_c/element_avalanche_c_fees.sql
@@ -35,4 +35,4 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('element_avalanche_c_events') }})
+FROM {{ ref('element_avalanche_c_events') }}

--- a/models/element/avalanche_c/element_avalanche_c_mints.sql
+++ b/models/element/avalanche_c/element_avalanche_c_mints.sql
@@ -30,5 +30,5 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('element_avalanche_c_events') }})
+FROM {{ ref('element_avalanche_c_events') }}
 WHERE evt_type = 'Mint'

--- a/models/element/bnb/element_bnb_burns.sql
+++ b/models/element/bnb/element_bnb_burns.sql
@@ -30,5 +30,5 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('element_bnb_events') }})
+FROM {{ ref('element_bnb_events') }}
 WHERE evt_type = 'Burn'

--- a/models/element/bnb/element_bnb_fees.sql
+++ b/models/element/bnb/element_bnb_fees.sql
@@ -35,4 +35,4 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('element_bnb_events') }})
+FROM {{ ref('element_bnb_events') }}

--- a/models/element/bnb/element_bnb_mints.sql
+++ b/models/element/bnb/element_bnb_mints.sql
@@ -30,5 +30,5 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('element_bnb_events') }})
+FROM {{ ref('element_bnb_events') }}
 WHERE evt_type = 'Mint'

--- a/models/element/ethereum/element_ethereum_burns.sql
+++ b/models/element/ethereum/element_ethereum_burns.sql
@@ -30,5 +30,5 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('element_ethereum_events') }})
+FROM {{ ref('element_ethereum_events') }}
 WHERE evt_type = 'Burn'

--- a/models/element/ethereum/element_ethereum_fees.sql
+++ b/models/element/ethereum/element_ethereum_fees.sql
@@ -35,4 +35,4 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('element_ethereum_events') }})
+FROM {{ ref('element_ethereum_events') }}

--- a/models/element/ethereum/element_ethereum_mints.sql
+++ b/models/element/ethereum/element_ethereum_mints.sql
@@ -30,5 +30,5 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('element_ethereum_events') }})
+FROM {{ ref('element_ethereum_events') }}
 WHERE evt_type = 'Mint'

--- a/models/superrare/superrare_ethereum_fees.sql
+++ b/models/superrare/superrare_ethereum_fees.sql
@@ -39,4 +39,4 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('superrare_ethereum_events') }})
+FROM {{ ref('superrare_ethereum_events') }}

--- a/models/superrare/superrare_ethereum_trades.sql
+++ b/models/superrare/superrare_ethereum_trades.sql
@@ -34,5 +34,5 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('superrare_ethereum_events') }})
+FROM {{ ref('superrare_ethereum_events') }}
 WHERE evt_type = 'Trade'

--- a/models/zora/ethereum/zora_ethereum_burns.sql
+++ b/models/zora/ethereum/zora_ethereum_burns.sql
@@ -34,5 +34,5 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('zora_ethereum_events') }})
+FROM {{ ref('zora_ethereum_events') }}
 WHERE evt_type = 'Burn'

--- a/models/zora/ethereum/zora_ethereum_fees.sql
+++ b/models/zora/ethereum/zora_ethereum_fees.sql
@@ -39,4 +39,4 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('zora_ethereum_events') }})
+FROM {{ ref('zora_ethereum_events') }}

--- a/models/zora/ethereum/zora_ethereum_mints.sql
+++ b/models/zora/ethereum/zora_ethereum_mints.sql
@@ -34,5 +34,5 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('zora_ethereum_events') }})
+FROM {{ ref('zora_ethereum_events') }}
 WHERE evt_type = 'Mint'

--- a/models/zora/ethereum/zora_ethereum_trades.sql
+++ b/models/zora/ethereum/zora_ethereum_trades.sql
@@ -34,5 +34,5 @@ tx_hash,
 tx_from,
 tx_to,
 unique_trade_id
-FROM ({{ ref('zora_ethereum_events') }})
+FROM {{ ref('zora_ethereum_events') }}
 WHERE evt_type = 'Trade'


### PR DESCRIPTION
Brief comments on the purpose of your changes:

I believe the `FROM (...)` syntax is not ANSI SQL compliant. This can make it difficult for some parsers to understand these views.

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
