### PR TITLE
OP Curve - Fix Metapool Decimals

### DIFF
--- a/models/curvefi/optimism/curvefi_optimism_trades.sql
+++ b/models/curvefi/optimism/curvefi_optimism_trades.sql
@@ -143,14 +143,16 @@ SELECT DISTINCT
         when lower(COALESCE(erc20a.symbol,p_bought.symbol)) > lower(COALESCE(erc20b.symbol,p_sold.symbol)) then concat(COALESCE(erc20b.symbol,p_sold.symbol), '-', COALESCE(erc20a.symbol,p_bought.symbol))
         else concat(COALESCE(erc20a.symbol,p_bought.symbol), '-', COALESCE(erc20b.symbol,p_sold.symbol))
     end as token_pair,
-    --metapools seem to always use the added coin's decimals if it's the one that's bought - even if the other token has less decimals (i.e. USDC)
-    dexs.token_bought_amount_raw / POWER(10 , (CASE WHEN pool_type = 'meta' AND bought_id = 0 THEN COALESCE(erc20b.decimals,p_sold.decimals) ELSE COALESCE(erc20a.decimals,p_bought.decimals) END) ) AS token_bought_amount,
+    --On Sell: Metapools seem to always use the added coin's decimals if it's the one that's bought - even if the other token has less decimals (i.e. USDC)
+    --On Buy: Metapools seem to always use the curve pool token's decimals (18) if bought_id = 0
+    dexs.token_bought_amount_raw / POWER(10 , (CASE WHEN pool_type = 'meta' AND bought_id = 0 THEN 18 ELSE COALESCE(erc20a.decimals,p_bought.decimals) END) ) AS token_bought_amount,
     dexs.token_sold_amount_raw / POWER(10 , (CASE WHEN pool_type = 'meta' AND bought_id = 0 THEN COALESCE(erc20a.decimals,p_bought.decimals) ELSE COALESCE(erc20b.decimals,p_sold.decimals) END) )  AS token_sold_amount,
     dexs.token_bought_amount_raw,
     dexs.token_sold_amount_raw,
     coalesce(
-	    --metapools seem to always use the added coin's decimals if it's the one that's bought - even if the other token has less decimals (i.e. USDC)
-        dexs.token_bought_amount_raw / POWER(10 , CASE WHEN pool_type = 'meta' AND bought_id = 0 THEN COALESCE(erc20b.decimals,p_sold.decimals) ELSE COALESCE(erc20a.decimals,p_bought.decimals) END) * p_bought.price,
+	    --On Sell: Metapools seem to always use the added coin's decimals if it's the one that's bought - even if the other token has less decimals (i.e. USDC)
+	    --On Buy: Metapools seem to always use the curve pool token's decimals (18) if bought_id = 0
+        dexs.token_bought_amount_raw / POWER(10 , CASE WHEN pool_type = 'meta' AND bought_id = 0 THEN 18 ELSE COALESCE(erc20a.decimals,p_bought.decimals) END) * p_bought.price,
         dexs.token_sold_amount_raw / POWER(10 , CASE WHEN pool_type = 'meta' AND bought_id = 0 THEN COALESCE(erc20a.decimals,p_bought.decimals) ELSE COALESCE(erc20b.decimals,p_sold.decimals) END) * p_sold.price
     ) as amount_usd,
     dexs.token_bought_address,


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Query checking the fix: https://dune.com/queries/1772295

Metapools on Curve seem to just use the curve pool's decimals (18) on the buy side, even if the token bought has < 18 decimals.

This should drop and replace all curve trades & downstream tables (i.e dex.trades)

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
