### PR TITLE
Add Compound v2 dao.votes and proposals

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -106,6 +106,13 @@ models:
         +schema: nft_optimism
         +materialized: view
 
+    compound:
+      +schema: compound
+      +materialized: view
+      ethereum:
+        +schema: compound_ethereum
+        +materialized: view
+
     uniswap:
       +schema: uniswap
       +materialized: view

--- a/models/compound/ethereum/compound_ethereum_schema.yml
+++ b/models/compound/ethereum/compound_ethereum_schema.yml
@@ -1,0 +1,100 @@
+version: 2
+
+models:
+  - name: compound_v2_ethereum_votes
+    meta:
+      blockchain: ethereum
+      sector: dao
+      contributors: soispoke
+    config:
+      tags: ['ethereum', 'votes', 'dao', 'cross-chain']
+    description: >
+      DAO votes on all chains across all contracts and versions
+    columns:
+      - name: blockchain
+      - name: project
+        description: "Project name of the DAO"
+      - name: version
+        description: "Version of the contract built and deployed by the DAO project"
+      - name: block_time
+        description: "UTC event block time of each DAO vote"
+      - name: tx_hash
+        description: "Unique transaction hash value tied to each vote on the DAO"
+      - &dao_name
+        name: dao_name
+        description: "DAO name"
+      - &dao_address
+        name: dao_address
+        description: "DAO wallet address"
+      - &proposal_id
+        name: proposal_id
+      - &votes
+        name: votes
+        description: "Votes weighted by the amount of governance tokens"
+      - &votes_share
+        name: votes_share
+        description: "Votes share in percent for a given proposal"
+      - &token_symbol
+        name: token_symbol
+      - &token_address
+        name: token_address
+      - &votes_value_usd
+        name: votes_value_usd
+        description: "USD amount of governance tokens used at the time of the vote"
+      - &voter_address
+        name: voter_address
+      - &support
+        name: support
+        description: "0 = Against, 1 = For, 2 = Abstain votes"
+        tests:
+        - accepted_values:
+            values: ['for', 'against', 'abstain']
+      - &reason
+        name: reason
+        description: "Optional onchain commments to explain votes"
+
+  - name: compound_v2_ethereum_proposals
+    meta:
+      blockchain: ethereum
+      sector: dao
+      contributors: soispoke
+    config:
+      tags: ['ethereum', 'proposals', 'dao', 'cross-chain']
+    description: >
+      DAO proposals on all chains across all contracts and versions
+    columns:
+      - name: blockchain
+      - name: project
+        description: "Project name of the DAO"
+      - name: version
+        description: "Version of the contract built and deployed by the DAO project"
+      - name: created_at
+        description: "UTC event block time at which the proposal was created"
+      - name: tx_hash
+        description: "Unique transaction hash value tied to each DAO proposal"
+      - *dao_name
+      - *dao_address
+      - name: proposal_id
+        tests:
+          - unique
+      - &votes_for
+        name: votes_for
+      - &votes_against
+        name: votes_against
+      - &votes_total
+        name: votes_total
+        description: "Total number of governance tokens used to vote on a given DAO proposal"
+      - &number_of_voters
+        name: number_of_voters
+      - &participation
+        name: participation
+        description: "Participation in percent: Number of governance tokens used to vote / Total token supply"
+      - &status
+        name: status
+        description: "Proposal status: Queued, Active, Executed, Canceled or Defeated"
+        tests:
+          - accepted_values:
+              values: ['Queued', 'Active', 'Executed', 'Canceled','Defeated']
+      - &description
+        name: description
+        description: "Description of the proposal"

--- a/models/compound/ethereum/compound_ethereum_sources.yml
+++ b/models/compound/ethereum/compound_ethereum_sources.yml
@@ -1,0 +1,87 @@
+version: 2
+
+sources: 
+  - name: compound_v2_ethereum
+    description: "Ethereum decoded tables related to Compound v2 contract"
+    freshness:
+      warn_after: { count: 12, period: hour }
+    tables:
+      - name: GovernorBravoDelegate_evt_VoteCast
+        loaded_at_field: evt_block_time
+        columns:
+          - &contract_address
+            name: contract_address
+            description: "DAO governor contract address"
+          - &evt_block_number
+            name: evt_block_number
+          - &evt_block_time
+            name: evt_block_time
+            description: "UTC event block time of each DAO vote"
+          - &evt_index
+            name: evt_index
+          - &evt_tx_hash
+            name: evt_tx_hash
+            description: "Unique transaction hash value tied to each vote on the DAO"
+          - &proposalId
+            name: proposalId
+          - &reason
+            name: reason
+          - &voter
+            name: voter
+          - &votes
+            name: votes
+      - name: GovernorBravoDelegate_evt_ProposalCreated
+        loaded_at_field: evt_block_time
+        columns:
+          - *contract_address
+          - *evt_block_number
+          - *evt_block_time
+          - *evt_index
+          - *evt_tx_hash
+          - &calldatas
+            name: calldatas
+          - &description
+            name: description
+          - &endBlock
+            name: endBlock
+          - &id
+            name: id
+          - &proposer
+            name: proposer
+          - &signatures
+            name: signatures
+          - &startBlock
+            name: startBlock
+          - &targets
+            name: targets
+          - &values
+            name: values
+      - name: GovernorBravoDelegate_evt_ProposalCanceled
+        loaded_at_field: evt_block_time
+        columns:
+          - *contract_address
+          - *evt_block_number
+          - *evt_block_time
+          - *evt_index
+          - *evt_tx_hash
+          - *id
+      - name: GovernorBravoDelegate_evt_ProposalExecuted
+        loaded_at_field: evt_block_time
+        columns:
+          - *contract_address
+          - *evt_block_number
+          - *evt_block_time
+          - *evt_index
+          - *evt_tx_hash
+          - *id
+      - name: GovernorBravoDelegate_evt_ProposalQueued
+        loaded_at_field: evt_block_time
+        columns:
+          - *contract_address
+          - &eta
+            name: eta
+          - *evt_block_number
+          - *evt_block_time
+          - *evt_index
+          - *evt_tx_hash
+          - *id

--- a/models/compound/ethereum/compound_v2_ethereum_proposals.sql
+++ b/models/compound/ethereum/compound_v2_ethereum_proposals.sql
@@ -1,0 +1,74 @@
+{{ config(
+    schema = 'compound_v2_ethereum',
+    alias = 'proposals',
+    partition_by = ['block_date'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['created_at', 'blockchain', 'project', 'version', 'tx_hash'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "compound_v2",
+                                \'["soispoke"]\') }}'
+    )
+}}
+
+{% set blockchain = 'ethereum' %}
+{% set project = 'compound' %}
+{% set project_version = 'v2' %}
+{% set dao_name = 'DAO: Compound' %}
+{% set dao_address = '0xc0da02939e1441f497fd74f78ce7decb17b66529' %}
+
+with cte_support as (SELECT 
+        voter as voter,
+        CASE WHEN support = 0 THEN sum(votes/1e18) ELSE 0 END AS votes_against,
+        CASE WHEN support = 1 THEN sum(votes/1e18) ELSE 0 END AS votes_for,
+        CASE WHEN support = 2 THEN sum(votes/1e18) ELSE 0 END AS votes_abstain,
+        proposalId
+FROM {{ source('compound_v2_ethereum', 'GovernorBravoDelegate_evt_VoteCast') }}
+GROUP BY support, proposalId, voter),
+
+cte_sum_votes as (
+SELECT COUNT(DISTINCT voter) as number_of_voters,
+       SUM(votes_for) as votes_for, 
+       SUM(votes_against) as votes_against, 
+       SUM(votes_abstain) as votes_abstain, 
+       SUM(votes_for) + SUM(votes_against) + SUM(votes_abstain) as votes_total,
+       proposalId
+from cte_support
+GROUP BY proposalId)
+
+SELECT DISTINCT
+    '{{blockchain}}' as blockchain,
+    '{{project}}' as project,
+    '{{project_version}}' as version,
+    pcr.evt_block_time as created_at,
+    date_trunc('DAY', pcr.evt_block_time) AS block_date,
+    pcr.evt_tx_hash as tx_hash, -- Proposal Created tx hash
+    '{{dao_name}}' as dao_name,
+    '{{dao_address}}' as dao_address,
+    proposer,
+    pcr.id as proposal_id,
+    csv.votes_for,
+    csv.votes_against,
+    csv.votes_abstain,
+    csv.votes_total,
+    csv.number_of_voters,
+    csv.votes_total / 1e9 * 100 AS participation, -- Total votes / Total supply (1B for Uniswap)
+    pcr.startBlock as start_block,
+    pcr.endBlock as end_block,
+    CASE 
+         WHEN pex.id is not null and now() > pex.evt_block_time THEN 'Executed' 
+         WHEN pca.id is not null and now() > pca.evt_block_time THEN 'Canceled'
+         WHEN pcr.startBlock < pcr.evt_block_number < pcr.endBlock THEN 'Active'
+         WHEN now() > pqu.evt_block_time AND startBlock > pcr.evt_block_number THEN 'Queued'
+         ELSE 'Defeated' END AS status,
+    description as description
+FROM  {{ source('compound_v2_ethereum', 'GovernorBravoDelegate_evt_ProposalCreated') }} pcr
+LEFT JOIN cte_sum_votes csv ON csv.proposalId = pcr.id
+LEFT JOIN {{ source('compound_v2_ethereum', 'GovernorBravoDelegate_evt_ProposalCanceled') }} pca ON pca.id = pcr.id
+LEFT JOIN {{ source('compound_v2_ethereum', 'GovernorBravoDelegate_evt_ProposalExecuted') }} pex ON pex.id = pcr.id
+LEFT JOIN {{ source('compound_v2_ethereum', 'GovernorBravoDelegate_evt_ProposalQueued') }} pqu ON pex.id = pcr.id
+{% if is_incremental() %}
+WHERE pcr.evt_block_time > (select max(created_at) from {{ this }})
+{% endif %}

--- a/models/compound/ethereum/compound_v2_ethereum_votes.sql
+++ b/models/compound/ethereum/compound_v2_ethereum_votes.sql
@@ -49,7 +49,7 @@ SELECT
 FROM {{ source('compound_v2_ethereum', 'GovernorBravoDelegate_evt_VoteCast') }} vc
 LEFT JOIN cte_sum_votes csv ON vc.proposalId = csv.proposalId
 LEFT JOIN {{ source('prices', 'usd') }} p ON p.minute = date_trunc('minute', evt_block_time)
-    AND p.symbol = 'UNI'
+    AND p.symbol = 'COMP'
     AND p.blockchain ='ethereum'
     {% if is_incremental() %}
     AND p.minute >= date_trunc("day", now() - interval '1 week')

--- a/models/compound/ethereum/compound_v2_ethereum_votes.sql
+++ b/models/compound/ethereum/compound_v2_ethereum_votes.sql
@@ -1,0 +1,59 @@
+{{ config(
+    schema = 'compound_v2_ethereum',
+    alias = 'votes',
+    partition_by = ['block_date'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_time', 'blockchain', 'project', 'version', 'tx_hash'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "compound_v2",
+                                \'["soispoke"]\') }}'
+    )
+}}
+
+{% set blockchain = 'ethereum' %}
+{% set project = 'compound' %}
+{% set project_version = 'v2' %}
+{% set dao_name = 'DAO: Compound' %}
+{% set dao_address = '0xc0da02939e1441f497fd74f78ce7decb17b66529' %}
+
+WITH cte_sum_votes as 
+(SELECT sum(votes/1e18) as sum_votes, 
+        proposalId
+FROM {{ source('compound_v2_ethereum', 'GovernorBravoDelegate_evt_VoteCast') }}
+GROUP BY proposalId)
+
+SELECT 
+    '{{blockchain}}' as blockchain,
+    '{{project}}' as project,
+    '{{project_version}}' as version,
+    vc.evt_block_time as block_time,
+    date_trunc('DAY', vc.evt_block_time) AS block_date,
+    vc.evt_tx_hash as tx_hash,
+    '{{dao_name}}' as dao_name,
+    '{{dao_address}}' as dao_address,
+    vc.proposalId as proposal_id,
+    vc.votes/1e18 as votes,
+    (votes/1e18) * (100) / (csv.sum_votes) as votes_share,
+    p.symbol as token_symbol,
+    p.contract_address as token_address, 
+    vc.votes/1e18 * p.price as votes_value_usd,
+    vc.voter as voter_address,
+    CASE WHEN vc.support = 0 THEN 'against'
+         WHEN vc.support = 1 THEN 'for'
+         WHEN vc.support = 2 THEN 'abstain'
+         END AS support,
+    vc.reason
+FROM {{ source('compound_v2_ethereum', 'GovernorBravoDelegate_evt_VoteCast') }} vc
+LEFT JOIN cte_sum_votes csv ON vc.proposalId = csv.proposalId
+LEFT JOIN {{ source('prices', 'usd') }} p ON p.minute = date_trunc('minute', evt_block_time)
+    AND p.symbol = 'UNI'
+    AND p.blockchain ='ethereum'
+    {% if is_incremental() %}
+    AND p.minute >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
+{% if is_incremental() %}
+WHERE evt_block_time > (select max(block_time) from {{ this }})
+{% endif %}

--- a/models/dao/dao_proposals.sql
+++ b/models/dao/dao_proposals.sql
@@ -8,7 +8,8 @@
 }}
 
 {% set dao_proposals_models = [
-'uniswap_v3_ethereum_proposals'
+'uniswap_v3_ethereum_proposals',
+'compound_v2_ethereum_proposals'
 ] %}
 
 SELECT *

--- a/models/dao/dao_votes.sql
+++ b/models/dao/dao_votes.sql
@@ -8,7 +8,8 @@
 }}
 
 {% set dao_votes_models = [
-'uniswap_v3_ethereum_votes'
+'uniswap_v3_ethereum_votes',
+'compound_v2_ethereum_votes'
 ] %}
 
 


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Adding Compound v2 dao.votes and proposals from Tally governor contract info (planning to do this for the 5 most active DAOs on Tally today)
**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
