### PR TITLE
[WIP] T-22566 - Hide views resulting in OOM in DuneSQL

### DIFF
--- a/models/aave/ethereum/aave_ethereum_borrow.sql
+++ b/models/aave/ethereum/aave_ethereum_borrow.sql
@@ -1,6 +1,6 @@
 {{ config(
       alias='borrow'
-      , post_hook='{{ expose_spells(\'["ethereum"]\',
+      , post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                   "project",
                                   "aave",
                                   \'["batwayne", "chuxin"]\') }}'

--- a/models/aave/ethereum/aave_ethereum_supply.sql
+++ b/models/aave/ethereum/aave_ethereum_supply.sql
@@ -1,6 +1,6 @@
 {{ config(
       alias='supply'
-      , post_hook='{{ expose_spells(\'["ethereum"]\',
+      , post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                   "project",
                                   "aave",
                                   \'["batwayne", "chuxin"]\') }}'

--- a/models/aave/ethereum/aave_v1_ethereum_borrow.sql
+++ b/models/aave/ethereum/aave_v1_ethereum_borrow.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'aave_v1_ethereum'
     , alias='borrow'
-    , post_hook='{{ expose_spells(\'["ethereum"]\',
+    , post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                   "project",
                                   "aave_v1",
                                   \'["batwayne", "chuxin"]\') }}'

--- a/models/aave/ethereum/aave_v1_ethereum_supply.sql
+++ b/models/aave/ethereum/aave_v1_ethereum_supply.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'aave_v1_ethereum'
     , alias='supply'
-    , post_hook='{{ expose_spells(\'["ethereum"]\',
+    , post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                   "project",
                                   "aave_v1",
                                   \'["batwayne", "chuxin"]\') }}'

--- a/models/ironbank/ethereum/ironbank_ethereum_redeem.sql
+++ b/models/ironbank/ethereum/ironbank_ethereum_redeem.sql
@@ -1,6 +1,6 @@
 {{ config(
     alias = 'redeem',
-    post_hook='{{ expose_spells(\'["ethereum"]\',
+    post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
                                 "project",
                                 "ironbank",
                                 \'["michael-ironbank"]\') }}'

--- a/models/opensea/opensea_burns.sql
+++ b/models/opensea/opensea_burns.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='burns',
-        post_hook='{{ expose_spells(\'["ethereum","solana"]\',
+        post_hook='{{ expose_spells_hide_trino(\'["ethereum","solana"]\',
                                             "project",
                                             "opensea",
                                             \'["soispoke"]\') }}'

--- a/models/prices/prices_usd_latest.sql
+++ b/models/prices/prices_usd_latest.sql
@@ -1,7 +1,7 @@
 {{ config(
         schema='prices',
         alias ='usd_latest',
-        post_hook='{{ expose_spells(\'["ethereum", "solana", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c"]\',
+        post_hook='{{ expose_spells_hide_trino(\'["ethereum", "solana", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c"]\',
                                     "sector",
                                     "prices",
                                     \'["hildobby"]\') }}'


### PR DESCRIPTION
The following views are currently timing out in DuneSQL:

- opensea.burns
- aave_ethereum.borrow
- aave_ethereum.supply
- aave_v1_ethereum.supply
- aave_v1_ethereum.borrow
- ironbank_ethereum.redeem
- prices.usd_latest

This PR aims to hide them as a short term solution. A long term solution will be applied as part of T-21577.