### PR TITLE
Migrate Balancer's BPT prices view to V2

### DIFF
--- a/models/balancer/arbitrum/balancer_arbitrum_schema.yml
+++ b/models/balancer/arbitrum/balancer_arbitrum_schema.yml
@@ -1,0 +1,31 @@
+version: 2
+
+models:
+  - name: balancer_arbitrum_view_bpt_prices
+    meta:
+      blockchain: arbitrum
+      project: balancer
+      contributors: victorstefenon
+    config:
+      tags: ['arbitrum', 'bpt', 'prices']
+    description: >
+      Balancer Pool Token (BPT) hourly median price by pool on Balancer, an automated portfolio manager and trading platform.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - hour
+            - contract_address
+    columns:
+      - &hour
+        name: hour
+        description: 'UTC event block time truncated to the hour mark'
+        tests:
+          - not_null
+      - &contract_address
+        name: contract_address
+        description: 'Balancer pool contract address'
+        tests:
+          - not_null
+      - &median_price
+        name: median_price
+        description: 'BPT median price'

--- a/models/balancer/arbitrum/balancer_arbitrum_sources.yml
+++ b/models/balancer/arbitrum/balancer_arbitrum_sources.yml
@@ -1,32 +1,9 @@
 version: 2
 
 sources:
-  - name: balancer_v1_ethereum
+  - name: balancer_v2_arbitrum
     description: >
-      Decoded tables related to Balancer V1, an automated portfolio manager and trading platform, on Ethereum.
-    tables:
-      - name: BFactory_evt_LOG_NEW_POOL
-        description: >
-          Decoded table related to the Balancer BFactory contract.
-        loaded_at_field: evt_block_time
-        columns:
-          - name: contract_address
-            description: 'Balancer BFactory contract address'
-          - name: evt_tx_hash
-            description: 'Transaction hash of the event'
-          - name: evt_index
-            description: 'Event index'
-          - name: evt_block_time
-            description: 'Timestamp for block event time in UTC'
-          - name: evt_block_number
-            description: 'Event block number'
-          - name: caller
-            description: 'Caller address that created the Balancer pool'
-          - name: pool
-            description: 'Balancer pool contract address'
-  - name: balancer_v2_ethereum
-    description: >
-      Decoded tables related to Balancer V2, an automated portfolio manager and trading platform, on Ethereum.
+      Decoded tables related to Balancer V2, an automated portfolio manager and trading platform, on Arbitrum.
     tables:
       - name: Vault_evt_Swap
         description: >

--- a/models/balancer/arbitrum/balancer_arbitrum_view_bpt_prices.sql
+++ b/models/balancer/arbitrum/balancer_arbitrum_view_bpt_prices.sql
@@ -1,0 +1,65 @@
+{{
+    config(
+        alias='arbitrum_view_bpt_prices',
+        post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                    "project",
+                                    "balancer",
+                                    \'["victorstefenon"]\') }}'
+    )
+}}
+
+WITH bpt_trades AS (
+    SELECT
+        block_time,
+        bpt_address,
+        bpt_amount_raw,
+        bpt_amount_raw / POWER(10, COALESCE(erc20a.decimals, 18)) AS bpt_amount,
+        token_amount_raw,
+        token_amount_raw / POWER(10, erc20b.decimals) AS token_amount,
+        p.price * token_amount_raw / POWER(10, erc20b.decimals) AS usd_amount
+    FROM (
+        SELECT
+            t.evt_block_time AS block_time,
+            CASE 
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.tokenIn
+                ELSE t.tokenOut
+            END AS bpt_address,
+            CASE 
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.amountIn
+                ELSE t.amountOut
+            END AS bpt_amount_raw,
+            CASE 
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.tokenOut
+                ELSE t.tokenIn
+            END AS token_address,
+            CASE
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.amountOut
+                ELSE t.amountIn
+            END AS token_amount_raw
+        FROM {{ source('balancer_v2_arbitrum', 'Vault_evt_Swap') }} t
+        WHERE t.tokenIn = SUBSTRING(t.poolId, 0, 42)
+        OR t.tokenOut = SUBSTRING(t.poolId, 0, 42)
+    ) dexs
+    LEFT JOIN {{ ref('tokens_erc20') }} erc20a ON erc20a.contract_address = dexs.bpt_address
+    AND erc20a.blockchain = "arbitrum"
+    JOIN {{ ref('tokens_erc20') }}  erc20b ON erc20b.contract_address = dexs.token_address
+    AND erc20b.blockchain = "arbitrum"
+    LEFT JOIN {{ source('prices', 'usd') }} p ON p.minute = date_trunc('minute', dexs.block_time)
+    AND p.contract_address = dexs.token_address AND p.blockchain = "arbitrum"
+),
+
+bpt_estimated_prices AS (
+    SELECT
+        block_time,
+        bpt_address,
+        usd_amount / bpt_amount AS price
+    FROM
+        bpt_trades
+)
+
+SELECT
+    date_trunc('hour', block_time) as hour,
+    bpt_address AS contract_address,
+    PERCENTILE(price, 0.5) AS median_price
+FROM bpt_estimated_prices
+GROUP BY 1, 2

--- a/models/balancer/ethereum/balancer_ethereum_schema.yml
+++ b/models/balancer/ethereum/balancer_ethereum_schema.yml
@@ -31,3 +31,32 @@ models:
       - &cumulative_amount
         name: cumulative_amount
         description: 'Balance of a token'
+
+  - name: balancer_ethereum_view_bpt_prices
+    meta:
+      blockchain: ethereum
+      project: balancer
+      contributors: victorstefenon
+    config:
+      tags: ['ethereum', 'bpt', 'prices']
+    description: >
+      Balancer Pool Token (BPT) hourly median price by pool on Balancer, an automated portfolio manager and trading platform.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - hour
+            - contract_address
+    columns:
+      - &hour
+        name: hour
+        description: 'UTC event block time truncated to the hour mark'
+        tests:
+          - not_null
+      - &contract_address
+        name: contract_address
+        description: 'Balancer pool contract address'
+        tests:
+          - not_null
+      - &median_price
+        name: median_price
+        description: 'BPT median price'

--- a/models/balancer/ethereum/balancer_ethereum_view_bpt_prices.sql
+++ b/models/balancer/ethereum/balancer_ethereum_view_bpt_prices.sql
@@ -1,0 +1,65 @@
+{{
+    config(
+        alias='ethereum_view_bpt_prices',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "project",
+                                    "balancer",
+                                    \'["victorstefenon"]\') }}'
+    )
+}}
+
+WITH bpt_trades AS (
+    SELECT
+        block_time,
+        bpt_address,
+        bpt_amount_raw,
+        bpt_amount_raw / POWER(10, COALESCE(erc20a.decimals, 18)) AS bpt_amount,
+        token_amount_raw,
+        token_amount_raw / POWER(10, erc20b.decimals) AS token_amount,
+        p.price * token_amount_raw / POWER(10, erc20b.decimals) AS usd_amount
+    FROM (
+        SELECT
+            t.evt_block_time AS block_time,
+            CASE 
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.tokenIn
+                ELSE t.tokenOut
+            END AS bpt_address,
+            CASE 
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.amountIn
+                ELSE t.amountOut
+            END AS bpt_amount_raw,
+            CASE 
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.tokenOut
+                ELSE t.tokenIn
+            END AS token_address,
+            CASE
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.amountOut
+                ELSE t.amountIn
+            END AS token_amount_raw
+        FROM {{ source('balancer_v2_ethereum', 'Vault_evt_Swap') }} t
+        WHERE t.tokenIn = SUBSTRING(t.poolId, 0, 42)
+        OR t.tokenOut = SUBSTRING(t.poolId, 0, 42)
+    ) dexs
+    LEFT JOIN {{ ref('tokens_erc20') }} erc20a ON erc20a.contract_address = dexs.bpt_address
+    AND erc20a.blockchain = "ethereum"
+    JOIN {{ ref('tokens_erc20') }}  erc20b ON erc20b.contract_address = dexs.token_address
+    AND erc20b.blockchain = "ethereum"
+    LEFT JOIN {{ source('prices', 'usd') }} p ON p.minute = date_trunc('minute', dexs.block_time)
+    AND p.contract_address = dexs.token_address AND p.blockchain = "ethereum"
+),
+
+bpt_estimated_prices AS (
+    SELECT
+        block_time,
+        bpt_address,
+        usd_amount / bpt_amount AS price
+    FROM
+        bpt_trades
+)
+
+SELECT
+    date_trunc('hour', block_time) as hour,
+    bpt_address AS contract_address,
+    PERCENTILE(price, 0.5) AS median_price
+FROM bpt_estimated_prices
+GROUP BY 1, 2

--- a/models/balancer/optimism/balancer_optimism_schema.yml
+++ b/models/balancer/optimism/balancer_optimism_schema.yml
@@ -1,0 +1,31 @@
+version: 2
+
+models:
+  - name: balancer_optimism_view_bpt_prices
+    meta:
+      blockchain: optimism
+      project: balancer
+      contributors: victorstefenon
+    config:
+      tags: ['optimism', 'bpt', 'prices']
+    description: >
+      Balancer Pool Token (BPT) hourly median price by pool on Balancer, an automated portfolio manager and trading platform.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - hour
+            - contract_address
+    columns:
+      - &hour
+        name: hour
+        description: 'UTC event block time truncated to the hour mark'
+        tests:
+          - not_null
+      - &contract_address
+        name: contract_address
+        description: 'Balancer pool contract address'
+        tests:
+          - not_null
+      - &median_price
+        name: median_price
+        description: 'BPT median price'

--- a/models/balancer/optimism/balancer_optimism_sources.yml
+++ b/models/balancer/optimism/balancer_optimism_sources.yml
@@ -1,32 +1,9 @@
 version: 2
 
 sources:
-  - name: balancer_v1_ethereum
+  - name: balancer_v2_optimism
     description: >
-      Decoded tables related to Balancer V1, an automated portfolio manager and trading platform, on Ethereum.
-    tables:
-      - name: BFactory_evt_LOG_NEW_POOL
-        description: >
-          Decoded table related to the Balancer BFactory contract.
-        loaded_at_field: evt_block_time
-        columns:
-          - name: contract_address
-            description: 'Balancer BFactory contract address'
-          - name: evt_tx_hash
-            description: 'Transaction hash of the event'
-          - name: evt_index
-            description: 'Event index'
-          - name: evt_block_time
-            description: 'Timestamp for block event time in UTC'
-          - name: evt_block_number
-            description: 'Event block number'
-          - name: caller
-            description: 'Caller address that created the Balancer pool'
-          - name: pool
-            description: 'Balancer pool contract address'
-  - name: balancer_v2_ethereum
-    description: >
-      Decoded tables related to Balancer V2, an automated portfolio manager and trading platform, on Ethereum.
+      Decoded tables related to Balancer V2, an automated portfolio manager and trading platform, on Optimism.
     tables:
       - name: Vault_evt_Swap
         description: >

--- a/models/balancer/optimism/balancer_optimism_view_bpt_prices.sql
+++ b/models/balancer/optimism/balancer_optimism_view_bpt_prices.sql
@@ -1,0 +1,65 @@
+{{
+    config(
+        alias='optimism_view_bpt_prices',
+        post_hook='{{ expose_spells(\'["optimism"]\',
+                                    "project",
+                                    "balancer",
+                                    \'["victorstefenon"]\') }}'
+    )
+}}
+
+WITH bpt_trades AS (
+    SELECT
+        block_time,
+        bpt_address,
+        bpt_amount_raw,
+        bpt_amount_raw / POWER(10, COALESCE(erc20a.decimals, 18)) AS bpt_amount,
+        token_amount_raw,
+        token_amount_raw / POWER(10, erc20b.decimals) AS token_amount,
+        p.price * token_amount_raw / POWER(10, erc20b.decimals) AS usd_amount
+    FROM (
+        SELECT
+            t.evt_block_time AS block_time,
+            CASE 
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.tokenIn
+                ELSE t.tokenOut
+            END AS bpt_address,
+            CASE 
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.amountIn
+                ELSE t.amountOut
+            END AS bpt_amount_raw,
+            CASE 
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.tokenOut
+                ELSE t.tokenIn
+            END AS token_address,
+            CASE
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.amountOut
+                ELSE t.amountIn
+            END AS token_amount_raw
+        FROM {{ source('balancer_v2_optimism', 'Vault_evt_Swap') }} t
+        WHERE t.tokenIn = SUBSTRING(t.poolId, 0, 42)
+        OR t.tokenOut = SUBSTRING(t.poolId, 0, 42)
+    ) dexs
+    LEFT JOIN {{ ref('tokens_erc20') }} erc20a ON erc20a.contract_address = dexs.bpt_address
+    AND erc20a.blockchain = "optimism"
+    JOIN {{ ref('tokens_erc20') }}  erc20b ON erc20b.contract_address = dexs.token_address
+    AND erc20b.blockchain = "optimism"
+    LEFT JOIN {{ source('prices', 'usd') }} p ON p.minute = date_trunc('minute', dexs.block_time)
+    AND p.contract_address = dexs.token_address AND p.blockchain = "optimism"
+),
+
+bpt_estimated_prices AS (
+    SELECT
+        block_time,
+        bpt_address,
+        usd_amount / bpt_amount AS price
+    FROM
+        bpt_trades
+)
+
+SELECT
+    date_trunc('hour', block_time) as hour,
+    bpt_address AS contract_address,
+    PERCENTILE(price, 0.5) AS median_price
+FROM bpt_estimated_prices
+GROUP BY 1, 2

--- a/models/balancer/polygon/balancer_polygon_schema.yml
+++ b/models/balancer/polygon/balancer_polygon_schema.yml
@@ -1,0 +1,31 @@
+version: 2
+
+models:
+  - name: balancer_polygon_view_bpt_prices
+    meta:
+      blockchain: polygon
+      project: balancer
+      contributors: victorstefenon
+    config:
+      tags: ['polygon', 'bpt', 'prices']
+    description: >
+      Balancer Pool Token (BPT) hourly median price by pool on Balancer, an automated portfolio manager and trading platform.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - hour
+            - contract_address
+    columns:
+      - &hour
+        name: hour
+        description: 'UTC event block time truncated to the hour mark'
+        tests:
+          - not_null
+      - &contract_address
+        name: contract_address
+        description: 'Balancer pool contract address'
+        tests:
+          - not_null
+      - &median_price
+        name: median_price
+        description: 'BPT median price'

--- a/models/balancer/polygon/balancer_polygon_sources.yml
+++ b/models/balancer/polygon/balancer_polygon_sources.yml
@@ -1,32 +1,9 @@
 version: 2
 
 sources:
-  - name: balancer_v1_ethereum
+  - name: balancer_v2_polygon
     description: >
-      Decoded tables related to Balancer V1, an automated portfolio manager and trading platform, on Ethereum.
-    tables:
-      - name: BFactory_evt_LOG_NEW_POOL
-        description: >
-          Decoded table related to the Balancer BFactory contract.
-        loaded_at_field: evt_block_time
-        columns:
-          - name: contract_address
-            description: 'Balancer BFactory contract address'
-          - name: evt_tx_hash
-            description: 'Transaction hash of the event'
-          - name: evt_index
-            description: 'Event index'
-          - name: evt_block_time
-            description: 'Timestamp for block event time in UTC'
-          - name: evt_block_number
-            description: 'Event block number'
-          - name: caller
-            description: 'Caller address that created the Balancer pool'
-          - name: pool
-            description: 'Balancer pool contract address'
-  - name: balancer_v2_ethereum
-    description: >
-      Decoded tables related to Balancer V2, an automated portfolio manager and trading platform, on Ethereum.
+      Decoded tables related to Balancer V2, an automated portfolio manager and trading platform, on Polygon.
     tables:
       - name: Vault_evt_Swap
         description: >

--- a/models/balancer/polygon/balancer_polygon_view_bpt_prices.sql
+++ b/models/balancer/polygon/balancer_polygon_view_bpt_prices.sql
@@ -1,0 +1,65 @@
+{{
+    config(
+        alias='polygon_view_bpt_prices',
+        post_hook='{{ expose_spells(\'["polygon"]\',
+                                    "project",
+                                    "balancer",
+                                    \'["victorstefenon"]\') }}'
+    )
+}}
+
+WITH bpt_trades AS (
+    SELECT
+        block_time,
+        bpt_address,
+        bpt_amount_raw,
+        bpt_amount_raw / POWER(10, COALESCE(erc20a.decimals, 18)) AS bpt_amount,
+        token_amount_raw,
+        token_amount_raw / POWER(10, erc20b.decimals) AS token_amount,
+        p.price * token_amount_raw / POWER(10, erc20b.decimals) AS usd_amount
+    FROM (
+        SELECT
+            t.evt_block_time AS block_time,
+            CASE 
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.tokenIn
+                ELSE t.tokenOut
+            END AS bpt_address,
+            CASE 
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.amountIn
+                ELSE t.amountOut
+            END AS bpt_amount_raw,
+            CASE 
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.tokenOut
+                ELSE t.tokenIn
+            END AS token_address,
+            CASE
+                WHEN t.tokenIn = SUBSTRING(t.poolId, 0, 42) THEN t.amountOut
+                ELSE t.amountIn
+            END AS token_amount_raw
+        FROM {{ source('balancer_v2_polygon', 'Vault_evt_Swap') }} t
+        WHERE t.tokenIn = SUBSTRING(t.poolId, 0, 42)
+        OR t.tokenOut = SUBSTRING(t.poolId, 0, 42)
+    ) dexs
+    LEFT JOIN {{ ref('tokens_erc20') }} erc20a ON erc20a.contract_address = dexs.bpt_address
+    AND erc20a.blockchain = "polygon"
+    JOIN {{ ref('tokens_erc20') }}  erc20b ON erc20b.contract_address = dexs.token_address
+    AND erc20b.blockchain = "polygon"
+    LEFT JOIN {{ source('prices', 'usd') }} p ON p.minute = date_trunc('minute', dexs.block_time)
+    AND p.contract_address = dexs.token_address AND p.blockchain = "polygon"
+),
+
+bpt_estimated_prices AS (
+    SELECT
+        block_time,
+        bpt_address,
+        usd_amount / bpt_amount AS price
+    FROM
+        bpt_trades
+)
+
+SELECT
+    date_trunc('hour', block_time) as hour,
+    bpt_address AS contract_address,
+    PERCENTILE(price, 0.5) AS median_price
+FROM bpt_estimated_prices
+GROUP BY 1, 2


### PR DESCRIPTION
author: @Stefenon 
cc: @hedgehog-jacek @mendesfabio 
@Stefenon please review the Dune checklist:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
