### PR TITLE
T-20616 Use UNION ALL in nft.trades

### DIFF
--- a/models/nft/nft_trades.sql
+++ b/models/nft/nft_trades.sql
@@ -38,7 +38,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('opensea_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -68,7 +68,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('magiceden_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -98,7 +98,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('looksrare_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -128,7 +128,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('x2y2_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -158,7 +158,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('sudoswap_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -188,7 +188,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('foundation_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -218,7 +218,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('archipelago_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -248,7 +248,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('cryptopunks_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -278,7 +278,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('element_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -308,7 +308,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('superrare_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,
@@ -338,7 +338,7 @@ FROM
                 tx_to,
                 unique_trade_id
         FROM {{ ref('zora_ethereum_trades') }}
-        UNION
+        UNION ALL
         SELECT
                 blockchain,
                 project,


### PR DESCRIPTION
Brief comments on the purpose of your changes:

If there are no duplicates between or within the tables in a union, then using UNION ALL is equivalent to UNION, and considerably faster. I've not verified that this is the case for the tables which participate in `nft.trades`.

In general, it is best to avoid using UNION in views which are not materialized.

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
