### PR TITLE
add polygon tables & update base sources

### DIFF
--- a/models/base_sources/arbitrum_base_sources.yml
+++ b/models/base_sources/arbitrum_base_sources.yml
@@ -58,13 +58,12 @@ sources:
             description: "Any binary data payload"
           - name: hash
             description: "Primary key of the transaction"
-            tests:
-              - unique
-              - not_null
           - name: type
             description: "Transaction type"
           - name: access_list
             description: "Specifies a list of addresses and storage keys"
+          - name: effective_gas_price
+          - name: gas_used_for_l1
 
       - name: traces
         loaded_at_field: block_time

--- a/models/base_sources/arbitrum_base_sources.yml
+++ b/models/base_sources/arbitrum_base_sources.yml
@@ -8,9 +8,6 @@ sources:
       warn_after: { count: 12, period: hour }
     tables:
       - name: transactions
-        description: "underlying transactions table. arbitrum.transactions is an exposed view of this table."
-        loaded_at_field: block_time
-      - name: transactions
         loaded_at_field: block_time
         description: "An Arbitrum transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:

--- a/models/base_sources/arbitrum_base_sources.yml
+++ b/models/base_sources/arbitrum_base_sources.yml
@@ -7,7 +7,7 @@ sources:
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
-      - name: transactions_0006
+      - name: transactions
         description: "underlying transactions table. arbitrum.transactions is an exposed view of this table."
         loaded_at_field: block_time
       - name: transactions

--- a/models/base_sources/arbitrum_base_sources.yml
+++ b/models/base_sources/arbitrum_base_sources.yml
@@ -1,32 +1,143 @@
 version: 2
 
 sources:
-# Base Tables
+  # Base Tables
   - name: arbitrum
-    description: "Arbitrum raw tables"
+    description: "Arbitrum raw tables including transactions, traces and logs."
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
+      - name: transactions_0006
+        description: "underlying transactions table. arbitrum.transactions is an exposed view of this table."
+        loaded_at_field: block_time
       - name: transactions
         loaded_at_field: block_time
+        description: "An Arbitrum transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:
-          - name: priority_fee_per_gas
+          - &block_date
+            name: block_date
+            description: "Block event date in UTC"
+          - &block_time
+            name: block_time
+            description: "Timestamp for block event time in UTC"
+          - &value
+            name: value
+            description: "Amount of ETH transferred from sender to recipient"
+          - &block_number
+            name: block_number
+            description: "Block number"
+          - name: gas_limit
+            description: "Maximum amount of gas units that can be consumed by the transaction"
+          - name: gas_price
+            description: "Gas price denoted in gwei, which itself is a denomination of ETH - each gwei is equal to 10-9 ETH"
+          - name: gas_used
+            description: "Number of gas units consumed by the transaction"
+          - name: max_fee_per_gas
+            description: "Maximum amount of gas willing to be paid for the transaction"
+          - name: max_priority_fee_per_gas
+            description: "Maximum amount of gas to be included as a tip to the miner"
+          - name: base_fee_per_gas
+            description: "Market price for gas"
           - name: nonce
+            description: "Number of confirmed transactions previously sent by this account"
           - name: index
-          - name: success
+            description: "Transaction index"
+          - &success
+            name: success
+            description: "Whether the transaction was completed successfully"
           - &from
             name: from
             description: "Wallet address that initiated the transaction"
           - &to
             name: to
             description: "Wallet address that received the transaction"
-          - name: block_hash
+          - &block_hash
+            name: block_hash
+            description: "Primary key of the block"
           - name: data
+            description: "Any binary data payload"
           - name: hash
+            description: "Primary key of the transaction"
+            tests:
+              - unique
+              - not_null
           - name: type
+            description: "Transaction type"
           - name: access_list
-          - name: effective_gas_price
-          - name: gas_used_for_l1
+            description: "Specifies a list of addresses and storage keys"
+
+      - name: traces
+        loaded_at_field: block_time
+        description: "An Arbitrum trace is a small atomic action that modify the internal state of the Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
+        columns:
+          - *block_date
+          - *block_time
+          - *block_number
+          - *value
+          - name: gas
+            description: "Amount of gas consumed by the trace"
+          - name: gas_used
+            description: "Number of gas units used by the trace"
+          - *block_hash
+          - name: success
+            description: "Whether the trace was completed successfully"
+          - &tx_index
+            name: tx_index
+            description: "Transaction index"
+          - name: subtraces
+            description: "Number of subtraces (i.e, number of calls at a particular level within a transaction)"
+          - name: error
+            description: "Error log"
+          - name: tx_success
+            description: "Whether the transaction was completed sucessfully"
+          - &tx_hash
+            name: tx_hash
+            description: "Primary key of the transaction"
+          - name: from
+            description: "Wallet address that initiated the trace"
+          - name: to
+            description: "Wallet address that received the trace"
+          - name: trace_address
+            description: "All returned traces, gives the exact location in the call trace"
+          - name: type
+            description: "Type of trace (e.g., call, create, suicide)"
+          - name: address
+            description: "Address of the trace creator"
+          - name: code
+            description: "Raw EVM code for the trace"
+          - name: call_type
+            description: "Hexadecimal representations of the trace's call type"
+          - name: input
+            description: "Input data for the trace"
+          - name: output
+            description: "Output data for the trace"
+          - name: refund_address
+            description: "Refund Address"
+
+      - name: logs
+        loaded_at_field: block_time
+        description: "An Arbitrum log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
+        columns:
+          - *block_date
+          - *block_time
+          - *block_number
+          - *block_hash
+          - name: contract_address
+            description: "Address of the arbitrum smart contract generating the log"
+          - name: topic1
+            description: "Topics are 32-byte (256 bit) “words” that are used to describe what’s going on in an event. The first topic usually consists of the signature of the name of the event that occurred, including the types (uint256, string, etc.) of its parameters."
+          - name: topic2
+            description: "Second topic"
+          - name: topic3
+            description: "Third topic"
+          - name: topic4
+            description: "Fourth topic"
+          - name: data
+            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings."
+          - *tx_hash
+          - name: index
+            description: "Log index"
+          - *tx_index
 
       - name: blocks
         freshness:
@@ -49,7 +160,8 @@ sources:
 
       - name: contracts
         freshness:
-          warn_after: { count: 7, period: day }
+          warn_after: { count: 1, period: day }
+          error_after: { count: 3, period: day }
         loaded_at_field: created_at
         description: "A view keeping track of what contracts are decoded on Dune on Arbitrum; contains information associated with the decoded contract such as namespace, name, address, ABI."
         columns:
@@ -77,14 +189,15 @@ sources:
               - accepted_values:
                   values: ["factory", "base", "dynamic"]
           - name: created_at
+            description: "Timestamp for contract creation"
 
-# ERC Transfer Tables
+  # ERC Transfer Tables
   - name: erc20_arbitrum
     description: "Transfers events for ERC20 tokens on Arbitrum."
     tables:
       - name: evt_transfer
         loaded_at_field: evt_block_time
-        description: "Transfers events for ERC20 tokens."
+        description: "Transfers events for ERC20 tokens on Arbitrum."
         freshness:
           warn_after: { count: 12, period: hour }
           error_after: { count: 24, period: hour }
@@ -132,7 +245,7 @@ sources:
 
       - name: evt_transferbatch
         loaded_at_field: evt_block_time
-        description: "Batch transfers events for ERC1155 tokens on Arbitrum."
+        description: "Batch transfers events for ERC1155 tokens on Arbirtrum."
         columns:
           - name: contract_address
             description: "ERC1155 token contract address"
@@ -149,7 +262,7 @@ sources:
           - name: values
             description: "Amounts of ERC1155 token transferred"
 
-  - name: erc721_arbitrum
+  - name: evt_transferbatch
     description: "Transfers events for ERC721 tokens on Arbitrum."
     tables:
       - name: evt_transfer

--- a/models/base_sources/arbitrum_base_sources.yml
+++ b/models/base_sources/arbitrum_base_sources.yml
@@ -10,14 +10,6 @@ sources:
       - name: transactions
         loaded_at_field: block_time
         columns:
-          - name: block_time
-          - name: value
-          - name: block_number
-          - name: gas_limit
-          - name: gas_price
-          - name: gas_used
-          - name: max_fee_per_gas
-          - name: max_priority_fee_per_gas
           - name: priority_fee_per_gas
           - name: nonce
           - name: index
@@ -115,3 +107,63 @@ sources:
           - *to
           - name: value
             description: "Amount of ERC20 token transferred"
+
+  - name: erc1155_arbitrum
+    description: "Transfers events for ERC1155 tokens on Arbitrum."
+    tables:
+      - name: evt_transfersingle
+        loaded_at_field: evt_block_time
+        description: "Single transfers events for ERC1155 tokens on Arbitrum."
+        columns:
+          - name: contract_address
+            description: "ERC1155 token contract address"
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - name: operator
+            description: "Addresses authorized (or approved) by a NFT owner to spend all of his token Ids."
+          - *from
+          - *to
+          - name: id
+            description: "ERC1155 token ID"
+          - name: value
+            description: "Amount of ERC1155 token transferred"
+
+      - name: evt_transferbatch
+        loaded_at_field: evt_block_time
+        description: "Batch transfers events for ERC1155 tokens on Arbitrum."
+        columns:
+          - name: contract_address
+            description: "ERC1155 token contract address"
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - name: operator
+            description: "Addresses authorized (or approved) by a NFT owner to spend all of his token Ids."
+          - *from
+          - *to
+          - name: ids
+            description: "ERC1155 token IDs"
+          - name: values
+            description: "Amounts of ERC1155 token transferred"
+
+  - name: erc721_arbitrum
+    description: "Transfers events for ERC721 tokens on Arbitrum."
+    tables:
+      - name: evt_transfer
+        loaded_at_field: evt_block_time
+        description: "Transfers events for ERC721 tokens on Arbitrum."
+        columns:
+          - &contract_address
+            name: contract_address
+            description: "ERC721 token contract address"
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - *from
+          - *to
+          - name: tokenId
+            description: "ERC721 token ID."

--- a/models/base_sources/avalanche_c_base_sources.yml
+++ b/models/base_sources/avalanche_c_base_sources.yml
@@ -7,7 +7,7 @@ sources:
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
-      - name: transactions_0006
+      - name: transactions
         description: "underlying transactions table. avalanche_c.transactions is an exposed view of this table."
         loaded_at_field: block_time
       - name: transactions

--- a/models/base_sources/avalanche_c_base_sources.yml
+++ b/models/base_sources/avalanche_c_base_sources.yml
@@ -10,24 +10,43 @@ sources:
       - name: transactions
         loaded_at_field: block_time
         columns:
+          - &block_date
+            name: block_date
+            description: "Block event date in UTC"
           - &block_time
             name: block_time
             description: "Timestamp for block event time in UTC"
-          - name: value
+          - &value
+            name: value
+            description: "Amount of AVAX transferred from sender to recipient"
           - &block_number
             name: block_number
             description: "Block number"
           - name: gas_limit
+            description: "Maximum amount of gas units that can be consumed by the transaction"
           - name: gas_price
+            description: "Gas price denoted in gwei, which itself is a denomination of AVAX - each gwei is equal to 10-9 AVAX"
           - name: gas_used
+            description: "Number of gas units consumed by the transaction"
           - name: max_fee_per_gas
+            description: "Maximum amount of gas willing to be paid for the transaction"
           - name: max_priority_fee_per_gas
-          - name: priority_fee_per_gas
+            description: "Maximum amount of gas to be included as a tip to the miner"
+          - name: base_fee_per_gas
+            description: "Market price for gas"
           - name: nonce
+            description: "Number of confirmed transactions previously sent by this account"
           - name: index
-          - name: success
-          - name: from
-          - name: to
+            description: "Transaction index"
+          - &success
+            name: success
+            description: "Whether the transaction was completed successfully"
+          - &from
+            name: from
+            description: "Wallet address that initiated the transaction"
+          - &to
+            name: to
+            description: "Wallet address that received the transaction"
           - &block_hash
             name: block_hash
             description: "Primary key of the block"
@@ -39,7 +58,57 @@ sources:
               - unique
               - not_null
           - name: type
+            description: "Transaction type"
           - name: access_list
+            description: "Specifies a list of addresses and storage keys"
+
+      - name: traces
+        loaded_at_field: block_time
+        description: "An Avalanche C-Chain trace is a small atomic action that modify the internal state of the Avalanche's Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
+        columns:
+          - *block_date
+          - *block_time
+          - *block_number
+          - *value
+          - name: gas
+            description: "Amount of gas consumed by the trace"
+          - name: gas_used
+            description: "Number of gas units used by the trace"
+          - *block_hash
+          - name: success
+            description: "Whether the trace was completed successfully"
+          - &tx_index
+            name: tx_index
+            description: "Transaction index"
+          - name: subtraces
+            description: "Number of subtraces (i.e, number of calls at a particular level within a transaction)"
+          - name: error
+            description: "Error log"
+          - name: tx_success
+            description: "Whether the transaction was completed sucessfully"
+          - &tx_hash
+            name: tx_hash
+            description: "Primary key of the transaction"
+          - name: from
+            description: "Wallet address that initiated the trace"
+          - name: to
+            description: "Wallet address that received the trace"
+          - name: trace_address
+            description: "All returned traces, gives the exact location in the call trace"
+          - name: type
+            description: "Type of trace (e.g., call, create, suicide)"
+          - name: address
+            description: "Address of the trace creator"
+          - name: code
+            description: "Raw EVM code for the trace"
+          - name: call_type
+            description: "Hexadecimal representations of the trace's call type"
+          - name: input
+            description: "Input data for the trace"
+          - name: output
+            description: "Output data for the trace"
+          - name: refund_address
+            description: "Refund Address"
           
       - name: blocks
         freshness:
@@ -90,20 +159,18 @@ sources:
               - accepted_values:
                   values: ["factory", "base", "dynamic"]
           - name: created_at
+            description: "Timestamp for contract creation"
 
       - name: logs
         loaded_at_field: block_time
         description: "An Avalanche C-Chain log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
         columns:
-          - *block_hash
-          - *block_number
+          - *block_date
           - *block_time
+          - *block_number
+          - *block_hash
           - name: contract_address
             description: "Address of the avalanche c-chain smart contract generating the log"
-          - name: data
-            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings."
-          - name: index
-            description: "Log index"
           - name: topic1
             description: "Topics are 32-byte (256 bit) “words” that are used to describe what’s going on in an event. The first topic usually consists of the signature of the name of the event that occurred, including the types (uint256, string, etc.) of its parameters."
           - name: topic2
@@ -112,53 +179,99 @@ sources:
             description: "Third topic"
           - name: topic4
             description: "Fourth topic"
-          - &tx_hash
-            name: tx_hash
-            description: "Primary key of the transaction"
-          - &tx_index
-            name: tx_index
-            description: "Transaction index"
-
-      - name: traces
-        loaded_at_field: block_time
-        description: "An Avalanche C-Chain trace is a small atomic action that modify the internal state of the Avalanche's Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
-        columns:
-          - name: address
-            description: "Address of the trace creator"
-          - *block_hash
-          - *block_number
-          - *block_time
-          - name: call_type
-            description: "Hexadecimal representations of the trace's call type"
-          - name: code
-            description: "Raw EVM code for the trace"
-          - name: error
-            description: "Error log"
-          - name: from
-            description: "Wallet address that initiated the trace"
-          - name: gas
-            description: "Amount of gas consumed by the trace"
-          - name: gas_used
-            description: "Number of gas units used by the trace"
-          - name: input
-            description: "Input data for the trace"
-          - name: output
-            description: "Output data for the trace"
-          - name: refund_address
-            description: "Refund Address"
-          - name: sub_traces
-            description: "Number of subtraces (i.e, number of calls at a particular level within a transaction)"
-          - name: success
-            description: "Whether the trace was completed successfully"
-          - name: to
-            description: "Wallet address that received the trace"
-          - name: trace_address
-            description: "All returned traces, gives the exact location in the call trace"
+          - name: data
+            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings."
           - *tx_hash
+          - name: index
+            description: "Log index"
           - *tx_index
-          - name: tx_success
-            description: "Whether the transaction was completed sucessfully"
-          - name: type
-            description: "Type of trace (e.g., call, create, suicide)"
+
+  # ERC Transfer Tables
+  - name: erc20_avalanche_c
+    description: "Transfers events for ERC20 tokens."
+    tables:
+      - name: evt_transfer
+        loaded_at_field: evt_block_time
+        description: "Transfers events for ERC20 tokens."
+        freshness:
+          warn_after: { count: 12, period: hour }
+          error_after: { count: 24, period: hour }
+        columns:
+          - name: contract_address
+            description: "ERC20 token contract address"
+          - &evt_tx_hash
+            name: evt_tx_hash
+            description: "Transaction hash of the event"
+          - &evt_index
+            name: evt_index
+            description: "Event index"
+          - &evt_block_time
+            name: evt_block_time
+            description: "Timestamp for block event time in UTC"
+          - &evt_block_number
+            name: evt_block_number
+            description: "Event block number"
+          - *from
+          - *to
           - name: value
-            description: "Raw amount of ERC20 token transferred"
+            description: "Amount of ERC20 token transferred"
+
+  - name: erc1155_avalanche_c
+    description: "Transfers events for ERC1155 tokens."
+    tables:
+      - name: evt_transfersingle
+        loaded_at_field: evt_block_time
+        description: "Single transfers events for ERC1155 tokens."
+        columns:
+          - name: contract_address
+            description: "ERC1155 token contract address"
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - name: operator
+            description: "Addresses authorized (or approved) by a NFT owner to spend all of his token Ids."
+          - *from
+          - *to
+          - name: id
+            description: "ERC1155 token ID"
+          - name: value
+            description: "Amount of ERC1155 token transferred"
+
+      - name: evt_transferbatch
+        loaded_at_field: evt_block_time
+        description: "Batch transfers events for ERC1155 tokens."
+        columns:
+          - name: contract_address
+            description: "ERC1155 token contract address"
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - name: operator
+            description: "Addresses authorized (or approved) by a NFT owner to spend all of his token Ids."
+          - *from
+          - *to
+          - name: ids
+            description: "ERC1155 token IDs"
+          - name: values
+            description: "Amounts of ERC1155 token transferred"
+
+  - name: erc721_avalanche_c
+    description: "Transfers events for ERC721 tokens."
+    tables:
+      - name: evt_transfer
+        loaded_at_field: evt_block_time
+        description: "Transfers events for ERC721 tokens."
+        columns:
+          - &contract_address
+            name: contract_address
+            description: "ERC721 token contract address"
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - *from
+          - *to
+          - name: tokenId
+            description: "ERC721 token ID."

--- a/models/base_sources/avalanche_c_base_sources.yml
+++ b/models/base_sources/avalanche_c_base_sources.yml
@@ -8,9 +8,6 @@ sources:
       warn_after: { count: 12, period: hour }
     tables:
       - name: transactions
-        description: "underlying transactions table. avalanche_c.transactions is an exposed view of this table."
-        loaded_at_field: block_time
-      - name: transactions
         loaded_at_field: block_time
         description: "An Avalanche_c transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:

--- a/models/base_sources/avalanche_c_base_sources.yml
+++ b/models/base_sources/avalanche_c_base_sources.yml
@@ -1,14 +1,18 @@
 version: 2
 
 sources:
-# Base Tables
+  # Base Tables
   - name: avalanche_c
-    description: "avalanche_c raw tables"
+    description: "Avalanche_c raw tables including transactions, traces and logs."
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
+      - name: transactions_0006
+        description: "underlying transactions table. avalanche_c.transactions is an exposed view of this table."
+        loaded_at_field: block_time
       - name: transactions
         loaded_at_field: block_time
+        description: "An Avalanche_c transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:
           - &block_date
             name: block_date
@@ -64,7 +68,7 @@ sources:
 
       - name: traces
         loaded_at_field: block_time
-        description: "An Avalanche C-Chain trace is a small atomic action that modify the internal state of the Avalanche's Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
+        description: "An Avalanche_c trace is a small atomic action that modify the internal state of the Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
         columns:
           - *block_date
           - *block_time
@@ -109,7 +113,32 @@ sources:
             description: "Output data for the trace"
           - name: refund_address
             description: "Refund Address"
-          
+
+      - name: logs
+        loaded_at_field: block_time
+        description: "An Avalanche_c log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
+        columns:
+          - *block_date
+          - *block_time
+          - *block_number
+          - *block_hash
+          - name: contract_address
+            description: "Address of the avalanche_c smart contract generating the log"
+          - name: topic1
+            description: "Topics are 32-byte (256 bit) “words” that are used to describe what’s going on in an event. The first topic usually consists of the signature of the name of the event that occurred, including the types (uint256, string, etc.) of its parameters."
+          - name: topic2
+            description: "Second topic"
+          - name: topic3
+            description: "Third topic"
+          - name: topic4
+            description: "Fourth topic"
+          - name: data
+            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings."
+          - *tx_hash
+          - name: index
+            description: "Log index"
+          - *tx_index
+
       - name: blocks
         freshness:
           warn_after: { count: 1, period: day }
@@ -131,9 +160,10 @@ sources:
 
       - name: contracts
         freshness:
-          warn_after: { count: 7, period: day }
+          warn_after: { count: 1, period: day }
+          error_after: { count: 3, period: day }
         loaded_at_field: created_at
-        description: "A view keeping track of what contracts are decoded on Dune on Avalanche; contains information associated with the decoded contract such as namespace, name, address, ABI."
+        description: "A view keeping track of what contracts are decoded on Dune on Avalanche_c; contains information associated with the decoded contract such as namespace, name, address, ABI."
         columns:
           - name: abi
             description: "ABI of the decoded contract"
@@ -161,38 +191,13 @@ sources:
           - name: created_at
             description: "Timestamp for contract creation"
 
-      - name: logs
-        loaded_at_field: block_time
-        description: "An Avalanche C-Chain log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
-        columns:
-          - *block_date
-          - *block_time
-          - *block_number
-          - *block_hash
-          - name: contract_address
-            description: "Address of the avalanche c-chain smart contract generating the log"
-          - name: topic1
-            description: "Topics are 32-byte (256 bit) “words” that are used to describe what’s going on in an event. The first topic usually consists of the signature of the name of the event that occurred, including the types (uint256, string, etc.) of its parameters."
-          - name: topic2
-            description: "Second topic"
-          - name: topic3
-            description: "Third topic"
-          - name: topic4
-            description: "Fourth topic"
-          - name: data
-            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings."
-          - *tx_hash
-          - name: index
-            description: "Log index"
-          - *tx_index
-
   # ERC Transfer Tables
   - name: erc20_avalanche_c
-    description: "Transfers events for ERC20 tokens."
+    description: "Transfers events for ERC20 tokens on Avalanche_c."
     tables:
       - name: evt_transfer
         loaded_at_field: evt_block_time
-        description: "Transfers events for ERC20 tokens."
+        description: "Transfers events for ERC20 tokens on Avalanche_c."
         freshness:
           warn_after: { count: 12, period: hour }
           error_after: { count: 24, period: hour }
@@ -217,11 +222,11 @@ sources:
             description: "Amount of ERC20 token transferred"
 
   - name: erc1155_avalanche_c
-    description: "Transfers events for ERC1155 tokens."
+    description: "Transfers events for ERC1155 tokens on Avalanche_c."
     tables:
       - name: evt_transfersingle
         loaded_at_field: evt_block_time
-        description: "Single transfers events for ERC1155 tokens."
+        description: "Single transfers events for ERC1155 tokens on Avalanche_c."
         columns:
           - name: contract_address
             description: "ERC1155 token contract address"
@@ -240,7 +245,7 @@ sources:
 
       - name: evt_transferbatch
         loaded_at_field: evt_block_time
-        description: "Batch transfers events for ERC1155 tokens."
+        description: "Batch transfers events for ERC1155 tokens on Avalanche_c."
         columns:
           - name: contract_address
             description: "ERC1155 token contract address"
@@ -258,11 +263,11 @@ sources:
             description: "Amounts of ERC1155 token transferred"
 
   - name: erc721_avalanche_c
-    description: "Transfers events for ERC721 tokens."
+    description: "Transfers events for ERC721 tokens on Avalanche_c."
     tables:
       - name: evt_transfer
         loaded_at_field: evt_block_time
-        description: "Transfers events for ERC721 tokens."
+        description: "Transfers events for ERC721 tokens on Avalanche_c."
         columns:
           - &contract_address
             name: contract_address

--- a/models/base_sources/bnb_base_sources.yml
+++ b/models/base_sources/bnb_base_sources.yml
@@ -8,9 +8,6 @@ sources:
       warn_after: { count: 12, period: hour }
     tables:
       - name: transactions
-        description: "underlying transactions table. bnb.transactions is an exposed view of this table."
-        loaded_at_field: block_time
-      - name: transactions
         loaded_at_field: block_time
         description: "An Bnb transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:

--- a/models/base_sources/bnb_base_sources.yml
+++ b/models/base_sources/bnb_base_sources.yml
@@ -7,7 +7,7 @@ sources:
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
-      - name: transactions_0006
+      - name: transactions
         description: "underlying transactions table. bnb.transactions is an exposed view of this table."
         loaded_at_field: block_time
       - name: transactions

--- a/models/base_sources/bnb_base_sources.yml
+++ b/models/base_sources/bnb_base_sources.yml
@@ -1,14 +1,18 @@
 version: 2
 
 sources:
-# Base Tables
+  # Base Tables
   - name: bnb
-    description: "bnb raw tables"
+    description: "bnb raw tables including transactions, traces and logs."
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
+      - name: transactions_0006
+        description: "underlying transactions table. bnb.transactions is an exposed view of this table."
+        loaded_at_field: block_time
       - name: transactions
         loaded_at_field: block_time
+        description: "An Bnb transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:
           - &block_date
             name: block_date
@@ -18,20 +22,22 @@ sources:
             description: "Timestamp for block event time in UTC"
           - &value
             name: value
-            description: "Amount of ETH transferred from sender to recipient"
+            description: "Amount of BNB transferred from sender to recipient"
           - &block_number
             name: block_number
             description: "Block number"
           - name: gas_limit
             description: "Maximum amount of gas units that can be consumed by the transaction"
           - name: gas_price
-            description: "Gas price denoted in gwei, which itself is a denomination of ETH - each gwei is equal to 10-9 ETH"
+            description: "Gas price denoted in gwei, which itself is a denomination of BNB - each gwei is equal to 10-9 BNB"
           - name: gas_used
             description: "Number of gas units consumed by the transaction"
           - name: max_fee_per_gas
             description: "Maximum amount of gas willing to be paid for the transaction"
           - name: max_priority_fee_per_gas
             description: "Maximum amount of gas to be included as a tip to the miner"
+          - name: base_fee_per_gas
+            description: "Market price for gas"
           - name: nonce
             description: "Number of confirmed transactions previously sent by this account"
           - name: index
@@ -59,7 +65,6 @@ sources:
             description: "Transaction type"
           - name: access_list
             description: "Specifies a list of addresses and storage keys"
-          - name: priority_fee_per_gas
 
       - name: traces
         loaded_at_field: block_time
@@ -118,7 +123,7 @@ sources:
           - *block_number
           - *block_hash
           - name: contract_address
-            description: "Address of the ethereum smart contract generating the log"
+            description: "Address of the bnb smart contract generating the log"
           - name: topic1
             description: "Topics are 32-byte (256 bit) “words” that are used to describe what’s going on in an event. The first topic usually consists of the signature of the name of the event that occurred, including the types (uint256, string, etc.) of its parameters."
           - name: topic2
@@ -155,9 +160,10 @@ sources:
 
       - name: contracts
         freshness:
-          warn_after: { count: 7, period: day }
+          warn_after: { count: 1, period: day }
+          error_after: { count: 3, period: day }
         loaded_at_field: created_at
-        description: "A view keeping track of what contracts are decoded on Dune on BNB; contains information associated with the decoded contract such as namespace, name, address, ABI."
+        description: "A view keeping track of what contracts are decoded on Dune on Bnb; contains information associated with the decoded contract such as namespace, name, address, ABI."
         columns:
           - name: abi
             description: "ABI of the decoded contract"
@@ -185,19 +191,19 @@ sources:
           - name: created_at
             description: "Timestamp for contract creation"
 
-  # BEP Transfer Tables
+  # ERC Transfer Tables
   - name: erc20_bnb
-    description: "Transfers events for BEP20 tokens on BNB."
+    description: "Transfers events for ERC20 tokens on BNB."
     tables:
       - name: evt_transfer
         loaded_at_field: evt_block_time
-        description: "Transfers events for BEP20 tokens on BNB."
+        description: "Transfers events for ERC20 tokens on BNB."
         freshness:
           warn_after: { count: 12, period: hour }
           error_after: { count: 24, period: hour }
         columns:
           - name: contract_address
-            description: "BEP20 token contract address"
+            description: "ERC20 token contract address"
           - &evt_tx_hash
             name: evt_tx_hash
             description: "Transaction hash of the event"
@@ -213,17 +219,17 @@ sources:
           - *from
           - *to
           - name: value
-            description: "Amount of BEP20 token transferred"
+            description: "Amount of ERC20 token transferred"
 
   - name: erc1155_bnb
-    description: "Transfers events for BEP1155 tokens on BNB."
+    description: "Transfers events for ERC1155 tokens on BNB."
     tables:
       - name: evt_transfersingle
         loaded_at_field: evt_block_time
-        description: "Single transfers events for BEP1155 tokens on BNB."
+        description: "Single transfers events for ERC1155 tokens on BNB."
         columns:
           - name: contract_address
-            description: "BEP1155 token contract address"
+            description: "ERC1155 token contract address"
           - *evt_tx_hash
           - *evt_index
           - *evt_block_time
@@ -233,16 +239,16 @@ sources:
           - *from
           - *to
           - name: id
-            description: "BEP1155 token ID"
+            description: "ERC1155 token ID"
           - name: value
-            description: "Amount of BEP1155 token transferred"
+            description: "Amount of ERC1155 token transferred"
 
       - name: evt_transferbatch
         loaded_at_field: evt_block_time
-        description: "Batch transfers events for BEP1155 tokens on BNB."
+        description: "Batch transfers events for ERC1155 tokens on BNB."
         columns:
           - name: contract_address
-            description: "BEP1155 token contract address"
+            description: "ERC1155 token contract address"
           - *evt_tx_hash
           - *evt_index
           - *evt_block_time
@@ -252,20 +258,20 @@ sources:
           - *from
           - *to
           - name: ids
-            description: "BEP1155 token IDs"
+            description: "ERC1155 token IDs"
           - name: values
-            description: "Amounts of BEP1155 token transferred"
+            description: "Amounts of ERC1155 token transferred"
 
   - name: erc721_bnb
-    description: "Transfers events for BEP721 tokens on BNB."
+    description: "Transfers events for ERC721 tokens on BNB."
     tables:
       - name: evt_transfer
         loaded_at_field: evt_block_time
-        description: "Transfers events for BEP721 tokens on BNB."
+        description: "Transfers events for ERC721 tokens on BNB."
         columns:
           - &contract_address
             name: contract_address
-            description: "BEP721 token contract address"
+            description: "ERC721 token contract address"
           - *evt_tx_hash
           - *evt_index
           - *evt_block_time
@@ -273,4 +279,4 @@ sources:
           - *from
           - *to
           - name: tokenId
-            description: "BEP721 token ID."
+            description: "ERC721 token ID."

--- a/models/base_sources/bnb_base_sources.yml
+++ b/models/base_sources/bnb_base_sources.yml
@@ -10,25 +10,129 @@ sources:
       - name: transactions
         loaded_at_field: block_time
         columns:
-          - name: block_time
-          - name: value
-          - name: block_number
+          - &block_date
+            name: block_date
+            description: "Block event date in UTC"
+          - &block_time
+            name: block_time
+            description: "Timestamp for block event time in UTC"
+          - &value
+            name: value
+            description: "Amount of ETH transferred from sender to recipient"
+          - &block_number
+            name: block_number
+            description: "Block number"
           - name: gas_limit
+            description: "Maximum amount of gas units that can be consumed by the transaction"
           - name: gas_price
+            description: "Gas price denoted in gwei, which itself is a denomination of ETH - each gwei is equal to 10-9 ETH"
           - name: gas_used
+            description: "Number of gas units consumed by the transaction"
           - name: max_fee_per_gas
+            description: "Maximum amount of gas willing to be paid for the transaction"
           - name: max_priority_fee_per_gas
-          - name: priority_fee_per_gas
+            description: "Maximum amount of gas to be included as a tip to the miner"
           - name: nonce
+            description: "Number of confirmed transactions previously sent by this account"
           - name: index
-          - name: success
-          - name: from
-          - name: to
-          - name: block_hash
+            description: "Transaction index"
+          - &success
+            name: success
+            description: "Whether the transaction was completed successfully"
+          - &from
+            name: from
+            description: "Wallet address that initiated the transaction"
+          - &to
+            name: to
+            description: "Wallet address that received the transaction"
+          - &block_hash
+            name: block_hash
+            description: "Primary key of the block"
           - name: data
+            description: "Any binary data payload"
           - name: hash
+            description: "Primary key of the transaction"
+            tests:
+              - unique
+              - not_null
           - name: type
+            description: "Transaction type"
           - name: access_list
+            description: "Specifies a list of addresses and storage keys"
+          - name: priority_fee_per_gas
+
+      - name: traces
+        loaded_at_field: block_time
+        description: "A BNB trace is a small atomic action that modify the internal state of the Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
+        columns:
+          - *block_date
+          - *block_time
+          - *block_number
+          - *value
+          - name: gas
+            description: "Amount of gas consumed by the trace"
+          - name: gas_used
+            description: "Number of gas units used by the trace"
+          - *block_hash
+          - name: success
+            description: "Whether the trace was completed successfully"
+          - &tx_index
+            name: tx_index
+            description: "Transaction index"
+          - name: subtraces
+            description: "Number of subtraces (i.e, number of calls at a particular level within a transaction)"
+          - name: error
+            description: "Error log"
+          - name: tx_success
+            description: "Whether the transaction was completed sucessfully"
+          - &tx_hash
+            name: tx_hash
+            description: "Primary key of the transaction"
+          - name: from
+            description: "Wallet address that initiated the trace"
+          - name: to
+            description: "Wallet address that received the trace"
+          - name: trace_address
+            description: "All returned traces, gives the exact location in the call trace"
+          - name: type
+            description: "Type of trace (e.g., call, create, suicide)"
+          - name: address
+            description: "Address of the trace creator"
+          - name: code
+            description: "Raw EVM code for the trace"
+          - name: call_type
+            description: "Hexadecimal representations of the trace's call type"
+          - name: input
+            description: "Input data for the trace"
+          - name: output
+            description: "Output data for the trace"
+          - name: refund_address
+            description: "Refund Address"
+
+      - name: logs
+        loaded_at_field: block_time
+        description: "A BNB log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
+        columns:
+          - *block_date
+          - *block_time
+          - *block_number
+          - *block_hash
+          - name: contract_address
+            description: "Address of the ethereum smart contract generating the log"
+          - name: topic1
+            description: "Topics are 32-byte (256 bit) “words” that are used to describe what’s going on in an event. The first topic usually consists of the signature of the name of the event that occurred, including the types (uint256, string, etc.) of its parameters."
+          - name: topic2
+            description: "Second topic"
+          - name: topic3
+            description: "Third topic"
+          - name: topic4
+            description: "Fourth topic"
+          - name: data
+            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings."
+          - *tx_hash
+          - name: index
+            description: "Log index"
+          - *tx_index
 
       - name: blocks
         freshness:
@@ -79,3 +183,94 @@ sources:
               - accepted_values:
                   values: ["factory", "base", "dynamic"]
           - name: created_at
+            description: "Timestamp for contract creation"
+
+  # BEP Transfer Tables
+  - name: erc20_bnb
+    description: "Transfers events for BEP20 tokens on BNB."
+    tables:
+      - name: evt_transfer
+        loaded_at_field: evt_block_time
+        description: "Transfers events for BEP20 tokens on BNB."
+        freshness:
+          warn_after: { count: 12, period: hour }
+          error_after: { count: 24, period: hour }
+        columns:
+          - name: contract_address
+            description: "BEP20 token contract address"
+          - &evt_tx_hash
+            name: evt_tx_hash
+            description: "Transaction hash of the event"
+          - &evt_index
+            name: evt_index
+            description: "Event index"
+          - &evt_block_time
+            name: evt_block_time
+            description: "Timestamp for block event time in UTC"
+          - &evt_block_number
+            name: evt_block_number
+            description: "Event block number"
+          - *from
+          - *to
+          - name: value
+            description: "Amount of BEP20 token transferred"
+
+  - name: erc1155_bnb
+    description: "Transfers events for BEP1155 tokens on BNB."
+    tables:
+      - name: evt_transfersingle
+        loaded_at_field: evt_block_time
+        description: "Single transfers events for BEP1155 tokens on BNB."
+        columns:
+          - name: contract_address
+            description: "BEP1155 token contract address"
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - name: operator
+            description: "Addresses authorized (or approved) by a NFT owner to spend all of his token Ids."
+          - *from
+          - *to
+          - name: id
+            description: "BEP1155 token ID"
+          - name: value
+            description: "Amount of BEP1155 token transferred"
+
+      - name: evt_transferbatch
+        loaded_at_field: evt_block_time
+        description: "Batch transfers events for BEP1155 tokens on BNB."
+        columns:
+          - name: contract_address
+            description: "BEP1155 token contract address"
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - name: operator
+            description: "Addresses authorized (or approved) by a NFT owner to spend all of his token Ids."
+          - *from
+          - *to
+          - name: ids
+            description: "BEP1155 token IDs"
+          - name: values
+            description: "Amounts of BEP1155 token transferred"
+
+  - name: erc721_bnb
+    description: "Transfers events for BEP721 tokens on BNB."
+    tables:
+      - name: evt_transfer
+        loaded_at_field: evt_block_time
+        description: "Transfers events for BEP721 tokens on BNB."
+        columns:
+          - &contract_address
+            name: contract_address
+            description: "BEP721 token contract address"
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - *from
+          - *to
+          - name: tokenId
+            description: "BEP721 token ID."

--- a/models/base_sources/ethereum_base_sources.yml
+++ b/models/base_sources/ethereum_base_sources.yml
@@ -193,11 +193,11 @@ sources:
 
   # ERC Transfer Tables
   - name: erc20_ethereum
-    description: "Transfers events for ERC20 tokens."
+    description: "Transfers events for ERC20 tokens on Ethereum."
     tables:
       - name: evt_transfer
         loaded_at_field: evt_block_time
-        description: "Transfers events for ERC20 tokens."
+        description: "Transfers events for ERC20 tokens on Ethereum."
         freshness:
           warn_after: { count: 12, period: hour }
           error_after: { count: 24, period: hour }
@@ -222,11 +222,11 @@ sources:
             description: "Amount of ERC20 token transferred"
 
   - name: erc1155_ethereum
-    description: "Transfers events for ERC1155 tokens."
+    description: "Transfers events for ERC1155 tokens on Ethereum."
     tables:
       - name: evt_transfersingle
         loaded_at_field: evt_block_time
-        description: "Single transfers events for ERC1155 tokens."
+        description: "Single transfers events for ERC1155 tokens on Ethereum."
         columns:
           - name: contract_address
             description: "ERC1155 token contract address"
@@ -245,7 +245,7 @@ sources:
 
       - name: evt_transferbatch
         loaded_at_field: evt_block_time
-        description: "Batch transfers events for ERC1155 tokens."
+        description: "Batch transfers events for ERC1155 tokens on Ethereum."
         columns:
           - name: contract_address
             description: "ERC1155 token contract address"
@@ -263,11 +263,11 @@ sources:
             description: "Amounts of ERC1155 token transferred"
 
   - name: erc721_ethereum
-    description: "Transfers events for ERC721 tokens."
+    description: "Transfers events for ERC721 tokens on Ethereum."
     tables:
       - name: evt_transfer
         loaded_at_field: evt_block_time
-        description: "Transfers events for ERC721 tokens."
+        description: "Transfers events for ERC721 tokens on Ethereum."
         columns:
           - &contract_address
             name: contract_address

--- a/models/base_sources/gnosis_base_sources.yml
+++ b/models/base_sources/gnosis_base_sources.yml
@@ -10,25 +10,105 @@ sources:
       - name: transactions
         loaded_at_field: block_time
         columns:
-          - name: block_time
-          - name: value
-          - name: block_number
+          - &block_date
+            name: block_date
+            description: "Block event date in UTC"
+          - &block_time
+            name: block_time
+            description: "Timestamp for block event time in UTC"
+          - &value
+            name: value
+            description: "Amount of xDAI transferred from sender to recipient"
+          - &block_number
+            name: block_number
+            description: "Block number"
           - name: gas_limit
+            description: "Maximum amount of gas units that can be consumed by the transaction"
           - name: gas_price
+            description: "Gas price denoted in gwei, which itself is a denomination of xDAI - each gwei is equal to 10-9 xDAI"
           - name: gas_used
+            description: "Number of gas units consumed by the transaction"
           - name: max_fee_per_gas
+            description: "Maximum amount of gas willing to be paid for the transaction"
           - name: max_priority_fee_per_gas
-          - name: priority_fee_per_gas
+            description: "Maximum amount of gas to be included as a tip to the miner"
           - name: nonce
+            description: "Number of confirmed transactions previously sent by this account"
           - name: index
-          - name: success
-          - name: from
-          - name: to
-          - name: block_hash
+            description: "Transaction index"
+          - &success
+            name: success
+            description: "Whether the transaction was completed successfully"
+          - &from
+            name: from
+            description: "Wallet address that initiated the transaction"
+          - &to
+            name: to
+            description: "Wallet address that received the transaction"
+          - &block_hash
+            name: block_hash
+            description: "Primary key of the block"
           - name: data
+            description: "Any binary data payload"
           - name: hash
+            description: "Primary key of the transaction"
+            tests:
+              - unique
+              - not_null
           - name: type
+            description: "Transaction type"
           - name: access_list
+            description: "Specifies a list of addresses and storage keys"
+          - name: priority_fee_per_gas
+          - name: priority_fee_per_gas
+
+      - name: traces
+        loaded_at_field: block_time
+        description: "A Gnosis trace is a small atomic action that modify the internal state of the Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
+        columns:
+          - *block_date
+          - *block_time
+          - *block_number
+          - *value
+          - name: gas
+            description: "Amount of gas consumed by the trace"
+          - name: gas_used
+            description: "Number of gas units used by the trace"
+          - *block_hash
+          - name: success
+            description: "Whether the trace was completed successfully"
+          - &tx_index
+            name: tx_index
+            description: "Transaction index"
+          - name: subtraces
+            description: "Number of subtraces (i.e, number of calls at a particular level within a transaction)"
+          - name: error
+            description: "Error log"
+          - name: tx_success
+            description: "Whether the transaction was completed sucessfully"
+          - &tx_hash
+            name: tx_hash
+            description: "Primary key of the transaction"
+          - name: from
+            description: "Wallet address that initiated the trace"
+          - name: to
+            description: "Wallet address that received the trace"
+          - name: trace_address
+            description: "All returned traces, gives the exact location in the call trace"
+          - name: type
+            description: "Type of trace (e.g., call, create, suicide)"
+          - name: address
+            description: "Address of the trace creator"
+          - name: code
+            description: "Raw EVM code for the trace"
+          - name: call_type
+            description: "Hexadecimal representations of the trace's call type"
+          - name: input
+            description: "Input data for the trace"
+          - name: output
+            description: "Output data for the trace"
+          - name: refund_address
+            description: "Refund Address"
 
       - name: blocks
         freshness:
@@ -79,61 +159,18 @@ sources:
               - accepted_values:
                   values: ["factory", "base", "dynamic"]
           - name: created_at
-
-      - name: traces
-        loaded_at_field: block_time
-        description: "A Gnosis trace is a small atomic action that modify the internal state of the Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
-        columns:
-          - name: block_time
-          - name: block_number
-          - name: value
-          - name: gas
-            description: "Amount of gas consumed by the trace"
-          - name: gas_used
-            description: "Number of gas units used by the trace"
-          - name: block_hash
-          - name: success
-            description: "Whether the trace was completed successfully"
-          - name: tx_index
-            description: "Transaction index"
-          - name: subtraces
-            description: "Number of subtraces (i.e, number of calls at a particular level within a transaction)"
-          - name: error
-            description: "Error log"
-          - name: tx_success
-            description: "Whether the transaction was completed sucessfully"
-          - name: tx_hash
-            description: "Primary key of the transaction"
-          - name: from
-            description: "Wallet address that initiated the trace"
-          - name: to
-            description: "Wallet address that received the trace"
-          - name: trace_address
-            description: "All returned traces, gives the exact location in the call trace"
-          - name: type
-            description: "Type of trace (e.g., call, create, suicide)"
-          - name: address
-            description: "Address of the trace creator"
-          - name: code
-            description: "Raw EVM code for the trace"
-          - name: call_type
-            description: "Hexadecimal representations of the trace's call type"
-          - name: input
-            description: "Input data for the trace"
-          - name: output
-            description: "Output data for the trace"
-          - name: refund_address
-            description: "Refund Address"
+            description: "Timestamp for contract creation"
 
       - name: logs
         loaded_at_field: block_time
         description: "An Ethereum log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
         columns:
-          - name: block_time
-          - name: block_number
-          - name: block_hash
+          - *block_date
+          - *block_time
+          - *block_number
+          - *block_hash
           - name: contract_address
-            description: "Address of the ethereum smart contract generating the log"
+            description: "Address of the gnosis smart contract generating the log"
           - name: topic1
             description: "Topics are 32-byte (256 bit) “words” that are used to describe what’s going on in an event. The first topic usually consists of the signature of the name of the event that occurred, including the types (uint256, string, etc.) of its parameters."
           - name: topic2
@@ -144,10 +181,10 @@ sources:
             description: "Fourth topic"
           - name: data
             description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings."
-          - name: tx_hash
+          - *tx_hash
           - name: index
             description: "Log index"
-          - name: tx_index
+          - *tx_index
 
   # ERC Transfer Tables
   - name: erc20_gnosis
@@ -162,15 +199,79 @@ sources:
         columns:
           - name: contract_address
             description: "ERC20 token contract address"
-          - name: evt_tx_hash
+          - &evt_tx_hash
+            name: evt_tx_hash
             description: "Transaction hash of the event"
-          - name: evt_index
+          - &evt_index
+            name: evt_index
             description: "Event index"
-          - name: evt_block_time
+          - &evt_block_time
+            name: evt_block_time
             description: "Timestamp for block event time in UTC"
-          - name: evt_block_number
+          - &evt_block_number
+            name: evt_block_number
             description: "Event block number"
-          - name: from
-          - name: to
+          - *from
+          - *to
           - name: value
             description: "Amount of ERC20 token transferred"
+
+  - name: erc1155_gnosis
+    description: "Transfers events for ERC1155 tokens."
+    tables:
+      - name: evt_transfersingle
+        loaded_at_field: evt_block_time
+        description: "Single transfers events for ERC1155 tokens."
+        columns:
+          - name: contract_address
+            description: "ERC1155 token contract address"
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - name: operator
+            description: "Addresses authorized (or approved) by a NFT owner to spend all of his token Ids."
+          - *from
+          - *to
+          - name: id
+            description: "ERC1155 token ID"
+          - name: value
+            description: "Amount of ERC1155 token transferred"
+
+      - name: evt_transferbatch
+        loaded_at_field: evt_block_time
+        description: "Batch transfers events for ERC1155 tokens."
+        columns:
+          - name: contract_address
+            description: "ERC1155 token contract address"
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - name: operator
+            description: "Addresses authorized (or approved) by a NFT owner to spend all of his token Ids."
+          - *from
+          - *to
+          - name: ids
+            description: "ERC1155 token IDs"
+          - name: values
+            description: "Amounts of ERC1155 token transferred"
+
+  - name: erc721_gnosis
+    description: "Transfers events for ERC721 tokens."
+    tables:
+      - name: evt_transfer
+        loaded_at_field: evt_block_time
+        description: "Transfers events for ERC721 tokens."
+        columns:
+          - &contract_address
+            name: contract_address
+            description: "ERC721 token contract address"
+          - *evt_tx_hash
+          - *evt_index
+          - *evt_block_time
+          - *evt_block_number
+          - *from
+          - *to
+          - name: tokenId
+            description: "ERC721 token ID."

--- a/models/base_sources/gnosis_base_sources.yml
+++ b/models/base_sources/gnosis_base_sources.yml
@@ -7,7 +7,7 @@ sources:
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
-      - name: transactions_0006
+      - name: transactions
         description: "underlying transactions table. gnosis.transactions is an exposed view of this table."
         loaded_at_field: block_time
       - name: transactions

--- a/models/base_sources/gnosis_base_sources.yml
+++ b/models/base_sources/gnosis_base_sources.yml
@@ -8,9 +8,6 @@ sources:
       warn_after: { count: 12, period: hour }
     tables:
       - name: transactions
-        description: "underlying transactions table. gnosis.transactions is an exposed view of this table."
-        loaded_at_field: block_time
-      - name: transactions
         loaded_at_field: block_time
         description: "A Gnosis transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:

--- a/models/base_sources/gnosis_base_sources.yml
+++ b/models/base_sources/gnosis_base_sources.yml
@@ -1,14 +1,18 @@
 version: 2
 
 sources:
-# Base Tables
+  # Base Tables
   - name: gnosis
-    description: "gnosis raw tables"
+    description: "Gnosis raw tables including transactions, traces and logs."
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
+      - name: transactions_0006
+        description: "underlying transactions table. gnosis.transactions is an exposed view of this table."
+        loaded_at_field: block_time
       - name: transactions
         loaded_at_field: block_time
+        description: "A Gnosis transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:
           - &block_date
             name: block_date
@@ -32,6 +36,8 @@ sources:
             description: "Maximum amount of gas willing to be paid for the transaction"
           - name: max_priority_fee_per_gas
             description: "Maximum amount of gas to be included as a tip to the miner"
+          - name: base_fee_per_gas
+            description: "Market price for gas"
           - name: nonce
             description: "Number of confirmed transactions previously sent by this account"
           - name: index
@@ -59,8 +65,6 @@ sources:
             description: "Transaction type"
           - name: access_list
             description: "Specifies a list of addresses and storage keys"
-          - name: priority_fee_per_gas
-          - name: priority_fee_per_gas
 
       - name: traces
         loaded_at_field: block_time
@@ -110,6 +114,31 @@ sources:
           - name: refund_address
             description: "Refund Address"
 
+      - name: logs
+        loaded_at_field: block_time
+        description: "An Ethereum log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
+        columns:
+          - *block_date
+          - *block_time
+          - *block_number
+          - *block_hash
+          - name: contract_address
+            description: "Address of the gnosis smart contract generating the log"
+          - name: topic1
+            description: "Topics are 32-byte (256 bit) “words” that are used to describe what’s going on in an event. The first topic usually consists of the signature of the name of the event that occurred, including the types (uint256, string, etc.) of its parameters."
+          - name: topic2
+            description: "Second topic"
+          - name: topic3
+            description: "Third topic"
+          - name: topic4
+            description: "Fourth topic"
+          - name: data
+            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings."
+          - *tx_hash
+          - name: index
+            description: "Log index"
+          - *tx_index
+
       - name: blocks
         freshness:
           warn_after: { count: 1, period: day }
@@ -131,7 +160,8 @@ sources:
 
       - name: contracts
         freshness:
-          warn_after: { count: 7, period: day }
+          warn_after: { count: 1, period: day }
+          error_after: { count: 3, period: day }
         loaded_at_field: created_at
         description: "A view keeping track of what contracts are decoded on Dune on Gnosis; contains information associated with the decoded contract such as namespace, name, address, ABI."
         columns:
@@ -161,38 +191,13 @@ sources:
           - name: created_at
             description: "Timestamp for contract creation"
 
-      - name: logs
-        loaded_at_field: block_time
-        description: "An Ethereum log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
-        columns:
-          - *block_date
-          - *block_time
-          - *block_number
-          - *block_hash
-          - name: contract_address
-            description: "Address of the gnosis smart contract generating the log"
-          - name: topic1
-            description: "Topics are 32-byte (256 bit) “words” that are used to describe what’s going on in an event. The first topic usually consists of the signature of the name of the event that occurred, including the types (uint256, string, etc.) of its parameters."
-          - name: topic2
-            description: "Second topic"
-          - name: topic3
-            description: "Third topic"
-          - name: topic4
-            description: "Fourth topic"
-          - name: data
-            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings."
-          - *tx_hash
-          - name: index
-            description: "Log index"
-          - *tx_index
-
   # ERC Transfer Tables
   - name: erc20_gnosis
-    description: "Transfers events for ERC20 tokens."
+    description: "Transfers events for ERC20 tokens on Gnosis."
     tables:
       - name: evt_transfer
         loaded_at_field: evt_block_time
-        description: "Transfers events for ERC20 tokens."
+        description: "Transfers events for ERC20 tokens on Gnosis."
         freshness:
           warn_after: { count: 12, period: hour }
           error_after: { count: 24, period: hour }
@@ -217,11 +222,11 @@ sources:
             description: "Amount of ERC20 token transferred"
 
   - name: erc1155_gnosis
-    description: "Transfers events for ERC1155 tokens."
+    description: "Transfers events for ERC1155 tokens on Gnosis."
     tables:
       - name: evt_transfersingle
         loaded_at_field: evt_block_time
-        description: "Single transfers events for ERC1155 tokens."
+        description: "Single transfers events for ERC1155 tokens on Gnosis."
         columns:
           - name: contract_address
             description: "ERC1155 token contract address"
@@ -240,7 +245,7 @@ sources:
 
       - name: evt_transferbatch
         loaded_at_field: evt_block_time
-        description: "Batch transfers events for ERC1155 tokens."
+        description: "Batch transfers events for ERC1155 tokens on Gnosis."
         columns:
           - name: contract_address
             description: "ERC1155 token contract address"
@@ -258,11 +263,11 @@ sources:
             description: "Amounts of ERC1155 token transferred"
 
   - name: erc721_gnosis
-    description: "Transfers events for ERC721 tokens."
+    description: "Transfers events for ERC721 tokens on Gnosis."
     tables:
       - name: evt_transfer
         loaded_at_field: evt_block_time
-        description: "Transfers events for ERC721 tokens."
+        description: "Transfers events for ERC721 tokens on Gnosis."
         columns:
           - &contract_address
             name: contract_address

--- a/models/base_sources/optimism_base_sources.yml
+++ b/models/base_sources/optimism_base_sources.yml
@@ -1,19 +1,22 @@
 version: 2
 
 sources:
-# Base Tables
+  # Base Tables
   - name: optimism
     description: "Optimism raw tables including transactions, traces and logs."
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
+      - name: transactions_0006
+        description: "underlying transactions table. optimism.transactions is an exposed view of this table."
+        loaded_at_field: block_time
       - name: transactions
-        tests:
-          - unique:
-              column_name: "(hash || '-' || block_number)"
         loaded_at_field: block_time
         description: "An Optimism transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:
+          - &block_date
+            name: block_date
+            description: "Block event date in UTC"
           - &block_time
             name: block_time
             description: "Timestamp for block event time in UTC"
@@ -56,30 +59,18 @@ sources:
           - name: hash
             description: "Primary key of the transaction"
             tests:
+              - unique
               - not_null
           - name: type
             description: "Transaction type"
           - name: access_list
             description: "Specifies a list of addresses and storage keys"
-          - name: l1_block_number
-            description: "Block number on L1"
-          - name: l1_fee
-            description: "L1 Fees that the Optimism protocol pays to submit L2 transactions to L1 (also referred to as L1 Security Fees or Security Costs)"
-          - name: l1_fee_scalar
-            description: "This value covers the change in L1 gas price between the time the transaction is submitted and when it is published, as well as the income Optimism needs to keep the system running. Currently set at 1.0"
-          - name: l1_gas_price
-            description: "Gas price on L1"
-          - name: l1_gas_used
-            description: "The gas used on L1 to publish the transaction"
-          - name: l1_timestamp
-            description: "The timestamp when the transaction is batched and confirmed on L1"
-          - name: l1_tx_origin
-            description: "L1 transaction origin address. This is not null for L1→L2 transactions: https://optimistic.etherscan.io/txsEnqueued"
 
       - name: traces
         loaded_at_field: block_time
-        description: "An Optimism trace is a small atomic action that modify the internal state of the Optimism Virtual Machine (OVM)."
+        description: "An Optimism trace is a small atomic action that modify the internal state of the Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
         columns:
+          - *block_date
           - *block_time
           - *block_number
           - *value
@@ -93,12 +84,12 @@ sources:
           - &tx_index
             name: tx_index
             description: "Transaction index"
-          - name: sub_traces
+          - name: subtraces
             description: "Number of subtraces (i.e, number of calls at a particular level within a transaction)"
           - name: error
             description: "Error log"
           - name: tx_success
-            description: "Whether the transaction was completed successfully"    
+            description: "Whether the transaction was completed sucessfully"
           - &tx_hash
             name: tx_hash
             description: "Primary key of the transaction"
@@ -127,24 +118,25 @@ sources:
         loaded_at_field: block_time
         description: "An Optimism log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
         columns:
+          - *block_date
           - *block_time
           - *block_number
           - *block_hash
           - name: contract_address
-            description: "Address of the Optimism smart contract generating the log"
+            description: "Address of the optimism smart contract generating the log"
           - name: topic1
             description: "Topics are 32-byte (256 bit) “words” that are used to describe what’s going on in an event. The first topic usually consists of the signature of the name of the event that occurred, including the types (uint256, string, etc.) of its parameters."
           - name: topic2
-            description: "Second topic"    
+            description: "Second topic"
           - name: topic3
-            description: "Third topic"   
+            description: "Third topic"
           - name: topic4
-            description: "Fourth topic"   
+            description: "Fourth topic"
           - name: data
-            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings." 
+            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings."
           - *tx_hash
           - name: index
-            description: "Log index" 
+            description: "Log index"
           - *tx_index
 
       - name: blocks
@@ -168,7 +160,8 @@ sources:
 
       - name: contracts
         freshness:
-          warn_after: { count: 7, period: day }
+          warn_after: { count: 1, period: day }
+          error_after: { count: 3, period: day }
         loaded_at_field: created_at
         description: "A view keeping track of what contracts are decoded on Dune on Optimism; contains information associated with the decoded contract such as namespace, name, address, ABI."
         columns:
@@ -196,6 +189,7 @@ sources:
               - accepted_values:
                   values: ["factory", "base", "dynamic"]
           - name: created_at
+            description: "Timestamp for contract creation"
 
   # ERC Transfer Tables
   - name: erc20_optimism

--- a/models/base_sources/optimism_base_sources.yml
+++ b/models/base_sources/optimism_base_sources.yml
@@ -8,9 +8,6 @@ sources:
       warn_after: { count: 12, period: hour }
     tables:
       - name: transactions
-        description: "underlying transactions table. optimism.transactions is an exposed view of this table."
-        loaded_at_field: block_time
-      - name: transactions
         loaded_at_field: block_time
         description: "An Optimism transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:

--- a/models/base_sources/optimism_base_sources.yml
+++ b/models/base_sources/optimism_base_sources.yml
@@ -7,7 +7,7 @@ sources:
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
-      - name: transactions_0006
+      - name: transactions
         description: "underlying transactions table. optimism.transactions is an exposed view of this table."
         loaded_at_field: block_time
       - name: transactions

--- a/models/base_sources/optimism_base_sources.yml
+++ b/models/base_sources/optimism_base_sources.yml
@@ -59,12 +59,26 @@ sources:
           - name: hash
             description: "Primary key of the transaction"
             tests:
-              - unique
               - not_null
           - name: type
             description: "Transaction type"
           - name: access_list
             description: "Specifies a list of addresses and storage keys"
+            description: "Specifies a list of addresses and storage keys"
+          - name: l1_block_number
+            description: "Block number on L1"
+          - name: l1_fee
+            description: "L1 Fees that the Optimism protocol pays to submit L2 transactions to L1 (also referred to as L1 Security Fees or Security Costs)"
+          - name: l1_fee_scalar
+            description: "This value covers the change in L1 gas price between the time the transaction is submitted and when it is published, as well as the income Optimism needs to keep the system running. Currently set at 1.0"
+          - name: l1_gas_price
+            description: "Gas price on L1"
+          - name: l1_gas_used
+            description: "The gas used on L1 to publish the transaction"
+          - name: l1_timestamp
+            description: "The timestamp when the transaction is batched and confirmed on L1"
+          - name: l1_tx_origin
+            description: "L1 transaction origin address. This is not null for L1→L2 transactions: https://optimistic.etherscan.io/txsEnqueued"
 
       - name: traces
         loaded_at_field: block_time

--- a/models/base_sources/polygon_base_sources.yml
+++ b/models/base_sources/polygon_base_sources.yml
@@ -1,19 +1,22 @@
 version: 2
 
 sources:
-# Base Tables
-  - name: optimism
-    description: "Optimism raw tables including transactions, traces and logs."
+  # Base Tables
+  - name: polygon
+    description: "Polygon raw tables including transactions, traces and logs."
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
-      - name: transactions
-        tests:
-          - unique:
-              column_name: "(hash || '-' || block_number)"
+      - name: transactions_0006
+        description: "underlying transactions table. polygon.transactions is an exposed view of this table."
         loaded_at_field: block_time
-        description: "An Optimism transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
+      - name: transactions
+        loaded_at_field: block_time
+        description: "An Ethereum transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:
+          - &block_date
+            name: block_date
+            description: "Block event date in UTC"
           - &block_time
             name: block_time
             description: "Timestamp for block event time in UTC"
@@ -56,30 +59,18 @@ sources:
           - name: hash
             description: "Primary key of the transaction"
             tests:
+              - unique
               - not_null
           - name: type
             description: "Transaction type"
           - name: access_list
             description: "Specifies a list of addresses and storage keys"
-          - name: l1_block_number
-            description: "Block number on L1"
-          - name: l1_fee
-            description: "L1 Fees that the Optimism protocol pays to submit L2 transactions to L1 (also referred to as L1 Security Fees or Security Costs)"
-          - name: l1_fee_scalar
-            description: "This value covers the change in L1 gas price between the time the transaction is submitted and when it is published, as well as the income Optimism needs to keep the system running. Currently set at 1.0"
-          - name: l1_gas_price
-            description: "Gas price on L1"
-          - name: l1_gas_used
-            description: "The gas used on L1 to publish the transaction"
-          - name: l1_timestamp
-            description: "The timestamp when the transaction is batched and confirmed on L1"
-          - name: l1_tx_origin
-            description: "L1 transaction origin address. This is not null for L1→L2 transactions: https://optimistic.etherscan.io/txsEnqueued"
 
       - name: traces
         loaded_at_field: block_time
-        description: "An Optimism trace is a small atomic action that modify the internal state of the Optimism Virtual Machine (OVM)."
+        description: "An Ethereum trace is a small atomic action that modify the internal state of the Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
         columns:
+          - *block_date
           - *block_time
           - *block_number
           - *value
@@ -93,12 +84,12 @@ sources:
           - &tx_index
             name: tx_index
             description: "Transaction index"
-          - name: sub_traces
+          - name: subtraces
             description: "Number of subtraces (i.e, number of calls at a particular level within a transaction)"
           - name: error
             description: "Error log"
           - name: tx_success
-            description: "Whether the transaction was completed successfully"    
+            description: "Whether the transaction was completed sucessfully"
           - &tx_hash
             name: tx_hash
             description: "Primary key of the transaction"
@@ -125,26 +116,27 @@ sources:
 
       - name: logs
         loaded_at_field: block_time
-        description: "An Optimism log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
+        description: "An Ethereum log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
         columns:
+          - *block_date
           - *block_time
           - *block_number
           - *block_hash
           - name: contract_address
-            description: "Address of the Optimism smart contract generating the log"
+            description: "Address of the polygon smart contract generating the log"
           - name: topic1
             description: "Topics are 32-byte (256 bit) “words” that are used to describe what’s going on in an event. The first topic usually consists of the signature of the name of the event that occurred, including the types (uint256, string, etc.) of its parameters."
           - name: topic2
-            description: "Second topic"    
+            description: "Second topic"
           - name: topic3
-            description: "Third topic"   
+            description: "Third topic"
           - name: topic4
-            description: "Fourth topic"   
+            description: "Fourth topic"
           - name: data
-            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings." 
+            description: "Additional data for the log. Data is not searchable (while topics are), but is a lot cheaper and can include large or complicated data like arrays or strings."
           - *tx_hash
           - name: index
-            description: "Log index" 
+            description: "Log index"
           - *tx_index
 
       - name: blocks
@@ -168,9 +160,10 @@ sources:
 
       - name: contracts
         freshness:
-          warn_after: { count: 7, period: day }
+          warn_after: { count: 1, period: day }
+          error_after: { count: 3, period: day }
         loaded_at_field: created_at
-        description: "A view keeping track of what contracts are decoded on Dune on Optimism; contains information associated with the decoded contract such as namespace, name, address, ABI."
+        description: "A view keeping track of what contracts are decoded on Dune on Ethereum; contains information associated with the decoded contract such as namespace, name, address, ABI."
         columns:
           - name: abi
             description: "ABI of the decoded contract"
@@ -196,14 +189,15 @@ sources:
               - accepted_values:
                   values: ["factory", "base", "dynamic"]
           - name: created_at
+            description: "Timestamp for contract creation"
 
   # ERC Transfer Tables
-  - name: erc20_optimism
-    description: "Transfers events for ERC20 tokens on Optimism."
+  - name: erc20_polygon
+    description: "Transfers events for ERC20 tokens on Polygon."
     tables:
       - name: evt_transfer
         loaded_at_field: evt_block_time
-        description: "Transfers events for ERC20 tokens on Optimism."
+        description: "Transfers events for ERC20 tokens on Polygon."
         freshness:
           warn_after: { count: 12, period: hour }
           error_after: { count: 24, period: hour }
@@ -227,12 +221,12 @@ sources:
           - name: value
             description: "Amount of ERC20 token transferred"
 
-  - name: erc1155_optimism
-    description: "Transfers events for ERC1155 tokens on Optimism."
+  - name: erc1155_polygon
+    description: "Transfers events for ERC1155 tokens on Polygon."
     tables:
       - name: evt_transfersingle
         loaded_at_field: evt_block_time
-        description: "Single transfers events for ERC1155 tokens on Optimism."
+        description: "Single transfers events for ERC1155 tokens on Polygon."
         columns:
           - name: contract_address
             description: "ERC1155 token contract address"
@@ -251,7 +245,7 @@ sources:
 
       - name: evt_transferbatch
         loaded_at_field: evt_block_time
-        description: "Batch transfers events for ERC1155 tokens on Optimism."
+        description: "Batch transfers events for ERC1155 tokens on Polygon."
         columns:
           - name: contract_address
             description: "ERC1155 token contract address"
@@ -268,12 +262,12 @@ sources:
           - name: values
             description: "Amounts of ERC1155 token transferred"
 
-  - name: erc721_optimism
-    description: "Transfers events for ERC721 tokens on Optimism."
+  - name: erc721_polygon
+    description: "Transfers events for ERC721 tokens on Polygon."
     tables:
       - name: evt_transfer
         loaded_at_field: evt_block_time
-        description: "Transfers events for ERC721 tokens on Optimism."
+        description: "Transfers events for ERC721 tokens on Polygon."
         columns:
           - &contract_address
             name: contract_address

--- a/models/base_sources/polygon_base_sources.yml
+++ b/models/base_sources/polygon_base_sources.yml
@@ -8,9 +8,6 @@ sources:
       warn_after: { count: 12, period: hour }
     tables:
       - name: transactions
-        description: "underlying transactions table. polygon.transactions is an exposed view of this table."
-        loaded_at_field: block_time
-      - name: transactions
         loaded_at_field: block_time
         description: "A Polygon transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:

--- a/models/base_sources/polygon_base_sources.yml
+++ b/models/base_sources/polygon_base_sources.yml
@@ -7,7 +7,7 @@ sources:
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
-      - name: transactions_0006
+      - name: transactions
         description: "underlying transactions table. polygon.transactions is an exposed view of this table."
         loaded_at_field: block_time
       - name: transactions

--- a/models/base_sources/polygon_base_sources.yml
+++ b/models/base_sources/polygon_base_sources.yml
@@ -12,7 +12,7 @@ sources:
         loaded_at_field: block_time
       - name: transactions
         loaded_at_field: block_time
-        description: "An Ethereum transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
+        description: "A Polygon transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
         columns:
           - &block_date
             name: block_date
@@ -22,14 +22,14 @@ sources:
             description: "Timestamp for block event time in UTC"
           - &value
             name: value
-            description: "Amount of ETH transferred from sender to recipient"
+            description: "Amount of MATIC transferred from sender to recipient"
           - &block_number
             name: block_number
             description: "Block number"
           - name: gas_limit
             description: "Maximum amount of gas units that can be consumed by the transaction"
           - name: gas_price
-            description: "Gas price denoted in gwei, which itself is a denomination of ETH - each gwei is equal to 10-9 ETH"
+            description: "Gas price denoted in gwei, which itself is a denomination of MATIC - each gwei is equal to 10-9 MATIC"
           - name: gas_used
             description: "Number of gas units consumed by the transaction"
           - name: max_fee_per_gas
@@ -68,7 +68,7 @@ sources:
 
       - name: traces
         loaded_at_field: block_time
-        description: "An Ethereum trace is a small atomic action that modify the internal state of the Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
+        description: "A Polygon trace is a small atomic action that modify the internal state of the Polygon Virtual Machine. The three main trace types are call, create, and suicide."
         columns:
           - *block_date
           - *block_time
@@ -116,7 +116,7 @@ sources:
 
       - name: logs
         loaded_at_field: block_time
-        description: "An Ethereum log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
+        description: "A polygon log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
         columns:
           - *block_date
           - *block_time
@@ -163,7 +163,7 @@ sources:
           warn_after: { count: 1, period: day }
           error_after: { count: 3, period: day }
         loaded_at_field: created_at
-        description: "A view keeping track of what contracts are decoded on Dune on Ethereum; contains information associated with the decoded contract such as namespace, name, address, ABI."
+        description: "A view keeping track of what contracts are decoded on Dune on Polygon; contains information associated with the decoded contract such as namespace, name, address, ABI."
         columns:
           - name: abi
             description: "ABI of the decoded contract"


### PR DESCRIPTION
Brief comments on the purpose of your changes:

@hildobby submitted this [pr](https://github.com/duneanalytics/spellbook/pull/1871) to update the base tables and include polygon tables. 

I copied the updates and submitted it in another pr here  per discussions on discord. 

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
