### PR TITLE
Add Arbitrum Gas Fees spell

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -182,7 +182,10 @@ models:
       optimism:
         +schema: gas_optimism
         +materialized: view
-
+      arbitrum:
+        +schema: gas_arbitrum
+        +materialized: view
+        
     gmx:
       +schema: gmx
       +materialized: view

--- a/models/gas/arbitrum/gas_arbitrum_fees.sql
+++ b/models/gas/arbitrum/gas_arbitrum_fees.sql
@@ -1,0 +1,50 @@
+{{ config(
+    alias = 'fees',
+    partition_by = ['block_date'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['tx_hash','block_number']
+    )
+}}
+
+SELECT 
+     'arbitrum' as blockchain,
+     date_trunc('day', block_time) AS block_date,
+     block_number,
+     block_time,
+     txns.hash AS tx_hash,
+     txns.from AS tx_sender, 
+     txns.to AS tx_receiver,
+     'ETH' as native_token_symbol,
+     value/1e18 AS tx_amount_native,
+     value/1e18 * p.price AS tx_amount_usd,
+     (effective_gas_price * txns.gas_used)/1e18 as tx_fee_native, 
+     (effective_gas_price * txns.gas_used)/1e18 * p.price AS tx_fee_usd,
+     cast(NULL as double) AS burned_native, -- Not applicable for L2s
+     cast(NULL as double) AS burned_usd, -- Not applicable for L2s
+     cast(NULL as string) as validator, -- Not applicable for L2s
+     txns.effective_gas_price/1e9 as gas_price_gwei,
+     txns.effective_gas_price/1e18 * p.price as gas_price_usd,
+     txns.gas_price/1e9 as gas_price_bid_gwei,
+     txns.gas_price/1e18 * p.price as gas_price_bid_usd,
+     txns.gas_used as gas_used,
+     txns.gas_limit as gas_limit,
+     txns.gas_used / txns.gas_limit * 100 as gas_usage_percent,
+     gas_used_for_l1 as l1_gas_used,
+     type as transaction_type
+FROM {{ source('arbitrum','transactions') }} txns
+JOIN {{ source('arbitrum','blocks') }} blocks ON blocks.number = txns.block_number
+{% if is_incremental() %}
+AND block_time >= date_trunc("day", now() - interval '2 days')
+AND blocks.time >= date_trunc("day", now() - interval '2 days')
+{% endif %}
+LEFT JOIN {{ source('prices','usd') }} p ON p.minute = date_trunc('minute', block_time)
+AND p.blockchain = 'arbitrum'
+AND p.symbol = 'WETH'
+{% if is_incremental() %}
+AND p.minute >= date_trunc("day", now() - interval '2 days')
+WHERE block_time >= date_trunc("day", now() - interval '2 days')
+AND blocks.time >= date_trunc("day", now() - interval '2 days')
+AND p.minute >= date_trunc("day", now() - interval '2 days')
+{% endif %}

--- a/models/gas/arbitrum/gas_arbitrum_fees_schema.yml
+++ b/models/gas/arbitrum/gas_arbitrum_fees_schema.yml
@@ -1,0 +1,87 @@
+version: 2
+
+models:
+  - name: gas_arbitrum_fees
+    meta:
+      blockchain: arbitrum
+      sector: gas
+      contributors: soispoke
+    config:
+      tags: ['arbitrum', 'gas', 'fees']
+    description: >
+        Gas Fees on Arbitrum rollup Layer 2
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_number
+            - tx_hash
+    columns:
+      - &blokchain
+        name: blockchain
+        description: "Blockchain name"    
+      - &block_time
+        name: block_time
+        description: "Timestamp for block event time in UTC"
+      - &block_number
+        name: block_number
+        description: "Block number"
+      - &tx_hash
+        name: tx_hash
+        description: "Primary key of the transaction"
+      - &tx_sender
+        name: tx_sender
+        description: "Initiated the transaction"
+      - &tx_receiver
+        name: tx_receiver
+        description: "Received the transaction"
+      - &native_token_symbol
+        name: native_token_symbol
+        description: "Symbol of native token (ETH) for the Ethereum Blockchain"
+      - &tx_amount_native
+        name: tx_amount_native
+        description: "Amount of native tokens (ETH) transferred from sender to recipient"
+      - &tx_amount_usd
+        name: tx_amount_usd
+        description: "Amount of $USD transferred from sender to recipient"
+      - &tx_fee_native
+        name: tx_fee_native
+        description: "Total amount of native tokens (ETH) paid in gas fees"
+      - &tx_fee_usd
+        name: tx_fee_usd
+        description: "Total amount of $USD paid in gas fees"
+      - &burned_native
+        name: burned_native
+        description: "Total amount of native tokens (ETH) burned for this transaction, not applicable to L2 because transactionsonly indirectly burn gas on L1"
+      - &burned_usd
+        name: burned_usd
+        description: "Total amount of $USD burned for this transaction, not applicable to L2 because transactionsonly indirectly burn gas on L1"    
+      - &validator
+        name: validator
+        description: "Address of blockchain validator for this transaction within the block, also referred to as miner before the Merge when Ethereum's consensus mechanism was PoW"  
+      - &gas_price_gwei
+        name: gas_price_gwei
+        description: "Gas price (per gas unit) denoted in gwei"
+      - &gas_price_usd
+        name: gas_price_usd
+        description: "Gas price (per gas unit) denoted in $USD"
+      - &gas_price_bid_gwei
+        name: gas_price_bid_gwei
+        description: "Gas price (per gas unit) estimated by ArbOs with a buffer denoted in gwei. All excess is refunded"
+      - &gas_price_bid_usd
+        name: gas_price_bid_usd
+        description: "Gas price (per gas unit) estimated by ArbOs with a buffer denoted in $USD. All excess is refunded"
+      - &gas_used
+        name: gas_used
+        description: "Amount of L2 gas units consumed by the transaction"
+      - &gas_limit
+        name: gas_limit
+        description: "Maximum amount of gas units that can be consumed by the transaction on Optimism L2"
+      - &gas_usage_percent
+        name: gas_usage_percent
+        description: "Percentage of Gas Used relative to the gas limit on Optimism L2"
+      - &l1_gas_used
+        name: l1_gas_used
+        description: "Amount of L1 gas units consumed by the transaction"
+      - &type
+        name: type
+        description: "Transaction type: Legacy (Pre EIP 1559) or DynamicFee (Post EIP-1559)"

--- a/models/gas/gas_fees.sql
+++ b/models/gas/gas_fees.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='fees',
-        post_hook='{{ expose_spells(\'["ethereum","bnb","avalanche_c","optimism"]\',
+        post_hook='{{ expose_spells(\'["ethereum","bnb","avalanche_c","optimism","arbitrum"]\',
                                 "sector",
                                 "gas",
                                 \'["soispoke"]\') }}'
@@ -11,7 +11,8 @@
 'gas_ethereum_fees',
 'gas_bnb_fees',
 'gas_avalanche_c_fees',
-'gas_optimism_fees'
+'gas_optimism_fees',
+'gas_arbitrum_fees'
 ] %}
 
 SELECT *

--- a/models/gas/gas_fees_schema.yml
+++ b/models/gas/gas_fees_schema.yml
@@ -3,11 +3,11 @@ version: 2
 models:
   - name: gas_fees
     meta:
-      blockchain: ethereum, bnb, avalanche_c, optimism
+      blockchain: ethereum, bnb, avalanche_c, optimism, arbitrum
       sector: gas
       contributors: soispoke
     config:
-      tags: ['ethereum', 'bnb', 'avalanche_c', 'optimism','gas', 'fees']
+      tags: ['ethereum', 'bnb', 'avalanche_c', 'optimism', 'arbitrum','gas', 'fees']
     description: >
         Gas Fees across chains
     columns:


### PR DESCRIPTION
Here it finally is: Adding Arbitrum Gas Spell to complete the rollup part of gas fees

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
