### PR TITLE
improve prices.usd_latest performance

### DIFF
--- a/models/prices/prices_schema.yml
+++ b/models/prices/prices_schema.yml
@@ -30,10 +30,17 @@ models:
   - name: prices_usd_latest
     meta:
       sector: prices
-      contributors: hildobby
+      contributors: hildobby, 0xRob
     config:
       tags: ['prices', 'usd', 'latest']
     description: "Latest prices table across blockchains"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - contract_address
+            - symbol
+            - decimals
     columns:
       - name: minute
         description: "UTC event block time truncated to the minute mark"

--- a/models/prices/prices_usd_latest.sql
+++ b/models/prices/prices_usd_latest.sql
@@ -4,24 +4,17 @@
         post_hook='{{ expose_spells(\'["ethereum", "solana", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c"]\',
                                     "sector",
                                     "prices",
-                                    \'["hildobby"]\') }}'
+                                    \'["hildobby", "0xRob"]\') }}'
         )
 }}
 
-SELECT pu.blockchain
+SELECT
+  pu.blockchain
 , pu.contract_address
 , pu.decimals
-, pu.minute
-, pu.price
 , pu.symbol
-FROM (
-    SELECT blockchain
-    , contract_address
-    , MAX(minute) AS latest
-    FROM {{ source('prices', 'usd') }}
-    GROUP BY blockchain, contract_address
-    ) latest
-LEFT JOIN {{ source('prices', 'usd') }} pu ON pu.blockchain=latest.blockchain
-    AND pu.contract_address=latest.contract_address
-    AND pu.minute=latest.latest
-
+, max(pu.minute)
+, max_by(pu.price, pu.minute)
+FROM {{ source('prices', 'usd') }} pu
+WHERE minute > now() - interval 7 day
+GROUP BY 1,2,3,4


### PR DESCRIPTION
Triggered by PR: https://github.com/duneanalytics/spellbook/pull/2366
This PR reduces the `prices.usd_latest` query to only take into account tokens that had an update in the last week.

This should improve the query performance on Spark and DuneSQL (although it doesn't look to bad [initially](https://dune.com/queries/1784575?d=11)) 