### PR TITLE
[CoW Protocol] Add schema for raw_app_data

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_raw_app_data.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_raw_app_data.yml
@@ -1,2 +1,0 @@
-# I am not sure if this file needs to be filled out or not,
-# because this table will be streamed into community sources.

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_raw_app_data.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_raw_app_data.yml
@@ -1,0 +1,2 @@
+# I am not sure if this file needs to be filled out or not,
+# because this table will be streamed into community sources.

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -102,8 +102,8 @@ models:
       - &fee_usd
         name: fee_usd
         description: "USD value of trade fee"
-      - &app_data
-        name: app_data
+      - &app_hash
+        name: app_hash
         description: "Hashed metadata related to trade event (full content available on IPFS)"
       - &receiver
         name: receiver
@@ -153,3 +153,21 @@ models:
       - &token_approvals
         name: token_approvals
         description: Number of ERC20 token approvals made within the settlement
+  - name: cow_protocol_ethereum_raw_app_data
+    meta:
+      blockchain: ethereum
+      project: cow_protocol
+      contributors: bh2smith
+    config:
+      tags: ['ethereum','cow_protocol','orders', 'dex', 'aggregator', 'app_data', 'ipfs_content']
+    description: >
+      CoW Protocol App Data corresponding to "appData" as contained in `trade` parameter 
+      of contract calls to gnosis_protocol_v2_ethereum.GPv2Settlement_call_settle
+    columns:
+      - *app_hash
+      - &first_seen_block
+        name: first_block_seen
+        description: Block Number of the first onchain occurrence of `app_hash`
+      - &content
+        name: content
+        description: JSON content corresponding to `app_hash` - fetched from IPFS

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -93,7 +93,7 @@ trades_with_token_units as (
                                     END)
 ),
 -- This, independent, aggregation defines a mapping of order_uid and trade
--- TODO - create a view for the following block mapping uid to app_data
+-- TODO - create a view for the following block mapping uid to app_hash
 order_ids as (
     select evt_tx_hash, collect_list(orderUid) as order_ids
     from (  select orderUid, evt_tx_hash, evt_index
@@ -134,7 +134,7 @@ trade_data as (
 uid_to_app_id as (
     select
         order_id as uid,
-        get_json_object(trades.col, '$.appData') as app_data,
+        get_json_object(trades.col, '$.appData') as app_hash,
         get_json_object(trades.col, '$.receiver') as receiver
     from reduced_order_ids order_ids
              join trade_data trades
@@ -190,7 +190,7 @@ valued_trades as (
                     THEN buy_price * units_bought * fee / units_sold
                 ELSE NULL::numeric
                END)                                        as fee_usd,
-           app_data,
+           app_hash,
            receiver
     FROM trades_with_token_units
              JOIN uid_to_app_id


### PR DESCRIPTION
This content is planned to be streamed into community sources. I added it to the `cow_protocol_ethereum_schema`, and not sure if anything else needs to be defined. Furthermore, we had to rename trade.app_data to trades.app_hash to be in alignment with the actual "app_data" --> which will be in the `content` column of this new table.

I was hoping to specify types and nullability here like this:

```sql
cow_protocol.raw_app_data (
    first_seen_block  long   NOT NULL,
    hash              string UNIQUE & NOT NULL,  -- bytea (bytes32 - similar to txHash)
    content           json   NULLABLE,
);
``` 
but I am not sure how.

cc @dsalv - as we have been in communication about this.
