### PR TITLE
[CoW Protocol] start counting dex_swaps from dex.trades

### DIFF
--- a/tests/cow_protocol/ethereum/cow_protocol_ethereum_assert_batches.sql
+++ b/tests/cow_protocol/ethereum/cow_protocol_ethereum_assert_batches.sql
@@ -1,17 +1,15 @@
 -- Try it out here: https://dune.com/queries/1389623
-with batches_with_trade_count as (
+with batches_with_trades as (
     select
-        s.evt_tx_hash,
-        s.evt_block_time,
-        count(t.evt_index) as num_trades
+        s.evt_tx_hash
     from {{ source('gnosis_protocol_v2_ethereum','GPv2Settlement_evt_Trade') }} t
     inner join {{ source('gnosis_protocol_v2_ethereum','GPv2Settlement_evt_Settlement') }} s
         on s.evt_tx_hash = t.evt_tx_hash
     group by s.evt_tx_hash, s.evt_block_time
 )
 
-select * from batches_with_trade_count
+select evt_tx_hash from batches_with_trades
 where evt_tx_hash not in (select tx_hash from {{ ref('cow_protocol_ethereum_batches' )}})
 -- The reference table is only refreshed once in a while,
 -- so we impose a time constraint on this test.
-and evt_block_time < date(now())
+and evt_block_time < date(now()) - interval '1 day'

--- a/tests/cow_protocol/ethereum/cow_protocol_ethereum_assert_batches.sql
+++ b/tests/cow_protocol/ethereum/cow_protocol_ethereum_assert_batches.sql
@@ -1,7 +1,8 @@
 -- Try it out here: https://dune.com/queries/1389623
 with batches_with_trades as (
     select
-        s.evt_tx_hash
+        s.evt_tx_hash,
+        s.evt_block_time
     from {{ source('gnosis_protocol_v2_ethereum','GPv2Settlement_evt_Trade') }} t
     inner join {{ source('gnosis_protocol_v2_ethereum','GPv2Settlement_evt_Settlement') }} s
         on s.evt_tx_hash = t.evt_tx_hash

--- a/tests/cow_protocol/ethereum/cow_protocol_ethereum_assert_trades.sql
+++ b/tests/cow_protocol/ethereum/cow_protocol_ethereum_assert_trades.sql
@@ -1,5 +1,5 @@
 -- Try it out here: https://dune.com/queries/1398185
-select *
+select evt_tx_hash
 from {{ source('gnosis_protocol_v2_ethereum', 'GPv2Settlement_evt_Trade') }}
 where evt_tx_hash not in (select tx_hash from {{ ref('cow_protocol_ethereum_batches')}})
-  and evt_block_time < date(now())
+and evt_block_time < date(now()) - interval '1 day'


### PR DESCRIPTION
Previously we were using NULL for our "single order solvers" in the `dex_swaps` field. This now populates the field with a count from dex.trades.

This has been tested out for the last week of batches here in this PoC Query: https://dune.com/queries/1290518

It is not yet entirely accurate since not all projects are part of `dex.trades` yet, however it is MUCH better than null.


Test Plan:

Existing unit test for this table should suffice.