### PR TITLE
Update the prices_tokens model to include the Xen Crypto tokens

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -146,6 +146,7 @@ VALUES
     ("ptp-platypus-finance","avalanche_c","PTP","0x22d4002028f537599be9f666d1c4fa138522f9c8",18),
     ("grape-grape-finance","avalanche_c","GRAPE","0x5541d83efad1f281571b343977648b75d95cdac2",18),
     ("tusd-trueusd","avalanche_c","TUSD","0x1c20e891bab6b1727d14da358fae2984ed9b59eb",18),
+    ("xen-xen-crypto", "avalanche_c", "XEN", "0xC0C5AA69Dbe4d6DDdfBc89c0957686ec60F24389", 18),
 
     ("1inch-1inch", "bnb", "1INCH", "0x111111111117dc0aa78b770fa6a738034120c302", 18),
     ("aave-aave-token", "bnb", "AAVE", "0xfb6115445bff7b52feb98650c87f44907e58f802", 18),
@@ -314,6 +315,7 @@ VALUES
     ("wirtual-wirtual","bnb" ,"WIRTUAL" ,"0xa19d3f4219e2ed6dc1cb595db20f70b8b6866734" ,18),
     ("ape-apecoin", "bnb" ,"APE" ,"0x0b079b33b6e72311c6be245f9f660cc385029fc3",18),
     ("metis-metis-token","bnb" ,"Metis" ,"0xe552fb52a4f19e44ef5a967632dbc320b0820639" ,18),
+    ("xen-xen-crypto", "bnb", "XEN", "0x2AB0e9e4eE70FFf1fB9D67031E44F6410170d00e", 18),
     ("0xbtc-0xbitcoin", "ethereum", "0xBTC", "0xb6ed7644c69416d67b522e20bc294a9a9b405b31", 8),
     ("1inch-1inch", "ethereum", "1INCH", "0x111111111117dc0aa78b770fa6a738034120c302", 18),
     ("aave-new", "ethereum", "AAVE", "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9", 18),
@@ -1608,6 +1610,7 @@ VALUES
     ("gyen-gyen", "ethereum", "ibJPY", "0x5555f75e3d5278082200fb451d1b6ba946d8e13b", 18),
     ("chf-swiss-franc-token", "ethereum", "ibCHF", "0x1cc481ce2bd2ec7bf67d1be64d4878b16078f309", 18),
     ("stmatic-lido-staked-matic", "ethereum", "STMATIC", "0x9ee91F9f426fA633d227f7a9b000E28b9dfd8599", 18),
+    ("xen-xen-crypto", "ethereum", "XEN", "0x06450dEe7FD2Fb8E39061434BAbCFC05599a6Fb8", 18),
 
     -- Query for Popular Traded Tokens on Gnosis Chain without prices: https://dune.com/queries/1719783
     ("dai-dai", "gnosis", "WXDAI", "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d", 18),

--- a/scripts/token_checker.py
+++ b/scripts/token_checker.py
@@ -21,6 +21,7 @@ class TokenChecker:
                              "bnb": "bnb-binance-coin",
                              "polygon": "matic-polygon",
                              "solana": "sol-solana",
+                             "avalanche_c": "avax-avalanche",
                              "ADD MISSING": "CHAINS MAPPINGS HERE"}
 
     def get_token(self):


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Add the Xen Crypto token for Ethereum, Avalanche, and BNB
https://coinpaprika.com/coin/xen-xen-crypto/

**For Dune Engine V2**

I've checked that:

### Pricing checks:
* [X] `coin_id` represents the ID of the coin on coinpaprika.com
* [X] all the coins are active on coinpaprika.com (please remove inactive ones)