### PR TITLE
T 23266 deploy on merge

### DIFF
--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - "main"
-      - "master"
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - "main"
+      - "master"
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.PAT_TOKEN }}
+        script: |
+          await github.rest.actions.createWorkflowDispatch({
+            owner: 'duneanalytics',
+            repo: 'spellbook-dagster',
+            workflow_id: 'deploy.yml',
+            ref: 'main'
+          })


### PR DESCRIPTION
This workflow will trigger a deploy to our dagster project whenever there is a merge to main on Spellbook. This will allow us to automatically deploy modified assets. 