### PR TITLE
[Easy] - curve avalanche temp fix

### DIFF
--- a/models/curvefi/avalanche_c/curvefi_avalanche_c_trades.sql
+++ b/models/curvefi/avalanche_c/curvefi_avalanche_c_trades.sql
@@ -462,9 +462,9 @@ WITH dexs AS (
             END as token_bought_address,
             CASE
                 WHEN sold_id = 0 THEN '{{debridge_usdc_avalanche_c_token}}'
-                WHEN sold_id = 1 THEN '{{dai_e_avalanche_c_token}}'
-                WHEN sold_id = 2 THEN '{{usdc_e_avalanche_c_token}}'
-                WHEN sold_id = 3 THEN '{{usdt_e_avalanche_c_token}}'
+                WHEN sold_id = 1 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 2 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 3 THEN '{{av3CRV_avalanche_c_token}}'
             END as token_sold_address,
             contract_address AS project_contract_address,
             evt_tx_hash AS tx_hash,
@@ -522,9 +522,9 @@ WITH dexs AS (
             END as token_bought_address,
             CASE
                 WHEN sold_id = 0 THEN '{{defrost_h20_avalanche_c_token}}'
-                WHEN sold_id = 1 THEN '{{dai_e_avalanche_c_token}}'
-                WHEN sold_id = 2 THEN '{{usdc_e_avalanche_c_token}}'
-                WHEN sold_id = 3 THEN '{{usdt_e_avalanche_c_token}}'
+                WHEN sold_id = 1 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 2 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 3 THEN '{{av3CRV_avalanche_c_token}}'
             END as token_sold_address,
             contract_address AS project_contract_address,
             evt_tx_hash AS tx_hash,
@@ -610,9 +610,9 @@ WITH dexs AS (
             END as token_bought_address,
             CASE
                 WHEN sold_id = 0 THEN '{{frax_avalanche_c_token}}'
-                WHEN sold_id = 1 THEN '{{dai_e_avalanche_c_token}}'
-                WHEN sold_id = 2 THEN '{{usdc_e_avalanche_c_token}}'
-                WHEN sold_id = 3 THEN '{{usdt_e_avalanche_c_token}}'
+                WHEN sold_id = 1 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 2 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 3 THEN '{{av3CRV_avalanche_c_token}}'
             END as token_sold_address,
             contract_address AS project_contract_address,
             evt_tx_hash AS tx_hash,
@@ -754,9 +754,9 @@ WITH dexs AS (
             END as token_bought_address,
             CASE
                 WHEN sold_id = 0 THEN '{{mai_avalanche_c_token}}'
-                WHEN sold_id = 1 THEN '{{dai_e_avalanche_c_token}}'
-                WHEN sold_id = 2 THEN '{{usdc_e_avalanche_c_token}}'
-                WHEN sold_id = 3 THEN '{{usdt_e_avalanche_c_token}}'
+                WHEN sold_id = 1 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 2 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 3 THEN '{{av3CRV_avalanche_c_token}}'
             END as token_sold_address,
             contract_address AS project_contract_address,
             evt_tx_hash AS tx_hash,
@@ -814,9 +814,9 @@ WITH dexs AS (
             END as token_bought_address,
             CASE
                 WHEN sold_id = 0 THEN '{{mim_avalanche_c_token}}'
-                WHEN sold_id = 1 THEN '{{dai_e_avalanche_c_token}}'
-                WHEN sold_id = 2 THEN '{{usdc_e_avalanche_c_token}}'
-                WHEN sold_id = 3 THEN '{{usdt_e_avalanche_c_token}}'
+                WHEN sold_id = 1 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 2 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 3 THEN '{{av3CRV_avalanche_c_token}}'
             END as token_sold_address,
             contract_address AS project_contract_address,
             evt_tx_hash AS tx_hash,
@@ -874,9 +874,9 @@ WITH dexs AS (
             END as token_bought_address,
             CASE
                 WHEN sold_id = 0 THEN '{{moremoney_avalanche_c_token}}'
-                WHEN sold_id = 1 THEN '{{dai_e_avalanche_c_token}}'
-                WHEN sold_id = 2 THEN '{{usdc_e_avalanche_c_token}}'
-                WHEN sold_id = 3 THEN '{{usdt_e_avalanche_c_token}}'
+                WHEN sold_id = 1 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 2 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 3 THEN '{{av3CRV_avalanche_c_token}}'
             END as token_sold_address,
             contract_address AS project_contract_address,
             evt_tx_hash AS tx_hash,
@@ -906,9 +906,9 @@ WITH dexs AS (
             END as token_bought_address,
             CASE
                 WHEN sold_id = 0 THEN '{{nxusd_avalanche_c_token}}'
-                WHEN sold_id = 1 THEN '{{dai_e_avalanche_c_token}}'
-                WHEN sold_id = 2 THEN '{{usdc_e_avalanche_c_token}}'
-                WHEN sold_id = 3 THEN '{{usdt_e_avalanche_c_token}}'
+                WHEN sold_id = 1 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 2 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 3 THEN '{{av3CRV_avalanche_c_token}}'
             END as token_sold_address,
             contract_address AS project_contract_address,
             evt_tx_hash AS tx_hash,
@@ -994,9 +994,9 @@ WITH dexs AS (
             END as token_bought_address,
             CASE
                 WHEN sold_id = 0 THEN '{{usdl_avalanche_c_token}}'
-                WHEN sold_id = 1 THEN '{{dai_e_avalanche_c_token}}'
-                WHEN sold_id = 2 THEN '{{usdc_e_avalanche_c_token}}'
-                WHEN sold_id = 3 THEN '{{usdt_e_avalanche_c_token}}'
+                WHEN sold_id = 1 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 2 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 3 THEN '{{av3CRV_avalanche_c_token}}'
             END as token_sold_address,
             contract_address AS project_contract_address,
             evt_tx_hash AS tx_hash,
@@ -1082,9 +1082,9 @@ WITH dexs AS (
             END as token_bought_address,
             CASE
                 WHEN sold_id = 0 THEN '{{usds_avalanche_c_token}}'
-                WHEN sold_id = 1 THEN '{{dai_e_avalanche_c_token}}'
-                WHEN sold_id = 2 THEN '{{usdc_e_avalanche_c_token}}'
-                WHEN sold_id = 3 THEN '{{usdt_e_avalanche_c_token}}'
+                WHEN sold_id = 1 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 2 THEN '{{av3CRV_avalanche_c_token}}'
+                WHEN sold_id = 3 THEN '{{av3CRV_avalanche_c_token}}'
             END as token_sold_address,
             contract_address AS project_contract_address,
             evt_tx_hash AS tx_hash,


### PR DESCRIPTION
Brief comments on the purpose of your changes:

The curve spell for dex trades on avalanche returns incorrect data for tokenexchange_underlying events. While the tokens being traded are stable coins, the token exchange underlying event returns the underlying lp token as the token that is sold. (i.e except if you're buying that's when the tokens [usdc, used & dai] amounts are returned but otherwise it returns the lp token). 

This is causing incorrect usd values in the dex.trades table, this is a temporary fix as I'm working on ellipsis a similar project on bnb and will update the curve avalanche spell to follow the same structure. 

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
