### PR TITLE
[CoW - HotFix] Deduplicate Order Rewards

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_order_rewards.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_order_rewards.sql
@@ -7,9 +7,9 @@
 
 -- PoC Query here - https://dune.com/queries/1752782
 select
+    distinct order_uid,
     tx_hash,
-    solver as solver_address,
+    solver,
     data.amount as cow_reward,
-    cast(data.surplus_fee as double) as surplus_fee,
-    order_uid
+    cast(data.surplus_fee as double) as surplus_fee
 from {{ source('cowswap', 'raw_order_rewards') }}


### PR DESCRIPTION
Turns out the entire rewards table has been duplicated... This query prevents that from making its way into our queries (although we will continue to debug the root cause as well).