### PR TITLE
blur fix unique ID

### DIFF
--- a/models/blur/ethereum/blur_ethereum_events.sql
+++ b/models/blur/ethereum/blur_ethereum_events.sql
@@ -69,7 +69,7 @@ SELECT
     , CASE WHEN get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.recipient') IS NOT NULL AND get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN 'ETH'
         WHEN get_json_object(get_json_object(bm.sell, '$.fees[0]'), '$.recipient') IS NOT NULL THEN pu.symbol
         END AS royalty_fee_currency_symbol
-    ,  'ethereum-blur-v1' || bm.evt_tx_hash || '-' || COALESCE(seller_fix.from, get_json_object(bm.sell, '$.trader')) || '-' || COALESCE(buyer_fix.to, get_json_object(bm.buy, '$.trader')) || '-' || get_json_object(bm.buy, '$.collection') || '-' || get_json_object(bm.buy, '$.tokenId') AS unique_trade_id
+    ,  'ethereum-blur-v1-' || bm.evt_block_number || '-' || bm.evt_tx_hash || '-' || bm.evt_index AS unique_trade_id
 FROM {{ source('blur_ethereum','BlurExchange_evt_OrdersMatched') }} bm
 JOIN {{ source('ethereum','transactions') }} et ON et.block_time=bm.evt_block_time
     AND et.hash=bm.evt_tx_hash


### PR DESCRIPTION
Quick fix for blur.events failing on duplicates.

tx that messed up the logic:
https://etherscan.io/tx/0xa647d0a3daf89e5420e12bd5ecff98c611a869228e43b02d9bb31b79495316e3
-> current impl misrepresents the token_ids here both as 0, which resulted in equal unique IDs.

Resolved by including the evt_index in the unique_id.  
