### PR TITLE
[Prices] Remove Bogus Token Price

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -427,7 +427,6 @@ VALUES
     ("eng-enigma", "ethereum", "ENG", "0xf0ee6b27b759c9893ce4f094b49ad28fd15a23e4", 8),
     ("enj-enjin-coin", "ethereum", "ENJ", "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c", 18),
     ("ens-ethereum-name-service", "ethereum", "ENS", "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72", 18),
-    ("erc20-erc20", "ethereum", "ERC20", "0xc3761eb917cd790b30dad99f6cc5b4ff93c4f9ea", 18),
     ("erowan-sifchain", "ethereum", "EROWAN", "0x07bac35846e5ed502aa91adf6a9e7aa210f2dcbe", 18),
     ("ersdl-unfederalreserve", "ethereum", "ERSDL", "0x5218e472cfcfe0b64a064f055b43b4cdc9efd3a6", 18),
     ("ethplo-ethplode", "ethereum", "ETHPLO", "0xe0c6ce3e73029f201e5c0bedb97f67572a93711c", 6),


### PR DESCRIPTION
This token is causing problems with Dex Trade valuation and clearly has a very bad price feed (in more than just the coin paprika market).

From [this transaction](https://etherscan.io/tx/0x918eacff2b6c1fdbb14920473974dd471301f9f305c010baa3085b9ed59c33a6) we can see that several trillion of this token were swapped for only 1.5K USDC. This implies that even Etherscan has incorrect valuation of the token.

Here we see our own bogus trade valuation: https://dune.com/queries/1901839?d=1

I believe the problem here to be related to "market depth". The prices are likely showing "spot prices" but don't account for the depth of the pool showing these prices. When such a large order comes in, the pool is only able to return very low amounts. The only solution I can think of at the moment is to cut this off at the source. Since the coin paprika page does not appear to display any active markets for this token. Maybe it does not make sense to keep it around... 


[Coin Paprika page for this token](https://coinpaprika.com/coin/erc20-erc20/) shows the value at ~0.007 cents at the time of this trade which clearly was not realized