### PR TITLE
Fix for duplications of ERC1155 transactions on Wyvern

### DIFF
--- a/models/opensea/ethereum/opensea_v1_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v1_ethereum_events.sql
@@ -162,7 +162,7 @@ SELECT DISTINCT
   'Buy' AS trade_category,
   wa.seller AS seller,
   CASE WHEN buyer=agg.contract_address AND erct2.to IS NOT NULL THEN erct2.to
-    WHEN buyer=agg.contract_address AND erct3.to IS NOT NULL THEN erct3.to
+    WHEN buyer=agg.contract_address AND concat('0x', substring(erct3.input,99, 40)) IS NOT NULL THEN concat('0x', substring(erct3.input,99, 40))
     ELSE buyer END AS buyer,
   CASE WHEN shared_storefront_address = '0x495f947276749ce646f68ac8c248420045cb7b5e' THEN 'Mint'
   WHEN evt_type is not NULL THEN evt_type ELSE 'Trade' END as evt_type,
@@ -218,7 +218,6 @@ LEFT JOIN ethereum.traces erct3 ON erct3.block_time = tx.block_time
     {% endif %}
     -- as we don't currently decode calls to erc1155 contracts, and wyvern doesn't trigger events
     -- joining directly to traces matching the call signature is the only way we can avoid duplicates on this level
-    -- infinte kudos to @0xBoxer for figuring this out
     
 LEFT JOIN {{ source('prices', 'usd') }} p ON p.minute = date_trunc('minute', tx.block_time)
     AND p.contract_address = wa.currency_contract

--- a/models/opensea/ethereum/opensea_v1_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v1_ethereum_events.sql
@@ -214,7 +214,7 @@ LEFT JOIN ethereum.traces erct3 ON erct3.block_time = tx.block_time
     AND slice(erct3.trace_address,1,2) = wa.call_trace_address
     AND substring(erct3.input,0,10) = '0xf242432a'
     {% if is_incremental() %}
-    and erct3.evt_block_time >= date_trunc("day", now() - interval '1 week')
+    and erct3.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
     -- as we don't currently decode calls to erc1155 contracts, and wyvern doesn't trigger events
     -- joining directly to traces matching the call signature is the only way we can avoid duplicates on this level

--- a/tests/opensea/ethereum/opensea_ethereum_assert_no_wyvern_duplicates.sql
+++ b/tests/opensea/ethereum/opensea_ethereum_assert_no_wyvern_duplicates.sql
@@ -1,0 +1,12 @@
+WITH unit_tests as
+(
+  select
+    token_id
+    ,count(*) count
+  from opensea.trades
+  where
+    block_number = 13914749
+    tx_hash = '0xa54e6fc7bd730c877902af79142ea2021f4bf865dad8ee79109037f1484366aa'
+  group by 1
+)
+select * from unit_test where token_in = 0 and count > 41


### PR DESCRIPTION
This is a draft PR to address an issue where some transactions from wyvern were getting duplicated due to issues in the join to erc1155.

Background:
- The primary reason why these duplicates occur is that some erc1155 transactions don't deduplicate on token_id
- The only other way we have to deduplicate these is by evt_index, but wyvern does not trigger events (so we join calls)
- At the moment we don't decode calls to erc1155 standard, so, as a workaround, @0xBoxer figured out we can join directly with ethereum.traces -- since we join on block time, the join's performance should not be that horrible

I added a very basic test to validate if this works, we should extend that test to account for other possibly duplicated txns.