### PR TITLE
Add BUSD & aOptOP to Optimism

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -1744,6 +1744,7 @@ VALUES
     ("pickle-pickle-finance", "optimism", "PICKLE", "0x0c5b4c92c948691EEBf185C17eeB9c230DC019E9", 18),
     ("bob-bob", "optimism", "BOB", "0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b", 18),
     ("bomb-fbomb","optimism","fBOMB","0x74ccbe53F77b08632ce0CB91D3A545bF6B8E0979",18),
+    ("busd-binance-usd","optimism","BUSD","0x9C9e5fD8bbc25984B178FdCE6117Defa39d2db39",18)
 
     ("aave-new","polygon","AAVE","0xd6df932a45c0f255f85145f286ea0b292b21c90b",18),
     ("ageur-ageur","polygon",'agEUR',"0xe0b52e49357fd4daf2c15e02058dce6bc0057db4",18),

--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -1744,7 +1744,7 @@ VALUES
     ("pickle-pickle-finance", "optimism", "PICKLE", "0x0c5b4c92c948691EEBf185C17eeB9c230DC019E9", 18),
     ("bob-bob", "optimism", "BOB", "0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b", 18),
     ("bomb-fbomb","optimism","fBOMB","0x74ccbe53F77b08632ce0CB91D3A545bF6B8E0979",18),
-    ("busd-binance-usd","optimism","BUSD","0x9C9e5fD8bbc25984B178FdCE6117Defa39d2db39",18)
+    ("busd-binance-usd","optimism","BUSD","0x9c9e5fd8bbc25984b178fdce6117defa39d2db39",18),
 
     ("aave-new","polygon","AAVE","0xd6df932a45c0f255f85145f286ea0b292b21c90b",18),
     ("ageur-ageur","polygon",'agEUR',"0xe0b52e49357fd4daf2c15e02058dce6bc0057db4",18),

--- a/models/tokens/optimism/tokens_optimism_erc20.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20.sql
@@ -282,6 +282,7 @@ WITH raw_token_list AS (
     ,('0x191c10aa4af7c30e871e70c95db0e4eb77237530', 'aOptLINK', 18, 'receipt')
     ,('0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', 'aOptSUSD', 18, 'receipt')
     ,('0x078f358208685046a11c85e8ad32895ded33a249', 'aOptWBTC', 8, 'receipt')
+    ,('0x513c7E3a9c69cA3e22550eF58AC1C0088e918FFf', 'aOptOP', 18, 'receipt')
     ,('0x74ccbe53F77b08632ce0CB91D3A545bF6B8E0979', 'fBOMB', 18, 'underlying')
     ,('0x9C9e5fD8bbc25984B178FdCE6117Defa39d2db39', 'BUSD', 18, 'underlying')
     ) AS temp_table (contract_address, symbol, decimals, token_type)

--- a/models/tokens/optimism/tokens_optimism_erc20.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20.sql
@@ -283,6 +283,7 @@ WITH raw_token_list AS (
     ,('0x6d80113e533a2c0fe82eabd35f1875dcea89ea97', 'aOptSUSD', 18, 'receipt')
     ,('0x078f358208685046a11c85e8ad32895ded33a249', 'aOptWBTC', 8, 'receipt')
     ,('0x74ccbe53F77b08632ce0CB91D3A545bF6B8E0979', 'fBOMB', 18, 'underlying')
+    ,('0x9C9e5fD8bbc25984B178FdCE6117Defa39d2db39', 'BUSD', 18, 'underlying')
     ) AS temp_table (contract_address, symbol, decimals, token_type)
 
 )


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
