### PR TITLE
Closes T-22435 : Unblock nft.linked_addresses

### DIFF
--- a/models/nft/nft_linked_addresses.sql
+++ b/models/nft/nft_linked_addresses.sql
@@ -8,14 +8,15 @@
     post_hook='{{ expose_spells(\'["ethereum","solana"]\',
                                 "sector",
                                 "nft",
-                                \'["springzh"]\') }}'
+                                \'["springzh","0xRob"]\') }}'
     )
 }}
 
 
 select distinct blockchain,
     case when buyer <= seller then buyer else seller end as master_address,
-    case when buyer <= seller then seller else buyer end as alternative_address
+    case when buyer <= seller then seller else buyer end as alternative_address,
+    max(block_time) as last_trade
 from {{ ref('nft_trades') }}
 where buyer is not null
     and seller is not null
@@ -23,3 +24,4 @@ where buyer is not null
 {% if is_incremental() %}
 and block_time >= date_trunc("day", now() - interval '1 week')
 {% endif %}
+GROUP BY 1,2,3

--- a/models/nft/nft_schema.yml
+++ b/models/nft/nft_schema.yml
@@ -351,11 +351,11 @@ models:
     meta:
       blockchain: ethereum, solana
       sector: nft
-      contributors: springzh
+      contributors: springzh, 0xRob
     config:
       tags: ['nft', 'opensea', 'looksrare', 'x2y2', 'magiceden', 'sudoswap', 'ethereum', 'solana', 'address']
     description: >
-        NFT linked addresses. Addresses that buy and sell NFTs from each other.
+        NFT linked addresses. Addresses that buy and sell NFTs from each other. By definition (master address < alt address) alphabetically.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -368,6 +368,8 @@ models:
         description: "Master address"
       - name: alternative_address
         description: "Alternative address"
+      - name: last_interaction
+        description: "block_time of the last trade between the pair"
 
 
   - name: nft_transfers


### PR DESCRIPTION
This adds a new column to nft.linked_addresses, `last_trade` which is updated on the incremental run. 
This change should fix the dbt run of this model. 