### PR TITLE
Report errors from DBT on Github action timeout

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: "dbt seed --select state:modified --state ."
 
       - name: dbt run initial model(s)
-        run: "dbt run --select state:modified --state ."
+        run: "dbt -x run --select state:modified --state ."
 
       - name: dbt test initial model(s)
         run: "dbt test --select state:new state:modified --state ."


### PR DESCRIPTION
This prevents a user from not getting feedback from errors if the workflow timesout. It also prevents a long running workflow that will inevitably have to be run again.

Link T-21390