### PR TITLE
[CoW Protocol] Fix AppData <--> OrderUid Mapping

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: "dbt seed --select state:modified --state ."
 
       - name: dbt run initial model(s)
-        run: "dbt -x run --select state:modified --state ."
+        run: "dbt -x run --select state:modified --state . --full-refresh"
 
       - name: dbt test initial model(s)
         run: "dbt test --select state:new state:modified --state ."

--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: "dbt seed --select state:modified --state ."
 
       - name: dbt run initial model(s)
-        run: "dbt -x run --select state:modified --state . --full-refresh"
+        run: "dbt -x run --select state:modified --state ."
 
       - name: dbt test initial model(s)
         run: "dbt test --select state:new state:modified --state ."

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -13,7 +13,7 @@
     )
 }}
 
--- Find the PoC Query here: https://dune.com/queries/1283229
+-- Find the PoC Query here: https://dune.com/queries/1759305
 WITH
 -- First subquery joins buy and sell token prices from prices.usd
 -- Also deducts fee from sell amount

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -22,7 +22,7 @@ trades_with_prices AS (
            evt_block_time            as block_time,
            evt_tx_hash               as tx_hash,
            evt_index,
-           settlement.contract_address          as project_contract_address,
+           trade.contract_address          as project_contract_address,
            owner                     as trader,
            orderUid                  as order_uid,
            sellToken                 as sell_token,
@@ -32,7 +32,7 @@ trades_with_prices AS (
            feeAmount                 as fee_amount,
            ps.price                  as sell_price,
            pb.price                  as buy_price
-    FROM {{ source('gnosis_protocol_v2_ethereum', 'GPv2Settlement_evt_Trade') }} settlement
+    FROM {{ source('gnosis_protocol_v2_ethereum', 'GPv2Settlement_evt_Trade') }} trade
              LEFT OUTER JOIN {{ source('prices', 'usd') }} as ps
                              ON sellToken = ps.contract_address
                                  AND ps.minute = date_trunc('minute', evt_block_time)
@@ -97,57 +97,54 @@ trades_with_token_units as (
                                     END)
 ),
 -- This, independent, aggregation defines a mapping of order_uid and trade
--- TODO - create a view for the following block mapping uid to app_data
-order_ids as (
-    select evt_tx_hash, collect_list(orderUid) as order_ids
-    from (  select orderUid, evt_tx_hash, evt_index
-            from {{ source('gnosis_protocol_v2_ethereum', 'GPv2Settlement_evt_Trade') }}
-             {% if is_incremental() %}
-             where evt_block_time >= date_trunc("day", now() - interval '1 week')
-             {% endif %}
-                     sort by evt_index
-         ) as _
-    group by evt_tx_hash
-),
-
-exploded_order_ids as (
-    select evt_tx_hash, posexplode(order_ids)
-    from order_ids
-),
-
-reduced_order_ids as (
+sorted_orders as (
     select
-        col as order_id,
-        -- This is a dirty hack!
-        collect_list(evt_tx_hash)[0] as evt_tx_hash,
-        collect_list(pos)[0] as pos
-    from exploded_order_ids
-    group by order_id
+        evt_tx_hash,
+        evt_block_number,
+        collect_list(orderUid) as order_ids
+    from (
+        select
+            evt_tx_hash,
+            evt_block_number,
+            orderUid
+        from gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Trade
+        {% if is_incremental() %}
+        WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
+        distribute by
+            evt_tx_hash, evt_block_number
+        sort by
+            evt_index
+    )
+    group by evt_tx_hash, evt_block_number
 ),
 
-trade_data as (
-    select call_tx_hash,
-           posexplode(trades)
-    from {{ source('gnosis_protocol_v2_ethereum', 'GPv2Settlement_call_settle') }}
-    where call_success = true
-    {% if is_incremental() %}
-    AND call_block_time >= date_trunc("day", now() - interval '1 week')
-    {% endif %}
+orders_and_trades as (
+    select
+        evt_tx_hash,
+        trades,
+        order_ids
+    from sorted_orders
+    inner join {{ source('gnosis_protocol_v2_ethereum', 'GPv2Settlement_call_settle') }}
+        on evt_block_number = call_block_number
+        and evt_tx_hash = call_tx_hash
+-- this is implied by the inner join
+--      and call_success = true
 ),
 
 uid_to_app_id as (
     select
-        order_id as uid,
-        get_json_object(trades.col, '$.appData') as app_data,
-        get_json_object(trades.col, '$.receiver') as receiver,
-        get_json_object(trades.col, '$.sellAmount') as limit_sell_amount,
-        get_json_object(trades.col, '$.buyAmount') as limit_buy_amount,
-        get_json_object(trades.col, '$.validTo') as valid_to,
-        get_json_object(trades.col, '$.flags') as flags
-    from reduced_order_ids order_ids
-             join trade_data trades
-                  on evt_tx_hash = call_tx_hash
-                      and order_ids.pos = trades.pos
+        uid,
+        get_json_object(trade, '$.appData') as app_data,
+        get_json_object(trade, '$.receiver') as receiver,
+        get_json_object(trade, '$.sellAmount') as limit_sell_amount,
+        get_json_object(trade, '$.buyAmount') as limit_buy_amount,
+        get_json_object(trade, '$.validTo') as valid_to,
+        get_json_object(trade, '$.flags') as flags
+    from orders_and_trades
+        lateral view posexplode(order_ids) o as i, uid
+        lateral view posexplode(trades) t as j, trade
+    where i = j
 ),
 
 valued_trades as (

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -134,7 +134,7 @@ orders_and_trades as (
 -- Validate Uid <--> app_data mapping here: https://dune.com/queries/1759039?d=1
 uid_to_app_id as (
     select
-        uid,
+        distinct uid,
         get_json_object(trade, '$.appData') as app_data,
         get_json_object(trade, '$.receiver') as receiver,
         get_json_object(trade, '$.sellAmount') as limit_sell_amount,

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -131,7 +131,7 @@ orders_and_trades as (
 -- this is implied by the inner join
 --      and call_success = true
 ),
-
+-- Validate Uid <--> app_data mapping here: https://dune.com/queries/1759039?d=1
 uid_to_app_id as (
     select
         uid,


### PR DESCRIPTION
We have recently discovered a bug in the OrderUid <--> AppData Mapping constructed as a combination of call data and event data for our trades table (it was known that this was a "dirty hack" of a query before and we finally came back to fix it).

This can be tested by examining the [PoC Sub Query](https://dune.com/queries/1759039?d=1) for [this Ethereum Transaction](https://etherscan.io/tx/0x828bad1003f0bb44cdf8a0eabe65dac57e81592c58f952a36d3f96e26a1cee0b#eventlog) 

Namely, that the [Trade Event Logs](https://etherscan.io/tx/0x828bad1003f0bb44cdf8a0eabe65dac57e81592c58f952a36d3f96e26a1cee0b#eventlog) align with the Input Data:

<img width="1277" alt="Screenshot 2022-12-14 at 20 49 13" src="https://user-images.githubusercontent.com/11778116/207699946-eed70ea2-1d84-4495-a79b-783af710f9fd.png">

The subqeury link above shows only the mapping for a given tx hash (with default as the one shown here). It is also linked directly in the SQL file update here.

We also update the [PoC Trade Query](https://dune.com/queries/1759305?start_ts_d83555=2022-05-13+00%3A00%3A00&end_ts_d83555=2022-05-15+00%3A00%3A00) (in the code as well because it had not been updated in a while).


cc @gentrexha and @josojo  for internal review.


# Additional Note

This bug would require a complete table rebuild.