### PR TITLE
Factory Creator bug in Optimism Contracts

### DIFF
--- a/models/contracts/optimism/contracts_optimism_contract_mapping.sql
+++ b/models/contracts/optimism/contracts_optimism_contract_mapping.sql
@@ -37,7 +37,7 @@ with base_level as (
   from (
     select 
       ct.`from` as creator_address
-      ,NULL::string as contract_factory
+      ,CAST(NULL AS string) as contract_factory
       ,ct.address as contract_address
       ,ct.block_time as created_time
       ,ct.tx_hash as creation_tx_hash
@@ -52,7 +52,7 @@ with base_level as (
       {% endif %}
     where 
       true
-    {% if is_incremental() %}
+      {% if is_incremental() %}
       and ct.block_time >= date_trunc('day', now() - interval '1 week')
 
     -- to get existing history of contract mapping
@@ -66,7 +66,7 @@ with base_level as (
       ,creation_tx_hash
       ,is_self_destruct
     from {{ this }}
-    {% endif %}
+      {% endif %} -- line 55 incremental filter
   ) as x
   group by 1, 2, 3, 4, 5, 6
 )
@@ -194,7 +194,7 @@ with base_level as (
     ,to_timestamp('2021-07-06 00:00:00') as created_time
     ,false as is_self_destruct
     ,'synthetix contracts' as source
-    ,NULL as creation_tx_hash
+    ,cast(NULL as string) as creation_tx_hash
   from {{ source('ovm1_optimism', 'synthetix_genesis_contracts') }} as snx
   where 
     true
@@ -286,7 +286,7 @@ select
   {% if is_incremental() %}
     th.contract_creator_if_factory
     {% else -%}
-    NULL
+    cast(NULL as string)
   {% endif %}
   ) as contract_creator_if_factory
   ,coalesce(c.is_self_destruct, false) as is_self_destruct

--- a/models/contracts/optimism/contracts_optimism_contract_mapping.sql
+++ b/models/contracts/optimism/contracts_optimism_contract_mapping.sql
@@ -255,7 +255,7 @@ select
   ,coalesce(co.contract_name, c.contract_name) as contract_name
   ,coalesce(c.creator_address, ovm1c.creator_address) as creator_address
   ,coalesce(c.created_time, to_timestamp(ovm1c.created_time)) as created_time
-  ,coalesce(c.contract_factory, th.contract_factory) as contract_creator_if_factory
+  ,coalesce(c.contract_factory, th.contract_creator_if_factory) as contract_creator_if_factory
   ,coalesce(c.is_self_destruct, false) as is_self_destruct
   ,c.creation_tx_hash
 from cleanup as c 
@@ -267,5 +267,5 @@ left join {{ ref('contracts_optimism_contract_overrides') }} as co --override co
   on lower(c.contract_address) = lower(co.contract_address)
 {% if is_incremental() %} -- this filter will only be applied on an incremental run 
 left join {{ this }} th -- grab if the contract was previously picked up as factory created
-  ON th.contract_address = c.contract_address
+  ON lower(th.contract_address) = lower(c.contract_address)
 {% endif %}

--- a/models/contracts/optimism/contracts_optimism_contract_mapping.sql
+++ b/models/contracts/optimism/contracts_optimism_contract_mapping.sql
@@ -222,7 +222,7 @@ with base_level as (
     ,false as is_self_destruct
     ,'ovm1 uniswap pools' as source
     ,NULL as creation_tx_hash
-  from {{ ref('uniswap_v3_optimism', 'ovm1_pool_mapping') }} as uni
+  from {{ ref('uniswap_optimism_ovm1_pool_mapping') }} as uni
   where 
     true
     {% if is_incremental() %} -- this filter will only be applied on an incremental run 

--- a/models/contracts/optimism/contracts_optimism_contract_mapping.sql
+++ b/models/contracts/optimism/contracts_optimism_contract_mapping.sql
@@ -255,7 +255,7 @@ select
   ,coalesce(co.contract_name, c.contract_name) as contract_name
   ,coalesce(c.creator_address, ovm1c.creator_address) as creator_address
   ,coalesce(c.created_time, to_timestamp(ovm1c.created_time)) as created_time
-  ,c.contract_factory as contract_creator_if_factory
+  ,coalesce(c.contract_factory, th.contract_factory) as contract_creator_if_factory
   ,coalesce(c.is_self_destruct, false) as is_self_destruct
   ,c.creation_tx_hash
 from cleanup as c 
@@ -265,3 +265,7 @@ left join {{ ref('contracts_optimism_project_name_mappings') }} as dnm -- fix na
   on lower(c.contract_project) = lower(dnm.dune_name)
 left join {{ ref('contracts_optimism_contract_overrides') }} as co --override contract maps
   on lower(c.contract_address) = lower(co.contract_address)
+{% if is_incremental() %} -- this filter will only be applied on an incremental run 
+left join {{ this }} th -- grab if the contract was previously picked up as factory created
+  ON th.contract_address = c.contract_address
+{% endif %}

--- a/models/contracts/optimism/contracts_optimism_contract_mapping.sql
+++ b/models/contracts/optimism/contracts_optimism_contract_mapping.sql
@@ -255,7 +255,13 @@ select
   ,coalesce(co.contract_name, c.contract_name) as contract_name
   ,coalesce(c.creator_address, ovm1c.creator_address) as creator_address
   ,coalesce(c.created_time, to_timestamp(ovm1c.created_time)) as created_time
-  ,coalesce(c.contract_factory, th.contract_creator_if_factory) as contract_creator_if_factory
+  ,coalesce(c.contract_factory, 
+  {% if is_incremental() %}
+    th.contract_creator_if_factory
+    {% else -%}
+    NULL
+  {% endif %}
+  ) as contract_creator_if_factory
   ,coalesce(c.is_self_destruct, false) as is_self_destruct
   ,c.creation_tx_hash
 from cleanup as c 


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Found a small bug in Optimism contract mapping where the `contract_creator_if_factory` field would get wiped once a contract fell out of the incremental window. This field is used for mapping & easily determining if the contract was created by a contract.

This fix joins with `this` in order to pull the `contract_creator_if_factory` form previously created contracts.

Q: Will this auto-update all historical entries in the table, or do we need to drop and re-run? cc @chuxinh 

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
