### PR TITLE
freshness check

### DIFF
--- a/.github/workflows/dbt_precommit_hooks.yml
+++ b/.github/workflows/dbt_precommit_hooks.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           format: space-delimited
           token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
       - name: Set modfied and added files as arg
         run: |
           echo "FILES=$(echo ${{ steps.abc.outputs.added_modified }})" >> $GITHUB_ENV

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_stages: [push, manual]
 exclude: ^deprecated-dune-v1-abstractions/
 repos:
-- repo: https://github.com/duneanalytics/pre-commit-dbt
+- repo: https://github.com/offbi/pre-commit-dbt
   rev: v1.0.0
   hooks:
   - id: dbt-compile

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_stages: [push, manual]
 exclude: ^deprecated-dune-v1-abstractions/
 repos:
-- repo: https://github.com/offbi/pre-commit-dbt
+- repo: https://github.com/duneanalytics/pre-commit-dbt
   rev: v1.0.0
   hooks:
   - id: dbt-compile

--- a/tests/dex/dex_trades_assert_freshness.sql
+++ b/tests/dex/dex_trades_assert_freshness.sql
@@ -1,0 +1,63 @@
+with delays as (
+    SELECT
+        project
+        , blockchain
+        , datediff(now(), max(block_time)) age_of_last_record_days
+    from {{ ref('dex_trades') }}
+    group by 1,2
+)
+
+, sources as
+-- Add sources for decoded projects where trades may not happen daily
+(
+select
+        'fraxswap' as project
+        , 'avalanche_c' as blockchain
+        , datediff(now(), max(evt_block_time)) age_of_last_record_days
+ from {{ source('fraxswap_avalanche_c', 'FraxswapPair_evt_Swap') }}
+ group by 1,2
+ union
+ select
+        'fraxswap' as project
+        , 'bnb' as blockchain
+        , datediff(now(), max(evt_block_time)) age_of_last_record_days
+ from {{ source('fraxswap_bnb','FraxswapPair_evt_Swap') }}
+ group by 1,2
+  union
+ select
+        'dfx' as project
+        , 'ethereum' as blockchain
+        , datediff(now(), max(evt_block_time)) age_of_last_record_days
+ from {{ source('dfx_finance_ethereum','Curve_evt_Trade') }}
+ group by 1,2
+   union
+ select
+        'hashflow' as project
+        , 'ethereum' as blockchain
+        , datediff(now(), max(evt_block_time)) age_of_last_record_days
+ from {{ source('hashflow_ethereum','pool_evt_trade') }}
+ group by 1,2
+    union
+ select
+        'hashflow' as project
+        , 'avalanche_c' as blockchain
+        , datediff(now(), max(evt_block_time)) age_of_last_record_days
+ from {{ source('hashflow_avalanche_c','Pool_evt_Trade') }}
+ group by 1,2
+      union
+ select
+        'zigzag' as project
+        , 'arbitrum' as blockchain
+        , datediff(now(), max(call_block_time)) age_of_last_record_days
+ from {{ source('zigzag_test_v6_arbitrum','zigzag_settelment_call_matchOrders') }}
+ group by 1,2
+)
+
+select
+    d.project,
+    d.blockchain,
+    coalesce(s.age_of_last_record_days, 0) - d.age_of_last_record_days as age_of_last_record_days_source_minus_table
+from delays d
+left join sources s
+on d.project = s.project and d.blockchain = s.blockchain
+where coalesce(s.age_of_last_record_days, 0) - d.age_of_last_record_days != 0


### PR DESCRIPTION
Brief comments on the purpose of your changes:

This test checks the "staleness" the day level for dex.trades. [Inspo](https://dune.com/queries/1772161?d=1) from @augustog. 

Key things to check here:
- The original query showed that ~6 of the project/blockchain pairs had no trades in the last day. Which we initially interpreted as staleness on our part. 
- I grabbed the underlying decoded trades table from their sources (or at least what appears to be) for those pairs. In the `sources` CTE, I do a similar calculation as we do from `delays` (age_of_last_record_days). 
- The test fails when either age_of_last_record_days is not zero or if the diff between the sources and delays value age_of_last_record_days is not zero. 

I will do some sleuthing to see if these projects really haven't seen action in the last day or so. If they have we need to escalate to decode.
