### PR TITLE
[CoW] Add block_number to Trades and Batches

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql
@@ -17,6 +17,7 @@ WITH
 -- Find the PoC Query here: https://dune.com/queries/1290518
 batch_counts as (
     select try_cast(date_trunc('day', s.evt_block_time) as date) as block_date,
+           s.evt_block_number,
            s.evt_block_time,
            s.evt_tx_hash,
            solver,
@@ -65,6 +66,7 @@ batch_values as (
 combined_batch_info as (
     select
         block_date,
+        evt_block_number                               as block_number,
         evt_block_time                                 as block_time,
         num_trades,
         CASE

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql
@@ -42,7 +42,7 @@ batch_counts as (
     {% if is_incremental() %}
     WHERE s.evt_block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-    group by s.evt_tx_hash, solver, s.evt_block_time, name
+    group by s.evt_block_number, s.evt_block_time, s.evt_tx_hash, solver, name
 ),
 
 batch_values as (

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -42,6 +42,9 @@ models:
       - &block_date
         name: block_date
         description: "UTC event block date of each trade"
+      - &block_number
+        name: block_number
+        description: "Block number that the transaction was included"
       - &block_time
         name: block_time
         description: "Timestamp for block event time in UTC"
@@ -137,6 +140,7 @@ models:
       CoW Protocol enriched batches table on Ethereum
     columns:
       - *block_date
+      - *block_number
       - *block_time
       - &num_trades
         name: num_trades

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -238,9 +238,7 @@ models:
     columns:
       - *block_date
       - *block_time
-      - &block_number
-        name: block_number
-        description: Block number when transaction was included.
+      - *block_number
       - *tx_hash
       - *valid_to
       - &quote_id

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -19,10 +19,11 @@ WITH
 -- Also deducts fee from sell amount
 trades_with_prices AS (
     SELECT try_cast(date_trunc('day', evt_block_time) as date) as block_date,
+           evt_block_number          as block_number,
            evt_block_time            as block_time,
            evt_tx_hash               as tx_hash,
            evt_index,
-           trade.contract_address          as project_contract_address,
+           trade.contract_address    as project_contract_address,
            owner                     as trader,
            orderUid                  as order_uid,
            sellToken                 as sell_token,
@@ -59,6 +60,7 @@ trades_with_prices AS (
 -- Second subquery gets token symbol and decimals from tokens.erc20 (to display units bought and sold)
 trades_with_token_units as (
     SELECT block_date,
+           block_number,
            block_time,
            tx_hash,
            evt_index,
@@ -165,6 +167,7 @@ eth_flow_senders as (
 
 valued_trades as (
     SELECT block_date,
+           block_number,
            block_time,
            tx_hash,
            evt_index,


### PR DESCRIPTION
It has come to our attention that queries would be much more efficient if we used a numerical column (such as block number) to navigate the "join space". This PR adds `block_number`to both abstractions `trades` and `batches`.