### PR TITLE
Kyberswap: Add AggregatorV2, V3, Elastic; Clone to new chains

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -560,8 +560,23 @@ models:
     kyberswap:
       +schema: kyberswap
       +materialized: view
+      arbitrum:
+        +schema: kyberswap_arbitrum
+        +materialized: view
       avalanche_c:
         +schema: kyberswap_avalanche_c
+        +materialized: view
+      binance_smart_chain:
+        +schema: kyberswap_bsc
+        +materialized: view
+      ethereum:
+        +schema: kyberswap_ethereum
+        +materialized: view
+      optimism:
+        +schema: kyberswap_optimism
+        +materialized: view
+      polygon:
+        +schema: kyberswap_polygon
         +materialized: view
 
     fraxswap:

--- a/models/kyberswap/arbitrum/kyberswap_arbitrum_schema.yml
+++ b/models/kyberswap/arbitrum/kyberswap_arbitrum_schema.yml
@@ -1,16 +1,16 @@
 version: 2
 
 models:
-  - name: kyberswap_avalanche_c_trades
+  - name: kyberswap_arbitrum_trades
     meta:
-      blockchain: avalanche_c
+      blockchain: arbitrum
       sector: dex
       project: kyberswap
-      contributors: zhongyiio
+      contributors: duc.le@kyber.network
     config:
-      tags: ['avalanche_c','dex','trades', 'kyberswap', 'zhongyiio', 'hosuke']
+      tags: ['arbitrum', 'dex', 'trades', 'kyberswap']
     description: >
-        Kyberswap trades on Avalanche (C-Chain) across all contracts and versions. This table will load dex trades downstream.
+        Kyberswap trades on Arbitrum across all contracts and versions. This table will load dex trades downstream.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -21,10 +21,6 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
-          blockchain: avalanche_c
-          project: kyberswap
-          version: dmm
     columns:
       - &blockchain
         name: blockchain
@@ -71,6 +67,9 @@ models:
       - &token_bought_address
         name: token_bought_address
         description: "Contract address of the token bought"
+        tests:
+          - dex_trades_token_bought:
+              dex_trades_seed: ref('dex_trades_seed')
       - &token_sold_address
         name: token_sold_address
         description: "Contract address of the token sold"

--- a/models/kyberswap/arbitrum/kyberswap_arbitrum_sources.yml
+++ b/models/kyberswap/arbitrum/kyberswap_arbitrum_sources.yml
@@ -1,8 +1,8 @@
 version: 2
 
 sources:
-  - name: kyber_avalanche_c_trades
-    description: "Avalanche (C-Chain) decoded tables related to Kyberswap contract"
+  - name: kyber_arbitrum_trades
+    description: "Arbitrum decoded tables related to Kyberswap contract"
     tables:
       - name: DMMPool_evt_Swap
       - name: DMMFactory_evt_PoolCreated

--- a/models/kyberswap/arbitrum/kyberswap_arbitrum_sources.yml
+++ b/models/kyberswap/arbitrum/kyberswap_arbitrum_sources.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sources:
-  - name: kyber_arbitrum_trades
+  - name: kyber_arbitrum
     description: "Arbitrum decoded tables related to Kyberswap contract"
     tables:
       - name: DMMPool_evt_Swap

--- a/models/kyberswap/arbitrum/kyberswap_arbitrum_trades.sql
+++ b/models/kyberswap/arbitrum/kyberswap_arbitrum_trades.sql
@@ -1,5 +1,5 @@
 {{ config(
-    alias = 'arbitrum_trades',
+    alias = 'trades',
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
@@ -31,8 +31,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                      AS tx_hash
         ,''                                                                 AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_arbitrum_trades', 'DMMPool_evt_Swap') }} t
-    INNER JOIN {{ source('kyber_arbitrum_trades', 'DMMFactory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_arbitrum', 'DMMPool_evt_Swap') }} t
+    INNER JOIN {{ source('kyber_arbitrum', 'DMMFactory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -58,8 +58,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                                 AS tx_hash
         ,''                                                                            AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_arbitrum_trades', 'Elastic_Pool_evt_swap') }} t
-    INNER JOIN {{ source('kyber_arbitrum_trades', 'Elastic_Factory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_arbitrum', 'Elastic_Pool_evt_swap') }} t
+    INNER JOIN {{ source('kyber_arbitrum', 'Elastic_Factory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -83,7 +83,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_arbitrum_trades', 'AggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_arbitrum', 'AggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -107,7 +107,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_arbitrum_trades', 'AggregationRouterV2_evt_Swapped') }}
+    FROM {{ source('kyber_arbitrum', 'AggregationRouterV2_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -131,7 +131,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_arbitrum_trades', 'AggregationRouterV3_evt_Swapped') }}
+    FROM {{ source('kyber_arbitrum', 'AggregationRouterV3_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -155,7 +155,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_arbitrum_trades', 'MetaAggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_arbitrum', 'MetaAggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -169,7 +169,7 @@ SELECT
     ,'kyberswap'                                                         AS project
     ,kyberswap_dex.version                                               AS version
     ,SELECT (CASE
-    WHEN (kyberswap_dev.version = 'dmm' or kyberswap_dev.version = 'elastic' ) then 'dex'
+    WHEN (kyberswap_dex.version = 'dmm' or kyberswap_dex.version = 'elastic' ) then 'dex'
     ELSE 'aggregator' END)                                               AS category
         ,try_cast(date_trunc('DAY', kyberswap_dex.block_time) AS date)   AS block_date
         ,kyberswap_dex.block_time

--- a/models/kyberswap/arbitrum/kyberswap_arbitrum_trades.sql
+++ b/models/kyberswap/arbitrum/kyberswap_arbitrum_trades.sql
@@ -1,14 +1,14 @@
 {{ config(
-    alias = 'avalanche_c_trades',
+    alias = 'arbitrum_trades',
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
-    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
                                 "project",
                                 "kyberswap",
-                                \'["zhongyiio", "hosuke"]\') }}'
+                                \'["zhongyiio", "hosuke", "duc.le@kyber.network"]\') }}'
     )
 }}
 
@@ -31,8 +31,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                      AS tx_hash
         ,''                                                                 AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'DMMPool_evt_Swap') }} t
-    INNER JOIN {{ source('kyber_avalanche_c_trades', 'DMMFactory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_arbitrum_trades', 'DMMPool_evt_Swap') }} t
+    INNER JOIN {{ source('kyber_arbitrum_trades', 'DMMFactory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -58,8 +58,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                                 AS tx_hash
         ,''                                                                            AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'Elastic_Pool_evt_swap') }} t
-    INNER JOIN {{ source('kyber_avalanche_c_trades', 'Elastic_Factory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_arbitrum_trades', 'Elastic_Pool_evt_swap') }} t
+    INNER JOIN {{ source('kyber_arbitrum_trades', 'Elastic_Factory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -83,7 +83,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_arbitrum_trades', 'AggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -107,7 +107,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouterV2_evt_Swapped') }}
+    FROM {{ source('kyber_arbitrum_trades', 'AggregationRouterV2_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -131,7 +131,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouterV3_evt_Swapped') }}
+    FROM {{ source('kyber_arbitrum_trades', 'AggregationRouterV3_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -155,7 +155,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'MetaAggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_arbitrum_trades', 'MetaAggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -165,40 +165,40 @@ kyberswap_dex AS (
 )
 
 SELECT
-    'avalanche_c'                                                         AS blockchain
-    ,'kyberswap'                                                          AS project
-    ,kyberswap_dex.version                                                AS version
+    'arbitrum'                                                           AS blockchain
+    ,'kyberswap'                                                         AS project
+    ,kyberswap_dex.version                                               AS version
     ,SELECT (CASE
     WHEN (kyberswap_dev.version = 'dmm' or kyberswap_dev.version = 'elastic' ) then 'dex'
-    ELSE 'aggregator' END)                                                AS category
-    ,try_cast(date_trunc('DAY', kyberswap_dex.block_time) AS date)        AS block_date
-    ,kyberswap_dex.block_time
-    ,erc20a.symbol                                                        AS token_bought_symbol
-    ,erc20b.symbol                                                        AS token_sold_symbol
-    ,CASE
-         WHEN lower(erc20a.symbol) > lower(erc20b.symbol) THEN concat(erc20b.symbol, '-', erc20a.symbol)
-         ELSE concat(erc20a.symbol, '-', erc20b.symbol)
-     END                                                                  AS token_pair
-    ,kyberswap_dex.token_bought_amount_raw / power(10, erc20a.decimals)   AS token_bought_amount
-    ,kyberswap_dex.token_sold_amount_raw / power(10, erc20b.decimals)     AS token_sold_amount
-    ,CAST(kyberswap_dex.token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw
-    ,CAST(kyberswap_dex.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw
+    ELSE 'aggregator' END)                                               AS category
+        ,try_cast(date_trunc('DAY', kyberswap_dex.block_time) AS date)   AS block_date
+        ,kyberswap_dex.block_time
+        ,erc20a.symbol                                                   AS token_bought_symbol
+        ,erc20b.symbol                                                   AS token_sold_symbol
+        ,CASE
+    WHEN lower(erc20a.symbol) > lower(erc20b.symbol) THEN concat(erc20b.symbol, '-', erc20a.symbol)
+    ELSE concat(erc20a.symbol, '-', erc20b.symbol)
+END                                                                      AS token_pair
+    ,kyberswap_dex.token_bought_amount_raw / power(10, erc20a.decimals)  AS token_bought_amount
+    ,kyberswap_dex.token_sold_amount_raw / power(10, erc20b.decimals)    AS token_sold_amount
+    ,kyberswap_dex.token_bought_amount_raw
+    ,kyberswap_dex.token_sold_amount_raw
     ,coalesce(kyberswap_dex.amount_usd
             ,(kyberswap_dex.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price
             ,(kyberswap_dex.token_sold_amount_raw / power(10, p_sold.decimals)) * p_sold.price
-     )                                                                    AS amount_usd
+     )                                                                   AS amount_usd
     ,kyberswap_dex.token_bought_address
     ,kyberswap_dex.token_sold_address
-    ,coalesce(kyberswap_dex.taker, tx.from)                               AS taker
+    ,coalesce(kyberswap_dex.taker, tx.from)                              AS taker
     ,kyberswap_dex.maker
     ,kyberswap_dex.project_contract_address
     ,kyberswap_dex.tx_hash
-    ,tx.from                                                              AS tx_from
-    ,tx.to                                                                AS tx_to
+    ,tx.from                                                             AS tx_from
+    ,tx.to                                                               AS tx_to
     ,kyberswap_dex.trace_address
     ,kyberswap_dex.evt_index
 FROM kyberswap_dex
-INNER JOIN {{ source('avalanche_c', 'transactions') }} tx
+INNER JOIN {{ source('arbitrum', 'transactions') }} tx
     ON kyberswap_dex.tx_hash = tx.hash
     {% if is_incremental() %}
     AND tx.block_time >= date_trunc("day", now() - interval '1 week')
@@ -207,14 +207,14 @@ INNER JOIN {{ source('avalanche_c', 'transactions') }} tx
     {% endif %}
 LEFT JOIN {{ ref('tokens_erc20') }} erc20a
     ON erc20a.contract_address = kyberswap_dex.token_bought_address
-    and erc20a.blockchain = 'avalanche_c'
+    and erc20a.blockchain = 'arbitrum'
 LEFT JOIN {{ ref('tokens_erc20') }} erc20b
     ON erc20b.contract_address = kyberswap_dex.token_sold_address
-    AND erc20b.blockchain = 'avalanche_c'
+    AND erc20b.blockchain = 'arbitrum'
 LEFT JOIN {{ source('prices', 'usd') }} p_bought
     ON p_bought.minute = date_trunc('minute', kyberswap_dex.block_time)
     AND p_bought.contract_address = kyberswap_dex.token_bought_address
-    AND p_bought.blockchain = 'avalanche_c'
+    AND p_bought.blockchain = 'arbitrum'
     {% if is_incremental() %}
     AND p_bought.minute >= date_trunc("day", now() - interval '1 week')
     {% else %}
@@ -223,7 +223,7 @@ LEFT JOIN {{ source('prices', 'usd') }} p_bought
 LEFT JOIN {{ source('prices', 'usd') }} p_sold
     ON p_sold.minute = date_trunc('minute', kyberswap_dex.block_time)
     AND p_sold.contract_address = kyberswap_dex.token_sold_address
-    AND p_sold.blockchain = 'avalanche_c'
+    AND p_sold.blockchain = 'arbitrum'
     {% if is_incremental() %}
     AND p_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% else %}

--- a/models/kyberswap/avalanche_c/kyberswap_avalanche_c_sources.yml
+++ b/models/kyberswap/avalanche_c/kyberswap_avalanche_c_sources.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sources:
-  - name: kyber_avalanche_c_trades
+  - name: kyber_avalanche_c
     description: "Avalanche (C-Chain) decoded tables related to Kyberswap contract"
     tables:
       - name: DMMPool_evt_Swap
@@ -9,6 +9,4 @@ sources:
       - name: Elastic_Pool_evt_swap
       - name: Elastic_Factory_evt_PoolCreated
       - name: AggregationRouter_evt_Swapped
-      - name: AggregationRouterV2_evt_Swapped
-      - name: AggregationRouterV3_evt_Swapped
       - name: MetaAggregationRouter_evt_Swapped

--- a/models/kyberswap/binance_smart_chain/kyberswap_bsc_schema.yml
+++ b/models/kyberswap/binance_smart_chain/kyberswap_bsc_schema.yml
@@ -1,16 +1,16 @@
 version: 2
 
 models:
-  - name: kyberswap_avalanche_c_trades
+  - name: kyberswap_bsc_trades
     meta:
-      blockchain: avalanche_c
+      blockchain: bsc
       sector: dex
       project: kyberswap
-      contributors: zhongyiio
+      contributors: duc.le@kyber.network
     config:
-      tags: ['avalanche_c','dex','trades', 'kyberswap', 'zhongyiio', 'hosuke']
+      tags: ['bsc', 'dex', 'trades', 'kyberswap']
     description: >
-        Kyberswap trades on Avalanche (C-Chain) across all contracts and versions. This table will load dex trades downstream.
+        Kyberswap trades on Binance Smart Chain across all contracts and versions. This table will load dex trades downstream.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -21,10 +21,6 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
-          blockchain: avalanche_c
-          project: kyberswap
-          version: dmm
     columns:
       - &blockchain
         name: blockchain
@@ -71,6 +67,9 @@ models:
       - &token_bought_address
         name: token_bought_address
         description: "Contract address of the token bought"
+        tests:
+          - dex_trades_token_bought:
+              dex_trades_seed: ref('dex_trades_seed')
       - &token_sold_address
         name: token_sold_address
         description: "Contract address of the token sold"

--- a/models/kyberswap/binance_smart_chain/kyberswap_bsc_sources.yml
+++ b/models/kyberswap/binance_smart_chain/kyberswap_bsc_sources.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sources:
-  - name: kyber_bsc_trades
+  - name: kyber_bsc
     description: "Binance Smart Chain decoded tables related to Kyberswap contract"
     tables:
       - name: DMMPool_evt_Swap

--- a/models/kyberswap/binance_smart_chain/kyberswap_bsc_sources.yml
+++ b/models/kyberswap/binance_smart_chain/kyberswap_bsc_sources.yml
@@ -1,8 +1,8 @@
 version: 2
 
 sources:
-  - name: kyber_avalanche_c_trades
-    description: "Avalanche (C-Chain) decoded tables related to Kyberswap contract"
+  - name: kyber_bsc_trades
+    description: "Binance Smart Chain decoded tables related to Kyberswap contract"
     tables:
       - name: DMMPool_evt_Swap
       - name: DMMFactory_evt_PoolCreated

--- a/models/kyberswap/binance_smart_chain/kyberswap_bsc_trades.sql
+++ b/models/kyberswap/binance_smart_chain/kyberswap_bsc_trades.sql
@@ -1,5 +1,5 @@
 {{ config(
-    alias = 'bsc_trades',
+    alias = 'trades',
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
@@ -31,8 +31,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                      AS tx_hash
         ,''                                                                 AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_bsc_trades', 'DMMPool_evt_Swap') }} t
-    INNER JOIN {{ source('kyber_bsc_trades', 'DMMFactory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_bsc', 'DMMPool_evt_Swap') }} t
+    INNER JOIN {{ source('kyber_bsc', 'DMMFactory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -58,8 +58,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                                 AS tx_hash
         ,''                                                                            AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_bsc_trades', 'Elastic_Pool_evt_swap') }} t
-    INNER JOIN {{ source('kyber_bsc_trades', 'Elastic_Factory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_bsc', 'Elastic_Pool_evt_swap') }} t
+    INNER JOIN {{ source('kyber_bsc', 'Elastic_Factory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -83,7 +83,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_bsc_trades', 'AggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_bsc', 'AggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -107,7 +107,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_bsc_trades', 'AggregationRouterV2_evt_Swapped') }}
+    FROM {{ source('kyber_bsc', 'AggregationRouterV2_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -131,7 +131,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_bsc_trades', 'AggregationRouterV3_evt_Swapped') }}
+    FROM {{ source('kyber_bsc', 'AggregationRouterV3_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -155,7 +155,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_bsc_trades', 'MetaAggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_bsc', 'MetaAggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -169,7 +169,7 @@ SELECT
     ,'kyberswap'                                                          AS project
     ,kyberswap_dex.version                                                AS version
     ,SELECT (CASE
-    WHEN (kyberswap_dev.version = 'dmm' or kyberswap_dev.version = 'elastic' ) then 'dex'
+    WHEN (kyberswap_dex.version = 'dmm' or kyberswap_dex.version = 'elastic' ) then 'dex'
     ELSE 'aggregator' END)                                                AS category
     ,try_cast(date_trunc('DAY', kyberswap_dex.block_time) AS date)        AS block_date
     ,kyberswap_dex.block_time

--- a/models/kyberswap/binance_smart_chain/kyberswap_bsc_trades.sql
+++ b/models/kyberswap/binance_smart_chain/kyberswap_bsc_trades.sql
@@ -1,14 +1,14 @@
 {{ config(
-    alias = 'avalanche_c_trades',
+    alias = 'bsc_trades',
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
-    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+    post_hook='{{ expose_spells(\'["bsc"]\',
                                 "project",
                                 "kyberswap",
-                                \'["zhongyiio", "hosuke"]\') }}'
+                                \'["zhongyiio", "hosuke", "duc.le@kyber.network"]\') }}'
     )
 }}
 
@@ -31,8 +31,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                      AS tx_hash
         ,''                                                                 AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'DMMPool_evt_Swap') }} t
-    INNER JOIN {{ source('kyber_avalanche_c_trades', 'DMMFactory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_bsc_trades', 'DMMPool_evt_Swap') }} t
+    INNER JOIN {{ source('kyber_bsc_trades', 'DMMFactory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -58,8 +58,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                                 AS tx_hash
         ,''                                                                            AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'Elastic_Pool_evt_swap') }} t
-    INNER JOIN {{ source('kyber_avalanche_c_trades', 'Elastic_Factory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_bsc_trades', 'Elastic_Pool_evt_swap') }} t
+    INNER JOIN {{ source('kyber_bsc_trades', 'Elastic_Factory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -83,7 +83,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_bsc_trades', 'AggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -107,7 +107,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouterV2_evt_Swapped') }}
+    FROM {{ source('kyber_bsc_trades', 'AggregationRouterV2_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -131,7 +131,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouterV3_evt_Swapped') }}
+    FROM {{ source('kyber_bsc_trades', 'AggregationRouterV3_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -155,7 +155,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'MetaAggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_bsc_trades', 'MetaAggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -165,7 +165,7 @@ kyberswap_dex AS (
 )
 
 SELECT
-    'avalanche_c'                                                         AS blockchain
+    'bsc'                                                                 AS blockchain
     ,'kyberswap'                                                          AS project
     ,kyberswap_dex.version                                                AS version
     ,SELECT (CASE
@@ -181,8 +181,8 @@ SELECT
      END                                                                  AS token_pair
     ,kyberswap_dex.token_bought_amount_raw / power(10, erc20a.decimals)   AS token_bought_amount
     ,kyberswap_dex.token_sold_amount_raw / power(10, erc20b.decimals)     AS token_sold_amount
-    ,CAST(kyberswap_dex.token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw
-    ,CAST(kyberswap_dex.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw
+    ,kyberswap_dex.token_bought_amount_raw
+    ,kyberswap_dex.token_sold_amount_raw
     ,coalesce(kyberswap_dex.amount_usd
             ,(kyberswap_dex.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price
             ,(kyberswap_dex.token_sold_amount_raw / power(10, p_sold.decimals)) * p_sold.price
@@ -198,7 +198,7 @@ SELECT
     ,kyberswap_dex.trace_address
     ,kyberswap_dex.evt_index
 FROM kyberswap_dex
-INNER JOIN {{ source('avalanche_c', 'transactions') }} tx
+INNER JOIN {{ source('bnb', 'transactions') }} tx
     ON kyberswap_dex.tx_hash = tx.hash
     {% if is_incremental() %}
     AND tx.block_time >= date_trunc("day", now() - interval '1 week')
@@ -207,14 +207,14 @@ INNER JOIN {{ source('avalanche_c', 'transactions') }} tx
     {% endif %}
 LEFT JOIN {{ ref('tokens_erc20') }} erc20a
     ON erc20a.contract_address = kyberswap_dex.token_bought_address
-    and erc20a.blockchain = 'avalanche_c'
+    and erc20a.blockchain = 'bsc'
 LEFT JOIN {{ ref('tokens_erc20') }} erc20b
     ON erc20b.contract_address = kyberswap_dex.token_sold_address
-    AND erc20b.blockchain = 'avalanche_c'
+    AND erc20b.blockchain = 'bsc'
 LEFT JOIN {{ source('prices', 'usd') }} p_bought
     ON p_bought.minute = date_trunc('minute', kyberswap_dex.block_time)
     AND p_bought.contract_address = kyberswap_dex.token_bought_address
-    AND p_bought.blockchain = 'avalanche_c'
+    AND p_bought.blockchain = 'bsc'
     {% if is_incremental() %}
     AND p_bought.minute >= date_trunc("day", now() - interval '1 week')
     {% else %}
@@ -223,7 +223,7 @@ LEFT JOIN {{ source('prices', 'usd') }} p_bought
 LEFT JOIN {{ source('prices', 'usd') }} p_sold
     ON p_sold.minute = date_trunc('minute', kyberswap_dex.block_time)
     AND p_sold.contract_address = kyberswap_dex.token_sold_address
-    AND p_sold.blockchain = 'avalanche_c'
+    AND p_sold.blockchain = 'bsc'
     {% if is_incremental() %}
     AND p_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% else %}

--- a/models/kyberswap/ethereum/kyberswap_ethereum_schema.yml
+++ b/models/kyberswap/ethereum/kyberswap_ethereum_schema.yml
@@ -1,16 +1,16 @@
 version: 2
 
 models:
-  - name: kyberswap_avalanche_c_trades
+  - name: kyberswap_ethereum_trades
     meta:
-      blockchain: avalanche_c
+      blockchain: ethereum
       sector: dex
       project: kyberswap
-      contributors: zhongyiio
+      contributors: duc.le@kyber.network
     config:
-      tags: ['avalanche_c','dex','trades', 'kyberswap', 'zhongyiio', 'hosuke']
+      tags: ['ethereum', 'dex', 'trades', 'kyberswap']
     description: >
-        Kyberswap trades on Avalanche (C-Chain) across all contracts and versions. This table will load dex trades downstream.
+        Kyberswap trades on Ethereum across all contracts and versions. This table will load dex trades downstream.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -21,10 +21,6 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
-          blockchain: avalanche_c
-          project: kyberswap
-          version: dmm
     columns:
       - &blockchain
         name: blockchain
@@ -71,6 +67,9 @@ models:
       - &token_bought_address
         name: token_bought_address
         description: "Contract address of the token bought"
+        tests:
+          - dex_trades_token_bought:
+              dex_trades_seed: ref('dex_trades_seed')
       - &token_sold_address
         name: token_sold_address
         description: "Contract address of the token sold"

--- a/models/kyberswap/ethereum/kyberswap_ethereum_sources.yml
+++ b/models/kyberswap/ethereum/kyberswap_ethereum_sources.yml
@@ -1,8 +1,8 @@
 version: 2
 
 sources:
-  - name: kyber_avalanche_c_trades
-    description: "Avalanche (C-Chain) decoded tables related to Kyberswap contract"
+  - name: kyber_ethereum_trades
+    description: "Ethereum decoded tables related to Kyberswap contract"
     tables:
       - name: DMMPool_evt_Swap
       - name: DMMFactory_evt_PoolCreated

--- a/models/kyberswap/ethereum/kyberswap_ethereum_sources.yml
+++ b/models/kyberswap/ethereum/kyberswap_ethereum_sources.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sources:
-  - name: kyber_ethereum_trades
+  - name: kyber_ethereum
     description: "Ethereum decoded tables related to Kyberswap contract"
     tables:
       - name: DMMPool_evt_Swap

--- a/models/kyberswap/ethereum/kyberswap_ethereum_trades.sql
+++ b/models/kyberswap/ethereum/kyberswap_ethereum_trades.sql
@@ -1,5 +1,5 @@
 {{ config(
-    alias = 'ethereum_trades',
+    alias = 'trades',
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
@@ -31,8 +31,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                      AS tx_hash
         ,''                                                                 AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_ethereum_trades', 'DMMPool_evt_Swap') }} t
-    INNER JOIN {{ source('kyber_ethereum_trades', 'DMMFactory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_ethereum', 'DMMPool_evt_Swap') }} t
+    INNER JOIN {{ source('kyber_ethereum', 'DMMFactory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -58,8 +58,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                                 AS tx_hash
         ,''                                                                            AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_ethereum_trades', 'Elastic_Pool_evt_swap') }} t
-    INNER JOIN {{ source('kyber_ethereum_trades', 'Elastic_Factory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_ethereum', 'Elastic_Pool_evt_swap') }} t
+    INNER JOIN {{ source('kyber_ethereum', 'Elastic_Factory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -83,7 +83,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_ethereum_trades', 'AggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_ethereum', 'AggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -107,7 +107,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_ethereum_trades', 'AggregationRouterV2_evt_Swapped') }}
+    FROM {{ source('kyber_ethereum', 'AggregationRouterV2_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -131,7 +131,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_ethereum_trades', 'AggregationRouterV3_evt_Swapped') }}
+    FROM {{ source('kyber_ethereum', 'AggregationRouterV3_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -155,7 +155,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_ethereum_trades', 'MetaAggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_ethereum', 'MetaAggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -169,7 +169,7 @@ SELECT
     ,'kyberswap'                                                          AS project
     ,kyberswap_dex.version                                                AS version
     ,SELECT (CASE
-    WHEN (kyberswap_dev.version = 'dmm' or kyberswap_dev.version = 'elastic' ) then 'dex'
+    WHEN (kyberswap_dex.version = 'dmm' or kyberswap_dex.version = 'elastic' ) then 'dex'
     ELSE 'aggregator' END)                                                AS category
     ,try_cast(date_trunc('DAY', kyberswap_dex.block_time) AS date)        AS block_date
     ,kyberswap_dex.block_time

--- a/models/kyberswap/ethereum/kyberswap_ethereum_trades.sql
+++ b/models/kyberswap/ethereum/kyberswap_ethereum_trades.sql
@@ -1,14 +1,14 @@
 {{ config(
-    alias = 'avalanche_c_trades',
+    alias = 'ethereum_trades',
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
-    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+    post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "project",
                                 "kyberswap",
-                                \'["zhongyiio", "hosuke"]\') }}'
+                                \'["zhongyiio", "hosuke", "duc.le@kyber.network"]\') }}'
     )
 }}
 
@@ -31,8 +31,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                      AS tx_hash
         ,''                                                                 AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'DMMPool_evt_Swap') }} t
-    INNER JOIN {{ source('kyber_avalanche_c_trades', 'DMMFactory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_ethereum_trades', 'DMMPool_evt_Swap') }} t
+    INNER JOIN {{ source('kyber_ethereum_trades', 'DMMFactory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -58,8 +58,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                                 AS tx_hash
         ,''                                                                            AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'Elastic_Pool_evt_swap') }} t
-    INNER JOIN {{ source('kyber_avalanche_c_trades', 'Elastic_Factory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_ethereum_trades', 'Elastic_Pool_evt_swap') }} t
+    INNER JOIN {{ source('kyber_ethereum_trades', 'Elastic_Factory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -83,7 +83,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_ethereum_trades', 'AggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -107,7 +107,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouterV2_evt_Swapped') }}
+    FROM {{ source('kyber_ethereum_trades', 'AggregationRouterV2_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -131,7 +131,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouterV3_evt_Swapped') }}
+    FROM {{ source('kyber_ethereum_trades', 'AggregationRouterV3_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -155,7 +155,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'MetaAggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_ethereum_trades', 'MetaAggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -165,7 +165,7 @@ kyberswap_dex AS (
 )
 
 SELECT
-    'avalanche_c'                                                         AS blockchain
+    'ethereum'                                                            AS blockchain
     ,'kyberswap'                                                          AS project
     ,kyberswap_dex.version                                                AS version
     ,SELECT (CASE
@@ -181,8 +181,8 @@ SELECT
      END                                                                  AS token_pair
     ,kyberswap_dex.token_bought_amount_raw / power(10, erc20a.decimals)   AS token_bought_amount
     ,kyberswap_dex.token_sold_amount_raw / power(10, erc20b.decimals)     AS token_sold_amount
-    ,CAST(kyberswap_dex.token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw
-    ,CAST(kyberswap_dex.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw
+    ,kyberswap_dex.token_bought_amount_raw
+    ,kyberswap_dex.token_sold_amount_raw
     ,coalesce(kyberswap_dex.amount_usd
             ,(kyberswap_dex.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price
             ,(kyberswap_dex.token_sold_amount_raw / power(10, p_sold.decimals)) * p_sold.price
@@ -198,7 +198,7 @@ SELECT
     ,kyberswap_dex.trace_address
     ,kyberswap_dex.evt_index
 FROM kyberswap_dex
-INNER JOIN {{ source('avalanche_c', 'transactions') }} tx
+INNER JOIN {{ source('ethereum', 'transactions') }} tx
     ON kyberswap_dex.tx_hash = tx.hash
     {% if is_incremental() %}
     AND tx.block_time >= date_trunc("day", now() - interval '1 week')
@@ -207,14 +207,14 @@ INNER JOIN {{ source('avalanche_c', 'transactions') }} tx
     {% endif %}
 LEFT JOIN {{ ref('tokens_erc20') }} erc20a
     ON erc20a.contract_address = kyberswap_dex.token_bought_address
-    and erc20a.blockchain = 'avalanche_c'
+    and erc20a.blockchain = 'ethereum'
 LEFT JOIN {{ ref('tokens_erc20') }} erc20b
     ON erc20b.contract_address = kyberswap_dex.token_sold_address
-    AND erc20b.blockchain = 'avalanche_c'
+    AND erc20b.blockchain = 'ethereum'
 LEFT JOIN {{ source('prices', 'usd') }} p_bought
     ON p_bought.minute = date_trunc('minute', kyberswap_dex.block_time)
     AND p_bought.contract_address = kyberswap_dex.token_bought_address
-    AND p_bought.blockchain = 'avalanche_c'
+    AND p_bought.blockchain = 'ethereum'
     {% if is_incremental() %}
     AND p_bought.minute >= date_trunc("day", now() - interval '1 week')
     {% else %}
@@ -223,7 +223,7 @@ LEFT JOIN {{ source('prices', 'usd') }} p_bought
 LEFT JOIN {{ source('prices', 'usd') }} p_sold
     ON p_sold.minute = date_trunc('minute', kyberswap_dex.block_time)
     AND p_sold.contract_address = kyberswap_dex.token_sold_address
-    AND p_sold.blockchain = 'avalanche_c'
+    AND p_sold.blockchain = 'ethereum'
     {% if is_incremental() %}
     AND p_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% else %}

--- a/models/kyberswap/kyberswap_trades.sql
+++ b/models/kyberswap/kyberswap_trades.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='trades',
-        post_hook='{{ expose_spells(\'["avalanche_c"]\',
+        post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "binance_smart_chain", "ethereum", "optimism", "polygon"]\',
                                 "project",
                                 "kyberswap",
                                 \'["zhongyiio", "hosuke"]\') }}'
@@ -8,7 +8,12 @@
 }}
 
 {% set kyber_models = [
-'kyberswap_avalanche_c_trades'
+'kyberswap_arbitrum_trades',
+'kyberswap_avalanche_c_trades',
+'kyberswap_bsc_trades',
+'kyberswap_ethereum_trades',
+'kyberswap_optimism_trades',
+'kyberswap_polygon_trades'
 ] %}
 
 
@@ -19,6 +24,7 @@ FROM (
         blockchain,
         project,
         version,
+        category,
         block_date,
         block_time,
         token_bought_symbol,

--- a/models/kyberswap/kyberswap_trades_schema.yml
+++ b/models/kyberswap/kyberswap_trades_schema.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: kyberswap_trades
     meta:
-      blockchain: avalanche_c
+      blockchain: arbitrum, avalanche_c, binance_smart_chain, ethereum, optimism, polygon
       sector: dex
       project: kyberswap
       contributors: zhongyiio
@@ -21,6 +21,9 @@ models:
       - &version
         name: version
         description: "Version of the contract built and deployed by the DEX project"  
+      - &category
+        name: category
+        description: "Category: Kyberswap Pool or Kyberswap Aggregator"
       - &block_date
         name: block_date
         description: "UTC event block date of each DEX trade"

--- a/models/kyberswap/optimism/kyberswap_optimism_schema.yml
+++ b/models/kyberswap/optimism/kyberswap_optimism_schema.yml
@@ -1,16 +1,16 @@
 version: 2
 
 models:
-  - name: kyberswap_avalanche_c_trades
+  - name: kyberswap_optimism_trades
     meta:
-      blockchain: avalanche_c
+      blockchain: optimism
       sector: dex
       project: kyberswap
-      contributors: zhongyiio
+      contributors: duc.le@kyber.network
     config:
-      tags: ['avalanche_c','dex','trades', 'kyberswap', 'zhongyiio', 'hosuke']
+      tags: ['optimism', 'dex', 'trades', 'kyberswap']
     description: >
-        Kyberswap trades on Avalanche (C-Chain) across all contracts and versions. This table will load dex trades downstream.
+        Kyberswap trades on Optimism across all contracts and versions. This table will load dex trades downstream.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -21,10 +21,6 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
-          blockchain: avalanche_c
-          project: kyberswap
-          version: dmm
     columns:
       - &blockchain
         name: blockchain
@@ -71,6 +67,9 @@ models:
       - &token_bought_address
         name: token_bought_address
         description: "Contract address of the token bought"
+        tests:
+          - dex_trades_token_bought:
+              dex_trades_seed: ref('dex_trades_seed')
       - &token_sold_address
         name: token_sold_address
         description: "Contract address of the token sold"

--- a/models/kyberswap/optimism/kyberswap_optimism_sources.yml
+++ b/models/kyberswap/optimism/kyberswap_optimism_sources.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sources:
-  - name: kyber_optimism_trades
+  - name: kyber_optimism
     description: "Optimism decoded tables related to Kyberswap contract"
     tables:
       - name: DMMPool_evt_Swap

--- a/models/kyberswap/optimism/kyberswap_optimism_sources.yml
+++ b/models/kyberswap/optimism/kyberswap_optimism_sources.yml
@@ -1,8 +1,8 @@
 version: 2
 
 sources:
-  - name: kyber_avalanche_c_trades
-    description: "Avalanche (C-Chain) decoded tables related to Kyberswap contract"
+  - name: kyber_optimism_trades
+    description: "Optimism decoded tables related to Kyberswap contract"
     tables:
       - name: DMMPool_evt_Swap
       - name: DMMFactory_evt_PoolCreated

--- a/models/kyberswap/optimism/kyberswap_optimism_trades.sql
+++ b/models/kyberswap/optimism/kyberswap_optimism_trades.sql
@@ -1,14 +1,14 @@
 {{ config(
-    alias = 'avalanche_c_trades',
+    alias = 'optimism_trades',
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
-    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+    post_hook='{{ expose_spells(\'["optimism"]\',
                                 "project",
                                 "kyberswap",
-                                \'["zhongyiio", "hosuke"]\') }}'
+                                \'["zhongyiio", "hosuke", "duc.le@kyber.network"]\') }}'
     )
 }}
 
@@ -31,8 +31,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                      AS tx_hash
         ,''                                                                 AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'DMMPool_evt_Swap') }} t
-    INNER JOIN {{ source('kyber_avalanche_c_trades', 'DMMFactory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_optimism_trades', 'DMMPool_evt_Swap') }} t
+    INNER JOIN {{ source('kyber_optimism_trades', 'DMMFactory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -58,8 +58,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                                 AS tx_hash
         ,''                                                                            AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'Elastic_Pool_evt_swap') }} t
-    INNER JOIN {{ source('kyber_avalanche_c_trades', 'Elastic_Factory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_optimism_trades', 'Elastic_Pool_evt_swap') }} t
+    INNER JOIN {{ source('kyber_optimism_trades', 'Elastic_Factory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -83,7 +83,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_optimism_trades', 'AggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -107,7 +107,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouterV2_evt_Swapped') }}
+    FROM {{ source('kyber_optimism_trades', 'AggregationRouterV2_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -131,7 +131,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouterV3_evt_Swapped') }}
+    FROM {{ source('kyber_optimism_trades', 'AggregationRouterV3_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -155,7 +155,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'MetaAggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_optimism_trades', 'MetaAggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -165,7 +165,7 @@ kyberswap_dex AS (
 )
 
 SELECT
-    'avalanche_c'                                                         AS blockchain
+    'optimism'                                                            AS blockchain
     ,'kyberswap'                                                          AS project
     ,kyberswap_dex.version                                                AS version
     ,SELECT (CASE
@@ -181,8 +181,8 @@ SELECT
      END                                                                  AS token_pair
     ,kyberswap_dex.token_bought_amount_raw / power(10, erc20a.decimals)   AS token_bought_amount
     ,kyberswap_dex.token_sold_amount_raw / power(10, erc20b.decimals)     AS token_sold_amount
-    ,CAST(kyberswap_dex.token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw
-    ,CAST(kyberswap_dex.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw
+    ,kyberswap_dex.token_bought_amount_raw
+    ,kyberswap_dex.token_sold_amount_raw
     ,coalesce(kyberswap_dex.amount_usd
             ,(kyberswap_dex.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price
             ,(kyberswap_dex.token_sold_amount_raw / power(10, p_sold.decimals)) * p_sold.price
@@ -198,7 +198,7 @@ SELECT
     ,kyberswap_dex.trace_address
     ,kyberswap_dex.evt_index
 FROM kyberswap_dex
-INNER JOIN {{ source('avalanche_c', 'transactions') }} tx
+INNER JOIN {{ source('optimism', 'transactions') }} tx
     ON kyberswap_dex.tx_hash = tx.hash
     {% if is_incremental() %}
     AND tx.block_time >= date_trunc("day", now() - interval '1 week')
@@ -207,14 +207,14 @@ INNER JOIN {{ source('avalanche_c', 'transactions') }} tx
     {% endif %}
 LEFT JOIN {{ ref('tokens_erc20') }} erc20a
     ON erc20a.contract_address = kyberswap_dex.token_bought_address
-    and erc20a.blockchain = 'avalanche_c'
+    and erc20a.blockchain = 'optimism'
 LEFT JOIN {{ ref('tokens_erc20') }} erc20b
     ON erc20b.contract_address = kyberswap_dex.token_sold_address
-    AND erc20b.blockchain = 'avalanche_c'
+    AND erc20b.blockchain = 'optimism'
 LEFT JOIN {{ source('prices', 'usd') }} p_bought
     ON p_bought.minute = date_trunc('minute', kyberswap_dex.block_time)
     AND p_bought.contract_address = kyberswap_dex.token_bought_address
-    AND p_bought.blockchain = 'avalanche_c'
+    AND p_bought.blockchain = 'optimism'
     {% if is_incremental() %}
     AND p_bought.minute >= date_trunc("day", now() - interval '1 week')
     {% else %}
@@ -223,7 +223,7 @@ LEFT JOIN {{ source('prices', 'usd') }} p_bought
 LEFT JOIN {{ source('prices', 'usd') }} p_sold
     ON p_sold.minute = date_trunc('minute', kyberswap_dex.block_time)
     AND p_sold.contract_address = kyberswap_dex.token_sold_address
-    AND p_sold.blockchain = 'avalanche_c'
+    AND p_sold.blockchain = 'optimism'
     {% if is_incremental() %}
     AND p_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% else %}

--- a/models/kyberswap/optimism/kyberswap_optimism_trades.sql
+++ b/models/kyberswap/optimism/kyberswap_optimism_trades.sql
@@ -1,5 +1,5 @@
 {{ config(
-    alias = 'optimism_trades',
+    alias = 'trades',
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
@@ -31,8 +31,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                      AS tx_hash
         ,''                                                                 AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_optimism_trades', 'DMMPool_evt_Swap') }} t
-    INNER JOIN {{ source('kyber_optimism_trades', 'DMMFactory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_optimism', 'DMMPool_evt_Swap') }} t
+    INNER JOIN {{ source('kyber_optimism', 'DMMFactory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -58,8 +58,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                                 AS tx_hash
         ,''                                                                            AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_optimism_trades', 'Elastic_Pool_evt_swap') }} t
-    INNER JOIN {{ source('kyber_optimism_trades', 'Elastic_Factory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_optimism', 'Elastic_Pool_evt_swap') }} t
+    INNER JOIN {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -83,7 +83,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_optimism_trades', 'AggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_optimism', 'AggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -107,7 +107,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_optimism_trades', 'AggregationRouterV2_evt_Swapped') }}
+    FROM {{ source('kyber_optimism', 'AggregationRouterV2_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -131,7 +131,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_optimism_trades', 'AggregationRouterV3_evt_Swapped') }}
+    FROM {{ source('kyber_optimism', 'AggregationRouterV3_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -155,7 +155,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_optimism_trades', 'MetaAggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_optimism', 'MetaAggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -169,7 +169,7 @@ SELECT
     ,'kyberswap'                                                          AS project
     ,kyberswap_dex.version                                                AS version
     ,SELECT (CASE
-    WHEN (kyberswap_dev.version = 'dmm' or kyberswap_dev.version = 'elastic' ) then 'dex'
+    WHEN (kyberswap_dex.version = 'dmm' or kyberswap_dex.version = 'elastic' ) then 'dex'
     ELSE 'aggregator' END)                                                AS category
     ,try_cast(date_trunc('DAY', kyberswap_dex.block_time) AS date)        AS block_date
     ,kyberswap_dex.block_time

--- a/models/kyberswap/polygon/kyberswap_polygon_schema.yml
+++ b/models/kyberswap/polygon/kyberswap_polygon_schema.yml
@@ -1,16 +1,16 @@
 version: 2
 
 models:
-  - name: kyberswap_avalanche_c_trades
+  - name: kyberswap_polygon_trades
     meta:
-      blockchain: avalanche_c
+      blockchain: polygon
       sector: dex
       project: kyberswap
-      contributors: zhongyiio
+      contributors: duc.le@kyber.network
     config:
-      tags: ['avalanche_c','dex','trades', 'kyberswap', 'zhongyiio', 'hosuke']
+      tags: ['polygon', 'dex', 'trades', 'kyberswap']
     description: >
-        Kyberswap trades on Avalanche (C-Chain) across all contracts and versions. This table will load dex trades downstream.
+        Kyberswap trades on Polygon across all contracts and versions. This table will load dex trades downstream.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -21,10 +21,6 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
-          blockchain: avalanche_c
-          project: kyberswap
-          version: dmm
     columns:
       - &blockchain
         name: blockchain
@@ -71,6 +67,9 @@ models:
       - &token_bought_address
         name: token_bought_address
         description: "Contract address of the token bought"
+        tests:
+          - dex_trades_token_bought:
+              dex_trades_seed: ref('dex_trades_seed')
       - &token_sold_address
         name: token_sold_address
         description: "Contract address of the token sold"

--- a/models/kyberswap/polygon/kyberswap_polygon_sources.yml
+++ b/models/kyberswap/polygon/kyberswap_polygon_sources.yml
@@ -1,8 +1,8 @@
 version: 2
 
 sources:
-  - name: kyber_avalanche_c_trades
-    description: "Avalanche (C-Chain) decoded tables related to Kyberswap contract"
+  - name: kyber_polygon_trades
+    description: "Polygon decoded tables related to Kyberswap contract"
     tables:
       - name: DMMPool_evt_Swap
       - name: DMMFactory_evt_PoolCreated

--- a/models/kyberswap/polygon/kyberswap_polygon_sources.yml
+++ b/models/kyberswap/polygon/kyberswap_polygon_sources.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sources:
-  - name: kyber_polygon_trades
+  - name: kyber_polygon
     description: "Polygon decoded tables related to Kyberswap contract"
     tables:
       - name: DMMPool_evt_Swap

--- a/models/kyberswap/polygon/kyberswap_polygon_trades.sql
+++ b/models/kyberswap/polygon/kyberswap_polygon_trades.sql
@@ -1,14 +1,14 @@
 {{ config(
-    alias = 'avalanche_c_trades',
+    alias = 'polygon_trades',
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
-    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+    post_hook='{{ expose_spells(\'["polygon"]\',
                                 "project",
                                 "kyberswap",
-                                \'["zhongyiio", "hosuke"]\') }}'
+                                \'["zhongyiio", "hosuke", "duc.le@kyber.network"]\') }}'
     )
 }}
 
@@ -31,8 +31,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                      AS tx_hash
         ,''                                                                 AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'DMMPool_evt_Swap') }} t
-    INNER JOIN {{ source('kyber_avalanche_c_trades', 'DMMFactory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_polygon_trades', 'DMMPool_evt_Swap') }} t
+    INNER JOIN {{ source('kyber_polygon_trades', 'DMMFactory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -58,8 +58,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                                 AS tx_hash
         ,''                                                                            AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'Elastic_Pool_evt_swap') }} t
-    INNER JOIN {{ source('kyber_avalanche_c_trades', 'Elastic_Factory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_polygon_trades', 'Elastic_Pool_evt_swap') }} t
+    INNER JOIN {{ source('kyber_polygon_trades', 'Elastic_Factory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -83,7 +83,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_polygon_trades', 'AggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -107,7 +107,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouterV2_evt_Swapped') }}
+    FROM {{ source('kyber_polygon_trades', 'AggregationRouterV2_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -131,7 +131,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'AggregationRouterV3_evt_Swapped') }}
+    FROM {{ source('kyber_polygon_trades', 'AggregationRouterV3_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -155,7 +155,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_avalanche_c_trades', 'MetaAggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_polygon_trades', 'MetaAggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -165,7 +165,7 @@ kyberswap_dex AS (
 )
 
 SELECT
-    'avalanche_c'                                                         AS blockchain
+    'polygon'                                                             AS blockchain
     ,'kyberswap'                                                          AS project
     ,kyberswap_dex.version                                                AS version
     ,SELECT (CASE
@@ -181,8 +181,8 @@ SELECT
      END                                                                  AS token_pair
     ,kyberswap_dex.token_bought_amount_raw / power(10, erc20a.decimals)   AS token_bought_amount
     ,kyberswap_dex.token_sold_amount_raw / power(10, erc20b.decimals)     AS token_sold_amount
-    ,CAST(kyberswap_dex.token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw
-    ,CAST(kyberswap_dex.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw
+    ,kyberswap_dex.token_bought_amount_raw
+    ,kyberswap_dex.token_sold_amount_raw
     ,coalesce(kyberswap_dex.amount_usd
             ,(kyberswap_dex.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price
             ,(kyberswap_dex.token_sold_amount_raw / power(10, p_sold.decimals)) * p_sold.price
@@ -198,7 +198,7 @@ SELECT
     ,kyberswap_dex.trace_address
     ,kyberswap_dex.evt_index
 FROM kyberswap_dex
-INNER JOIN {{ source('avalanche_c', 'transactions') }} tx
+INNER JOIN {{ source('polygon', 'transactions') }} tx
     ON kyberswap_dex.tx_hash = tx.hash
     {% if is_incremental() %}
     AND tx.block_time >= date_trunc("day", now() - interval '1 week')
@@ -207,14 +207,14 @@ INNER JOIN {{ source('avalanche_c', 'transactions') }} tx
     {% endif %}
 LEFT JOIN {{ ref('tokens_erc20') }} erc20a
     ON erc20a.contract_address = kyberswap_dex.token_bought_address
-    and erc20a.blockchain = 'avalanche_c'
+    and erc20a.blockchain = 'polygon'
 LEFT JOIN {{ ref('tokens_erc20') }} erc20b
     ON erc20b.contract_address = kyberswap_dex.token_sold_address
-    AND erc20b.blockchain = 'avalanche_c'
+    AND erc20b.blockchain = 'polygon'
 LEFT JOIN {{ source('prices', 'usd') }} p_bought
     ON p_bought.minute = date_trunc('minute', kyberswap_dex.block_time)
     AND p_bought.contract_address = kyberswap_dex.token_bought_address
-    AND p_bought.blockchain = 'avalanche_c'
+    AND p_bought.blockchain = 'polygon'
     {% if is_incremental() %}
     AND p_bought.minute >= date_trunc("day", now() - interval '1 week')
     {% else %}
@@ -223,7 +223,7 @@ LEFT JOIN {{ source('prices', 'usd') }} p_bought
 LEFT JOIN {{ source('prices', 'usd') }} p_sold
     ON p_sold.minute = date_trunc('minute', kyberswap_dex.block_time)
     AND p_sold.contract_address = kyberswap_dex.token_sold_address
-    AND p_sold.blockchain = 'avalanche_c'
+    AND p_sold.blockchain = 'polygon'
     {% if is_incremental() %}
     AND p_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% else %}

--- a/models/kyberswap/polygon/kyberswap_polygon_trades.sql
+++ b/models/kyberswap/polygon/kyberswap_polygon_trades.sql
@@ -1,5 +1,5 @@
 {{ config(
-    alias = 'polygon_trades',
+    alias = 'trades',
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
@@ -31,8 +31,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                      AS tx_hash
         ,''                                                                 AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_polygon_trades', 'DMMPool_evt_Swap') }} t
-    INNER JOIN {{ source('kyber_polygon_trades', 'DMMFactory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_polygon', 'DMMPool_evt_Swap') }} t
+    INNER JOIN {{ source('kyber_polygon', 'DMMFactory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -58,8 +58,8 @@ kyberswap_dex AS (
         ,t.evt_tx_hash                                                                 AS tx_hash
         ,''                                                                            AS trace_address
         ,t.evt_index
-    FROM {{ source('kyber_polygon_trades', 'Elastic_Pool_evt_swap') }} t
-    INNER JOIN {{ source('kyber_polygon_trades', 'Elastic_Factory_evt_PoolCreated') }} p
+    FROM {{ source('kyber_polygon', 'Elastic_Pool_evt_swap') }} t
+    INNER JOIN {{ source('kyber_polygon', 'Elastic_Factory_evt_PoolCreated') }} p
         ON t.contract_address = p.pool
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -83,7 +83,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_polygon_trades', 'AggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_polygon', 'AggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -107,7 +107,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_polygon_trades', 'AggregationRouterV2_evt_Swapped') }}
+    FROM {{ source('kyber_polygon', 'AggregationRouterV2_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -131,7 +131,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_polygon_trades', 'AggregationRouterV3_evt_Swapped') }}
+    FROM {{ source('kyber_polygon', 'AggregationRouterV3_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -155,7 +155,7 @@ kyberswap_dex AS (
         ,evt_tx_hash                                                       AS tx_hash
         ,''                                                                AS trace_address
         ,evt_index
-    FROM {{ source('kyber_polygon_trades', 'MetaAggregationRouter_evt_Swapped') }}
+    FROM {{ source('kyber_polygon', 'MetaAggregationRouter_evt_Swapped') }}
     WHERE
         {% if is_incremental() %}
         evt_block_time >= date_trunc("day", now() - interval '1 week')
@@ -169,7 +169,7 @@ SELECT
     ,'kyberswap'                                                          AS project
     ,kyberswap_dex.version                                                AS version
     ,SELECT (CASE
-    WHEN (kyberswap_dev.version = 'dmm' or kyberswap_dev.version = 'elastic' ) then 'dex'
+    WHEN (kyberswap_dex.version = 'dmm' or kyberswap_dex.version = 'elastic' ) then 'dex'
     ELSE 'aggregator' END)                                                AS category
     ,try_cast(date_trunc('DAY', kyberswap_dex.block_time) AS date)        AS block_date
     ,kyberswap_dex.block_time


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
