### PR TITLE
add native chain tokens as table

### DIFF
--- a/models/tokens/tokens_native.sql
+++ b/models/tokens/tokens_native.sql
@@ -1,0 +1,13 @@
+{{ config( alias='native')}}
+
+SELECT chain, symbol, price_symbol, LOWER(price_address) as price_address, decimals
+FROM (VALUES
+         ('ethereum', 'ETH', 'WETH', '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 18)
+         , ('optimism', 'ETH', 'WETH', '0x4200000000000000000000000000000000000006', 18)
+         , ('polygon', 'MATIC', 'MATIC', '0x0000000000000000000000000000000000001010', 18)
+         , ('arbitrum', 'ETH', 'WETH', '0x82af49447d8a07e3bd95bd0d56f35241523fbab1', 18)
+         , ('avalanche_c', 'AVAX', 'WAVAX', '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7', 18)
+         , ('gnosis', 'xDAI', 'WXDAI', '0xe91d153e0b41518a2ce8dd3d7944fa863463a97d', 18)
+         , ('bnb', 'BNB', 'WBNB', '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c', 8)
+         , ('solana', 'SOL', 'SOL', 'so11111111111111111111111111111111111111112', 18) --not sure if solana decimals are correct here
+     ) AS temp_table (chain, symbol, price_symbol, price_address, decimals)

--- a/models/tokens/tokens_schema.yml
+++ b/models/tokens/tokens_schema.yml
@@ -34,3 +34,24 @@ models:
         description: "NFT Token's symbol"
       - name: decimals
         description: "NFT Token's number of decimals"
+
+  - name: tokens_native
+    meta:
+      blockchain: avalanche_c, bnb, ethereum, gnosis, optimism, ethereum, arbitrum, solana
+      sector: tokens
+      contributors: ilemi
+    config:
+      tags: ['tokens','native', 'avalanche_c', 'bnb','ethereum', 'gnosis','optimism','ethereum','solana','arbitrum']
+    description: >
+        The chain native token and symbol, and the prices.usd symbol/address that is closest.
+    columns:
+      - name: chain
+        description: "the chain, as it's named in Dune" 
+      - name: symbol
+        description: "Token's symbol"
+      - name: price_symbol
+        description: "Token's prices.usd symbol"
+      - name: price_address
+        description: "Token's prices.usd contract address"
+      - name: decimals
+        description: "Token's number of decimals"


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
