### PR TITLE
removing incorrect $PLT from prices.usd

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -94,7 +94,6 @@ VALUES
     ("multi-multichain","arbitrum","MULTI","0x9fb9a33956351cf4fa040f65a13b835a3c8764e3",18),
     ("myc-mycelium","arbitrum","MYC","0xc74fe4c715510ec2f8c61d70d397b32043f55abe",18),
     ("perp-perpetual-protocol","arbitrum","PERP","0x753d224bcf9aafacd81558c32341416df61d3dac",18),
-    ("plt-plutus-defi","arbitrum","PLS","0x51318b7d00db7acc4026c88c3952b66278b6a67f",18),
     ("rai-rai-reflex-index","arbitrum","RAI","0xaef5bbcbfa438519a5ea80b4c7181b4e78d419f2",18),
     ("rdpx-dopex-rebate-token","arbitrum","RDPX","0x32eb7902d4134bf98a28b963d26de779af92a212",18),
     ("rgt-rari-governance-token","arbitrum","RGT","0xef888bca6ab6b1d26dbec977c455388ecd794794",18),


### PR DESCRIPTION
https://api.coinpaprika.com/v1/coins/plt-plutus-defi

this is a different $PLT token, causing the usd_amount in dex.trades to be inflated.

https://discord.com/channels/757637422384283659/1068296138110799953/1068420867400421416

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
