### PR TITLE
Expose cryptopunks_ethereum.current_listings in DuneSQL

### DIFF
--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_current_listings.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_current_listings.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='current_listings',
         unique_key='punk_id',
-        post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",
                                     "cryptopunks",
                                     \'["cat"]\') }}'


### PR DESCRIPTION
This view is working fine on DuneSQL (see [query](https://dune.com/queries/1784772?d=11&category=abstraction&namespace=cow_protocol)), therefore I'm exposing it back.