### PR TITLE
Update prices_tokens.sql

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -1771,7 +1771,7 @@ VALUES
     ("bob-bob", "polygon", "BOB", "0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b", 18),
     ("ric-ricochet","polygon","RIC","0x263026e7e53dbfdce5ae55ade22493f828922965",18),
     ("nuls-nuls", "polygon", "NULS", "0x8b8e48a8cc52389cd16a162e5d8bd514fabf4ba0", 8),
-    ("blank-blockwallet","polygon", "BLANK", "0xc49079e96ceaf20c9900f1b77aa09d2d5a011341", 18),
+    ("blank-blockwallet","polygon", "BLANK", "0xf4C83080E80AE530d6f8180572cBbf1Ac9D5d435", 18),
     ("fin-fin", "polygon", "FIN", "0x576c990a8a3e7217122e9973b2230a3be9678e94", 18),
 
     ("aury-aurory", "solana", "AURY", "AURYydfxJib1ZkTir1Jn1J9ECYUtjb6rKQVmtYaixWPP", 9),


### PR DESCRIPTION
Brief comments on the purpose of your changes:

fixed BLANK token Polygon address submitted by mistake in the previous PR.

Polygon scan link: https://polygonscan.com/token/0xf4c83080e80ae530d6f8180572cbbf1ac9d5d435


**For Dune Engine V2**

I've checked that:

### Pricing checks:
* [x] `coin_id` represents the ID of the coin on coinpaprika.com
* [x] all the coins are active on coinpaprika.com (please remove inactive ones)
