### PR TITLE
[DO NOT MERGE] Revert opensea.events and nft.burns changes

### DIFF
--- a/models/blur/ethereum/blur_ethereum_events.sql
+++ b/models/blur/ethereum/blur_ethereum_events.sql
@@ -26,14 +26,14 @@ SELECT
     , CASE WHEN get_json_object(bm.buy, '$.amount')=1 THEN 'Single Item Trade'
         ELSE 'Bundle Trade'
         END AS trade_type
-    , CAST(get_json_object(bm.buy, '$.amount') AS DECIMAL(38,0)) AS number_of_items
+    , get_json_object(bm.buy, '$.amount') AS number_of_items
     , 'Trade' AS evt_type
     , COALESCE(seller_fix.from, get_json_object(bm.sell, '$.trader')) AS seller
     , COALESCE(buyer_fix.to, get_json_object(bm.buy, '$.trader')) AS buyer
     , CASE WHEN et.from=buyer_fix.to OR et.from=COALESCE(buyer_fix.to, get_json_object(bm.buy, '$.trader')) THEN 'Buy'
         ELSE 'Offer Accepted'
         END AS trade_category
-    , CAST(get_json_object(bm.buy, '$.price') AS DECIMAL(38,0)) AS amount_raw
+    , get_json_object(bm.buy, '$.price') AS amount_raw
     , CASE WHEN get_json_object(bm.buy, '$.paymentToken')='0x0000000000000000000000000000000000000000' THEN get_json_object(bm.buy, '$.price')/POWER(10, 18)
         ELSE get_json_object(bm.buy, '$.price')/POWER(10, pu.decimals)
         END AS amount_original

--- a/models/foundation/ethereum/foundation_ethereum_events.sql
+++ b/models/foundation/ethereum/foundation_ethereum_events.sql
@@ -138,13 +138,13 @@ SELECT DISTINCT t.blockchain
 , CASE WHEN agg.contract_address IS NOT NULL THEN 'Bundle Trade'
     ELSE 'Single Item Purchase'
     END AS trade_type
-, CAST(t.number_of_items AS DECIMAL(38,0)) AS number_of_items
+, t.number_of_items
 , t.trade_category
 , t.evt_type
 , t.seller
 , t.buyer
 , t.amount_original
-, CAST(t.amount_raw AS DECIMAL(38,0)) AS amount_raw
+, t.amount_raw
 , t.currency_symbol
 , t.currency_contract
 , t.project_contract_address

--- a/models/opensea/opensea_events.sql
+++ b/models/opensea/opensea_events.sql
@@ -85,8 +85,8 @@ FROM
                 CAST(NULL AS DOUBLE) as royalty_fee_amount,
                 CAST(NULL AS DOUBLE) as royalty_fee_amount_usd,
                 CAST(NULL AS DOUBLE) as royalty_fee_percentage,
-                CAST(NULL AS VARCHAR(5)) as royalty_fee_receive_address,
-                CAST(NULL AS VARCHAR(5)) as royalty_fee_currency_symbol,
+                CAST(NULL AS DOUBLE) as royalty_fee_receive_address,
+                CAST(NULL AS DOUBLE) as royalty_fee_currency_symbol,
                 unique_trade_id
         FROM {{ ref('opensea_solana_events') }}
 )


### PR DESCRIPTION
This PR undoes the changes introduced by https://github.com/duneanalytics/spellbook/pull/2247 and https://github.com/duneanalytics/spellbook/pull/2247

Hopefully we won't need it, but I'm leaving it ready in case the model updates break databricks (I'm hoping it won't, I triple checked everything locally)