### PR TITLE
[Easy] add fantom & polygon miners to miner labels - Ready for review 

### DIFF
--- a/models/labels/miners/labels_miners.sql
+++ b/models/labels/miners/labels_miners.sql
@@ -1,5 +1,5 @@
 {{config(alias='miners',
-        post_hook='{{ expose_spells(\'["ethereum", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c","fantom","polygon"]\',
                                     "sector",
                                     "labels",
                                     \'["soispoke"]\') }}')
@@ -64,3 +64,23 @@ SELECT DISTINCT array('optimism') as blockchain,
        date('2022-09-28') as created_at,
        now() as modified_at
 FROM {{ source('optimism','blocks') }} 
+UNION 
+SELECT DISTINCT array('fantom') as blockchain,
+       miner, 
+       'Fantom Miner' as name,
+       'contracts' as category,
+       'soispoke' as contributor,
+       'query' AS source,
+       date('2023-01-25') as created_at,
+       now() as modified_at
+FROM {{ source('fantom','blocks') }} 
+UNION 
+SELECT DISTINCT array('polygon') as blockchain,
+       miner, 
+       'Polygon Miner' as name,
+       'contracts' as category,
+       'soispoke' as contributor,
+       'query' AS source,
+       date('2023-01-25') as created_at,
+       now() as modified_at
+FROM {{ source('polygon','blocks') }} 

--- a/models/labels/miners/labels_miners_schema.yml
+++ b/models/labels/miners/labels_miners_schema.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: labels_miners
     meta:
-      blockchain: ethereum, arbitrum, gnosis, optimism, bnb, avalanche_c
+      blockchain: ethereum, arbitrum, gnosis, optimism, bnb, avalanche_c, fantom, polygon
       sector: labels
       category: miners
       contributors:  soispoke


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
