### PR TITLE
Escape some reserved time related keywords

### DIFF
--- a/models/keep3r_network/ethereum/keep3r_network_ethereum_view_job_liquidity_log.sql
+++ b/models/keep3r_network/ethereum/keep3r_network_ethereum_view_job_liquidity_log.sql
@@ -102,7 +102,7 @@ df AS (
         migs.evt_index,
         migs.job,
         migs.keep3r,
-        migs.timestamp,
+        migs.`timestamp`,
         migs.tx_hash,
         liqs.token AS token,
         NULL AS amount

--- a/tests/balances/ethereum/balances_ethereum_erc20_day_assert_samples.sql
+++ b/tests/balances/ethereum/balances_ethereum_erc20_day_assert_samples.sql
@@ -12,7 +12,7 @@ with sampled_wallets as
 (SELECT case when round(test_data.amount_raw/power(10, 18), 4) = round(token_balances.amount_raw/power(10, 18), 4) then True else False end as amount_raw_test
 FROM {{ ref('balances_ethereum_erc20_daily_entries') }} as test_data
 JOIN sampled_wallets as token_balances
-ON test_data.timestamp = token_balances.day
+ON test_data.`timestamp` = token_balances.`day`
 AND test_data.wallet_address = token_balances.wallet_address
 AND test_data.token_address = token_balances.token_address)
 

--- a/tests/balances/ethereum/balances_ethereum_erc20_hour_assert_samples.sql
+++ b/tests/balances/ethereum/balances_ethereum_erc20_hour_assert_samples.sql
@@ -13,7 +13,7 @@ with sampled_wallets as
 (SELECT case when round(test_data.amount_raw/power(10, 22), 3) = round(token_balances.amount_raw/power(10, 22), 3) then True else False end as amount_raw_test
 FROM {{ ref('balances_ethereum_erc20_latest_entries') }} as test_data
 JOIN sampled_wallets as token_balances
-ON test_data.timestamp = token_balances.hour
+ON test_data.`timestamp` = token_balances.`hour`
 AND test_data.wallet_address = token_balances.wallet_address
 AND test_data.token_address = token_balances.token_address)
 

--- a/tests/balances/ethereum/balances_ethereum_erc20_hour_assert_specific_wallet.sql
+++ b/tests/balances/ethereum/balances_ethereum_erc20_hour_assert_specific_wallet.sql
@@ -4,7 +4,7 @@ WITH unit_tests as
 (SELECT case when round(test_data.amount_raw/power(10, 22), 3) = round(token_balances.amount_raw/power(10, 22), 3) then True else False end as amount_raw_test
 FROM {{ ref('balances_ethereum_erc20_specific_wallet') }} as test_data
 JOIN (select * from {{ ref('balances_ethereum_erc20_hour') }} where wallet_address = '0xff0cefdbd6bf757cc0cc361ddfbde432186ccaa6') as token_balances
-ON test_data.timestamp = token_balances.hour
+ON test_data.`timestamp` = token_balances.`hour`
 AND test_data.wallet_address = token_balances.wallet_address
 AND test_data.token_address = token_balances.token_address)
 


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Timestamp, hour and day are reserved keywords in some SQL dialects, so we must escape them to be able to parse them. Hopefully we can find a more general solution to this over time.

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
