### PR TITLE
Change Avalanche chain explorer from avascan.io to snowtrace.io

### DIFF
--- a/macros/public/get_chain_explorer.sql
+++ b/macros/public/get_chain_explorer.sql
@@ -8,7 +8,7 @@
          when 'optimism' = chain_ then 'https://optimistic.etherscan.io'
          when 'polygon' = chain_ then 'https://polygonscan.com'
          when 'arbitrum' = chain_ then 'https://arbiscan.io'
-         when 'avalanche_c' = chain_ then 'https://avascan.io'
+         when 'avalanche_c' = chain_ then 'https://snowtrace.io'
          when 'gnosis' = chain_ then 'https://gnosisscan.io'
          when 'bnb' = chain_ then 'https://bscscan.com'
          when 'solana' = chain_ then 'https://solscan.io'


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Avascan is down quite often from experience and snowtrace is the true etherscan fork despite the names which make it seem like the opposite.

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
