### PR TITLE
Add Furio token contract to tokens_bnb_bep20

### DIFF
--- a/models/tokens/bnb/tokens_bnb_bep20.sql
+++ b/models/tokens/bnb/tokens_bnb_bep20.sql
@@ -5523,4 +5523,5 @@ SELECT LOWER(contract_address) AS contract_address, symbol, decimals
 ,('0xad6742a35fb341a9cc6ad674738dd8da98b94fb1', 'WOM', 18)
 ,('0x0782b6d8c4551b9760e74c0545a9bcd90bdc41e5', 'HAY', 18)
 ,('0x1bdd3cf7f79cfb8edbb955f20ad99211551ba275', 'BNBx', 18)
+,('0x48378891d6e459ca9a56b88b406e8f4eab2e39bf', '$FUR', 18)
 ) AS temp_table (contract_address, symbol, decimals)


### PR DESCRIPTION
Brief comments on the purpose of your changes:

I have added the Furio token contract to tokens_bnb_bep20.sql so that it will included in dex.trades and dex.prices. The prices.usd data for this Token is incomplete (coinpaprika data does not include the first 3 weeks of prices)

**For Dune Engine V2**

I've checked that:

### General checks:
* [X ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)

I queried the temporary table generated during the dbt run check using dune.com and the added token contract was included

![image](https://user-images.githubusercontent.com/76560590/208659281-b2f354d5-42b0-4649-a778-258c948d0ae7.png)
