### PR TITLE
Hide more views on DuneSQL

### DIFF
--- a/models/aztec/ethereum/aztec_v2_ethereum_daily_bridge_activity.sql
+++ b/models/aztec/ethereum/aztec_v2_ethereum_daily_bridge_activity.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'aztec_v2_ethereum',
     alias = 'daily_bridge_activity',
-    post_hook='{{ expose_spells(\'["ethereum"]\',
+    post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                 "project",
                                 "aztec_v2",
                                 \'["Henrystats"]\') }}'

--- a/models/aztec/ethereum/aztec_v2_ethereum_daily_deposits.sql
+++ b/models/aztec/ethereum/aztec_v2_ethereum_daily_deposits.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'aztec_v2_ethereum',
     alias = 'daily_deposits',
-    post_hook='{{ expose_spells(\'["ethereum"]\',
+    post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                 "project",
                                 "aztec_v2",
                                 \'["Henrystats"]\') }}'

--- a/models/aztec/ethereum/aztec_v2_ethereum_daily_estimated_rollup_tvl.sql
+++ b/models/aztec/ethereum/aztec_v2_ethereum_daily_estimated_rollup_tvl.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'aztec_v2_ethereum',
     alias = 'daily_estimated_rollup_tvl',
-    post_hook='{{ expose_spells(\'["ethereum"]\',
+    post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                 "project",
                                 "aztec_v2",
                                 \'["Henrystats"]\') }}'

--- a/models/bridge/bridge_flows.sql
+++ b/models/bridge/bridge_flows.sql
@@ -1,7 +1,7 @@
 {{ config(
         schema = 'bridge',
         alias ='flows',
-        post_hook='{{ expose_spells(\'["optimism"]\',
+        post_hook='{{ expose_spells_hide_trino(\'["optimism"]\',
                                 "sector",
                                 "bridge",
                                 \'["msilb7","soispoke]\') }}'

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
@@ -1,5 +1,5 @@
 {{ config(alias='app_data',
-        post_hook='{{ expose_spells(\'["ethereum"]\',
+        post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                     "project",
                                     "cow_protocol",
                                     \'["bh2smith"]\') }}'

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_order_rewards.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_order_rewards.sql
@@ -1,5 +1,5 @@
 {{ config(alias='order_rewards',
-        post_hook='{{ expose_spells(\'["ethereum"]\',
+        post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                     "project",
                                     "cow_protocol",
                                     \'["bh2smith"]\') }}'

--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_current_bids.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_current_bids.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='current_bids',
         unique_key='punk_id',
-        post_hook='{{ expose_spells(\'["ethereum"]\',
+        post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                     "project",
                                     "cryptopunks",
                                     \'["cat"]\') }}'


### PR DESCRIPTION
I found more spell views that are not compatible with Trino. These tables were not stored in our Metastore with `dune.data_explorer.category = abstraction` as we expected it to be for a spell, but with `dune.data_explorer.abstraction.name=<project>` instead.