### PR TITLE
Deploy key for Dagster CI workflow

### DIFF
--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -17,7 +17,7 @@ jobs:
         echo "PAT_TOKEN=$(echo $SPELLBOOK_PAT_TOKEN)" >> $GITHUB_ENV
     - uses: actions/github-script@v6
       with:
-        github-token: ${{ github.PAT_TOKEN }}
+        github-token: ${{ secrets.TEST_TOKEN }}
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -15,8 +15,7 @@ jobs:
     steps:
     - uses: actions/github-script@v6
       with:
-#        github-token: ${{ secrets.PAT_TOKEN }}
-        github-token: $SPELLBOOK_PAT_TOKEN[spellbook_pat_token]
+        github-token: $SPELLBOOK_PAT_TOKEN
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -1,5 +1,4 @@
 on:
-  pull_request:
   push:
     branches:
       - "main"

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -10,7 +10,8 @@ jobs:
     steps:
     - uses: actions/github-script@v6
       with:
-        github-token: $SPELLBOOK_PAT_TOKEN
+        github-token: ${{ secrets.PAT_TOKEN }}
+#        github-token: $SPELLBOOK_PAT_TOKEN
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -8,7 +8,6 @@ concurrency:
   group:  ${{ github.workflow }}
   cancel-in-progress: true
 
-
 jobs:
   dispatch:
     runs-on: [ self-hosted, linux, spellbook ]

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -12,9 +12,12 @@ jobs:
   dispatch:
     runs-on: [ self-hosted, linux, spellbook ]
     steps:
+    - name: Set environment variables
+      run: |
+        echo "PAT_TOKEN=$(echo echo $SPELLBOOK_PAT_TOKEN)" >> $GITHUB_ENV
     - uses: actions/github-script@v6
       with:
-        github-token: $SPELLBOOK_PAT_TOKEN
+        github-token: $PAT_TOKEN
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/github-script@v6
       with:
-        github-token: ${{ secrets.PAT }}
+        github-token: 'test'
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/github-script@v6
       with:
 #        github-token: ${{ secrets.PAT_TOKEN }}
-        github-token: $SPELLBOOK_PAT_TOKEN.spellbook_pat_token
+        github-token: $SPELLBOOK_PAT_TOKEN[spellbook_pat_token]
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/github-script@v6
       with:
-        github-token: 'test'
+        github-token: ${{ secrets.PAT_TOKEN }}
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -10,8 +10,8 @@ jobs:
     steps:
     - uses: actions/github-script@v6
       with:
-        github-token: ${{ secrets.PAT_TOKEN }}
-#        github-token: $SPELLBOOK_PAT_TOKEN
+#        github-token: ${{ secrets.PAT_TOKEN }}
+        github-token: "$SPELLBOOK_PAT_TOKEN"
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/github-script@v6
       with:
-        github-token: ${{ secrets.SPELLBOOK_PAT_TOKEN }}
+        github-token: $SPELLBOOK_PAT_TOKEN
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -1,5 +1,5 @@
 on:
-  workflow_dispatch:
+  pull_request:
   push:
     branches:
       - "main"

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/github-script@v6
       with:
-        github-token: ${{ secrets.PAT_TOKEN }}
+        ssh-key: ${{ secrets.COMMIT_KEY }}
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: Set environment variables
       run: |
-        echo "PAT_TOKEN=$(echo echo $SPELLBOOK_PAT_TOKEN)" >> $GITHUB_ENV
+        echo "PAT_TOKEN=$(echo $SPELLBOOK_PAT_TOKEN)" >> $GITHUB_ENV
     - uses: actions/github-script@v6
       with:
         github-token: $PAT_TOKEN

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
     - uses: actions/github-script@v6
       with:
-        ssh-key: ${{ secrets.COMMIT_KEY }}
+        github-token: ${{ secrets.PAT }}
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',
             repo: 'spellbook-dagster',
-            workflow_id: '38005040',
+            workflow_id: 'deploy.yml',
             ref: 'main'
           })

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -17,7 +17,7 @@ jobs:
         echo "PAT_TOKEN=$(echo $SPELLBOOK_PAT_TOKEN)" >> $GITHUB_ENV
     - uses: actions/github-script@v6
       with:
-        github-token: ${{ secrets.TEST_TOKEN }}
+        github-token: ${{ secrets.SPELLBOOK_PAT_TOKEN }}
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -12,11 +12,11 @@ jobs:
   dispatch:
     runs-on: [ self-hosted, linux, spellbook ]
     steps:
-      - name: Set pat token
-        id: set-pat-token
-        run: |
-            echo "token=$SPELLBOOK_PAT_TOKEN" >> $GITHUB_OUTPUT
-            exit 0
+    - name: Set pat token
+      id: set-pat-token
+      run: |
+          echo "token=$SPELLBOOK_PAT_TOKEN" >> $GITHUB_OUTPUT
+          exit 0
     - uses: actions/github-script@v6
       with:
         github-token: ${{ steps.set-pat-token.outputs.token }}

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -15,6 +15,6 @@ jobs:
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',
             repo: 'spellbook-dagster',
-            workflow_id: 'deploy.yml',
+            workflow_id: '38005040',
             ref: 'main'
           })

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   dispatch:
-     runs-on: [ self-hosted, linux, spellbook ]
+    runs-on: [ self-hosted, linux, spellbook ]
     steps:
     - uses: actions/github-script@v6
       with:

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -12,9 +12,14 @@ jobs:
   dispatch:
     runs-on: [ self-hosted, linux, spellbook ]
     steps:
+      - name: Set pat token
+        id: set-pat-token
+        run: |
+            echo "token=$SPELLBOOK_PAT_TOKEN" >> $GITHUB_OUTPUT
+            exit 0
     - uses: actions/github-script@v6
       with:
-        github-token: echo $SPELLBOOK_PAT_TOKEN
+        github-token: ${{ steps.set-pat-token.outputs.token }}
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - "main"
 
+concurrency:
+  group:  ${{ github.workflow }}
+  cancel-in-progress: true
+
+
 jobs:
   dispatch:
     runs-on: [ self-hosted, linux, spellbook ]
@@ -11,7 +16,7 @@ jobs:
     - uses: actions/github-script@v6
       with:
 #        github-token: ${{ secrets.PAT_TOKEN }}
-        github-token: "$spellbook_pat_token"
+        github-token: ${{ secrets.SPELLBOOK_PAT_TOKEN }}
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/github-script@v6
       with:
 #        github-token: ${{ secrets.PAT_TOKEN }}
-        github-token: ${{ secrets.SPELLBOOK_PAT_TOKEN }}
+        github-token: $SPELLBOOK_PAT_TOKEN.spellbook_pat_token
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -12,12 +12,9 @@ jobs:
   dispatch:
     runs-on: [ self-hosted, linux, spellbook ]
     steps:
-    - name: Set environment variables
-      run: |
-        echo "PAT_TOKEN=$(echo $SPELLBOOK_PAT_TOKEN)" >> $GITHUB_ENV
     - uses: actions/github-script@v6
       with:
-        github-token: ${{ secrets.SPELLBOOK_PAT_TOKEN }}
+        github-token: echo $SPELLBOOK_PAT_TOKEN
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -6,11 +6,11 @@ on:
 
 jobs:
   dispatch:
-    runs-on: ubuntu-latest
+     runs-on: [ self-hosted, linux, spellbook ]
     steps:
     - uses: actions/github-script@v6
       with:
-        github-token: ${{ secrets.PAT_TOKEN }}
+        github-token: ${{ secrets.SPELLBOOK_PAT_TOKEN }}
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/github-script@v6
       with:
 #        github-token: ${{ secrets.PAT_TOKEN }}
-        github-token: "$SPELLBOOK_PAT_TOKEN"
+        github-token: "$spellbook_pat_token"
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -17,7 +17,7 @@ jobs:
         echo "PAT_TOKEN=$(echo $SPELLBOOK_PAT_TOKEN)" >> $GITHUB_ENV
     - uses: actions/github-script@v6
       with:
-        github-token: $PAT_TOKEN
+        github-token: ${{ github.PAT_TOKEN }}
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'duneanalytics',


### PR DESCRIPTION
This updates the workflow to use a deploy key instead of a personal access token (which had never been supplied) because a deploy token has a much narrower scope of permissions.

When this workflow works, it will cause the dagster deploy workflow to redeploy whenever there is a merge and the reconciliation sensor will pick up any modified models and run them. 