### PR TITLE
[Easy] Implement dex aggregator trader labels

### DIFF
--- a/models/labels/dex_aggregator_traders/ethereum/labels_dex_aggregator_traders_ethereum.sql
+++ b/models/labels/dex_aggregator_traders/ethereum/labels_dex_aggregator_traders_ethereum.sql
@@ -1,0 +1,19 @@
+{{config(alias='dex_aggregator_traders_ethereum')}}
+
+with 
+ dex_traders as (
+    select distinct taker as address
+    from {{ref('dex_aggregator_trades')}}
+    where blockchain = 'ethereum'
+  )
+select
+  array("ethereum") as blockchain,
+  address,
+  "DEX Aggregator Trader" AS name,
+  "dex_aggregator_traders" AS category,
+  "gentrexha" AS contributor,
+  "query" AS source,
+  timestamp('2022-12-14') as created_at,
+  now() as updated_at
+from
+  dex_traders

--- a/models/labels/dex_aggregator_traders/labels_dex_aggregator_traders.sql
+++ b/models/labels/dex_aggregator_traders/labels_dex_aggregator_traders.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        alias='dex_aggregator_traders',
+        post_hook='{{ expose_spells(\'["ethereum"]\', "sector", "labels", \'["gentrexha"]\') }}'
+    )
+}}
+
+SELECT * FROM {{ ref('labels_dex_aggregator_traders_ethereum') }}

--- a/models/labels/dex_aggregator_traders/labels_dex_aggregator_traders_schema.yml
+++ b/models/labels/dex_aggregator_traders/labels_dex_aggregator_traders_schema.yml
@@ -1,0 +1,56 @@
+version: 2
+
+models:
+  - name: labels_dex_aggregator_traders
+    meta:
+      blockchain: ethereum
+      sector: labels
+      category: dex_aggregator_traders
+      contributors: gentrexha
+    config:
+      tags: ['labels', 'dex', 'dex_aggregator']
+    description: "DEX traders query labels across chains"
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain"   
+      - &address
+        name: address
+        description: "Address of known DEX Aggregator trader"
+      - &name
+        name: name
+        description: "Label name (DEX Aggregator Trader)"
+      - &category
+        name: category
+        description: "Label category (dex_aggregator_trader)"
+      - &contributor
+        name: contributor
+        description: "Wizard(s) contributing to labels"
+      - &source
+        name: source
+        description: "How were labels generated (query)"
+      - &created_at
+        name: created_at
+        description: "When were labels created"
+      - &updated_at
+        name: updated_at
+        description: "When were labels updated for the last time"
+
+  - name: labels_dex_aggregator_traders_ethereum
+    meta:
+      blockchain: ethereum
+      sector: labels
+      category: dex_aggregator_traders
+      contributors: gentrexha
+    config:
+      tags: ['labels', 'ethereum', 'dex', 'dex_aggregator']
+    description: "DEX Aggregator traders query labels on ethereum"
+    columns:
+      - *blockchain
+      - *address
+      - *name
+      - *category
+      - *contributor
+      - *source
+      - *created_at
+      - *updated_at

--- a/models/labels/dex_traders/ethereum/labels_dex_traders_ethereum.sql
+++ b/models/labels/dex_traders/ethereum/labels_dex_traders_ethereum.sql
@@ -1,0 +1,19 @@
+{{config(alias='dex_traders_ethereum')}}
+
+with 
+ dex_traders as (
+    select distinct taker
+    from dex.trades
+    where blockchain = 'ethereum'
+  )
+select
+  array("ethereum") as blockchain,
+  address,
+  "DEX Trader" AS name,
+  "dex_traders" AS category,
+  "gentrexha" AS contributor,
+  "query" AS source,
+  timestamp('2022-12-14') as created_at,
+  now() as updated_at
+from
+  dex_traders

--- a/models/labels/dex_traders/ethereum/labels_dex_traders_ethereum.sql
+++ b/models/labels/dex_traders/ethereum/labels_dex_traders_ethereum.sql
@@ -3,7 +3,7 @@
 with 
  dex_traders as (
     select distinct taker
-    from dex.trades
+    from {{ref('dex_trades')}}
     where blockchain = 'ethereum'
   )
 select

--- a/models/labels/dex_traders/ethereum/labels_dex_traders_ethereum.sql
+++ b/models/labels/dex_traders/ethereum/labels_dex_traders_ethereum.sql
@@ -2,7 +2,7 @@
 
 with 
  dex_traders as (
-    select distinct taker
+    select distinct taker as address
     from {{ref('dex_trades')}}
     where blockchain = 'ethereum'
   )

--- a/models/labels/dex_traders/labels_dex_traders.sql
+++ b/models/labels/dex_traders/labels_dex_traders.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        alias='dex_traders',
+        post_hook='{{ expose_spells(\'["ethereum"]\', "sector", "labels", \'["gentrexha"]\') }}'
+    )
+}}
+
+SELECT * FROM {{ ref('labels_dex_traders_ethereum') }}

--- a/models/labels/dex_traders/labels_dex_traders_schema.yml
+++ b/models/labels/dex_traders/labels_dex_traders_schema.yml
@@ -1,0 +1,54 @@
+version: 2
+
+models:
+  - name: labels_dex_traders
+    meta:
+      blockchain: ethereum
+      sector: labels
+      category: dex_traders
+      contributors: gentrexha
+    config:
+      tags: ['labels', 'dex']
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain"   
+      - &address
+        name: address
+        description: "Address of known DEX trader"
+      - &name
+        name: name
+        description: "Label name (DEX Trader)"
+      - &category
+        name: category
+        description: "Label category (dex_trader)"
+      - &contributor
+        name: contributor
+        description: "Wizard(s) contributing to labels"
+      - &source
+        name: source
+        description: "How were labels generated (query)"
+      - &created_at
+        name: created_at
+        description: "When were labels created"
+      - &updated_at
+        name: updated_at
+        description: "When were labels updated for the last time"
+
+  - name: labels_dex_traders_ethereum
+    meta:
+      blockchain: ethereum
+      sector: labels
+      category: dex_traders
+      contributors: gentrexha
+    config:
+      tags: ['labels', 'ethereum', 'dex']
+    columns:
+      - *blockchain
+      - *address
+      - *name
+      - *category
+      - *contributor
+      - *source
+      - *created_at
+      - *updated_at

--- a/models/labels/dex_traders/labels_dex_traders_schema.yml
+++ b/models/labels/dex_traders/labels_dex_traders_schema.yml
@@ -9,6 +9,7 @@ models:
       contributors: gentrexha
     config:
       tags: ['labels', 'dex']
+    description: "DEX traders query labels across chains"
     columns:
       - &blockchain
         name: blockchain
@@ -43,6 +44,7 @@ models:
       contributors: gentrexha
     config:
       tags: ['labels', 'ethereum', 'dex']
+    description: "DEX traders query labels on ethereum"
     columns:
       - *blockchain
       - *address


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Adding a dex aggregator trader label for addresses that have completed a trade on a dex aggreagtor.

Tagging @bh2smith  for internal review

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

~~### Pricing checks:~~
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

~~### Join logic:~~
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

~~### Incremental logic:~~
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
