### PR TITLE
aave proposal spell status column fix

### DIFF
--- a/models/aave/ethereum/aave_ethereum_proposals.sql
+++ b/models/aave/ethereum/aave_ethereum_proposals.sql
@@ -19,8 +19,8 @@
 {% set dao_address = '0xec568fffba86c094cf06b22134b23074dfe2252c' %}
 
 with cte_latest_block as (
-SELECT MAX(`number`) AS latest_block
-FROM {{ source('ethereum','blocks') }}
+SELECT MAX(b.number) AS latest_block
+FROM {{ source('ethereum','blocks') }} b
 ),
 
 cte_support as (SELECT 

--- a/models/aave/ethereum/aave_ethereum_proposals.sql
+++ b/models/aave/ethereum/aave_ethereum_proposals.sql
@@ -9,7 +9,7 @@
     post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "project",
                                 "aave",
-                                \'["soispoke"]\') }}'
+                                \'["soispoke","pandajackson42"]\') }}'
     )
 }}
 
@@ -18,7 +18,12 @@
 {% set dao_name = 'DAO: AAVE' %}
 {% set dao_address = '0xec568fffba86c094cf06b22134b23074dfe2252c' %}
 
-with cte_support as (SELECT 
+with cte_latest_block as (
+SELECT MAX(`number`) AS latest_block
+FROM {{ source('ethereum','blocks') }}
+),
+
+cte_support as (SELECT 
         voter as voter,
         CASE WHEN support = 0 THEN sum(votingPower/1e18) ELSE 0 END AS votes_against,
         CASE WHEN support = 1 THEN sum(votingPower/1e18) ELSE 0 END AS votes_for,
@@ -59,15 +64,16 @@ SELECT DISTINCT
     CASE 
          WHEN pex.id is not null and now() > pex.evt_block_time THEN 'Executed' 
          WHEN pca.id is not null and now() > pca.evt_block_time THEN 'Canceled'
-         WHEN pcr.startBlock < pcr.evt_block_number < pcr.endBlock THEN 'Active'
-         WHEN now() > pqu.evt_block_time AND startBlock > pcr.evt_block_number THEN 'Queued'
+         WHEN (SELECT latest_block FROM cte_latest_block) <= pcr.startBlock THEN 'Pending'
+         WHEN (SELECT latest_block FROM cte_latest_block) <= pcr.endBlock THEN 'Active'
+         WHEN pqu.id is not null and now() > pqu.evt_block_time and now() < CAST(CAST(pqu.executionTime AS numeric) AS TIMESTAMP) THEN 'Queued'
          ELSE 'Defeated' END AS status,
     cast(NULL as string) as description
 FROM  {{ source('aave_ethereum', 'AaveGovernanceV2_evt_ProposalCreated') }} pcr
 LEFT JOIN cte_sum_votes csv ON csv.id = pcr.id
 LEFT JOIN {{ source('aave_ethereum', 'AaveGovernanceV2_evt_ProposalCanceled') }} pca ON pca.id = pcr.id
 LEFT JOIN {{ source('aave_ethereum', 'AaveGovernanceV2_evt_ProposalExecuted') }} pex ON pex.id = pcr.id
-LEFT JOIN {{ source('aave_ethereum', 'AaveGovernanceV2_evt_ProposalQueued') }} pqu ON pex.id = pcr.id
+LEFT JOIN {{ source('aave_ethereum', 'AaveGovernanceV2_evt_ProposalQueued') }} pqu ON pqu.id = pcr.id
 {% if is_incremental() %}
 WHERE pcr.evt_block_time > (select max(created_at) from {{ this }})
 {% endif %}

--- a/models/aave/ethereum/aave_ethereum_schema.yml
+++ b/models/aave/ethereum/aave_ethereum_schema.yml
@@ -308,7 +308,7 @@ models:
         description: "Participation in percent: Number of governance tokens used to vote / Total token supply"
       - &status
         name: status
-        description: "Proposal status: Queued, Active, Executed, Canceled or Defeated"
+        description: "Proposal status: Pending, Queued, Active, Executed, Canceled or Defeated"
         tests:
           - accepted_values:
               values: ['Pending', 'Queued', 'Active', 'Executed', 'Canceled','Defeated']

--- a/models/aave/ethereum/aave_ethereum_schema.yml
+++ b/models/aave/ethereum/aave_ethereum_schema.yml
@@ -311,7 +311,7 @@ models:
         description: "Proposal status: Queued, Active, Executed, Canceled or Defeated"
         tests:
           - accepted_values:
-              values: ['Queued', 'Active', 'Executed', 'Canceled','Defeated']
+              values: ['Pending', 'Queued', 'Active', 'Executed', 'Canceled','Defeated']
       - &description
         name: description
         description: "Description of the proposal"


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory) https://dune.com/queries/1870627
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] the filename is unique and ends with .sql

Current decision conditions for proposal status have some flaws, status for some proposals cannot be rightly determined.

![aave](https://user-images.githubusercontent.com/114440592/211551469-7bcee834-f8f8-479f-8b42-1ae64ce3972f.PNG)

![result_compare](https://user-images.githubusercontent.com/114440592/211551040-cd47ded1-d49d-4cf8-a717-8385a97ffdf2.png)

For example, current status for proposal 131-141 are all wrong.

This PR implement a short term approach to fix most results. https://dune.com/queries/1869212

Long term, we need to use exexutor and strategy info to fetch the supply, quorum and differential parameters, in order to get the correct result for all proposals.

https://github.com/aave/governance-v2/blob/master/contracts/governance/AaveGovernanceV2.sol#L411-L431

https://github.com/aave/governance-v2/blob/master/contracts/governance/ProposalValidator.sol