### PR TITLE
Revert "Blur trade tokenid fix & several platform_fee_percentage typo…

### DIFF
--- a/models/archipelago/ethereum/archipelago_ethereum_schema.yml
+++ b/models/archipelago/ethereum/archipelago_ethereum_schema.yml
@@ -81,7 +81,7 @@ models:
         name: platform_fee_amount
         description:  "Platform fee amount in original token currency (properly formatted in decimals)"
       - &platform_fee_percentage
-        name: platform_fee_percentage
+        name: platform_fee_amount_usd
         description:  "Platform fee in % of the amount paid for a given trade"
       - &royalty_fee_amount_raw
         name: royalty_fee_amount_raw

--- a/models/blur/ethereum/blur_ethereum_events.sql
+++ b/models/blur/ethereum/blur_ethereum_events.sql
@@ -20,7 +20,7 @@ SELECT
     , date_trunc('day', bm.evt_block_time) AS block_date
     , bm.evt_block_time AS block_time
     , bm.evt_block_number AS block_number
-    , get_json_object(bm.sell, '$.tokenId') AS token_id
+    , get_json_object(bm.buy, '$.tokenId') AS token_id
     , erct.token_standard
     , nft.name AS collection
     , CASE WHEN get_json_object(bm.buy, '$.amount')=1 THEN 'Single Item Trade'
@@ -95,7 +95,7 @@ LEFT JOIN {{ ref('tokens_ethereum_nft') }} nft ON get_json_object(bm.buy, '$.col
 LEFT JOIN {{ ref('nft_ethereum_transfers') }} erct ON erct.block_time=bm.evt_block_time
     AND get_json_object(bm.buy, '$.collection')=erct.contract_address
     AND erct.tx_hash=bm.evt_tx_hash
-    AND get_json_object(bm.sell, '$.tokenId')=erct.token_id
+    AND get_json_object(bm.buy, '$.tokenId')=erct.token_id
     AND erct.from=get_json_object(bm.sell, '$.trader')
     {% if not is_incremental() %}
     AND erct.block_time >= '{{project_start_date}}'
@@ -106,7 +106,7 @@ LEFT JOIN {{ ref('nft_ethereum_transfers') }} erct ON erct.block_time=bm.evt_blo
 LEFT JOIN {{ ref('nft_ethereum_transfers') }} buyer_fix ON buyer_fix.block_time=bm.evt_block_time
     AND get_json_object(bm.buy, '$.collection')=buyer_fix.contract_address
     AND buyer_fix.tx_hash=bm.evt_tx_hash
-    AND get_json_object(bm.sell, '$.tokenId')=buyer_fix.token_id
+    AND get_json_object(bm.buy, '$.tokenId')=buyer_fix.token_id
     AND get_json_object(bm.buy, '$.trader')=agg.contract_address
     AND buyer_fix.from=agg.contract_address
     {% if not is_incremental() %}
@@ -118,7 +118,7 @@ LEFT JOIN {{ ref('nft_ethereum_transfers') }} buyer_fix ON buyer_fix.block_time=
 LEFT JOIN {{ ref('nft_ethereum_transfers') }} seller_fix ON seller_fix.block_time=bm.evt_block_time
     AND get_json_object(bm.buy, '$.collection')=seller_fix.contract_address
     AND seller_fix.tx_hash=bm.evt_tx_hash
-    AND get_json_object(bm.sell, '$.tokenId')=seller_fix.token_id
+    AND get_json_object(bm.buy, '$.tokenId')=seller_fix.token_id
     AND get_json_object(bm.sell, '$.trader')=agg.contract_address
     AND seller_fix.to=agg.contract_address
     {% if not is_incremental() %}

--- a/models/blur/ethereum/blur_ethereum_schema.yml
+++ b/models/blur/ethereum/blur_ethereum_schema.yml
@@ -99,7 +99,7 @@ models:
         name: platform_fee_amount_usd
         description:  "Platform fee amount in USD"
       - &platform_fee_percentage
-        name: platform_fee_percentage
+        name: platform_fee_amount_usd
         description:  "Platform fee in % of the amount paid for a given trade"
       - &royalty_fee_amount_raw
         name: royalty_fee_amount_raw

--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_schema.yml
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_schema.yml
@@ -108,7 +108,7 @@ models:
         name: platform_fee_amount_usd
         description: "Platform fee amount in USD"
       - &platform_fee_percentage
-        name: platform_fee_percentage
+        name: platform_fee_amount_usd
         description: "Platform fee in % of the amount paid for a given trade"
       - &royalty_fee_amount_raw
         name: royalty_fee_amount_raw

--- a/models/element/element_schema.yml
+++ b/models/element/element_schema.yml
@@ -99,7 +99,7 @@ models:
         name: platform_fee_amount_usd
         description:  "Platform fee amount in USD"
       - &platform_fee_percentage
-        name: platform_fee_percentage
+        name: platform_fee_amount_usd
         description:  "Platform fee in % of the amount paid for a given trade"
       - &royalty_fee_amount_raw
         name: royalty_fee_amount_raw

--- a/models/foundation/ethereum/foundation_ethereum_schema.yml
+++ b/models/foundation/ethereum/foundation_ethereum_schema.yml
@@ -102,7 +102,7 @@ models:
         name: platform_fee_amount_usd
         description:  "Platform fee amount in USD"
       - &platform_fee_percentage
-        name: platform_fee_percentage
+        name: platform_fee_amount_usd
         description:  "Platform fee in % of the amount paid for a given trade"
       - &royalty_fee_amount_raw
         name: royalty_fee_amount_raw

--- a/models/looksrare/ethereum/looksrare_ethereum_schema.yml
+++ b/models/looksrare/ethereum/looksrare_ethereum_schema.yml
@@ -99,7 +99,7 @@ models:
         name: platform_fee_amount_usd
         description:  "Platform fee amount in USD"
       - &platform_fee_percentage
-        name: platform_fee_percentage
+        name: platform_fee_amount_usd
         description:  "Platform fee in % of the amount paid for a given trade"
       - &royalty_fee_amount_raw
         name: royalty_fee_amount_raw

--- a/models/magiceden/magiceden_schema.yml
+++ b/models/magiceden/magiceden_schema.yml
@@ -99,7 +99,7 @@ models:
         name: platform_fee_amount_usd
         description:  "Platform fee amount in USD"
       - &platform_fee_percentage
-        name: platform_fee_percentage
+        name: platform_fee_amount_usd
         description:  "Platform fee in % of the amount paid for a given trade"
       - &royalty_fee_amount_raw
         name: royalty_fee_amount_raw

--- a/models/opensea/opensea_schema.yml
+++ b/models/opensea/opensea_schema.yml
@@ -99,7 +99,7 @@ models:
         name: platform_fee_amount_usd
         description:  "Platform fee amount in USD"
       - &platform_fee_percentage
-        name: platform_fee_percentage
+        name: platform_fee_amount_usd
         description:  "Platform fee in % of the amount paid for a given trade"
       - &royalty_fee_amount_raw
         name: royalty_fee_amount_raw

--- a/models/superrare/superrare_ethereum_schema.yml
+++ b/models/superrare/superrare_ethereum_schema.yml
@@ -99,7 +99,7 @@ models:
         name: platform_fee_amount_usd
         description:  "Platform fee amount in USD"
       - &platform_fee_percentage
-        name: platform_fee_percentage
+        name: platform_fee_amount_usd
         description:  "Platform fee in % of the amount paid for a given trade"
       - &superrare_sale_type
         name: superrare_sale_type

--- a/models/zora/ethereum/zora_ethereum_schema.yml
+++ b/models/zora/ethereum/zora_ethereum_schema.yml
@@ -99,7 +99,7 @@ models:
         name: platform_fee_amount_usd
         description:  "Platform fee amount in USD"
       - &platform_fee_percentage
-        name: platform_fee_percentage
+        name: platform_fee_amount_usd
         description:  "Platform fee in % of the amount paid for a given trade"
       - &royalty_fee_amount_raw
         name: royalty_fee_amount_raw


### PR DESCRIPTION
… fix (#2348)"

This reverts commit 278fc04e9fa8eabeca08068b05b012db38e7795a.

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
