### PR TITLE
How to Speed Up Gas Fees?

### DIFF
--- a/models/gas/gas_fees.sql
+++ b/models/gas/gas_fees.sql
@@ -1,10 +1,5 @@
 {{ config(
         alias ='fees',
-        partition_by = ['block_date'],
-        materialized = 'incremental',
-        file_format = 'delta',
-        incremental_strategy = 'merge',
-        unique_key = ['blockchain','tx_hash','block_number'],
         post_hook='{{ expose_spells(\'["ethereum","bnb","avalanche_c","optimism","arbitrum"]\',
                                 "sector",
                                 "gas",
@@ -47,7 +42,7 @@ FROM (
         transaction_type
     FROM {{ ref(gas_model) }}
     {% if not loop.last %}
-    UNION
+    UNION ALL
     {% endif %}
     {% endfor %}
 )

--- a/models/gas/gas_fees.sql
+++ b/models/gas/gas_fees.sql
@@ -1,5 +1,10 @@
 {{ config(
         alias ='fees',
+        partition_by = ['block_date'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['blockchain','tx_hash','block_number']
         post_hook='{{ expose_spells(\'["ethereum","bnb","avalanche_c","optimism","arbitrum"]\',
                                 "sector",
                                 "gas",

--- a/models/gas/gas_fees.sql
+++ b/models/gas/gas_fees.sql
@@ -4,7 +4,7 @@
         materialized = 'incremental',
         file_format = 'delta',
         incremental_strategy = 'merge',
-        unique_key = ['blockchain','tx_hash','block_number']
+        unique_key = ['blockchain','tx_hash','block_number'],
         post_hook='{{ expose_spells(\'["ethereum","bnb","avalanche_c","optimism","arbitrum"]\',
                                 "sector",
                                 "gas",


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**
~Hi, i started trying to use the gas fees table, but noticed that it was often slow when looking across chains (i.e. query optimism and ethereum in the same query).~

~I wonder if changing the final table to an materialized build would help? Feel free to close / modify if not.~

Edit: Never mind, incremental build for the final one doesn't follow other models. Maybe changing from Union to Union all?
cc @soispoke 

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
