### PR TITLE
Dune version of hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_stages: [push, manual]
 exclude: ^deprecated-dune-v1-abstractions/
 repos:
-- repo: https://github.com/offbi/pre-commit-dbt
+- repo: https://github.com/duneanalytics/pre-commit-dbt
   rev: v1.0.0
   hooks:
   - id: dbt-compile


### PR DESCRIPTION
We reverted this [change](https://github.com/duneanalytics/spellbook/commit/3749a4f80753739f0e84405eeeeaf3748fae7526) about two weeks ago because we couldn't use main as the version. I've created a [new release](https://github.com/duneanalytics/pre-commit-dbt) on the  pre-commit hooks fork and now we should be able to point to it. 