### PR TITLE
[Easy] Add 11 missing tokens

### DIFF
--- a/models/tokens/ethereum/tokens_ethereum_erc20.sql
+++ b/models/tokens/ethereum/tokens_ethereum_erc20.sql
@@ -20691,5 +20691,16 @@ FROM (VALUES
         ('0xfffb03083625d86ce1c2a7d6d3467b487385e8e6', 'CBAI', 9),
         ('0xffff981b7f8730faabd44906aa02fac15c22f2ce', 'NF', 9),
         ('0xffffffff2ba8f66d4e51811c5190992176930278', 'COMBO', 18),
-        ('0xfffffffff15abf397da76f1dcc1a1604f45126db', 'FSW', 18)
+        ('0xfffffffff15abf397da76f1dcc1a1604f45126db', 'FSW', 18),
+        ('0x0a6373644a8c7cd3b851ec80fb52feee28e9ee14', 'SHIBARIUM', 8),
+        ('0x4dd942baa75810a3c1e876e79d5cd35e09c97a76', 'D2T', 18),
+        ('0x56322c14cb5f53531c231b8f9ab178bf5d893a5e', 'AZA', 18),
+        ('0x5a9780bfe63f3ec57f01b087cd65bd656c9034a8', 'COM', 12),
+        ('0x5b4c95f76b8bd3ada1d8baa717cf658e14cf0dbf', 'GURA', 18),
+        ('0x5da21d9e63f1ea13d34e48b7223bcc97e3ecd687', 'wsETH2', 18),
+        ('0x6a5468752f8db94134b6508dabac54d3b45efce6', 'yvCurve-CRVETH', 18),
+        ('0x93eeb426782bd88fcd4b48d7b0368cf061044928', 'TRG', 18),
+        ('0xc97511a1ddb162c8742d39ff320cfdcd13fbcf7e', 'yvCurve-USDP', 18),
+        ('0xcfcffe432a48db53f59c301422d2edd77b2a88d7', 'TEXAN', 18),
+        ('0xe27efbe0fbd6afe1a41aa8f5ef68cb8c75514fd2', 'SUPI', 9)
      ) AS temp_table (contract_address, symbol, decimals)


### PR DESCRIPTION
python -m src.missing_tokens
Execute on Network Network.MAINNET
Fetching V2 missing tokens for Network.MAINNET from https://dune.com/queries/1403073?Blockchain=ethereum

V2 results:

('0x0a6373644a8c7cd3b851ec80fb52feee28e9ee14', 'SHIBARIUM', 8),
('0x4dd942baa75810a3c1e876e79d5cd35e09c97a76', 'D2T', 18),
('0x56322c14cb5f53531c231b8f9ab178bf5d893a5e', 'AZA', 18),
('0x5a9780bfe63f3ec57f01b087cd65bd656c9034a8', 'COM', 12),
('0x5b4c95f76b8bd3ada1d8baa717cf658e14cf0dbf', 'GURA', 18),
('0x5da21d9e63f1ea13d34e48b7223bcc97e3ecd687', 'wsETH2', 18),
('0x6a5468752f8db94134b6508dabac54d3b45efce6', 'yvCurve-CRVETH', 18),
('0x93eeb426782bd88fcd4b48d7b0368cf061044928', 'TRG', 18),
('0xc97511a1ddb162c8742d39ff320cfdcd13fbcf7e', 'yvCurve-USDP', 18),
('0xcfcffe432a48db53f59c301422d2edd77b2a88d7', 'TEXAN', 18),
('0xe27efbe0fbd6afe1a41aa8f5ef68cb8c75514fd2', 'SUPI', 9),

