### PR TITLE
Added `WOM`, `HAY`, `BNBx` to `tokens.erc20`

### DIFF
--- a/models/tokens/bnb/tokens_bnb_bep20.sql
+++ b/models/tokens/bnb/tokens_bnb_bep20.sql
@@ -5520,4 +5520,7 @@ SELECT LOWER(contract_address) AS contract_address, symbol, decimals
 ,('0x65d83463fc023bffbd8ac9a1a2e1037f4bbdb399', 'dexSHARE-BNB', 18)
 ,('0x01b279a06f5f26bd3f469a3e730097184973fc8a', 'dexIRA-BNB', 18)
 ,('0x05134427ca04fe0712b29fb50c4d573f63e5cb22', 'vBABY', 18)
+,('0xad6742a35fb341a9cc6ad674738dd8da98b94fb1', 'WOM', 18)
+,('0x0782b6d8c4551b9760e74c0545a9bcd90bdc41e5', 'HAY', 18)
+,('0x1bdd3cf7f79cfb8edbb955f20ad99211551ba275', 'BNBx', 18)
 ) AS temp_table (contract_address, symbol, decimals)


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [x] `coin_id` represents the ID of the coin on coinpaprika.com
* [x] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
