### PR TITLE
[bug] fix airswap model not updating on incremental runs

### DIFF
--- a/models/airswap/ethereum/airswap_ethereum_trades.sql
+++ b/models/airswap/ethereum/airswap_ethereum_trades.sql
@@ -115,7 +115,7 @@ INNER JOIN {{ source('ethereum', 'transactions') }} tx
     AND tx.block_time >= '{{project_start_date}}'
     {% endif %}
     {% if is_incremental() %}
-    AND tx.block_time = date_trunc("day", now() - interval '1 week')
+    AND tx.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
 LEFT JOIN {{ ref('tokens_erc20') }} erc20a
     ON erc20a.contract_address = dexs.token_bought_address


### PR DESCRIPTION
Airswap model is falling behind by days, but works perfectly when running a full_refresh and raises no errors while running an incremental refresh.

The culprit is an incremental filter set to = instead of >=.

This PR fixes it.