### PR TITLE
[Easy] Add PLN price mapping For Chainlink Polygon

### DIFF
--- a/models/chainlink/polygon/chainlink_polygon_oracle_addresses.sql
+++ b/models/chainlink/polygon/chainlink_polygon_oracle_addresses.sql
@@ -28,5 +28,6 @@ FROM (values
         ("KRW / USD",8,"0x24b820870f726da9b0d83b0b28a93885061dbf50","0xfd54f97a6c408561b5df798c04ae08b27ca0d7f7"),
         ("MXN / USD",8,"0x171b16562ea3476f5c61d1b8dad031dba0768545","0x2e2ed40fc4f1774def278830f8fe3b6e77956ec8"),
         ("NGN / USD",8,"0x0df812c4d675d155815b1216ce1da9e68f1b7050","0x0000000000000000000000000000000000000000"),
-        ("NZD / USD",8,"0xa302a0b8a499fd0f00449df0a490dede21105955","0xe63032a70f6eb617970829fbfa365d7c44bdbbbf")
+        ("NZD / USD",8,"0xa302a0b8a499fd0f00449df0a490dede21105955","0xe63032a70f6eb617970829fbfa365d7c44bdbbbf"),
+        ("PLN / USD",8,"0xb34bce11040702f71c11529d00179b2959bce6c0","0x08f8d217e6f07ae423a2ad2ffb226ffcb577708d")
 ) a (feed_name, decimals, proxy_address, aggregator_address)

--- a/models/chainlink/polygon/chainlink_polygon_oracle_token_mapping.sql
+++ b/models/chainlink/polygon/chainlink_polygon_oracle_token_mapping.sql
@@ -28,5 +28,6 @@ FROM (values
         ("KRW / USD","0x24b820870f726da9b0d83b0b28a93885061dbf50","0xa22f6bc96f13bcc84df36109c973d3c0505a067e",0),
         ("MXN / USD","0x171b16562ea3476f5c61d1b8dad031dba0768545","0xbd1fe73e1f12bd2bc237de9b626f056f21f86427",0),
         ("NGN / USD","0x0df812c4d675d155815b1216ce1da9e68f1b7050","0x182c76e977161f703bb8f111047df6c43cfacc56",0),
-        ("NZD / USD","0xa302a0b8a499fd0f00449df0a490dede21105955","0x08e6d1f0c4877ef2993ad733fc6f1d022d0e9dbf",0)
+        ("NZD / USD","0xa302a0b8a499fd0f00449df0a490dede21105955","0x08e6d1f0c4877ef2993ad733fc6f1d022d0e9dbf",0),
+        ("PLN / USD","0xb34bce11040702f71c11529d00179b2959bce6c0","0x08e6d1f0c4877ef2993ad733fc6f1d022d0e9dbf",0)
 ) a (feed_name, proxy_address, underlying_token_address, extra_decimals)

--- a/models/chainlink/polygon/chainlink_polygon_oracle_token_mapping.sql
+++ b/models/chainlink/polygon/chainlink_polygon_oracle_token_mapping.sql
@@ -28,6 +28,6 @@ FROM (values
         ("KRW / USD","0x24b820870f726da9b0d83b0b28a93885061dbf50","0xa22f6bc96f13bcc84df36109c973d3c0505a067e",0),
         ("MXN / USD","0x171b16562ea3476f5c61d1b8dad031dba0768545","0xbd1fe73e1f12bd2bc237de9b626f056f21f86427",0),
         ("NGN / USD","0x0df812c4d675d155815b1216ce1da9e68f1b7050","0x182c76e977161f703bb8f111047df6c43cfacc56",0),
-        ("NZD / USD","0xa302a0b8a499fd0f00449df0a490dede21105955","0x08e6d1f0c4877ef2993ad733fc6f1d022d0e9dbf",0),
+        ("NZD / USD","0xa302a0b8a499fd0f00449df0a490dede21105955","0x6b526daf03b4c47af2bcc5860b12151823ff70e0",0),
         ("PLN / USD","0xb34bce11040702f71c11529d00179b2959bce6c0","0x08e6d1f0c4877ef2993ad733fc6f1d022d0e9dbf",0)
 ) a (feed_name, proxy_address, underlying_token_address, extra_decimals)


### PR DESCRIPTION
edit existing feed and adding pln mapping for chainlink polygon

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
