### PR TITLE
Fix aave v1 liquidation call in supply spell

### DIFF
--- a/models/aave/ethereum/aave_v1_ethereum_supply.sql
+++ b/models/aave/ethereum/aave_v1_ethereum_supply.sql
@@ -64,7 +64,7 @@ SELECT
     '1' AS version,
     'deposit_liquidation' AS transaction_type,
     CASE
-        WHEN _reserve = '{{aave_mock_address}}' THEN '{{weth_address}}' --Using WETH instead of Aave "mock" address
+        WHEN _collateral = '{{aave_mock_address}}' THEN '{{weth_address}}' --Using WETH instead of Aave "mock" address
         ELSE _collateral
     END AS token,
     _user AS depositor,


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [x] `coin_id` represents the ID of the coin on coinpaprika.com
* [x] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
