### PR TITLE
Moving one row to a different file in punk spells  

### DIFF
--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_current_owners_per_token.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_current_owners_per_token.sql
@@ -10,7 +10,11 @@
 select punk_id
         , to as current_owner
         , evt_block_time as last_transfer_time
-from  {{ ref('cryptopunks_ethereum_punk_transfers') }}
+from 
+(       select *
+                , row_number() over (partition by punk_id order by evt_block_number desc, evt_index desc) as punk_id_tx_rank
+        from  {{ ref('cryptopunks_ethereum_punk_transfers') }}
+) a
 where punk_id_tx_rank = 1 
 order by cast(punk_id as int) asc
 ;

--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_owners_over_time.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_owners_over_time.sql
@@ -50,4 +50,5 @@ select day
         , count(wallet) filter (where holding > 0) as unique_wallets
 from combined_table
 group by 1
+order by day desc
 ;

--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_punk_transfers.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_punk_transfers.sql
@@ -10016,19 +10016,18 @@ with original_holders as (
 )
 
 select *
-        , row_number() over (partition by punk_id order by evt_block_number desc, evt_index desc) as punk_id_tx_rank
-from
-(   select  from
-            , to
-            , evt_block_time
-            , evt_block_time_week
-            , evt_block_number
-            , evt_index
-            , punk_id
-            , evt_tx_hash 
-    from 
-    (
-    select  a.from
+from 
+(
+select  from
+        , to
+        , evt_block_time
+        , evt_block_time_week
+        , evt_block_number
+        , evt_index
+        , punk_id
+        , evt_tx_hash 
+from 
+(   select  a.from
             , a.to
             , a.evt_block_time
             , date_trunc('week',a.evt_block_time) as evt_block_time_week
@@ -10047,21 +10046,22 @@ from
                             , '0x58e5d5a525e3b40bc15abaa38b5882678db1ee68befd2f60bafe3a7fd06db9e3' -- PunkBought
                             , '0x05af636b70da6819000c49f85b21fa82081c632069bb626f30932034099107d8' -- PunkTransfer
                         )
-        {% if is_incremental() %} and a.evt_block_time >= date_trunc('day', now() - interval '1 week') {% endif %}    
-    
-    union all 
-    
-    select  cast(NULL as varchar(5)) as from
-            , address as to
-            , cast('2017-06-23 19:37:59' as timestamp) as evt_block_time
-            , date_trunc('week',cast('2017-06-23 19:37:59' as timestamp)) as evt_block_time_week
-            , cast(3919418 as int) as evt_block_number
-            , cast(1 as int) as evt_index
-            , punk_id
-            , cast(NULL as varchar(5)) as evt_tx_hash
-    from original_holders
-    where {% if is_incremental() %} cast('2017-06-23 19:37:59' as timestamp) >= date_trunc('day', now() - interval '1 week') {% endif %}    
-    
-    ) a
-    group by 1,2,3,4,5,6,7,8
-) b
+) c 
+{% if is_incremental() %} where c.evt_block_time >= date_trunc('day', now() - interval '1 week') {% endif %}    
+group by 1,2,3,4,5,6,7,8
+
+union all 
+
+select  cast(NULL as varchar(5)) as from
+        , address as to
+        , cast('2017-06-23 19:37:59' as timestamp) as evt_block_time
+        , date_trunc('week',cast('2017-06-23 19:37:59' as timestamp)) as evt_block_time_week
+        , cast(3919418 as int) as evt_block_number
+        , cast(1 as int) as evt_index
+        , punk_id
+        , cast(NULL as varchar(5)) as evt_tx_hash
+from original_holders
+where {% if is_incremental() %} cast('2017-06-23 19:37:59' as timestamp) >= date_trunc('day', now() - interval '1 week') {% endif %}
+
+) d 
+order by evt_block_number desc, evt_index desc 

--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_punk_transfers.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_punk_transfers.sql
@@ -10046,8 +10046,9 @@ from
                             , '0x58e5d5a525e3b40bc15abaa38b5882678db1ee68befd2f60bafe3a7fd06db9e3' -- PunkBought
                             , '0x05af636b70da6819000c49f85b21fa82081c632069bb626f30932034099107d8' -- PunkTransfer
                         )
+        {% if is_incremental() %} and a.evt_block_time >= date_trunc('day', now() - interval '1 week') {% endif %}    
+
 ) c 
-{% if is_incremental() %} where c.evt_block_time >= date_trunc('day', now() - interval '1 week') {% endif %}    
 group by 1,2,3,4,5,6,7,8
 
 union all 
@@ -10061,7 +10062,7 @@ select  cast(NULL as varchar(5)) as from
         , punk_id
         , cast(NULL as varchar(5)) as evt_tx_hash
 from original_holders
-where {% if is_incremental() %} cast('2017-06-23 19:37:59' as timestamp) >= date_trunc('day', now() - interval '1 week') {% endif %}
+{% if is_incremental() %} where cast('2017-06-23 19:37:59' as timestamp) >= date_trunc('day', now() - interval '1 week') {% endif %}
 
 ) d 
 order by evt_block_number desc, evt_index desc 

--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_schema.yml
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_schema.yml
@@ -257,8 +257,6 @@ models:
         description: "Punk ID #"   
       - name: evt_tx_hash
         description: "Transfer transaction hash"
-      - name: punk_id_tx_rank
-        description: "Transfer rank per Punk ID # (1 = most recent)"   
 
   - name: cryptopunks_ethereum_listings_over_time
     meta:


### PR DESCRIPTION
Brief comments on the purpose of your changes:

The row_number() wasn't working in the incremental table + is better suited to be directly in the current owners view query so moving it around.


**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
