### PR TITLE
Added FTX US Address

### DIFF
--- a/models/labels/cex/labels_cex_ethereum.sql
+++ b/models/labels/cex/labels_cex_ethereum.sql
@@ -49,6 +49,8 @@ FROM (VALUES
     -- FTX, Source: https://etherscan.io/accounts/label/ftx
     , (array('ethereum'), '0x2faf487a4414fe77e2327f0bf4ae2a264a776ad2', 'FTX 1', 'cex', 'hildobby', 'static', timestamp('2022-08-28'), now())
     , (array('ethereum'), '0xc098b2a3aa256d2140208c3de6543aaef5cd3a94', 'FTX 2', 'cex', 'hildobby', 'static', timestamp('2022-08-28'), now())
+    -- FTX US, Source: https://twitter.com/lawmaster/status/1589510088875642881?s=20&t=6c-qunbJWh0k6_f0TQ9KAw
+    , (array('ethereum'), '0x7abe0ce388281d2acf297cb089caef3819b13448', 'FTX US', 'cex', '1chioku', 'static', timestamp('2022-11-07'), now())
     -- Coinbase, Source: https://etherscan.io/accounts/label/coinbase
     , (array('ethereum'), '0x71660c4005ba85c37ccec55d0c4493e66fe775d3', 'Coinbase 1', 'cex', 'hildobby', 'static', timestamp('2022-08-28'), now())
     , (array('ethereum'), '0x503828976d22510aad0201ac7ec88293211d23da', 'Coinbase 2', 'cex', 'hildobby', 'static', timestamp('2022-08-28'), now())


### PR DESCRIPTION
Brief comments on the purpose of your changes:

FTX US address, sauce: https://docs.google.com/spreadsheets/d/1lBNOmTZnKTkiPCROX9NfGqqd8S-1XNChb3Dh_l_KSW0/edit#gid=95051987 from [@lawmaster](https://twitter.com/lawmaster/status/1589510081694949377?s=20&t=6c-qunbJWh0k6_f0TQ9KAw)

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributors)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
