### PR TITLE
swap macro to hide model in trino

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
@@ -1,5 +1,5 @@
 {{ config(alias='app_data',
-        post_hook='{{ expose_spells(\'["ethereum"]\',
+        post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                     "project",
                                     "cow_protocol",
                                     \'["bh2smith"]\') }}'


### PR DESCRIPTION
Brief comments on the purpose of your changes:

The underlying community data is not queryable in trino/dune sql at the moment. We are working to fix this issue but for now we will hide it from the data explorer. 