### PR TITLE
[Easy]Modify pre-commit-config to point to dune's repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_stages: [push, manual]
 exclude: ^deprecated-dune-v1-abstractions/
 repos:
-- repo: https://github.com/offbi/pre-commit-dbt
+- repo: https://github.com/duneanalytics/pre-commit-dbt
   rev: v1.0.0
   hooks:
   - id: dbt-compile

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_stages: [push, manual]
 exclude: ^deprecated-dune-v1-abstractions/
 repos:
 - repo: https://github.com/duneanalytics/pre-commit-dbt
-  rev: v1.0.0
+  rev: main
   hooks:
   - id: dbt-compile
   - id: check-script-ref-and-source


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Modify pre-commit-config to point to dune's pre-commit-dbt repo.