### PR TITLE
Add ETH Transfers to L1

### DIFF
--- a/models/transfers/ethereum/transfers_ethereum_eth.sql
+++ b/models/transfers/ethereum/transfers_ethereum_eth.sql
@@ -25,6 +25,8 @@ with eth_transfers as (
         ,r.block_number as tx_block_number 
         ,substring(t.data, 1, 10) as tx_method_id
         ,r.tx_hash || '-' || cast(r.trace_address as string) as unique_transfer_id
+        ,t.to AS tx_to
+        ,t.`from` AS tx_from
     from {{ source('ethereum', 'traces') }} as r 
     join {{ source('ethereum', 'transactions') }} as t 
         on r.tx_hash = t.hash

--- a/models/transfers/ethereum/transfers_ethereum_eth.sql
+++ b/models/transfers/ethereum/transfers_ethereum_eth.sql
@@ -1,0 +1,44 @@
+{{ 
+    config(
+        alias ='eth', 
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key='unique_transfer_id',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "sector",
+                                    "transfers",
+                                    \'["msilb7", "chuxin"]\') }}'
+    )
+}}
+with eth_transfers as (
+    select 
+        r.from
+        ,r.to
+        --Using the ETH deposit placeholder address to match with prices tables
+        ,lower('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') as contract_address
+        ,cast(r.value as double) AS value
+        ,cast(r.value as double)/1e18 as value_decimal
+        ,r.tx_hash
+        ,r.trace_address
+        ,r.block_time as tx_block_time 
+        ,r.block_number as tx_block_number 
+        ,substring(t.data, 1, 10) as tx_method_id
+        ,r.tx_hash || '-' || cast(r.trace_address as string) as unique_transfer_id
+    from {{ source('ethereum', 'traces') }} as r 
+    join {{ source('ethereum', 'transactions') }} as t 
+        on r.tx_hash = t.hash
+        and r.block_number = t.block_number
+    where 
+        (r.call_type not in ('delegatecall', 'callcode', 'staticcall') or r.call_type is null)
+        and r.tx_success
+        and r.success
+        and r.value > '0'
+        {% if is_incremental() %} -- this filter will only be applied on an incremental run 
+        and r.block_time >= date_trunc('day', now() - interval '1 week')
+        and t.block_time >= date_trunc('day', now() - interval '1 week')
+        {% endif %}
+)
+select *
+from eth_transfers
+;

--- a/models/transfers/ethereum/transfers_ethereum_eth.sql
+++ b/models/transfers/ethereum/transfers_ethereum_eth.sql
@@ -15,7 +15,7 @@ with eth_transfers as (
     select 
         r.from
         ,r.to
-        --Using the ETH deposit placeholder address to match with prices tables
+        --Using the ETH placeholder address to match with prices tables
         ,lower('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') as contract_address
         ,cast(r.value as double) AS value
         ,cast(r.value as double)/1e18 as value_decimal

--- a/models/transfers/ethereum/transfers_ethereum_schema.yml
+++ b/models/transfers/ethereum/transfers_ethereum_schema.yml
@@ -329,3 +329,56 @@ models:
         description: "UTC timestamp when table was last updated"
       - name: recency_index
         description: "Index of most recent balance ascending. recency_index=1 is the wallet/contract pair's most recent balance"
+  
+  - name: transfers_optimism_eth
+      meta:
+        blockchain: optimism
+        sector: transfers
+        project: eth
+        contributors: msilb7, chuxin
+      config:
+        tags: ["transfers", "optimism", "eth"]
+      description: "Events of native ETH transfers on Ethereum."
+      columns:
+        - &from
+          name: from
+          description: "Wallet address that initiated the transaction"
+
+        - &to
+          name: to
+          description: "Wallet address that received the transaction"
+
+        - name: contract_address
+          description: "Using the ETH deposit placeholder address to match with prices tables"
+
+        - &value
+          name: value
+          description: "Amount of ETH transferred from sender to recipient"
+
+        - &value_decimal
+          name: value_decimal
+          description: "Amount of ETH transferred in decimals from sender to recipient"
+
+        - &tx_hash
+          name: tx_hash
+          description: "Primary key of the transaction"
+          tests:
+            - not_null
+
+        - name: trace_address
+          description: "All returned traces, gives the exact location in the call trace"
+
+        - &tx_block_time
+          name: tx_block_time
+          description: "Timestamp for block event time in UTC"
+
+        - &tx_block_number
+          name: tx_block_number
+          description: "Block number"
+
+        - &tx_method_id
+          name: tx_method_id
+          description: "Function calls specified by the first four bytes of data sent with a transaction"
+
+        - *unique_transfer_id
+ 

--- a/models/transfers/ethereum/transfers_ethereum_schema.yml
+++ b/models/transfers/ethereum/transfers_ethereum_schema.yml
@@ -379,5 +379,9 @@ models:
       - &tx_method_id
         name: tx_method_id
         description: "Function calls specified by the first four bytes of data sent with a transaction"
-
-      - *unique_transfer_id
+        
+      - name: unique_transfer_id
+        description: "Unique transfer ID (used for testing for duplicates), made up with tx_hash and trace_address"
+        tests:
+          - not_null
+          - unique

--- a/models/transfers/ethereum/transfers_ethereum_schema.yml
+++ b/models/transfers/ethereum/transfers_ethereum_schema.yml
@@ -330,55 +330,54 @@ models:
       - name: recency_index
         description: "Index of most recent balance ascending. recency_index=1 is the wallet/contract pair's most recent balance"
   
-  - name: transfers_optimism_eth
-      meta:
-        blockchain: optimism
-        sector: transfers
-        project: eth
-        contributors: msilb7, chuxin
-      config:
-        tags: ["transfers", "optimism", "eth"]
-      description: "Events of native ETH transfers on Ethereum."
-      columns:
-        - &from
-          name: from
-          description: "Wallet address that initiated the transaction"
+  - name: transfers_ethereum_eth
+    meta:
+      blockchain: ethereum
+      sector: transfers
+      project: eth
+      contributors: msilb7, chuxin
+    config:
+      tags: ["transfers", "ethereum", "eth"]
+    description: "Events of native ETH transfers on Ethereum."
+    columns:
+      - &from
+        name: from
+        description: "Wallet address that initiated the transaction"
 
-        - &to
-          name: to
-          description: "Wallet address that received the transaction"
+      - &to
+        name: to
+        description: "Wallet address that received the transaction"
 
-        - name: contract_address
-          description: "Using the ETH deposit placeholder address to match with prices tables"
+      - name: contract_address
+        description: "Using the ETH deposit placeholder address to match with prices tables"
 
-        - &value
-          name: value
-          description: "Amount of ETH transferred from sender to recipient"
+      - &value
+        name: value
+        description: "Amount of ETH transferred from sender to recipient"
 
-        - &value_decimal
-          name: value_decimal
-          description: "Amount of ETH transferred in decimals from sender to recipient"
+      - &value_decimal
+        name: value_decimal
+        description: "Amount of ETH transferred in decimals from sender to recipient"
 
-        - &tx_hash
-          name: tx_hash
-          description: "Primary key of the transaction"
-          tests:
-            - not_null
+      - &tx_hash
+        name: tx_hash
+        description: "Primary key of the transaction"
+        tests:
+          - not_null
 
-        - name: trace_address
-          description: "All returned traces, gives the exact location in the call trace"
+      - name: trace_address
+        description: "All returned traces, gives the exact location in the call trace"
 
-        - &tx_block_time
-          name: tx_block_time
-          description: "Timestamp for block event time in UTC"
+      - &tx_block_time
+        name: tx_block_time
+        description: "Timestamp for block event time in UTC"
 
-        - &tx_block_number
-          name: tx_block_number
-          description: "Block number"
+      - &tx_block_number
+        name: tx_block_number
+        description: "Block number"
 
-        - &tx_method_id
-          name: tx_method_id
-          description: "Function calls specified by the first four bytes of data sent with a transaction"
+      - &tx_method_id
+        name: tx_method_id
+        description: "Function calls specified by the first four bytes of data sent with a transaction"
 
-        - *unique_transfer_id
- 
+      - *unique_transfer_id

--- a/models/transfers/ethereum/transfers_ethereum_schema.yml
+++ b/models/transfers/ethereum/transfers_ethereum_schema.yml
@@ -385,3 +385,11 @@ models:
         tests:
           - not_null
           - unique
+          
+      - &tx_to
+        name: tx_to
+        description: "To Address for the Transaction"
+
+      - &tx_from
+          name: tx_from
+          description: "From Address for the Transaction"

--- a/models/transfers/ethereum/transfers_ethereum_schema.yml
+++ b/models/transfers/ethereum/transfers_ethereum_schema.yml
@@ -343,53 +343,41 @@ models:
       - &from
         name: from
         description: "Wallet address that initiated the transaction"
-
       - &to
         name: to
         description: "Wallet address that received the transaction"
-
       - name: contract_address
         description: "Using the ETH deposit placeholder address to match with prices tables"
-
       - &value
         name: value
         description: "Amount of ETH transferred from sender to recipient"
-
       - &value_decimal
         name: value_decimal
         description: "Amount of ETH transferred in decimals from sender to recipient"
-
       - &tx_hash
         name: tx_hash
         description: "Primary key of the transaction"
         tests:
           - not_null
-
       - name: trace_address
         description: "All returned traces, gives the exact location in the call trace"
-
       - &tx_block_time
         name: tx_block_time
         description: "Timestamp for block event time in UTC"
-
       - &tx_block_number
         name: tx_block_number
         description: "Block number"
-
       - &tx_method_id
         name: tx_method_id
         description: "Function calls specified by the first four bytes of data sent with a transaction"
-        
       - name: unique_transfer_id
         description: "Unique transfer ID (used for testing for duplicates), made up with tx_hash and trace_address"
         tests:
           - not_null
           - unique
-          
       - &tx_to
         name: tx_to
         description: "To Address for the Transaction"
-
       - &tx_from
           name: tx_from
           description: "From Address for the Transaction"

--- a/models/transfers/optimism/transfers_optimism_eth.sql
+++ b/models/transfers/optimism/transfers_optimism_eth.sql
@@ -25,6 +25,8 @@ with eth_transfers as (
         ,r.block_number as tx_block_number 
         ,substring(t.data, 1, 10) as tx_method_id
         ,r.tx_hash || '-' || cast(r.trace_address as string) as unique_transfer_id
+        ,t.to AS tx_to
+        ,t.`from` AS tx_from
     from {{ source('optimism', 'traces') }} as r 
     join {{ source('optimism', 'transactions') }} as t 
         on r.tx_hash = t.hash

--- a/models/transfers/optimism/transfers_optimism_eth.sql
+++ b/models/transfers/optimism/transfers_optimism_eth.sql
@@ -57,6 +57,8 @@ with eth_transfers as (
         ,r.evt_block_number as tx_block_number
         ,substring(t.data, 1, 10) as tx_method_id
         ,r.evt_tx_hash || '-' || cast(array(r.evt_index) as string) as unique_transfer_id
+        ,t.to AS tx_to
+        ,t.`from` AS tx_from
     from {{ source('erc20_optimism', 'evt_transfer') }} as r
     join {{ source('optimism', 'transactions') }} as t 
         on r.evt_tx_hash = t.hash

--- a/models/transfers/optimism/transfers_optimism_eth.sql
+++ b/models/transfers/optimism/transfers_optimism_eth.sql
@@ -17,8 +17,8 @@ with eth_transfers as (
         ,r.to
         --Using the ETH deposit placeholder address to match with prices tables
         ,lower('0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000') as contract_address
-        ,r.value
-        ,r.value/1e18 as value_decimal
+        ,cast(r.value as double) AS value
+        ,cast(r.value as double)/1e18 as value_decimal
         ,r.tx_hash
         ,r.trace_address
         ,r.block_time as tx_block_time 
@@ -28,6 +28,7 @@ with eth_transfers as (
     from {{ source('optimism', 'traces') }} as r 
     join {{ source('optimism', 'transactions') }} as t 
         on r.tx_hash = t.hash
+        and r.block_number = t.block_number
     where 
         (r.call_type not in ('delegatecall', 'callcode', 'staticcall') or r.call_type is null)
         and r.tx_success
@@ -46,8 +47,8 @@ with eth_transfers as (
         ,r.to
         --Using the ETH deposit placeholder address to match with prices tables
         ,lower('0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000') as contract_address
-        ,r.value
-        ,r.value/1e18 as value_decimal
+        ,cast(r.value as double) AS value
+        ,cast(r.value as double)/1e18 as value_decimal
         ,r.evt_tx_hash as tx_hash
         ,array(r.evt_index) as trace_address
         ,r.evt_block_time as tx_block_time
@@ -57,6 +58,7 @@ with eth_transfers as (
     from {{ source('erc20_optimism', 'evt_transfer') }} as r
     join {{ source('optimism', 'transactions') }} as t 
         on r.evt_tx_hash = t.hash
+        and r.evt_block_number = t.block_number
     where 
         r.contract_address = lower('0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000')
         and t.success

--- a/models/transfers/optimism/transfers_optimism_schema.yml
+++ b/models/transfers/optimism/transfers_optimism_schema.yml
@@ -14,54 +14,41 @@ models:
       - &from
         name: from
         description: "Wallet address that initiated the transaction"
-
       - &to
         name: to
         description: "Wallet address that received the transaction"
-
       - name: contract_address
         description: "Using the ETH deposit placeholder address to match with prices tables"
-
       - &value
         name: value
         description: "Amount of ETH transferred from sender to recipient"
-
       - &value_decimal
         name: value_decimal
         description: "Amount of ETH transferred in decimals from sender to recipient"
-
       - &tx_hash
         name: tx_hash
         description: "Primary key of the transaction"
         tests:
           - not_null
-
       - name: trace_address
         description: "All returned traces, gives the exact location in the call trace"
-
       - &tx_block_time
         name: tx_block_time
         description: "Timestamp for block event time in UTC"
-
       - &tx_block_number
         name: tx_block_number
         description: "Block number"
-
       - &tx_method_id
         name: tx_method_id
         description: "Function calls specified by the first four bytes of data sent with a transaction"
-
       - name: unique_transfer_id
         description: "Unique transfer ID (used for testing for duplicates), made up with tx_hash and trace_address"
         tests:
           - not_null
           - unique
-      
       - &tx_to
         name: tx_to
         description: "To Address for the Transaction"
-
       - &tx_from
           name: tx_from
           description: "From Address for the Transaction"
-

--- a/models/transfers/optimism/transfers_optimism_schema.yml
+++ b/models/transfers/optimism/transfers_optimism_schema.yml
@@ -56,3 +56,12 @@ models:
         tests:
           - not_null
           - unique
+      
+      - &tx_to
+        name: tx_to
+        description: "To Address for the Transaction"
+
+      - &tx_from
+          name: tx_from
+          description: "From Address for the Transaction"
+


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

Add ETH transfers to L1 & make small type fixes to ETH transfers on OP.

The /eth/ subfolder in Optimism was removed in #2426 so keeping that consistent here.

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
