### PR TITLE
[Easy] Seperate mainet tokens from wrapped tokens in DAO Transactions Table [Ready for Review]

### DIFF
--- a/models/dao/transactions/ethereum/dao_transactions_ethereum_eth.sql
+++ b/models/dao/transactions/ethereum/dao_transactions_ethereum_eth.sql
@@ -27,7 +27,7 @@ transactions as (
         SELECT 
             block_time, 
             tx_hash, 
-            LOWER('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2') as token, 
+            LOWER('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') as token, 
             value as value, 
             to as dao_wallet_address, 
             'tx_in' as tx_type, 
@@ -52,7 +52,7 @@ transactions as (
         SELECT 
             block_time, 
             tx_hash, 
-            LOWER('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2') as token, 
+            LOWER('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') as token, 
             value as value, 
             from as dao_wallet_address, 
             'tx_out' as tx_type,
@@ -82,10 +82,10 @@ SELECT
     t.block_time, 
     t.tx_type,
     t.token as asset_contract_address,
-    COALESCE(er.symbol, t.token) as asset,
+    'ETH' asset,
     t.value as raw_value, 
-    t.value/POW(10, COALESCE(er.decimals, 18)) as value, 
-    t.value/POW(10, COALESCE(er.decimals, 18)) * p.price as usd_value, 
+    t.value/POW(10, 18) as value, 
+    t.value/POW(10, 18) * p.price as usd_value, 
     t.tx_hash, 
     t.tx_index,
     t.address_interacted_with,
@@ -96,13 +96,9 @@ INNER JOIN
 dao_tmp dt 
     ON t.dao_wallet_address = dt.dao_wallet_address
 LEFT JOIN 
-{{ ref('tokens_erc20') }} er 
-    ON t.token = er.contract_address
-    AND er.blockchain = 'ethereum'
-LEFT JOIN 
 {{ source('prices', 'usd') }} p 
     ON p.minute = date_trunc('minute', t.block_time)
-    AND p.contract_address = t.token
+    AND p.symbol = 'WETH'
     AND p.blockchain = 'ethereum'
     {% if not is_incremental() %}
     AND p.minute >= '{{transactions_start_date}}'

--- a/models/dao/transactions/gnosis/dao_transactions_gnosis_eth.sql
+++ b/models/dao/transactions/gnosis/dao_transactions_gnosis_eth.sql
@@ -27,7 +27,7 @@ transactions as (
         SELECT 
             block_time, 
             tx_hash, 
-            LOWER('0xe91d153e0b41518a2ce8dd3d7944fa863463a97d') as token, 
+            LOWER('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') as token, 
             value as value, 
             to as dao_wallet_address, 
             'tx-in' as tx_type, 
@@ -52,7 +52,7 @@ transactions as (
         SELECT 
             block_time, 
             tx_hash, 
-            LOWER('0xe91d153e0b41518a2ce8dd3d7944fa863463a97d') as token, 
+            LOWER('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') as token, 
             value as value, 
             from as dao_wallet_address, 
             'tx_out' as tx_type, 
@@ -82,10 +82,10 @@ SELECT
     t.block_time, 
     t.tx_type,
     t.token as asset_contract_address,
-    COALESCE(er.symbol, t.token) as asset,
+    'xDAI' as asset,
     t.value as raw_value, 
-    t.value/POW(10, COALESCE(er.decimals, 18)) as value, 
-    t.value/POW(10, COALESCE(er.decimals, 18)) * p.price as usd_value, 
+    t.value/POW(10, 18) as value, 
+    t.value/POW(10, 18) * p.price as usd_value, 
     t.tx_hash, 
     t.tx_index,
     t.address_interacted_with,
@@ -96,13 +96,9 @@ INNER JOIN
 dao_tmp dt 
     ON t.dao_wallet_address = dt.dao_wallet_address
 LEFT JOIN 
-{{ ref('tokens_erc20') }} er 
-    ON t.token = er.contract_address
-    AND er.blockchain = 'gnosis'
-LEFT JOIN 
 {{ source('prices', 'usd') }} p 
     ON p.minute = date_trunc('minute', t.block_time)
-    AND p.contract_address = t.token
+    AND p.symbol = 'WXDAI'
     AND p.blockchain = 'gnosis'
     {% if not is_incremental() %}
     AND p.minute >= '{{transactions_start_date}}'

--- a/models/dao/transactions/polygon/dao_transactions_polygon_eth.sql
+++ b/models/dao/transactions/polygon/dao_transactions_polygon_eth.sql
@@ -27,7 +27,7 @@ transactions as (
         SELECT 
             block_time, 
             tx_hash, 
-            LOWER('0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270') as token, 
+            LOWER('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') as token, 
             value as value, 
             to as dao_wallet_address, 
             'tx_in' as tx_type, 
@@ -52,7 +52,7 @@ transactions as (
         SELECT 
             block_time, 
             tx_hash, 
-            LOWER('0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270') as token, 
+            LOWER('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') as token, 
             value as value, 
             from as dao_wallet_address, 
             'tx_out' as tx_type,
@@ -82,10 +82,10 @@ SELECT
     t.block_time, 
     t.tx_type,
     t.token as asset_contract_address,
-    COALESCE(er.symbol, t.token) as asset,
+    'MATIC' as asset,
     t.value as raw_value, 
-    t.value/POW(10, COALESCE(er.decimals, 18)) as value, 
-    t.value/POW(10, COALESCE(er.decimals, 18)) * p.price as usd_value, 
+    t.value/POW(10, 18) as value, 
+    t.value/POW(10, 18) * p.price as usd_value, 
     t.tx_hash, 
     t.tx_index,
     t.address_interacted_with,
@@ -96,13 +96,9 @@ INNER JOIN
 dao_tmp dt 
     ON t.dao_wallet_address = dt.dao_wallet_address
 LEFT JOIN 
-{{ ref('tokens_erc20') }} er 
-    ON t.token = er.contract_address
-    AND er.blockchain = 'polygon'
-LEFT JOIN 
 {{ source('prices', 'usd') }} p 
     ON p.minute = date_trunc('minute', t.block_time)
-    AND p.contract_address = t.token
+    AND p.symbol = 'MATIC'
     AND p.blockchain = 'polygon'
     {% if not is_incremental() %}
     AND p.minute >= '{{transactions_start_date}}'


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Just a minor fix to change ETH transactions assets from wrapped to main net. 

WETH ----> ETH 
WXDAI ----> XDAI 
WMATIC ----> MATIC 

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
