### PR TITLE
Add missing prices for nft.trades

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -1613,6 +1613,13 @@ VALUES
     ("stmatic-lido-staked-matic", "ethereum", "STMATIC", "0x9ee91F9f426fA633d227f7a9b000E28b9dfd8599", 18),
     ("xen-xen-crypto", "ethereum", "XEN", "0x06450dEe7FD2Fb8E39061434BAbCFC05599a6Fb8", 18),
     ("bob-bob", "ethereum", "BOB", "0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b", 18),
+    ("kltr-kollector", "ethereum", "KLTR", "0xa92c49C403386111C1629AEe00936eED2A9E74a6", 18),
+    ("lmt-lympo-market-token", "ethereum", "LMT", "0x327673aE6B33Bd3d90f0096870059994f30Dc8AF", 18),
+    ("ndr-node-runners", "ethereum", "NDR", "0x739763a258640919981F9bA610AE65492455bE53", 18),
+    ("surf-surffinance", "ethereum", "SURF", "0xEa319e87Cf06203DAe107Dd8E5672175e3Ee976c", 18),
+    ("ern-ethernity-chain", "ethereum", "ERN", "0xBBc2AE13b23d715c30720F079fcd9B4a74093505", 18),
+    ("artem-artem-coin", "ethereum", "ARTEM", "0x9B83f827928aBdf18cF1F7e67053572b9bceff3a", 18),
+    ("aqt-alpha-quark-token", "ethereum", "AQT", "0x2a9bDCFF37aB68B95A53435ADFd8892e86084F93", 18),
 
     -- Query for Popular Traded Tokens on Gnosis Chain without prices: https://dune.com/queries/1719783
     ("dai-dai", "gnosis", "WXDAI", "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d", 18),

--- a/scripts/test_token_checker.py
+++ b/scripts/test_token_checker.py
@@ -20,10 +20,10 @@ def test_test_token_checker_attrs2():
     assert "0x7cb16cb78ea464ad35c8a50abf95dff3c9e09d5d" == token['contract_address']
 
 
-def test_token_missing_contract1():
+def test_token_missing_contract1(caplog):
     test_line = '("dai-dai", "avalanche_c", "DAI", "0xd586e7f844cea2f87f50152665bcbc2c279d8d70", 18),'
-    with pytest.raises(AssertionError):
-        checker.validate_token(test_line)
+    checker.validate_token(test_line)
+    assert [log for log in caplog.records if log.levelname == "WARNING"]
 
 
 def test_token_missing_contract2():

--- a/scripts/token_checker.py
+++ b/scripts/token_checker.py
@@ -65,7 +65,7 @@ class TokenChecker:
         api_token = self.tokens_by_id[token['id']]
         # Confirm Symbol
         if token['symbol']:
-            assert api_token['symbol'] == token['symbol'] \
+            assert api_token['symbol'].lower() == token['symbol'].lower() \
                 , f"ERROR: {token['id']} Provided symbol: {token['symbol']} does not match CoinPaprika source: {api_token['symbol']}"
         else:
             logging.warning(f"WARN: Line: {new_line} Symbol is None")

--- a/scripts/token_checker.py
+++ b/scripts/token_checker.py
@@ -78,17 +78,20 @@ class TokenChecker:
 
         if token['blockchain']:
             assert token['blockchain'] in self.chain_slugs \
-                , f"WARN: chain: {token['blockchain']} not supported in the price checker, could not check contract or chain"
+                , f"ERROR: chain: {token['blockchain']} not supported in the price checker, could not check contract or chain"
 
             if token['contract_address']:
-                assert token['contract_address'] in self.contracts_by_chain[token['blockchain']] \
-                    , f"WARN: contract {token['contract_address']} for token {token['id']} not found in the contracts for chain: {token['blockchain']}" \
-                      f" (Not uncommon! share block explorer link to confirm contract)"
-                # Confirm Contract Listed
-                api_contract_id = self.contracts_by_chain[token['blockchain']][token['contract_address']]
-                assert token['id'] == api_contract_id['id'] \
-                    , f"WARN: {token['id']} for provided contract address: {token['contract_address']} for chain {token['blockchain']} does not match CoinPaprika id :{api_contract_id['id']}" \
-                      f" (Not uncommon! share block explorer link to confirm contract)"
+                if token['contract_address'] in self.contracts_by_chain[token['blockchain']]:
+                    # Confirm Contract Listed
+                    api_contract_id = self.contracts_by_chain[token['blockchain']][token['contract_address']]
+                    assert token['id'] == api_contract_id['id'] \
+                        , f"ERROR: ID: {token['id']} (contract address: {token['contract_address']},chain {token['blockchain']}) does not match CoinPaprika id :{api_contract_id['id']}" \
+                          f" (Not uncommon! share block explorer link to confirm contract)"
+                else:
+                    logging.warning(
+                        f"WARN: contract {token['contract_address']} for token {token['id']} not found in the "
+                        f"contracts for chain: {token['blockchain']}"
+                        f"(Not uncommon! share block explorer link to confirm contract)")
             else:
                 logging.warning(f"WARN: Line: {new_line} contract_address is None")
         else:


### PR DESCRIPTION
Adds prices from tokens used in nft trades.

Includes tweaks from https://github.com/duneanalytics/spellbook/pull/2437 for the token checker.