### PR TITLE
Materialize all token tables

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -300,27 +300,27 @@ models:
 
     tokens:
       +schema: tokens
-      +materialized: view
+      +materialized: table
       ethereum:
         +schema: tokens_ethereum
-        +materialized: view
+        +materialized: table
       optimism:
         +schema: tokens_optimism
-        +materialized: view
+        +materialized: table
       avalanche_c:
         +schema: tokens_avalanche_c
       bnb:
         +schema: tokens_bnb
-        +materialized: view
+        +materialized: table
       gnosis:
         +schema: tokens_gnosis
-        +materialized: view
+        +materialized: table
       arbitrum:
         +schema: tokens_arbitrum
-        +materialized: view
+        +materialized: table
       polygon:
         +schema: tokens_polygon
-        +materialized: view
+        +materialized: table
 
     transfers:
       +schema: transfers

--- a/models/tokens/optimism/tokens_optimism_schema.yml
+++ b/models/tokens/optimism/tokens_optimism_schema.yml
@@ -46,13 +46,16 @@ models:
       tags: ['tokens', 'optimism', 'nft', 'erc721']
     description: >
         Selection of NFT token addresses bridged from Ethereum to Optimism.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - contract_address
+            - contract_address_l1
     columns:
       - name: category
         description: "Category of the NFT Project"
       - name: contract_address
         description: "The contract address is the unique address of where the NFTs are stored on Optimism."
-        tests:
-          - unique
       - name: name
         description: "NFT Project name"
       - name: standard


### PR DESCRIPTION
Token tables are basically just CSVs. Storing these as SQL can increase planning time a lot (e.g., `select * from tokens.erc20 limit 1` can take 1 minute of planning time before it executes in < 1 second). To avoid this we materialize the views.

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
