### PR TITLE
Hop Optimism Fixes

### DIFF
--- a/models/hop_protocol/optimism/hop_protocol_optimism_flows.sql
+++ b/models/hop_protocol/optimism/hop_protocol_optimism_flows.sql
@@ -46,6 +46,8 @@ SELECT
 
 FROM (
 
+    -- Withdrawals away from Optimism
+    
     select 
      ts.evt_block_time AS block_time
     ,ts.evt_block_number AS block_number
@@ -65,7 +67,8 @@ FROM (
     {% if is_incremental() %}
     WHERE evt_block_time >= (NOW() - interval '14 days')
     {% endif %}
-    UNION ALL
+
+    UNION ALL -- Deposits to Optimism from L1
     
     select 
      tl.evt_block_time AS block_time
@@ -87,7 +90,7 @@ FROM (
     WHERE evt_block_time >= (NOW() - interval '14 days')
     {% endif %}
     
-    UNION ALL
+    UNION ALL -- Deposits to Optimism from Non-L1 Chains
     
     select 
      wb.evt_block_time AS block_time

--- a/models/hop_protocol/optimism/hop_protocol_optimism_flows.sql
+++ b/models/hop_protocol/optimism/hop_protocol_optimism_flows.sql
@@ -102,13 +102,9 @@ FROM (
     ,wb.contract_address AS project_contract_address
     , wb.transferId AS transfer_id
     , CASE
-            WHEN wb.contract_address = '0x83f6244bd87662118d96d9a6d44f09dfff14b30e' THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'ethereum mainnet') --ETH 
-            WHEN wb.contract_address = '0x7191061d5d4c60f598214cc6913502184baddf18' THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'ethereum mainnet') --DAI 
-            WHEN wb.contract_address = '0xa81d244a1814468c734e5b4101f7b9c0c577a8fc' THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'ethereum mainnet') --USDC
-            WHEN wb.contract_address = '0x03d7f750777ec48d39d080b020d83eb2cb4e3547' THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'ethereum mainnet') --HOP
-            WHEN wb.contract_address = '0x46ae9bab8cea96610807a275ebd36f8e916b5c61' THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'ethereum mainnet') --USDT
-            WHEN arb.transferId IS NOT NULL THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'arbitrum')
-            WHEN poly.transferId IS NOT NULL THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'polygon')
+            WHEN hpa.l2Bridge IS NOT NULL THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'ethereum mainnet') --ETH 
+            WHEN arb.transferId IS NOT NULL THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'arbitrum one')
+            WHEN poly.transferId IS NOT NULL THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'polygon mainnet')
             WHEN gno.transferId IS NOT NULL THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'gnosis')
         ELSE NULL
         END
@@ -133,6 +129,9 @@ FROM (
             {% if is_incremental() %}
             AND gno.evt_block_time >= (NOW() - interval '45 days')
               {% endif %}
+        LEFT JOIN {{ ref('hop_protocol_addresses') }} hpa
+            ON hpa.l2Bridge = wb.contract_address
+            AND hpa.l1CanonicalBridge = '0x0000000000000000000000000000000000000000'
     {% if is_incremental() %}
     WHERE wb.evt_block_time >= (NOW() - interval '14 days')
     {% endif %}

--- a/models/hop_protocol/optimism/hop_protocol_optimism_flows.sql
+++ b/models/hop_protocol/optimism/hop_protocol_optimism_flows.sql
@@ -102,7 +102,6 @@ FROM (
     ,wb.contract_address AS project_contract_address
     , wb.transferId AS transfer_id
     , CASE
-            WHEN hpa.l2Bridge IS NOT NULL THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'ethereum mainnet') --ETH 
             WHEN arb.transferId IS NOT NULL THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'arbitrum one')
             WHEN poly.transferId IS NOT NULL THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'polygon mainnet')
             WHEN gno.transferId IS NOT NULL THEN (SELECT chain_id FROM {{ ref('chain_ids') }} WHERE lower(chain_name) = 'gnosis')
@@ -129,9 +128,6 @@ FROM (
             {% if is_incremental() %}
             AND gno.evt_block_time >= (NOW() - interval '45 days')
               {% endif %}
-        LEFT JOIN {{ ref('hop_protocol_addresses') }} hpa
-            ON hpa.l2Bridge = wb.contract_address
-            AND hpa.l1CanonicalBridge = '0x0000000000000000000000000000000000000000'
     {% if is_incremental() %}
     WHERE wb.evt_block_time >= (NOW() - interval '14 days')
     {% endif %}


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Recent PRs tried to solve for missing chain labels, and inadvertently mapped all transfers from non-L1 chains as ethereum mainnet. The real source of the issue seemed to be that chain names were not properly mapped to their full name in chain registries (i.e. 'polygon mainnet' vs 'polygon', 'arbitrum one' vs 'arbitrum').

This fix reverts the changes & should respond with a valid source/destination chain for all Hop transfers on Optimism. cc @soispoke - Not sure how table builds get created, but we might need to drop and restart Hop & bridge flows tables?

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
