### PR TITLE
[WIP] Model run tracking package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 manifest.json
 macros/dune/create_views_of_dependencies.sql
 macros/dune/alter_table_locations.sql
+elementary*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -31,6 +31,8 @@ models:
     +post-hook:
       sql: "{{ optimize_spell(this, model.config.materialized) }}"
       transaction: true
+    elementary:
+      +schema: "elementary"
     aave:
       +schema: aave
       +materialized: view

--- a/models/elementary/elemenary_schema.yml
+++ b/models/elementary/elemenary_schema.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: elementary
+    description: Stand in. Elementary requires a schema in dbt_project but this causes an error because the path is unused.

--- a/models/elementary/elementary.sql
+++ b/models/elementary/elementary.sql
@@ -1,0 +1,1 @@
+select 1 as "empty_table - see schema description"

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 0.9.2
+  - package: elementary-data/elementary
+    version: 0.6.2
+    ## Docs: https://docs.elementary-data.com


### PR DESCRIPTION
@jeff-dude @soispoke @0xRobin 

This isn't ready to merge but these changes add the [elementary package](https://docs.elementary-data.com/introduction) to our project. This should give us a lot more visibility into our runs over time because it handles organizing the dbt artifacts for us. 

I'll need to work through how to set this up on the GH runner and on DBT Cloud before merging but I was able to generate some local results after configuring the profile.yml (@0xRobin that will require local credentials unfortunately).