### PR TITLE
Quick fix on punk listings query

### DIFF
--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_current_listings.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_current_listings.sql
@@ -17,6 +17,7 @@ with all_listings as (
             , `minValue`/1e18 as listed_price
             , `toAddress` as listing_offered_to 
             , evt_block_number
+            , evt_index
             , evt_block_time
             , evt_tx_hash
     from {{ source('cryptopunks_ethereum','CryptoPunksMarket_evt_PunkOffered') }}
@@ -30,6 +31,7 @@ with all_listings as (
             , null as listed_price
             , null as listing_offered_to
             , evt_block_number
+            , evt_index
             , evt_block_time
             , evt_tx_hash
     from {{ source('cryptopunks_ethereum','CryptoPunksMarket_evt_PunkNoLongerForSale') }}
@@ -41,6 +43,7 @@ with all_listings as (
             , null as listed_price
             , null as listing_offered_to
             , evt_block_number
+            , evt_index
             , evt_block_time
             , evt_tx_hash
     from {{ source('cryptopunks_ethereum','CryptoPunksMarket_evt_PunkBought') }}
@@ -52,6 +55,7 @@ with all_listings as (
             , null as listed_price
             , null as listing_offered_to
             , evt_block_number
+            , evt_index
             , evt_block_time
             , evt_tx_hash
     from {{ source('cryptopunks_ethereum','CryptoPunksMarket_evt_PunkTransfer') }}
@@ -63,7 +67,7 @@ select b.punk_id
 from 
 (
     select *
-            , row_number() over (partition by punk_id order by evt_block_time desc) as punk_event_index
+            , row_number() over (partition by punk_id order by evt_block_number desc, evt_index desc ) as punk_event_index
     from 
     (
     select * from all_listings


### PR DESCRIPTION
Accidentally used block time instead of block number! Quick fix to update 

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
