### PR TITLE
element_bnb.events partition on block date

### DIFF
--- a/models/element/avalanche_c/element_avalanche_c_events.sql
+++ b/models/element/avalanche_c/element_avalanche_c_events.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'element_avalanche_c',
     alias = 'events',
-    partition_by = ['block_time'],
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -121,6 +121,7 @@ SELECT alet.blockchain
 , alet.project
 , alet.version
 , alet.block_time
+, date_trunc('day', alet.block_time) AS block_date
 , alet.token_id
 , ava_nft_tokens.name AS collection
 , alet.amount_raw/POWER(10, ava_erc20_tokens.decimals)*prices.price AS amount_usd

--- a/models/element/bnb/element_bnb_events.sql
+++ b/models/element/bnb/element_bnb_events.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'element_bnb',
     alias = 'events',
-    partition_by = ['block_time'],
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -121,6 +121,7 @@ SELECT alet.blockchain
 , alet.project
 , alet.version
 , alet.block_time
+, date_trunc('day', alet.block_time) AS block_date
 , alet.token_id
 , bnb_nft_tokens.name AS collection
 , alet.amount_raw/POWER(10, bnb_bep20_tokens.decimals)*prices.price AS amount_usd

--- a/models/element/ethereum/element_ethereum_events.sql
+++ b/models/element/ethereum/element_ethereum_events.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'element_ethereum',
     alias = 'events',
-    partition_by = ['block_time'],
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -121,6 +121,7 @@ SELECT alet.blockchain
 , alet.project
 , alet.version
 , alet.block_time
+, date_trunc('day', alet.block_time) AS block_date
 , alet.token_id
 , eth_nft_tokens.name AS collection
 , alet.amount_raw/POWER(10, eth_erc20_tokens.decimals)*prices.price AS amount_usd


### PR DESCRIPTION
Brief comments on the purpose of your changes:
After taking a look at @sohwak's contribution on swapping union for union all, I saw that querytime was especially high on element_bnb.events and I believe that is due to selection block_time instead of block_date as the partition key. 

This will require a full refresh of the tables if it works. 
