### PR TITLE
Remove hardcoded fields from nft_trades

### DIFF
--- a/models/nft/nft_trades.sql
+++ b/models/nft/nft_trades.sql
@@ -53,8 +53,7 @@ FROM (
         block_number,
         tx_from,
         tx_to,
-        unique_trade_id,
-        'testchange' as test
+        unique_trade_id
     FROM {{ nft_model }}
     {% if not loop.last %}
     UNION ALL


### PR DESCRIPTION
Found this hardcoded field that I don't think belongs in `nft.trades`