### PR TITLE
[CoW] Fix Fee USD Calculation

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -205,16 +205,10 @@ valued_trades as (
            fee,
            fee_atoms,
            (CASE
-                WHEN sell_price IS NOT NULL THEN
-                    CASE
-                        WHEN buy_price IS NOT NULL and buy_price * units_bought > sell_price * units_sold
-                            then buy_price * units_bought * fee / units_sold
-                        ELSE sell_price * fee
-                        END
-                WHEN sell_price IS NULL AND buy_price IS NOT NULL
-                    THEN buy_price * units_bought * fee / units_sold
+                WHEN sell_price IS NOT NULL THEN sell_price * fee
+                WHEN buy_price IS NOT NULL THEN buy_price * units_bought * fee / units_sold
                 ELSE NULL::numeric
-               END)                                        as fee_usd,
+           END)                                            as fee_usd,
            app_data,
            case
               when receiver = '0x0000000000000000000000000000000000000000'

--- a/models/cow_protocol/gnosis/cow_protocol_gnosis_trades.sql
+++ b/models/cow_protocol/gnosis/cow_protocol_gnosis_trades.sql
@@ -189,6 +189,11 @@ valued_trades as (
            fee_atoms,
            (CASE
                 WHEN sell_price IS NOT NULL THEN sell_price * fee
+             -- Note that this formulation is subject to some precision error in a few irregular cases:
+             -- E.g. In this transaction 0x84d57d1d57e01dd34091c763765ddda6ff713ad67840f39735f0bf0cced11f02
+             -- buy_price * units_bought * fee / units_sold
+             -- 1.001076 * 0.005 * 0.0010148996324193 / 3e-18 = 1693319440706.3
+             -- So, if sell_price had been null here (thankfully it is not), we would have a vastly inaccurate fee valuation
                 WHEN buy_price IS NOT NULL THEN buy_price * units_bought * fee / units_sold
                 ELSE NULL::numeric
            END)                                            as fee_usd,

--- a/models/cow_protocol/gnosis/cow_protocol_gnosis_trades.sql
+++ b/models/cow_protocol/gnosis/cow_protocol_gnosis_trades.sql
@@ -188,16 +188,10 @@ valued_trades as (
            fee,
            fee_atoms,
            (CASE
-                WHEN sell_price IS NOT NULL THEN
-                    CASE
-                        WHEN buy_price IS NOT NULL and buy_price * units_bought > sell_price * units_sold
-                            then buy_price * units_bought * fee / units_sold
-                        ELSE sell_price * fee
-                        END
-                WHEN sell_price IS NULL AND buy_price IS NOT NULL
-                    THEN buy_price * units_bought * fee / units_sold
+                WHEN sell_price IS NOT NULL THEN sell_price * fee
+                WHEN buy_price IS NOT NULL THEN buy_price * units_bought * fee / units_sold
                 ELSE NULL::numeric
-               END)                                        as fee_usd,
+           END)                                            as fee_usd,
            app_data,
            case
               when receiver = '0x0000000000000000000000000000000000000000'


### PR DESCRIPTION
We recently discovered a HUGE precision/rounding error on the calculation of `fee_usd` in the case when sell_price is not null. Since the fees are taken in sell token, there is no reason for us to try to take the larger of the two. here.

That is, when sell_price is not null, then  is `fee_usd = sell_price * fee`.

cc @josojo for internal approval

In particular [this transaction](https://etherscan.io/tx/0x84d57d1d57e01dd34091c763765ddda6ff713ad67840f39735f0bf0cced11f02)

I will link the issue with the old calculation inline near the code change.

Included also is a [PoC query](https://dune.com/queries/1841840) showing what the new fee calculation will look like in comparison.