### PR TITLE
Add `tokens.erc20` on Polygon

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -282,6 +282,9 @@ models:
       arbitrum:
         +schema: tokens_arbitrum
         +materialized: view
+      polygon:
+        +schema: tokens_polygon
+        +materialized: view
 
     transfers:
       +schema: transfers

--- a/models/tokens/polygon/tokens_polygon_erc20.sql
+++ b/models/tokens/polygon/tokens_polygon_erc20.sql
@@ -1,0 +1,12 @@
+{{ config( alias='erc20')}}
+
+SELECT LOWER(contract_address) AS contract_address, symbol, decimals
+  FROM (VALUES 
+
+('0x8f3cf7ad23cd3cadbd9735aff958023239c6a063', 'DAI', 18)
+,('0x0000000000000000000000000000000000001010', 'MATIC', 18)
+,('0x2791bca1f2de4661ed88a30c99a7a9449aa84174', 'USDC', 6)
+,('0xc2132d05d31c914a87c6611c10748aeb04b58e8f', 'USDT', 6)
+,('0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6', 'WBTC', 8)
+
+) AS temp_table (contract_address, symbol, decimals)

--- a/models/tokens/polygon/tokens_polygon_schema.yml
+++ b/models/tokens/polygon/tokens_polygon_schema.yml
@@ -1,0 +1,21 @@
+version: 2
+
+models:
+  - name: tokens_polygon_erc20
+    meta:
+      blockchain: polygon
+      sector: tokens
+      project: erc20
+      contributors: sohwak
+    config:
+      tags: ['table', 'metadata', 'erc20', 'optimism']
+    description: "ERC20 Token Addresses, Symbols and Decimals"
+    columns:
+      - name: contract_address
+        description: "ERC20 token contract address on Polygon"
+        tests:
+          - unique
+      - name: symbol
+        description: "ERC20 token symbol"
+      - name: decimals
+        description: "Number of decimals, refers to how divisible an ERC20 token can be"

--- a/models/tokens/tokens_erc20.sql
+++ b/models/tokens/tokens_erc20.sql
@@ -15,3 +15,5 @@ UNION
 SELECT 'gnosis' as blockchain, * FROM  {{ ref('tokens_gnosis_erc20') }}
 UNION
 SELECT 'optimism' as blockchain, * FROM  {{ ref('tokens_optimism_erc20') }}
+UNION
+SELECT 'polygon' as blockchain, * FROM  {{ ref('tokens_polygon_erc20') }}


### PR DESCRIPTION
Brief comments on the purpose of your changes:

- Add `tokens.erc20` on Polygon
- Added 5 tokens that currently exist in `prices.usd` (blockchain=polygon).

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
