### PR TITLE
hide nft.fees and nft.trades in trino

### DIFF
--- a/models/nft/nft_fees.sql
+++ b/models/nft/nft_fees.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='fees',
-        post_hook='{{ expose_spells(\'["ethereum","solana"]\',
+        post_hook='{{ expose_spells_hide_trino(\'["ethereum","solana"]\',
                                     "sector",
                                     "nft",
                                     \'["soispoke"]\') }}')

--- a/models/nft/nft_trades.sql
+++ b/models/nft/nft_trades.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='trades',
-        post_hook='{{ expose_spells(\'["ethereum","solana"]\',
+        post_hook='{{ expose_spells_hide_trino(\'["ethereum","solana"]\',
                                     "sector",
                                     "nft",
                                     \'["soispoke"]\') }}')


### PR DESCRIPTION
@belen-pruvost @jeff-dude @augustog 
`nft.fees` and `nft.trade` are broken in production at the moment.
This quickly hides them from Trino, which should unblock `main`?

Errors:
nft.fees:
``` [CANNOT_UP_CAST_DATATYPE] Cannot up cast spark_catalog.sudoswap_ethereum.events.token_id from "STRING" to "INT". The type .```

nft.trades:
``` [CANNOT_UP_CAST_DATATYPE] Cannot up cast spark_catalog.archipelago_ethereum.events.number_of_items from "DECIMAL(38,0)" to.```

These 2 PRs are probably related
https://github.com/duneanalytics/spellbook/pull/2272
https://github.com/duneanalytics/spellbook/pull/2273

No clue why nft.trades is broken but nft.events is not..