### PR TITLE
Add FTX Funds Drainer to Labels

### DIFF
--- a/models/labels/hackers/labels_hackers_ethereum.sql
+++ b/models/labels/hackers/labels_hackers_ethereum.sql
@@ -104,5 +104,6 @@ FROM (VALUES
 (array('ethereum'),'0xc062dceed93087c9112ff7b02d53e928e49cec09','Gatecoin Hacker 3','hackers','ilemi','static', timestamp('2022-08-28'), now()),
 (array('ethereum'),'0xc8b759860149542a98a3eb57c14aadf59d6d89b9','Cryptopia Hacker 1','hackers','ilemi','static', timestamp('2022-08-28'), now()),
 (array('ethereum'),'0x844f03375f7da2292da550aebfd52dff2cc6ad75','RUNE Token Exploiter','hackers','ilemi','static', timestamp('2022-08-28'), now()),
-(array('ethereum'),'0x09923e35f19687a524bbca7d42b92b6748534f25','Nexus Mutual Hacker 1','hackers','ilemi','static', timestamp('2022-08-28'), now())
+(array('ethereum'),'0x09923e35f19687a524bbca7d42b92b6748534f25','Nexus Mutual Hacker 1','hackers','ilemi','static', timestamp('2022-08-28'), now()),
+(array('ethereum'),'0x59ABf3837Fa962d6853b4Cc0a19513AA031fd32b','FTX Funds Drainer','hackers','augustog','static', timestamp('2022-11-15'), now())      
     ) AS x (blockchain, address, name, category, contributor, source, created_at, updated_at)


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Minor addition to labels dataset: FTX Accounts Drainer (src: https://www.twitter.com/zachxbt/status/1591276687228035074)