### PR TITLE
Allow for local compile of incremental models. 

### DIFF
--- a/macros/dune/is_incremental.sql
+++ b/macros/dune/is_incremental.sql
@@ -1,0 +1,12 @@
+{% macro is_incremental() %}
+    {#-- do not run introspective queries in parsing #}
+    {% if not execute %}
+        {{ return(False) }}
+    {% else %}
+        {% set relation = adapter.get_relation(this.database, this.schema, this.table) %}
+        {{ return(relation is not none
+                  and relation.type == 'table'
+                  and model.config.materialized == 'incremental'
+                  and not should_full_refresh()) }}
+    {% endif %}
+{% endmacro %}

--- a/macros/dune/is_incremental.sql
+++ b/macros/dune/is_incremental.sql
@@ -1,4 +1,10 @@
 {% macro is_incremental() %}
+    {#-- allow for command line compile of incremental models  #}
+    {#-- Usage: dbt compile --vars '{force-incremental: True}'  #}
+    {% if var('force-incremental', False) %}
+        {{ return(True) }}
+    {% endif %}
+
     {#-- do not run introspective queries in parsing #}
     {% if not execute %}
         {{ return(False) }}

--- a/macros/dune/macros_schema.yml
+++ b/macros/dune/macros_schema.yml
@@ -9,7 +9,7 @@ macros:
         description: "Custom schema name"
       - name: node
         type: column name or expression
-        description: "Node"  
+        description: "Node"
 
   - name: generate_alias_name
     description: "This overrides the dbt-core function for setting aliases. For PR test, the alias is set to the user schema and file name. "
@@ -39,3 +39,9 @@ macros:
   - name: spark__create_csv_table
     description: >
       Same as create_table_as but for seeds with spark package
+
+  - name: is_incremental
+    description: >
+      Overrides the core is_incremental marco to allow the usage of a force-incremental command line variable.
+      This enables us to easily get the compiled incremental models. 
+      Example usage: dbt compile --vars '{force-incremental: True}'


### PR DESCRIPTION
This PR:

Enhances the default `is_incremental` logic to allow an override with a command line parameter.
The default value is set as False.
Usage:
`dbt compile --vars '{force-incremental: True}'`

The base logic was taken from here: [is_incremental.sql](https://github.com/dbt-labs/dbt-core/blob/1.2.latest/core/dbt/include/global_project/macros/materializations/models/incremental/is_incremental.sql)