### PR TITLE
[CoW] Deduplicate parsed App Data

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
@@ -9,7 +9,7 @@
 with
 partially_unpacked_app_content as (
     select
-        app_hash,
+        distinct app_hash,
         content.appCode as app_code,
         content.environment,
         content.metadata.orderClass.orderClass as order_class,


### PR DESCRIPTION
Similar to the change made in https://github.com/duneanalytics/spellbook/pull/2351, we want to avoid duplicate records in the spell that parses the raw_app_data table. I have tested this and it indeed removes duplicates. I find it very strange that this is happening (i.e. being duplicated and only ever once), but I will be away the next two weeks and will not have a chance to dig deeper into the root cause. cc @dsalv 