### PR TITLE
[Easy] [Labels] Include dex aggregator trades in arb trader label

### DIFF
--- a/models/labels/arbitrage_traders/ethereum/labels_arbitrage_traders_ethereum.sql
+++ b/models/labels/arbitrage_traders/ethereum/labels_arbitrage_traders_ethereum.sql
@@ -49,13 +49,17 @@ with
     SELECT 
       distinct t1.taker as address
     FROM
-      SELECT * FROM {{ref('dex_trades')}}
-      UNION ALL
-      SELECT * FROM {{ref('dex_aggregator_trades')}} t1
+      (
+        SELECT * FROM {{ref('dex_trades')}}
+        UNION ALL
+        SELECT * FROM {{ref('dex_aggregator_trades')}}
+      ) t1
       INNER JOIN
-      SELECT * FROM {{ref('dex_trades')}}
-      UNION ALL
-      SELECT * FROM {{ref('dex_aggregator_trades')}} t2 ON t1.tx_hash = t2.tx_hash
+      (
+        SELECT * FROM {{ref('dex_trades')}}
+        UNION ALL
+        SELECT * FROM {{ref('dex_aggregator_trades')}}
+      ) t2 ON t1.tx_hash = t2.tx_hash
     WHERE
       t1.blockchain = 'ethereum'
       AND t2.blockchain = 'ethereum'

--- a/models/labels/arbitrage_traders/ethereum/labels_arbitrage_traders_ethereum.sql
+++ b/models/labels/arbitrage_traders/ethereum/labels_arbitrage_traders_ethereum.sql
@@ -49,8 +49,13 @@ with
     SELECT 
       distinct t1.taker as address
     FROM
-      {{ref('dex_trades')}} t1
-      INNER JOIN {{ref('dex_trades')}} t2 ON t1.tx_hash = t2.tx_hash
+      SELECT * FROM {{ref('dex_trades')}}
+      UNION ALL
+      SELECT * FROM {{ref('dex_aggregator_trades')}} t1
+      INNER JOIN
+      SELECT * FROM {{ref('dex_trades')}}
+      UNION ALL
+      SELECT * FROM {{ref('dex_aggregator_trades')}} t2 ON t1.tx_hash = t2.tx_hash
     WHERE
       t1.blockchain = 'ethereum'
       AND t2.blockchain = 'ethereum'


### PR DESCRIPTION
Include dex aggregator trades in the arb trader label which has been considering only dex_trades up until now.

cc @soispoke which has been responsible for labels recently