### PR TITLE
excluding a token from pricefeed

### DIFF
--- a/models/prices/prices_tokens.sql
+++ b/models/prices/prices_tokens.sql
@@ -687,7 +687,7 @@ VALUES
     ("unfi-unifi-protocol", "ethereum", "UNFI", "0x441761326490cacf7af299725b6292597ee822c2", 18),
     ("uni-uniswap", "ethereum", "UNI", "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984", 18),
     ("uniq-uniqly", "ethereum", "UNIQ", "0x3758e00b100876c854636ef8db61988931bb8025", 18),
-    ("up-unifi-protocol", "ethereum", "UP", "0xb6c5c839cef46082a2b51164e8db649c121f147e", 18),
+    --("up-unifi-protocol", "ethereum", "UP", "0xb6c5c839cef46082a2b51164e8db649c121f147e", 18), broken price feed
     ("usdc-usd-coin", "ethereum", "USDC", "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", 6),
     ("usdn-neutrino-usd", "ethereum", "USDN", "0x674c6ad92fd080e4004b2312b45f796a192d27a0", 18),
     ("usdt-tether", "ethereum", "USDT", "0xdac17f958d2ee523a2206206994597c13d831ec7", 6),


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [X] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [X] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [X] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [X] column names are `lowercase_snake_cased`
* [X] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [X] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [X] `coin_id` represents the ID of the coin on coinpaprika.com
* [X] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [X] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [X] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [X] where block_time >= date_trunc("day", now() - interval '1 week')
* [X] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [X] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
