### PR TITLE
dex.trades volume test

### DIFF
--- a/models/dex/dex_schema.yml
+++ b/models/dex/dex_schema.yml
@@ -50,6 +50,9 @@ models:
       - &amount_usd
         name: amount_usd
         description: "USD value of the trade at time of execution"
+        tests:
+          - dbt_utils.accepted_range:
+              max_value: 1000000
       - &token_bought_address
         name: token_bought_address
         description: "Contract address of the token bought"

--- a/models/dex/dex_schema.yml
+++ b/models/dex/dex_schema.yml
@@ -52,7 +52,7 @@ models:
         description: "USD value of the trade at time of execution"
         tests:
           - dbt_utils.accepted_range:
-              max_value: 5000000
+              max_value: 100000000
       - &token_bought_address
         name: token_bought_address
         description: "Contract address of the token bought"

--- a/models/dex/dex_schema.yml
+++ b/models/dex/dex_schema.yml
@@ -52,7 +52,7 @@ models:
         description: "USD value of the trade at time of execution"
         tests:
           - dbt_utils.accepted_range:
-              max_value: 1000000
+              max_value: 5000000
       - &token_bought_address
         name: token_bought_address
         description: "Contract address of the token bought"

--- a/models/dex/dex_schema.yml
+++ b/models/dex/dex_schema.yml
@@ -50,9 +50,6 @@ models:
       - &amount_usd
         name: amount_usd
         description: "USD value of the trade at time of execution"
-        tests:
-          - dbt_utils.accepted_range:
-              max_value: 100000000
       - &token_bought_address
         name: token_bought_address
         description: "Contract address of the token bought"

--- a/tests/dex/dex_trades_assert_volume.sql
+++ b/tests/dex/dex_trades_assert_volume.sql
@@ -1,0 +1,28 @@
+with volume as (
+    SELECT
+        project
+        , blockchain
+        , sum(amount_usd) volume
+    from {{ ref('dex_trades') }}
+    where block_time >= now() - interval '7 days'
+    group by 1,2
+)
+
+-- Game on to dethone.
+, cur_top_project as (
+select project,
+       blockchain,
+       volume as expected_top_volume
+from volume
+where project = 'uniswap'
+and blockchain = 'ethereum')
+
+select
+   v.project,
+   v.blockchain,
+   v.volume,
+   ctp.expected_top_volume,
+ ctp.expected_top_volume - v.volume as delta_with_current_top_project
+from volume v
+cross join cur_top_project ctp
+where  round(ctp.expected_top_volume - v.volume, 4) < 0


### PR DESCRIPTION
This test hardcodes Uniswap on Ethereum as the most active dex and when volume is surpassed on other dexs' the test will fail. I like this test despite the inclusion of a hard code because should pay attention when something like that happens for real and when it happens due to a data error. 

This test will fail until we fix Curve. It does not fail on V1 through a manual [test](https://dune.com/queries/1780756?d=4). 

My goal is to add additional curve tests and resolve that issue before merging this test. 