### PR TITLE
Replace STRING with VARCHAR in curvefi_ethereum_view_pools

### DIFF
--- a/models/curvefi/ethereum/curvefi_ethereum_view_pools.sql
+++ b/models/curvefi/ethereum/curvefi_ethereum_view_pools.sql
@@ -110,16 +110,16 @@ plain_pools_deployed AS (
         _coins [3] AS coin2,
         _coins [4] AS coin3,
         CAST(
-            NULL AS VARCHAR
+            NULL AS VARCHAR(5)
         ) AS undercoin0,
         CAST(
-            NULL AS VARCHAR
+            NULL AS VARCHAR(5)
         ) AS undercoin1,
         CAST(
-            NULL AS VARCHAR
+            NULL AS VARCHAR(5)
         ) AS undercoin2,
         CAST(
-            NULL AS VARCHAR
+            NULL AS VARCHAR(5)
         ) AS undercoin3
     FROM
         plain_calls
@@ -160,10 +160,10 @@ meta_pools_deployed AS (
             WHEN _base_pool = '{{curvefi_ethereum_REN_swap_contract}}' THEN '{{renCRV_ethereum_token}}' --changing from swap to token contract
         END AS coin1,
         CAST(
-            NULL AS VARCHAR
+            NULL AS VARCHAR(5)
         ) AS coin2,
         CAST(
-            NULL AS VARCHAR
+            NULL AS VARCHAR(5)
         ) AS coin3,
         _coin AS undercoin0,
         --Listing underlying coins for the ExchangeUnderlying function
@@ -212,16 +212,16 @@ v2_pools_deployed AS (
         coins [3] AS coin2,
         coins [4] AS coin3,
         CAST(
-            NULL AS VARCHAR
+            NULL AS VARCHAR(5)
         ) AS undercoin0,
         CAST(
-            NULL AS VARCHAR
+            NULL AS VARCHAR(5)
         ) AS undercoin1,
         CAST(
-            NULL AS VARCHAR
+            NULL AS VARCHAR(5)
         ) AS undercoin2,
         CAST(
-            NULL AS VARCHAR
+            NULL AS VARCHAR(5)
         ) AS undercoin3
     FROM
         {{ source(

--- a/models/curvefi/ethereum/curvefi_ethereum_view_pools.sql
+++ b/models/curvefi/ethereum/curvefi_ethereum_view_pools.sql
@@ -110,16 +110,16 @@ plain_pools_deployed AS (
         _coins [3] AS coin2,
         _coins [4] AS coin3,
         CAST(
-            NULL AS STRING
+            NULL AS VARCHAR
         ) AS undercoin0,
         CAST(
-            NULL AS STRING
+            NULL AS VARCHAR
         ) AS undercoin1,
         CAST(
-            NULL AS STRING
+            NULL AS VARCHAR
         ) AS undercoin2,
         CAST(
-            NULL AS STRING
+            NULL AS VARCHAR
         ) AS undercoin3
     FROM
         plain_calls
@@ -160,10 +160,10 @@ meta_pools_deployed AS (
             WHEN _base_pool = '{{curvefi_ethereum_REN_swap_contract}}' THEN '{{renCRV_ethereum_token}}' --changing from swap to token contract
         END AS coin1,
         CAST(
-            NULL AS STRING
+            NULL AS VARCHAR
         ) AS coin2,
         CAST(
-            NULL AS STRING
+            NULL AS VARCHAR
         ) AS coin3,
         _coin AS undercoin0,
         --Listing underlying coins for the ExchangeUnderlying function
@@ -212,16 +212,16 @@ v2_pools_deployed AS (
         coins [3] AS coin2,
         coins [4] AS coin3,
         CAST(
-            NULL AS STRING
+            NULL AS VARCHAR
         ) AS undercoin0,
         CAST(
-            NULL AS STRING
+            NULL AS VARCHAR
         ) AS undercoin1,
         CAST(
-            NULL AS STRING
+            NULL AS VARCHAR
         ) AS undercoin2,
         CAST(
-            NULL AS STRING
+            NULL AS VARCHAR
         ) AS undercoin3
     FROM
         {{ source(


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
