### PR TITLE
Future proofing Blur for future ERC1155 support+buyer/seller fix

### DIFF
--- a/models/blur/ethereum/blur_ethereum_events.sql
+++ b/models/blur/ethereum/blur_ethereum_events.sql
@@ -18,9 +18,7 @@ SELECT 'ethereum' AS blockchain
 , bm.evt_block_time AS block_time
 , bm.evt_block_number AS block_number
 , get_json_object(bm.buy, '$.tokenId') AS token_id
-, CASE WHEN erct.evt_block_time IS NOT NULL THEN 'erc721'
-    ELSE 'erc1155'
-    END AS token_standard
+, erct.token_standard
 , nft.name AS collection
 , CASE WHEN get_json_object(bm.buy, '$.amount')=1 THEN 'Single Item Trade'
     ELSE 'Bundle Trade'
@@ -84,29 +82,29 @@ LEFT JOIN {{ source('prices','usd') }} pu ON pu.blockchain='ethereum'
     AND pu.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
 LEFT JOIN {{ ref('tokens_ethereum_nft') }} nft ON get_json_object(bm.buy, '$.collection')=nft.contract_address
-LEFT JOIN {{ source('erc721_ethereum','evt_transfer') }} erct ON erct.evt_block_time=bm.evt_block_time
+LEFT JOIN {{ ref('nft_ethereum_transfers') }} erct ON erct.block_time=bm.evt_block_time
     AND get_json_object(bm.buy, '$.collection')=erct.contract_address
-    AND erct.evt_tx_hash=bm.evt_tx_hash
-    AND get_json_object(bm.buy, '$.tokenId')=erct.tokenId
+    AND erct.tx_hash=bm.evt_tx_hash
+    AND get_json_object(bm.buy, '$.tokenId')=erct.token_id
     AND erct.from=get_json_object(bm.sell, '$.trader')
     {% if is_incremental() %}
-    AND erct.evt_block_time >= date_trunc("day", now() - interval '1 week')
+    AND erct.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ source('erc721_ethereum','evt_transfer') }} maker_fix ON maker_fix.evt_block_time=bm.evt_block_time
+LEFT JOIN {{ ref('nft_ethereum_transfers') }} maker_fix ON maker_fix.block_time=bm.evt_block_time
     AND get_json_object(bm.buy, '$.collection')=maker_fix.contract_address
-    AND maker_fix.evt_tx_hash=bm.evt_tx_hash
-    AND get_json_object(bm.buy, '$.tokenId')=maker_fix.tokenId
+    AND maker_fix.tx_hash=bm.evt_tx_hash
+    AND get_json_object(bm.buy, '$.tokenId')=maker_fix.token_id
     AND maker_fix.from=agg.contract_address
     {% if is_incremental() %}
-    AND maker_fix.evt_block_time >= date_trunc("day", now() - interval '1 week')
+    AND maker_fix.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ source('erc721_ethereum','evt_transfer') }} taker_fix ON taker_fix.evt_block_time=bm.evt_block_time
+LEFT JOIN {{ ref('nft_ethereum_transfers') }} taker_fix ON taker_fix.block_time=bm.evt_block_time
     AND get_json_object(bm.buy, '$.collection')=taker_fix.contract_address
-    AND taker_fix.evt_tx_hash=bm.evt_tx_hash
-    AND get_json_object(bm.buy, '$.tokenId')=taker_fix.tokenId
+    AND taker_fix.tx_hash=bm.evt_tx_hash
+    AND get_json_object(bm.buy, '$.tokenId')=taker_fix.token_id
     AND taker_fix.to=agg.contract_address
     {% if is_incremental() %}
-    AND taker_fix.evt_block_time >= date_trunc("day", now() - interval '1 week')
+    AND taker_fix.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
 {% if is_incremental() %}
 WHERE bm.evt_block_time >= date_trunc("day", now() - interval '1 week')

--- a/models/blur/ethereum/blur_ethereum_events.sql
+++ b/models/blur/ethereum/blur_ethereum_events.sql
@@ -11,65 +11,71 @@
                                 \'["hildobby"]\') }}')
 }}
 
-SELECT 'ethereum' AS blockchain
-, 'blur' AS project
-, 'v1' AS version
-, date_trunc('day', bm.evt_block_time) AS block_date
-, bm.evt_block_time AS block_time
-, bm.evt_block_number AS block_number
-, get_json_object(bm.buy, '$.tokenId') AS token_id
-, erct.token_standard
-, nft.name AS collection
-, CASE WHEN get_json_object(bm.buy, '$.amount')=1 THEN 'Single Item Trade'
-    ELSE 'Bundle Trade'
-    END AS trade_type
-, get_json_object(bm.buy, '$.amount') AS number_of_items
-, 'Trade' AS evt_type
-, COALESCE(seller_fix.from, get_json_object(bm.sell, '$.trader')) AS seller
-, COALESCE(buyer_fix.to, get_json_object(bm.buy, '$.trader')) AS buyer
-, CASE WHEN et.from=buyer_fix.to OR et.from=COALESCE(buyer_fix.to, get_json_object(bm.buy, '$.trader')) THEN 'Buy'
-    ELSE 'Offer Accepted'
-    END AS trade_category
-, get_json_object(bm.buy, '$.price') AS amount_raw
-, CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN get_json_object(bm.buy, '$.price')/POWER(10, 18)
-    ELSE get_json_object(bm.buy, '$.price')/POWER(10, pu.decimals)
-    END AS amount_original
-, CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN pu.price*get_json_object(bm.buy, '$.price')/POWER(10, 18)
-    ELSE pu.price*get_json_object(bm.buy, '$.price')/POWER(10, pu.decimals)
-    END AS amount_usd
-, CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN 'ETH'
-    ELSE pu.symbol
-    END AS currency_symbol
-, CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-    ELSE get_json_object(bm.buy, '$.paymentToken')
-    END AS currency_contract
-, bm.contract_address AS project_contract_address
-, get_json_object(bm.buy, '$.collection') AS nft_contract_address
-, agg.name AS aggregator_name
-, agg.contract_address AS aggregator_address
-, bm.evt_tx_hash AS tx_hash
-, et.from AS tx_from
-, et.to AS tx_to
-, 0 AS platform_fee_amount_raw
-, 0 AS platform_fee_amount
-, 0 AS platform_fee_amount_usd
-, 0 AS platform_fee_percentage
-, COALESCE(get_json_object(bm.buy, '$.price')*get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.rate')/10000, 0) AS royalty_fee_amount_raw
-, CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN COALESCE(get_json_object(bm.buy, '$.price')/POWER(10, 18)*get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.rate')/10000, 0)
-    ELSE COALESCE(get_json_object(bm.buy, '$.price')/POWER(10, pu.decimals)*get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.rate')/10000, 0)
-    END AS royalty_fee_amount
-, CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN COALESCE(pu.price*get_json_object(bm.buy, '$.price')/POWER(10, 18)*get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.rate')/10000, 0)
-    ELSE COALESCE(pu.price*get_json_object(bm.buy, '$.price')/POWER(10, pu.decimals)*get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.rate')/10000, 0)
-    END AS royalty_fee_amount_usd
-, COALESCE(get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.rate')/100, 0) AS royalty_fee_percentage
-, get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.recipient') AS royalty_fee_receive_address
-, CASE WHEN get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.recipient') IS NOT NULL AND get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN 'ETH'
-    WHEN get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.recipient') IS NOT NULL THEN pu.symbol
-    END AS royalty_fee_currency_symbol
-,  'ethereum-blur-v1' || bm.evt_tx_hash || '-' || COALESCE(seller_fix.from, get_json_object(bm.sell, '$.trader')) || '-' || COALESCE(buyer_fix.to, get_json_object(bm.buy, '$.trader')) || '-' || get_json_object(bm.buy, '$.collection') || '-' || get_json_object(bm.buy, '$.tokenId') AS unique_trade_id
+{% set project_start_date = '2022-10-18' %}
+
+SELECT
+    'ethereum' AS blockchain
+    , 'blur' AS project
+    , 'v1' AS version
+    , date_trunc('day', bm.evt_block_time) AS block_date
+    , bm.evt_block_time AS block_time
+    , bm.evt_block_number AS block_number
+    , get_json_object(bm.buy, '$.tokenId') AS token_id
+    , erct.token_standard
+    , nft.name AS collection
+    , CASE WHEN get_json_object(bm.buy, '$.amount')=1 THEN 'Single Item Trade'
+        ELSE 'Bundle Trade'
+        END AS trade_type
+    , get_json_object(bm.buy, '$.amount') AS number_of_items
+    , 'Trade' AS evt_type
+    , COALESCE(seller_fix.from, get_json_object(bm.sell, '$.trader')) AS seller
+    , COALESCE(buyer_fix.to, get_json_object(bm.buy, '$.trader')) AS buyer
+    , CASE WHEN et.from=buyer_fix.to OR et.from=COALESCE(buyer_fix.to, get_json_object(bm.buy, '$.trader')) THEN 'Buy'
+        ELSE 'Offer Accepted'
+        END AS trade_category
+    , get_json_object(bm.buy, '$.price') AS amount_raw
+    , CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN get_json_object(bm.buy, '$.price')/POWER(10, 18)
+        ELSE get_json_object(bm.buy, '$.price')/POWER(10, pu.decimals)
+        END AS amount_original
+    , CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN pu.price*get_json_object(bm.buy, '$.price')/POWER(10, 18)
+        ELSE pu.price*get_json_object(bm.buy, '$.price')/POWER(10, pu.decimals)
+        END AS amount_usd
+    , CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN 'ETH'
+        ELSE pu.symbol
+        END AS currency_symbol
+    , CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        ELSE get_json_object(bm.buy, '$.paymentToken')
+        END AS currency_contract
+    , bm.contract_address AS project_contract_address
+    , get_json_object(bm.buy, '$.collection') AS nft_contract_address
+    , agg.name AS aggregator_name
+    , agg.contract_address AS aggregator_address
+    , bm.evt_tx_hash AS tx_hash
+    , et.from AS tx_from
+    , et.to AS tx_to
+    , 0 AS platform_fee_amount_raw
+    , 0 AS platform_fee_amount
+    , 0 AS platform_fee_amount_usd
+    , 0 AS platform_fee_percentage
+    , COALESCE(get_json_object(bm.buy, '$.price')*get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.rate')/10000, 0) AS royalty_fee_amount_raw
+    , CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN COALESCE(get_json_object(bm.buy, '$.price')/POWER(10, 18)*get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.rate')/10000, 0)
+        ELSE COALESCE(get_json_object(bm.buy, '$.price')/POWER(10, pu.decimals)*get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.rate')/10000, 0)
+        END AS royalty_fee_amount
+    , CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN COALESCE(pu.price*get_json_object(bm.buy, '$.price')/POWER(10, 18)*get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.rate')/10000, 0)
+        ELSE COALESCE(pu.price*get_json_object(bm.buy, '$.price')/POWER(10, pu.decimals)*get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.rate')/10000, 0)
+        END AS royalty_fee_amount_usd
+    , COALESCE(get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.rate')/100, 0) AS royalty_fee_percentage
+    , get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.recipient') AS royalty_fee_receive_address
+    , CASE WHEN get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.recipient') IS NOT NULL AND get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN 'ETH'
+        WHEN get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.recipient') IS NOT NULL THEN pu.symbol
+        END AS royalty_fee_currency_symbol
+    ,  'ethereum-blur-v1' || bm.evt_tx_hash || '-' || COALESCE(seller_fix.from, get_json_object(bm.sell, '$.trader')) || '-' || COALESCE(buyer_fix.to, get_json_object(bm.buy, '$.trader')) || '-' || get_json_object(bm.buy, '$.collection') || '-' || get_json_object(bm.buy, '$.tokenId') AS unique_trade_id
 FROM {{ source('blur_ethereum','BlurExchange_evt_OrdersMatched') }} bm
-LEFT JOIN {{ source('ethereum','transactions') }} et ON et.block_time=bm.evt_block_time
+JOIN {{ source('ethereum','transactions') }} et ON et.block_time=bm.evt_block_time
     AND et.hash=bm.evt_tx_hash
+    {% if not is_incremental() %}
+    AND et.block_time >= '{{project_start_date}}'
+    {% endif %}
     {% if is_incremental() %}
     AND et.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
@@ -78,6 +84,9 @@ LEFT JOIN {{ source('prices','usd') }} pu ON pu.blockchain='ethereum'
     AND pu.minute=date_trunc('minute', bm.evt_block_time)
     AND (pu.contract_address=get_json_object(bm.buy, '$.paymentToken')
         OR (pu.contract_address='0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AND get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000'))
+    {% if not is_incremental() %}
+    AND pu.minute >= '{{project_start_date}}'
+    {% endif %}
     {% if is_incremental() %}
     AND pu.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
@@ -87,6 +96,9 @@ LEFT JOIN {{ ref('nft_ethereum_transfers') }} erct ON erct.block_time=bm.evt_blo
     AND erct.tx_hash=bm.evt_tx_hash
     AND get_json_object(bm.buy, '$.tokenId')=erct.token_id
     AND erct.from=get_json_object(bm.sell, '$.trader')
+    {% if not is_incremental() %}
+    AND erct.block_time >= '{{project_start_date}}'
+    {% endif %}
     {% if is_incremental() %}
     AND erct.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
@@ -96,6 +108,9 @@ LEFT JOIN {{ ref('nft_ethereum_transfers') }} buyer_fix ON buyer_fix.block_time=
     AND get_json_object(bm.buy, '$.tokenId')=buyer_fix.token_id
     AND get_json_object(bm.buy, '$.trader')=agg.contract_address
     AND buyer_fix.from=agg.contract_address
+    {% if not is_incremental() %}
+    AND buyer_fix.block_time >= '{{project_start_date}}'
+    {% endif %}
     {% if is_incremental() %}
     AND buyer_fix.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
@@ -105,9 +120,13 @@ LEFT JOIN {{ ref('nft_ethereum_transfers') }} seller_fix ON seller_fix.block_tim
     AND get_json_object(bm.buy, '$.tokenId')=seller_fix.token_id
     AND get_json_object(bm.sell, '$.trader')=agg.contract_address
     AND seller_fix.to=agg.contract_address
+    {% if not is_incremental() %}
+    AND seller_fix.block_time >= '{{project_start_date}}'
+    {% endif %}
     {% if is_incremental() %}
     AND seller_fix.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
 {% if is_incremental() %}
 WHERE bm.evt_block_time >= date_trunc("day", now() - interval '1 week')
 {% endif %}
+;

--- a/models/blur/ethereum/blur_ethereum_events.sql
+++ b/models/blur/ethereum/blur_ethereum_events.sql
@@ -25,9 +25,9 @@ SELECT 'ethereum' AS blockchain
     END AS trade_type
 , get_json_object(bm.buy, '$.amount') AS number_of_items
 , 'Trade' AS evt_type
-, COALESCE(taker_fix.from, get_json_object(bm.sell, '$.trader')) AS seller
-, COALESCE(maker_fix.to, get_json_object(bm.buy, '$.trader')) AS buyer
-, CASE WHEN et.from=maker_fix.to OR et.from=get_json_object(bm.buy, '$.trader') THEN 'Buy'
+, COALESCE(seller_fix.from, get_json_object(bm.sell, '$.trader')) AS seller
+, COALESCE(buyer_fix.to, get_json_object(bm.buy, '$.trader')) AS buyer
+, CASE WHEN et.from=buyer_fix.to OR et.from=COALESCE(buyer_fix.to, get_json_object(bm.buy, '$.trader')) THEN 'Buy'
     ELSE 'Offer Accepted'
     END AS trade_category
 , get_json_object(bm.buy, '$.price') AS amount_raw
@@ -66,7 +66,7 @@ SELECT 'ethereum' AS blockchain
 , CASE WHEN get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.recipient') IS NOT NULL AND get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN 'ETH'
     WHEN get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.recipient') IS NOT NULL THEN pu.symbol
     END AS royalty_fee_currency_symbol
-,  'ethereum-blur-v1' || bm.evt_tx_hash || '-' || COALESCE(taker_fix.from, get_json_object(bm.sell, '$.trader')) || '-' || COALESCE(maker_fix.to, get_json_object(bm.buy, '$.trader')) || '-' || get_json_object(bm.buy, '$.collection') || '-' || get_json_object(bm.buy, '$.tokenId') AS unique_trade_id
+,  'ethereum-blur-v1' || bm.evt_tx_hash || '-' || COALESCE(seller_fix.from, get_json_object(bm.sell, '$.trader')) || '-' || COALESCE(buyer_fix.to, get_json_object(bm.buy, '$.trader')) || '-' || get_json_object(bm.buy, '$.collection') || '-' || get_json_object(bm.buy, '$.tokenId') AS unique_trade_id
 FROM {{ source('blur_ethereum','BlurExchange_evt_OrdersMatched') }} bm
 LEFT JOIN {{ source('ethereum','transactions') }} et ON et.block_time=bm.evt_block_time
     AND et.hash=bm.evt_tx_hash
@@ -90,21 +90,23 @@ LEFT JOIN {{ ref('nft_ethereum_transfers') }} erct ON erct.block_time=bm.evt_blo
     {% if is_incremental() %}
     AND erct.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('nft_ethereum_transfers') }} maker_fix ON maker_fix.block_time=bm.evt_block_time
-    AND get_json_object(bm.buy, '$.collection')=maker_fix.contract_address
-    AND maker_fix.tx_hash=bm.evt_tx_hash
-    AND get_json_object(bm.buy, '$.tokenId')=maker_fix.token_id
-    AND maker_fix.from=agg.contract_address
+LEFT JOIN {{ ref('nft_ethereum_transfers') }} buyer_fix ON buyer_fix.block_time=bm.evt_block_time
+    AND get_json_object(bm.buy, '$.collection')=buyer_fix.contract_address
+    AND buyer_fix.tx_hash=bm.evt_tx_hash
+    AND get_json_object(bm.buy, '$.tokenId')=buyer_fix.token_id
+    AND get_json_object(bm.buy, '$.trader')=agg.contract_address
+    AND buyer_fix.from=agg.contract_address
     {% if is_incremental() %}
-    AND maker_fix.block_time >= date_trunc("day", now() - interval '1 week')
+    AND buyer_fix.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('nft_ethereum_transfers') }} taker_fix ON taker_fix.block_time=bm.evt_block_time
-    AND get_json_object(bm.buy, '$.collection')=taker_fix.contract_address
-    AND taker_fix.tx_hash=bm.evt_tx_hash
-    AND get_json_object(bm.buy, '$.tokenId')=taker_fix.token_id
-    AND taker_fix.to=agg.contract_address
+LEFT JOIN {{ ref('nft_ethereum_transfers') }} seller_fix ON seller_fix.block_time=bm.evt_block_time
+    AND get_json_object(bm.buy, '$.collection')=seller_fix.contract_address
+    AND seller_fix.tx_hash=bm.evt_tx_hash
+    AND get_json_object(bm.buy, '$.tokenId')=seller_fix.token_id
+    AND get_json_object(bm.sell, '$.trader')=agg.contract_address
+    AND seller_fix.to=agg.contract_address
     {% if is_incremental() %}
-    AND taker_fix.block_time >= date_trunc("day", now() - interval '1 week')
+    AND seller_fix.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
 {% if is_incremental() %}
 WHERE bm.evt_block_time >= date_trunc("day", now() - interval '1 week')


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
