### PR TITLE
Chore: update Reserve Rights token address

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -613,7 +613,6 @@ VALUES
     ("rndr-render-token", "ethereum", "RNDR", "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24", 18),
     ("rook-keeperdao", "ethereum", "ROOK", "0xfa5047c9c78b8877af97bdcb85db743fd7313d4a", 18),
     ("rpl-rocket-pool", "ethereum", "RPL", "0xb4efd85c19999d84251304bda99e90b92300bd93", 18),
-    ("rsr-reserve-rights", "ethereum", "RSR", "0x320623b8e4ff03373931769a31fc52a4e78b5d70", 18),
     ("sai-single-collateral-dai", "ethereum", "SAI", "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359", 18),
     ("salt-salt", "ethereum", "SALT", "0x4156d3342d5c385a87d264f90653733592000581", 8),
     ("san-santiment-network-token", "ethereum", "SAN", "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098", 18),

--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -613,7 +613,7 @@ VALUES
     ("rndr-render-token", "ethereum", "RNDR", "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24", 18),
     ("rook-keeperdao", "ethereum", "ROOK", "0xfa5047c9c78b8877af97bdcb85db743fd7313d4a", 18),
     ("rpl-rocket-pool", "ethereum", "RPL", "0xb4efd85c19999d84251304bda99e90b92300bd93", 18),
-    ("rsr-reserve-rights", "ethereum", "RSR", "0x8762db106b2c2a0bccb3a80d1ed41273552616e8", 18),
+    ("rsr-reserve-rights", "ethereum", "RSR", "0x320623b8e4ff03373931769a31fc52a4e78b5d70", 18),
     ("sai-single-collateral-dai", "ethereum", "SAI", "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359", 18),
     ("salt-salt", "ethereum", "SALT", "0x4156d3342d5c385a87d264f90653733592000581", 8),
     ("san-santiment-network-token", "ethereum", "SAN", "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098", 18),


### PR DESCRIPTION
RSR token address is updated. See below recent DEX activity for RSR linked to the new address and the stale activity for the old token.

New:
![image](https://user-images.githubusercontent.com/71284258/208220965-aeb6fb64-aa34-4653-8fe9-37d0939051f7.png)
 
Old:
![image](https://user-images.githubusercontent.com/71284258/208221049-28edbcac-ab84-40a3-9f91-2954990684c9.png)
