### PR TITLE
Update wombat_bnb_trades.sql

### DIFF
--- a/models/wombat/bnb/wombat_bnb_schema.yml
+++ b/models/wombat/bnb/wombat_bnb_schema.yml
@@ -6,7 +6,7 @@ models:
       blockchain: bnb
       sector: dex
       project: wombat
-      contributors: umer_h_adil
+      contributors: [umer_h_adil, hosuke]
     config:
       tags: ['bnb', 'trades', 'dex', 'umer_h_adil']
     description: >

--- a/models/wombat/bnb/wombat_bnb_trades.sql
+++ b/models/wombat/bnb/wombat_bnb_trades.sql
@@ -76,7 +76,7 @@ inner join {{ source('bnb', 'transactions') }} tx
     and tx.block_time >= '{{project_start_date}}'
     {% endif %}
     {% if is_incremental() %}
-    and tx.block_time = date_trunc("day", now() - interval '1 week')
+    and tx.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
 -- bought tokens
 left join {{ ref('tokens_erc20') }} erc20_b

--- a/models/wombat/bnb/wombat_bnb_trades.sql
+++ b/models/wombat/bnb/wombat_bnb_trades.sql
@@ -8,36 +8,43 @@
     post_hook='{{ expose_spells(\'["bnb"]\',
                                 "project",
                                 "wombat_v1",
-                                \'["umer_h_adil"]\') }}'
+                                \'["umer_h_adil", "hosuke"]\') }}'
     )
 }}
 
 {% set project_start_date = '2022-04-18' %}
+{% set wombat_bnb_swap_evt_tables = [
+    source('wombat_bnb', 'Pool_evt_Swap')
+    , source('wombat_bnb', 'HighCovRatioFeePool_evt_Swap')
+    , source('wombat_bnb', 'DynamicPool_evt_Swap')
+    , source('wombat_bnb', 'mWOM_Pool_evt_Swap')
+    , source('wombat_bnb', 'qWOM_WOMPool_evt_Swap')
+    , source('wombat_bnb', 'WMX_WOM_Pool_evt_Swap')
+] %}
 
 with wombat_swaps_all_pools as (
-    -- main pool
-    select toAmount, fromAmount, toToken, fromToken, evt_block_time, evt_tx_hash, evt_index, to, contract_address
-    from {{ source('wombat_bnb', 'Pool_evt_Swap') }}
-    union all
-    -- side pool
-    select toAmount, fromAmount, toToken, fromToken, evt_block_time, evt_tx_hash, evt_index, to, contract_address
-    from {{ source('wombat_bnb', 'HighCovRatioFeePool_evt_Swap') }}
-    union all
-    -- bnb pool
-    select toAmount, fromAmount, toToken, fromToken, evt_block_time, evt_tx_hash, evt_index, to, contract_address
-    from {{ source('wombat_bnb', 'DynamicPool_evt_Swap') }}
-    union all
-    -- mwom pool
-    select toAmount, fromAmount, toToken, fromToken, evt_block_time, evt_tx_hash, evt_index, to, contract_address
-    from {{ source('wombat_bnb', 'mWOM_Pool_evt_Swap') }}
-    union all
-    -- qwom pool
-    select toAmount, fromAmount, toToken, fromToken, evt_block_time, evt_tx_hash, evt_index, to, contract_address
-    from {{ source('wombat_bnb', 'qWOM_WOMPool_evt_Swap') }}
-    union all
-    -- wmx pool
-    select toAmount, fromAmount, toToken, fromToken, evt_block_time, evt_tx_hash, evt_index, to, contract_address
-    from {{ source('wombat_bnb', 'WMX_WOM_Pool_evt_Swap') }})
+    {% for swap_evt_table in wombat_bnb_swap_evt_tables %}
+        select  toAmount
+                , fromAmount
+                , toToken
+                , fromToken
+                , evt_block_time
+                , evt_tx_hash
+                , evt_index
+                , t.to
+                , contract_address
+        from {{ swap_evt_table }} t
+        {% if is_incremental() %}
+        where evt_block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}
+
+        {% if not loop.last %}
+        union all
+        {% endif %}
+
+    {% endfor%}
+)
+
 select
 	'bnb' as blockchain
 	, 'wombat' as project


### PR DESCRIPTION
Changed '= date_trunc' to '>= date_trunc'

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
