### PR TITLE
[CoW Protocol] Fix Batches Table!

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql
@@ -33,11 +33,13 @@ batch_counts as (
     from {{ source('gnosis_protocol_v2_ethereum', 'GPv2Settlement_evt_Settlement') }} s
         left outer join {{ source('gnosis_protocol_v2_ethereum', 'GPv2Settlement_evt_Interaction') }} i
             on i.evt_tx_hash = s.evt_tx_hash
+            {% if is_incremental() %}
+            AND i.evt_block_time >= date_trunc("day", now() - interval '1 week')
+            {% endif %}
         join cow_protocol_ethereum.solvers
             on solver = address
     {% if is_incremental() %}
     WHERE s.evt_block_time >= date_trunc("day", now() - interval '1 week')
-    AND i.evt_block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
     group by s.evt_tx_hash, solver, s.evt_block_time, name
 ),


### PR DESCRIPTION
Based on the ongoing discussion in #1752, we took a very careful look at the query building this table, to discover that the incremental change logic was not including records which were contained in the "outer" part of the outer join. In brief, what we had was

```sql
select 
from table_a 
left outer join table_b 
    join on condition
-- this was not captured by the outer join because the field values were null.
where condition on table_b.block_time 
```

What we have here is 

```sql
select 
from table_a 
left outer join table b 
    join on condition
       -- Now is captured
       and condition on table_b.block_time 
```

This [PoC query](https://dune.com/queries/1290518) demonstrates that the [missing records](https://dune.com/queries/1389623) are contained in the new query!
