### PR TITLE
Fix column names in cex labels tables

### DIFF
--- a/models/labels/cex/labels_cex_bnb.sql
+++ b/models/labels/cex/labels_cex_bnb.sql
@@ -4,7 +4,7 @@
                                     "labels",
                                     \'["soispoke"]\') }}')}}
 
-SELECT blockchain, lower(address), name, category, contributor, source, created_at, updated_at
+SELECT blockchain, lower(address) as address, name, category, contributor, source, created_at, updated_at
 FROM (VALUES
     -- Binance
     (array('bnb'), '0x631Fc1EA2270e98fbD9D92658eCe0F5a269Aa161', 'Binance 1', 'cex', 'soispoke', 'static', timestamp('2022-08-28'), now()),

--- a/models/labels/cex/labels_cex_ethereum.sql
+++ b/models/labels/cex/labels_cex_ethereum.sql
@@ -4,7 +4,7 @@
                                     "labels",
                                     \'["hildobby","soispoke"]\') }}')}}
 
-SELECT blockchain, lower(address), name, category, contributor, source, created_at, updated_at
+SELECT blockchain, lower(address) as address, name, category, contributor, source, created_at, updated_at
 FROM (VALUES
     -- Binance, Source: https://etherscan.io/accounts/label/binance
     (array('ethereum'),'0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be', 'Binance 1', 'cex', 'hildobby', 'static', timestamp('2022-08-28'), now())


### PR DESCRIPTION
just a quick fix of the column names lower(address) to address


**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
