### PR TITLE
Quick fix - typo + new contracts

### DIFF
--- a/models/nft/ethereum/metadata/nft_ethereum_metadata_art_blocks_collections.sql
+++ b/models/nft/ethereum/metadata/nft_ethereum_metadata_art_blocks_collections.sql
@@ -384,6 +384,9 @@
         , ('0x99a9b7c1116f9ceeb1652de04d5969cce509b069', 388, 1000000, 'Your Story', 'encapsuled', 'Presents', 'N/A', '0x99a9b7c1116f9ceeb1652de04d5969cce509b069-388')
         , ('0x99a9b7c1116f9ceeb1652de04d5969cce509b069', 389, 1000000, 'Miragem', 'Third Vision', 'Presents', 'N/A', '0x99a9b7c1116f9ceeb1652de04d5969cce509b069-389')
         , ('0x99a9b7c1116f9ceeb1652de04d5969cce509b069', 390, 1000000, 'Imposter Syndrome', 'ippsketch', 'Presents', 'N/A', '0x99a9b7c1116f9ceeb1652de04d5969cce509b069-390')
+        , ('0x99a9b7c1116f9ceeb1652de04d5969cce509b069', 394, 1000000, 'Volute', 'RVig', 'Presents', 'N/A', '0x99a9b7c1116f9ceeb1652de04d5969cce509b069-394')
+        , ('0x99a9b7c1116f9ceeb1652de04d5969cce509b069', 395, 1000000, 'Implications', 'ixnayokay', 'Presents', 'N/A', '0x99a9b7c1116f9ceeb1652de04d5969cce509b069-395')
+        , ('0x99a9b7c1116f9ceeb1652de04d5969cce509b069', 396, 1000000, 'Good, Computer', 'Dean Blacc', 'Presents', 'N/A', '0x99a9b7c1116f9ceeb1652de04d5969cce509b069-396')
 
         -- explorations
         , ('0x942bc2d3e7a589fe5bd4a5c6ef9727dfd82f5c8a',0,1000000,'Friendship Bracelets','Alexis André','Explorations','N/A','0x942bc2d3e7a589fe5bd4a5c6ef9727dfd82f5c8a-0')

--- a/models/nft/ethereum/metadata/nft_ethereum_metadata_fellowship_gallery.sql
+++ b/models/nft/ethereum/metadata/nft_ethereum_metadata_fellowship_gallery.sql
@@ -62,7 +62,7 @@ from (VALUES
         ('0x28398a2c1459119efa3e6699e928612ea4909a13','Our Life in The Shadows','Tania Franco Klein','SuperRare','https://superrare.com/taniafrancoklein'),
         ('0x23e3f2ea133f2c80558e181c4f78f4da3bc7c477','House Hunting','Todd Hido','Foundation','https://foundation.app/collection/thhh'),
         ('0xb8c55c77b3617ef22a4f552f9a47503e021c6623','Roaming','Todd Hido','Foundation','https://foundation.app/collection/thr-00f3')
-        , ('0x49e6b0cfb1880fd7afb69c062613238049a4b56b','By Accident - The Negatives',' Marcel De Baer','Foundation','https://foundation.app/collection/ngtvs')
+        , ('0x49e6b0cfb1880fd7afb69c062613238049a4b56b','By Accident - The Negatives','Marcel De Baer','Foundation','https://foundation.app/collection/ngtvs')
 
 ) as temp_table (contract_address, collection_name, artist_name, platform, website)
     


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Quick update - I found a typo on one of my PRs from last week + adding a few new contracts


**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
