### PR TITLE
T-20626 - Change bancor trades model to be Trino compatible

### DIFF
--- a/models/bancor/ethereum/bancor_ethereum_trades.sql
+++ b/models/bancor/ethereum/bancor_ethereum_trades.sql
@@ -134,7 +134,7 @@ SELECT
 FROM
     conversions t
 
-UNION
+UNION ALL
 
 SELECT
     '3' AS version,
@@ -179,8 +179,8 @@ FROM {{ source('bancor3_ethereum', 'BancorNetwork_evt_TokensTraded') }} t
     end as token_pair,
     dexs.token_bought_amount_raw / power(10, erc20a.decimals) AS token_bought_amount,
     dexs.token_sold_amount_raw / power(10, erc20b.decimals) AS token_sold_amount,
-    dexs.token_bought_amount_raw,
-    dexs.token_sold_amount_raw,
+    CAST(dexs.token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw,
+    CAST(dexs.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw,
     coalesce(
         dexs.amount_usd,
         (dexs.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price,


### PR DESCRIPTION
Checked the row count on union vs union all part of the query, and it's resulting in the same number of rows