### PR TITLE
Add rETH to prices_tokens.sql

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -1619,6 +1619,7 @@ VALUES
     ("xen-xen-crypto", "ethereum", "XEN", "0x06450dee7fd2fb8e39061434babcfc05599a6fb8", 18),
     ("bob-bob", "ethereum", "BOB", "0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b", 18),
     ("unbnk-unbanked", "ethereum", "UNBNK", "0x06b884e60794ce02aafab13791b59a2e6a07442f", 18),
+    ("reth-rocket-pool-eth", "ethereum", "rETH", "0xae78736cd615f374d3085123a210448e74fc6393", 18),
 
     -- Query for Popular Traded Tokens on Gnosis Chain without prices: https://dune.com/queries/1719783
     ("dai-dai", "gnosis", "WXDAI", "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d", 18),


### PR DESCRIPTION
Brief comments on the purpose of your changes:
- Add rETH (rocketpool ETH) price to `prices_tokens.sql` for a more complete picture of the liquid staking derivative market

**For Dune Engine V2**

I've checked that:
- Contract address is [correct](https://etherscan.io/token/0xae78736cd615f374d3085123a210448e74fc6393?a=0x341c05c0e9b33c0e38d64de76516b2ce970bb3be) 
- Contract address is in lowercase.
- Symbol is correct based on [etherscan](https://etherscan.io/token/0xae78736cd615f374d3085123a210448e74fc6393?a=0x341c05c0e9b33c0e38d64de76516b2ce970bb3be) and [Rocketpool's docs](https://docs.rocketpool.net/guides/staking/overview.html#the-reth-token)
- Token is listed on [coinpaprika](https://coinpaprika.com/coin/reth-rocket-pool-eth/).
- [Price feed is active](https://api.coinpaprika.com/v1/coins/reth-rocket-pool-eth/).

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
