### PR TITLE
[CoW Protocol] Add spell for "Unpacked" ETHFlow Orders

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_eth_flow_orders.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_eth_flow_orders.sql
@@ -1,0 +1,50 @@
+{{  config(
+        alias='eth_flow_orders',
+        materialized='incremental',
+        partition_by = ['placement_date'],
+        unique_key = ['tx_hash'],
+        on_schema_change='sync_all_columns',
+        file_format ='delta',
+        incremental_strategy='merge',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "project",
+                                    "cow_protocol",
+                                    \'["bh2smith"]\') }}'
+    )
+}}
+
+-- PoC Query: https://dune.com/queries/1762226
+with
+eth_flow_orders as (
+    select
+        sender,
+        cast(date_trunc('day', evt_block_time) as date) as block_date,
+        evt_block_time as block_time,
+        evt_block_number as block_number,
+        evt_tx_hash as tx_hash,
+        -- This validity is always infinite. Instead we unpack this from the data field.
+        -- from_unixtime(get_json_object(event.order, '$.validTo')) as valid_to,
+        from_unixtime(conv(substring(data, 19, 8), 16, 10)) as valid_to,
+        conv(substring(data, 3, 16), 16, 10) as quote_id,
+        -- These are unpacked so to hopefully make the join on trade events more efficient.
+        get_json_object(event.order, '$.sellAmount') as sell_amount,
+        get_json_object(event.order, '$.feeAmount') as fee_amount,
+        -- Additional potentially relevant fields (for unfilled orders)
+        get_json_object(event.order, '$.buyAmount') as buy_amount,
+        get_json_object(event.order, '$.buyToken') as buy_token,
+        get_json_object(event.order, '$.receiver') as receiver,
+        get_json_object(event.order, '$.appData') as app_hash,
+        -- OrderHash returned by createOrder with excluded fix values (owner = contract_address, validTo = max u32)
+        -- https://github.com/cowprotocol/ethflowcontract/blob/9c74c8ba36ff9ff3e255172b02454f831c066865/src/CoWSwapEthFlow.sol#L81-L84
+        concat(output_orderHash, substring(event.contract_address, 3, 40), 'ffffffff') as order_uid
+    from {{ source('cow_protocol_ethereum', 'CoWSwapEthFlow_evt_OrderPlacement') }} event
+    inner join {{ source('cow_protocol_ethereum', 'CoWSwapEthFlow_call_createOrder') }} call
+        on call_block_number = evt_block_number
+        and call_tx_hash = evt_tx_hash
+        and call_success = true
+    {% if is_incremental() %}
+    WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
+)
+
+select * from eth_flow_orders

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_sources.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_sources.yml
@@ -1,6 +1,6 @@
 version: 2
 
-sources: 
+sources:
   - name: gnosis_protocol_v2_ethereum
     description: "Ethereum decoded tables related to CoW Protocol contract"
     tables:
@@ -133,3 +133,39 @@ sources:
           - name: tx_hash
           - name: data
           - name: order_uid
+  - name: cow_protocol_ethereum
+    description: "Ethereum decoded tables related to CoW Protocol contract's"
+    tables:
+      - name: CoWSwapEthFlow_evt_OrderPlacement
+        description: "CoWSwapEthFlow Order Placement Events"
+        columns:
+          - *contract_address
+          - *evt_block_number
+          - *evt_block_time
+          - *evt_index
+          - *evt_tx_hash
+          - &order
+            name: order
+            description: "Contains json encoded data for an EthFlowOrder: https://github.com/cowprotocol/ethflowcontract/blob/main/src/libraries/EthFlowOrder.sol#L19-L45"
+          - &data
+            name: data
+            description: "Hex Encoded data containing quoteId and validTo: https://github.com/cowprotocol/ethflowcontract/blob/9c74c8ba36ff9ff3e255172b02454f831c066865/src/CoWSwapEthFlow.sol#L110-L113"
+          - &sender
+            name: sender
+            description: "User who placed the order"
+          - &signature
+            name: signature
+            description: "Onchain EIP1271 signature"
+      - name: CoWSwapEthFlow_call_createOrder
+        description: "CoWSwapEthFlow createOrder function calls with input parameters and return value"
+        columns:
+          - *call_block_number
+          - *call_block_time
+          - *call_success
+          - *call_trace_address
+          - *call_tx_hash
+          - *contract_address
+          - *order
+          - &output_orderHash
+            name: output_orderHash
+            description: "ETH Flow Order Hash corresponds directly to a GPv2 Order Uid by concatenation with owner = contract_address and validTo = `ffffffff`"


### PR DESCRIPTION
Recent deployment and indexing of the ETHFlow contract events and functions give us access to this order data, but unpacking all the encoded structures in every query is painful and repetitive. This table (designed with an incremental merge strategy), makes it more convenient to access relevant ETHFlow Orders

[PoC Query](https://dune.com/queries/1762226)

** Note that ** I am not entirely sure if the incremental merge a strategy is the correct approach here... please let me know.

cc @josojo  and @gentrexha  for internal review.