### PR TITLE
[CoW Protocol] Fix Receiver Field

### DIFF
--- a/deprecated-dune-v1-abstractions/ethereum/gnosis_protocol_v2/insert_trades.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/gnosis_protocol_v2/insert_trades.sql
@@ -151,7 +151,11 @@ BEGIN
                        fee_atoms,
                        fee_usd,
                        order_uid,
-                       receiver,
+                       case
+                          when receiver = '\x0000000000000000000000000000000000000000'
+                            then trader
+                          else receiver
+                       end                                    as receiver,
                        sell_price,
                        sell_token_address,
                        sell_token,

--- a/deprecated-dune-v1-abstractions/ethereum/gnosis_protocol_v2/insert_trades.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/gnosis_protocol_v2/insert_trades.sql
@@ -191,17 +191,22 @@ END
 $function$;
 
 
--- fill 2021: This is only ever relevant 1 time.
+-- fill 2021: This is only ever relevant for rebuilds
+DELETE FROM gnosis_protocol_v2.trades
+;
+
 SELECT gnosis_protocol_v2.insert_trades(
                '2021-03-03', --! Deployment date
                '2022-01-01'
            )
-WHERE NOT EXISTS(
-        SELECT *
-        FROM gnosis_protocol_v2.trades
-        WHERE block_time >= '2021-03-03'
-          AND block_time < '2022-01-01'
-    );
+           ;
+
+
+-- fill 2022: This is only ever relevant for rebuilds
+SELECT gnosis_protocol_v2.insert_trades(
+               '2022-01-01'
+           )
+           ;
 
 -- For the two cron jobs defined below,
 -- one is intended to back fill lagging price feed (while also including most recent trades).

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -199,7 +199,11 @@ valued_trades as (
                 ELSE NULL::numeric
                END)                                        as fee_usd,
            app_data,
-           receiver,
+           case
+              when receiver = '0x0000000000000000000000000000000000000000'
+              then trader
+              else receiver
+           end                                    as receiver,
            limit_sell_amount,
            limit_buy_amount,
            valid_to,

--- a/models/cow_protocol/gnosis/cow_protocol_gnosis_trades.sql
+++ b/models/cow_protocol/gnosis/cow_protocol_gnosis_trades.sql
@@ -199,7 +199,11 @@ valued_trades as (
                 ELSE NULL::numeric
                END)                                        as fee_usd,
            app_data,
-           receiver,
+           case
+              when receiver = '0x0000000000000000000000000000000000000000'
+              then trader
+              else receiver
+           end                                    as receiver,
            limit_sell_amount,
            limit_buy_amount,
            valid_to,


### PR DESCRIPTION
The smart contract sets the trade receiver as follows:

```
if receiver = ZERO_ADDRESS --> use order owner
```

There are only a handful of these types of orders in the history of the protocol, but enough, that this was causing an issue (not noticed until recently). 

This fixes the receiver field so that it acts like the contract:

https://github.com/cowprotocol/contracts/blob/ff6fb7cad7787b8d43a6468809cacb799601a10e/src/contracts/libraries/GPv2Order.sol#L112-L127

This change requires a complete rebuild of the trades table in both Dune V1 and V2.



