### PR TITLE
[CoW] Update trader ETH Flow orders

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_eth_flow_orders.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_eth_flow_orders.sql
@@ -48,18 +48,4 @@ eth_flow_orders as (
     {% endif %}
 )
 
-select
-  block_date,
-  block_time,
-  block_number,
-  tx_hash,
-  valid_to,
-  quote_id,
-  sell_amount,
-  fee,
-  buy_amount,
-  buy_token,
-  receiver,
-  app_hash,
-  order_uid
-from eth_flow_orders
+select * from eth_flow_orders

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -251,5 +251,8 @@ models:
         description: buy amount as part of the signed user order
       - *buy_token
       - *receiver
+      - &sender
+        name: sender
+        description: sender of order placement transaction. Equivalent to "trader"
       - *app_hash
       - *order_uid

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -13,7 +13,7 @@
     )
 }}
 
--- Find the PoC Query here: https://dune.com/queries/1759305
+-- Find the PoC Query here: https://dune.com/queries/1779431
 WITH
 -- First subquery joins buy and sell token prices from prices.usd
 -- Also deducts fee from sell amount
@@ -147,14 +147,31 @@ uid_to_app_id as (
     where i = j
 ),
 
+eth_flow_senders as (
+    select
+        sender,
+        concat(output_orderHash, substring(event.contract_address, 3, 40), 'ffffffff') as order_uid
+    from {{ source('cow_protocol_ethereum', 'CoWSwapEthFlow_evt_OrderPlacement') }} event
+    inner join {{ source('cow_protocol_ethereum', 'CoWSwapEthFlow_call_createOrder') }} call
+        on call_block_number = evt_block_number
+        and call_tx_hash = evt_tx_hash
+        and call_success = true
+    {% if is_incremental() %}
+    WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')
+    AND call_block_time >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
+),
+
+
 valued_trades as (
     SELECT block_date,
            block_time,
            tx_hash,
            evt_index,
            project_contract_address,
-           order_uid,
-           trader,
+           trades.order_uid,
+           -- ETH Flow orders have trader = sender of orderCreation.
+           case when sender is not null then sender else trader end as trader,
            sell_token_address,
            sell_token,
            buy_token_address,
@@ -205,9 +222,11 @@ valued_trades as (
            limit_buy_amount,
            valid_to,
            flags
-    FROM trades_with_token_units
-             JOIN uid_to_app_id
-                  ON uid = order_uid
+    FROM trades_with_token_units trades
+    JOIN uid_to_app_id
+        ON uid = order_uid
+    LEFT OUTER JOIN eth_flow_senders efs
+        ON trades.order_uid = efs.order_uid
 )
 
 select * from valued_trades

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -173,7 +173,7 @@ valued_trades as (
            -- ETH Flow orders have trader = sender of orderCreation.
            case when sender is not null then sender else trader end as trader,
            sell_token_address,
-           sell_token,
+           case when sender is not null then 'ETH' else sell_token end as sell_token,
            buy_token_address,
            buy_token,
            case


### PR DESCRIPTION
We forgot to include the sender column in the `eth_flow` orders table. This PR changes the trader column to the sender of the ETH flow orderCreation. Otherwise the trader is shown "incorrectly" as the ETH Flow contract itself.

We also change the `sell_token` to ETH instead of what looks like WETH.

Check out the [POC query](https://dune.com/queries/1779431) on 

```sh
order_uid=0xb7e1f2599dd2268cd98f9fff203ec4d94ac9f5f0be86a2986bf9d6816e78e89f40a50cf069e992aa4536211b23f286ef88752187ffffffff
```

or any order_uid ending with `ffffffff`

 and validate that the `sender` address is NOT either of 
 
 ```
'0xd02de8da0b71e1b59489794f423fabba2adc4d93' 
'0x40a50cf069e992aa4536211b23f286ef88752187'
```


cc @josojo and @gentrexha for internal review.