### PR TITLE
[draft] adding detailed documentation to spells

### DIFF
--- a/models/labels/sandwich_attackers/README.md
+++ b/models/labels/sandwich_attackers/README.md
@@ -13,8 +13,8 @@ The logic to identify a sandwich attacker is as follows:
 7. (index of t1 >= index of t2 + 2) or (index of t2 >= index of t1 + 2)
 8. Exclude uniswap v2 router address since this gets included as a false positive for some reason
 
-This logic should work to include both buy-first and less common sell-first sandwiches
-By excluding point 6, we also include sandwich attacks that made a loss
-By using '>=' instead of just '=' in point 7, we can also include sandwich attackers that are perhaps not using flashbots and not tightly bundling their transactions
+This logic should work to include both buy-first and less common sell-first sandwiches.  
+By excluding point 6, we also include sandwich attacks that made a loss.  
+By using '>=' instead of just '=' in point 7, we can also include sandwich attackers that are perhaps not using flashbots and not tightly bundling their transactions.
 
 {% enddocs %}

--- a/models/labels/sandwich_attackers/labels_sandwich_attackers_schema.yml
+++ b/models/labels/sandwich_attackers/labels_sandwich_attackers_schema.yml
@@ -44,7 +44,8 @@ models:
       contributors: alexth
     config:
       tags: ['labels', 'ethereum', 'sandwich', 'bot','sandwich_attackers', 'dex']
-    description:  "{{ doc('sandwich_attackers') }}"
+    description:  >
+            {{doc("sandwich_attackers")}}
     columns:
       - *blockchain
       - *address

--- a/models/uniswap/arbitrum/READMEs.md
+++ b/models/uniswap/arbitrum/READMEs.md
@@ -8,10 +8,11 @@ This model transforms the trade events from Uniswap v3 pool contracts on the Arb
 ### Data Sources
 The following data sources are used in this model:
 
-1. ``uniswap_v3_arbitrum.Pair_evt_Swap``: contains the Swap events emitted when a trade occurs on a Uniswap v3 pool
-2. ``uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated``: contains information about the pool contract
-3. ``tokens.erc20``: contains the symbol and decimals of token0 and token1
-4. ``prices.usd``: contains the price of token0 and token1 in USD
+1. [uniswap_v3_arbitrum.Pair_evt_Swap](/#!/source/source.spellbook.uniswap_v3_arbitrum.Pair_evt_Swap) : contains the Swap events emitted when a trade occurs on a Uniswap v3 pool
+2. [uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated](/#!/source/source.spellbook.uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated) : contains information about the pool contract
+3. [tokens.erc20](/#!/source/source.spellbook.tokens_erc20) : contains the symbol and decimals of token0 and token1
+4. [prices.usd](/#!/source/source.spellbook.prices.usd) : contains the price of token0 and token1 in USD
+5. [arbitrum.transactions](/#!/source/source.spellbook.arbitrum.transactions) : contains the transaction hash, block_number and tx_from of the transaction that emitted the Swap event
   
 ### Data Transformations
 The contract_address of the pool contract in the Swap event is used to join with the ``uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated`` event to obtain the contract addresses of token0 and token1.  
@@ -22,3 +23,16 @@ The amounts of token0 and token1 that were bought and sold are used to calculate
 The taker in the Swap event is not necessarily the trader that bought and sold token0 and token1. The trader can potentially be derived from the EOA (Externally Owned Account) that signed the transaction.  
 
 {% enddocs %}
+
+
+{% docs uniswap_arbitrum_trades %}
+## Uniswap trades on Arbitrum
+
+This model unions the data of different protocol versions. However, currently only Uniswap V3 is deployed on Arbitrum.
+
+### models involved
+
+- [uniswap_v3_arbitrum_trades](/#!/model/model.spellbook.uniswap_v3_arbitrum_trades)
+
+{% enddocs %}
+

--- a/models/uniswap/arbitrum/readme.md
+++ b/models/uniswap/arbitrum/readme.md
@@ -2,26 +2,23 @@
 
 ## Uniswap V3 trades on Arbitrum
 
-## Introduction
-This is a model that standardizes the data for Uniswap v3 data on the Arbitrum blockchain. 
-It is written in SparkSQL and used to standardize the data to make it easier for analysts to run queries.
+### Conceptual Summary
+This model transforms the trade events from Uniswap v3 pool contracts on the Arbitrum network into a table that is easier to work with. The transformed data includes information about the tokens traded, the amounts of tokens bought and sold, and the USD value of the trade. The model also adds metadata about the tokens, such as their symbol and decimals.
+  
+### Data Sources
+The following data sources are used in this model:
 
-On a high level, the model joins prices, token information and pool information to all trades and standardizes the data so it can be inserted in dex.trades upstream.
-
-## Data Standardization Pipeline
-The data standardization pipeline performs the following operations:
-
-Queries all Uniswap V3 Pools on Arbitrum using the Pair_evt_Swap table
-Joins the UniswapV3Factory_evt_PoolCreated table to get token0 and token1 addresses which are needed for further joins
-Adds the blockchain name (Arbitrum), project name (Uniswap), and version (3) to the results
-Adds the block date to partition the data
-Adds the symbol of token0 and token1 to the results
-Orders the symbols of token0 and token1 alphabetically and concatenates them with a dash to create a consistent token_pair
-Calculates the display amount of token0 and token1 that was bought/sold
-Calculates the amount in USD by either using the value of amount_usd (if available), or by multiplying the raw amount with the token's price.
-Table Description
-The following table lists the columns and their descriptions in the resulting standardized data table:
-
-
+1. ``uniswap_v3_arbitrum.Pair_evt_Swap``: contains the Swap events emitted when a trade occurs on a Uniswap v3 pool
+2. ``uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated``: contains information about the pool contract
+3. ``tokens.erc20``: contains the symbol and decimals of token0 and token1
+4. ``prices.usd``: contains the price of token0 and token1 in USD
+  
+### Data Transformations
+The contract_address of the pool contract in the Swap event is used to join with the ``uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated`` event to obtain the contract addresses of token0 and token1.  
+The contract addresses of token0 and token1 are used to join with the ``tokens.erc20`` table to obtain the symbol and decimals of the tokens.  
+The decimals of token0 and token1 are used to calculate the display amount of tokens bought and sold.  
+The contract_address of token0 and token1 are used to join with the ``prices.usd`` table to obtain the price of the tokens in USD.  
+The amounts of token0 and token1 that were bought and sold are used to calculate the USD value of the trade.  
+The taker in the Swap event is not necessarily the trader that bought and sold token0 and token1. The trader can potentially be derived from the EOA (Externally Owned Account) that signed the transaction.  
 
 {% enddocs %}

--- a/models/uniswap/arbitrum/readme.md
+++ b/models/uniswap/arbitrum/readme.md
@@ -1,0 +1,27 @@
+{% docs uniswap_v3_arbitrum_trades %}
+
+## Uniswap V3 trades on Arbitrum
+
+## Introduction
+This is a model that standardizes the data for Uniswap v3 data on the Arbitrum blockchain. 
+It is written in SparkSQL and used to standardize the data to make it easier for analysts to run queries.
+
+On a high level, the model joins prices, token information and pool information to all trades and standardizes the data so it can be inserted in dex.trades upstream.
+
+## Data Standardization Pipeline
+The data standardization pipeline performs the following operations:
+
+Queries all Uniswap V3 Pools on Arbitrum using the Pair_evt_Swap table
+Joins the UniswapV3Factory_evt_PoolCreated table to get token0 and token1 addresses which are needed for further joins
+Adds the blockchain name (Arbitrum), project name (Uniswap), and version (3) to the results
+Adds the block date to partition the data
+Adds the symbol of token0 and token1 to the results
+Orders the symbols of token0 and token1 alphabetically and concatenates them with a dash to create a consistent token_pair
+Calculates the display amount of token0 and token1 that was bought/sold
+Calculates the amount in USD by either using the value of amount_usd (if available), or by multiplying the raw amount with the token's price.
+Table Description
+The following table lists the columns and their descriptions in the resulting standardized data table:
+
+
+
+{% enddocs %}

--- a/models/uniswap/arbitrum/uniswap_arbitrum_schema.yml
+++ b/models/uniswap/arbitrum/uniswap_arbitrum_schema.yml
@@ -105,7 +105,7 @@ models:
     config:
       tags: ['arbitrum','dex','trades', 'uniswap']
     description: >
-        Uniswap trades on Arbitrum across all contracts and versions. This table will load dex trades downstream.
+            {{doc("uniswap_arbitrum_trades")}}
     columns:
       - *blockchain
       - *project

--- a/models/uniswap/arbitrum/uniswap_arbitrum_schema.yml
+++ b/models/uniswap/arbitrum/uniswap_arbitrum_schema.yml
@@ -10,7 +10,7 @@ models:
     config:
       tags: ['arbitrum','uniswap_v3','trades', 'uniswap','dex']
     description: >
-        Uniswap V3 contract trades on Arbitrum
+            {{doc("uniswap_v3_arbitrum_trades")}}
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:

--- a/models/uniswap/arbitrum/uniswap_arbitrum_trades.sql
+++ b/models/uniswap/arbitrum/uniswap_arbitrum_trades.sql
@@ -7,6 +7,8 @@
 'uniswap_v3_arbitrum_trades'
 ] %}
 
+--this model pulls data from all the trade models that are deployed on arbitrum at the moment.
+-- at the moment this is only uniswap v3  
 
 SELECT *
 FROM (

--- a/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades.sql
+++ b/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades.sql
@@ -15,29 +15,36 @@
 
 {% set project_start_date = '2021-06-01' %}  -- Uniswap v3 was deployed on Arbitrum on 2021-06-01
 
--- Uniswap v3 trades are derived from the Swap event emitted by the pool contract
--- The Swap event contains the amount of token0 and token1 that were bought and sold
--- The Swap event also contains the address of the pool contract
--- The pool address can be used to join with the UniswapV3Factory_evt_PoolCreated event
--- The UniswapV3Factory_evt_PoolCreated event contains the addresses of token0 and token1
--- The addresses of token0 and token1 can be used to join with the tokens_erc20 table
--- The tokens_erc20 table contains the symbol and decimals of token0 and token1
--- The symbol and decimals of token0 and token1 can be used to calculate the display amount of token0 and token1 that were bought and sold
--- The amount of token0 and token1 that were bought and sold can be used to calculate the amount of USD that was bought and sold
--- The amount of USD that was bought and sold can be used to calculate the price of token0 and token1
--- The prices.usd table contains the price of token0 and token1 and is joined using the contract_address of token0 and token1
--- The Swap event does not contain the address of the trader that bought and sold token0 and token1
--- The address of the trader that bought and sold token0 and token1 can be derived from the transaction that emitted the Swap event
--- The transaction that emitted the Swap event can be joined with the transactions table
--- The transactions table contains the address of the trader that bought and sold token0 and token1
--- The address of the trader that bought and sold token0 and token1 can be used to calculate the amount of USD that was bought and sold
+ 
+ /* 
+ This model is for Uniswap v3 trades on Arbitrum
+ The model transforms the Swap event from the Uniswap v3 pool contracts into a table that is easier to work with
+ The model adds metadata about the tokens traded and the price of the tokens traded
 
+ Uniswap v3 trades are derived from the table uniswap_v3_arbitrum.Pair_evt_Swap
+ The Swap event is emitted when a trade occurs on a Uniswap v3 pool 
+ The Swap event contains the amount of token0 and token1 that were bought and sold
+ The Swap event contains 
+ The Swap event also contains the contract_address of the pool contract
+ The pool's contract_address can be used to join with the uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated event
+ The uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated event contains the contract_address of token0 and token1
+ The contract_address of token0 and token1 can be used to join with the tokens_erc20 table
+ The tokens.erc20 table contains the symbol and decimals of token0 and token1
+ The decimals of token0 and token1 can be used to calculate the display amount of token0 and token1
+ The prices.usd table contains the price of token0 and token1 and is joined using the contract_address of token0 and token1
+ The amount of token0 and token1 that were bought and sold can be used to calculate the USD value of the trade
+ The taker in the swap event is not neccesarilly the trader that bought and sold token0 and token1. It can also be a contract that is swapping on behalf of a trader.
+ The address of the trader that bought and sold token0 and token1 can be derived from the EOA that signed the transaction.
+*/
+
+
+--querying the data from the Swap events, gathering metadata from factory contract and doing first data transformations
 WITH dexs AS
 (
     --Uniswap v3
     SELECT
-        t.evt_block_time AS block_time
-        ,t.recipient AS taker
+        t.evt_block_time AS block_time -- the block time of the block in which this event was emitted
+        ,t.recipient AS taker -- the address of the taker of this trade
         ,'' AS maker -- Uniswap v3 does not have a maker
         ,CASE WHEN amount0 < '0' THEN abs(amount0) ELSE abs(amount1) END AS token_bought_amount_raw -- when amount0 is negative it means trader_a is buying token0 from the pool
         ,CASE WHEN amount0 < '0' THEN abs(amount1) ELSE abs(amount0) END AS token_sold_amount_raw -- when amount0 is negative it means trader_a is buying token1 from the pool
@@ -46,47 +53,46 @@ WITH dexs AS
         ,CASE WHEN amount0 < '0' THEN f.token1 ELSE f.token0 END AS token_sold_address -- when amount0 is negative it means trader_a is buying token1 from the pool
         ,CAST(t.contract_address as string) as project_contract_address -- Uniswap v3 pool contract address
         ,t.evt_tx_hash AS tx_hash -- the transaction in which this event was emitted
-        ,'' AS trace_address 
+        ,'' AS trace_address -- there is no trace_address since this is an event
         ,t.evt_index -- the index of this event in the transaction
         FROM
-        {{ source('uniswap_v3_arbitrum', 'Pair_evt_Swap') }} t -- all Uniswap V3 Swap events on Arbitrum
-        INNER JOIN 
-        uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated f ON f.pool = t.contract_address  -- Joining Uniswap V3 Factory PoolCreated event to get token0 and token1 addresses which are needed for further joins
+        {{ source('uniswap_v3_arbitrum', 'Pair_evt_Swap') }} t -- all Uniswap V3 Swap events across all pools on Arbitrum
+        INNER JOIN uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated f ON f.pool = t.contract_address  -- Joining Uniswap V3 Factory PoolCreated event to get token0 and token1 addresses which are needed for further joins
 
 )
+-- Standardizing the data, joining with prices, transactions and tokens tables to arrive at final state. We also add static metadata to the table.
 SELECT
-    'arbitrum' AS blockchain -- add the blockchain name to the results
-    ,'uniswap' AS project -- add the project name to the results
-    ,'3' AS version -- add the version of the project to the results
-    ,TRY_CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date -- adding block_date to partition the data on
-    ,dexs.block_time 
-    ,erc20a.symbol AS token_bought_symbol -- adding the symbol of token0 to the results
-    ,erc20b.symbol AS token_sold_symbol -- adding the symbol of token1 to the results
-    ,case
-        when lower(erc20a.symbol) > lower(erc20b.symbol) then concat(erc20b.symbol, '-', erc20a.symbol)
-        else concat(erc20a.symbol, '-', erc20b.symbol)
+    'arbitrum' AS blockchain -- add the blockchain name to the table
+    ,'uniswap' AS project -- add the project name to the table
+    ,'3' AS version -- add the version of the project to the table
+    ,TRY_CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date -- adding block_date as a partition column
+    ,dexs.block_time -- the block time of the block in which this event was emitted
+    ,erc20a.symbol AS token_bought_symbol -- adding the symbol of token0 to the table
+    ,erc20b.symbol AS token_sold_symbol -- adding the symbol of token1 to the table
+    ,case when lower(erc20a.symbol) > lower(erc20b.symbol)  then concat(erc20b.symbol, '-', erc20a.symbol)
+                                                            else concat(erc20a.symbol, '-', erc20b.symbol)
         end as token_pair -- ordering the symbols of token0 and token1 alphabetically and concatenating them with a dash in order to create consistent token_pairs
     ,dexs.token_bought_amount_raw / power(10, erc20a.decimals) AS token_bought_amount -- calculating the display amount of token0 that was bought
     ,dexs.token_sold_amount_raw / power(10, erc20b.decimals) AS token_sold_amount -- calculating the display amount of token1 that was sold
-    ,dexs.token_bought_amount_raw 
-    ,dexs.token_sold_amount_raw
+    ,dexs.token_bought_amount_raw -- the raw amount of token0 that was bought 
+    ,dexs.token_sold_amount_raw -- the raw amount of token1 that was sold
     ,coalesce(
         dexs.amount_usd
         ,(dexs.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price
         ,(dexs.token_sold_amount_raw / power(10, p_sold.decimals)) * p_sold.price
-        ) AS amount_usd -- calculating the amount of USD that was bought or sold by using either the price of the token sold or the token bought from the prices.usd table
+        ) AS amount_usd -- calculating the amount of USD that was bought or sold by using either the price of the token sold or the token bought from the prices.usd table. Will default to null if both tokens are not in the prices.usd table
     ,dexs.token_bought_address -- the address of the token that was bought
     ,dexs.token_sold_address -- the address of the token that was sold
     ,coalesce(dexs.taker, tx.from) AS taker -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
-    ,dexs.maker 
+    ,dexs.maker -- there is no maker in Uniswap V3
     ,dexs.project_contract_address -- the address of the Uniswap V3 pool contract
     ,dexs.tx_hash -- the transaction in which this event was emitted
-    ,tx.from AS tx_from -- the address that initated the transaction in which this event was emitted
-    ,tx.to AS tx_to -- the address that received the top level call in which this transaction
-    ,dexs.trace_address 
+    ,tx.from AS tx_from -- the address that initated the transaction in which this event was emitted. This is relevant where there is aggreagators or multiple hops in this trade.
+    ,tx.to AS tx_to -- the address that received the top level call in which this event was emitted. Relevant when aggregators are involved in the trade.
+    ,dexs.trace_address -- this trade originates in an event so there is no trace_address
     ,dexs.evt_index -- the index of this event in the transaction
     FROM dexs
-    -- join the tokens_erc20 tables to get the symbol, decimals of the tokens that were bought and sold. No time element so can always do this
+    -- join the tokens_erc20 tables to get the symbol and decimals of the tokens that were bought and sold. This is not tied to a time so we don't need to worry about incremental runs.
     LEFT JOIN {{ ref('tokens_erc20') }} erc20a          ON erc20a.contract_address = dexs.token_bought_address      AND erc20a.blockchain = 'arbitrum'
     LEFT JOIN {{ ref('tokens_erc20') }} erc20b          ON erc20b.contract_address = dexs.token_sold_address        AND erc20b.blockchain = 'arbitrum'
 
@@ -96,7 +102,7 @@ SELECT
     LEFT JOIN {{ source('prices', 'usd') }} p_sold   ON p_sold.minute   = date_trunc('minute', dexs.block_time)  AND p_sold.contract_address   = dexs.token_bought_address   AND p_sold.blockchain   = 'arbitrum' AND p_sold.minute   >= '{{project_start_date}}'
     {% endif %}
             
-    {% if is_incremental() %} -- if the run is incremental, join only the transactions and prices of the last week that happened in the last week
+    {% if is_incremental() %} -- if the run is incremental, join only the transactions and prices that happened in the last week
     INNER JOIN  {{ source('arbitrum', 'transactions') }} tx ON tx.hash = dexs.tx_hash AND tx.block_time >= date_trunc("day", now() - interval '1 week')
     LEFT JOIN {{ source('prices', 'usd') }} p_bought ON p_bought.minute = date_trunc('minute', dexs.block_time)  AND p_bought.contract_address = dexs.token_bought_address   AND p_bought.blockchain = 'arbitrum' AND p_bought.minute >= date_trunc("day", now() - interval '1 week')
     LEFT JOIN {{ source('prices', 'usd') }} p_sold   ON p_sold.minute   = date_trunc('minute', dexs.block_time)  AND p_sold.contract_address   = dexs.token_bought_address   AND p_sold.blockchain   = 'arbitrum' AND p_sold.minute >= date_trunc("day", now() - interval '1 week')

--- a/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades.sql
+++ b/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades.sql
@@ -38,45 +38,22 @@ WITH dexs AS
     SELECT
         t.evt_block_time AS block_time
         ,t.recipient AS taker
-        ,'' AS maker
         ,'' AS maker -- Uniswap v3 does not have a maker
         ,CASE WHEN amount0 < '0' THEN abs(amount0) ELSE abs(amount1) END AS token_bought_amount_raw -- when amount0 is negative it means trader_a is buying token0 from the pool
-        ,CASE WHEN amount0 < '0' THEN abs(amount1) ELSE abs(amount0) END AS token_sold_amount_raw
         ,CASE WHEN amount0 < '0' THEN abs(amount1) ELSE abs(amount0) END AS token_sold_amount_raw -- when amount0 is negative it means trader_a is buying token1 from the pool
-        ,NULL AS amount_usd
-        ,CASE WHEN amount0 < '0' THEN f.token0 ELSE f.token1 END AS token_bought_address
-        ,CASE WHEN amount0 < '0' THEN f.token1 ELSE f.token0 END AS token_sold_address
-        ,CAST(t.contract_address as string) as project_contract_address
-        ,t.evt_tx_hash AS tx_hash
-        ,'' AS trace_address
-        ,t.evt_index
+        ,NULL AS amount_usd -- Uniswap v3 does not have a price oracle in the Swap event
         ,CASE WHEN amount0 < '0' THEN f.token0 ELSE f.token1 END AS token_bought_address -- when amount0 is negative it means trader_a is buying token0 from the pool
         ,CASE WHEN amount0 < '0' THEN f.token1 ELSE f.token0 END AS token_sold_address -- when amount0 is negative it means trader_a is buying token1 from the pool
         ,CAST(t.contract_address as string) as project_contract_address -- Uniswap v3 pool contract address
         ,t.evt_tx_hash AS tx_hash -- the transaction in which this event was emitted
         ,'' AS trace_address 
         ,t.evt_index -- the index of this event in the transaction
-    FROM
-        {{ source('uniswap_v3_arbitrum', 'Pair_evt_Swap') }} t
-        uniswap_v3_arbitrum.Pair_evt_Swap t -- querying all Uniswap V3 Pools on Arbitrum
-    INNER JOIN 
-        {{ source('uniswap_v3_arbitrum', 'UniswapV3Factory_evt_PoolCreated') }} f
-        ON f.pool = t.contract_address
-    {% if is_incremental() %}
-    WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
-    {% endif %}
-        uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated f -- Joining Uniswap V3 Factory PoolCreated event to get token0 and token1 addresses which are needed for further joins
-        ON f.pool = t.contract_address 
+        FROM
+        {{ source('uniswap_v3_arbitrum', 'Pair_evt_Swap') }} t -- all Uniswap V3 Swap events on Arbitrum
+        INNER JOIN 
+        uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated f ON f.pool = t.contract_address  -- Joining Uniswap V3 Factory PoolCreated event to get token0 and token1 addresses which are needed for further joins
 
 )
-SELECT DISTINCT
-    'arbitrum' AS blockchain
-    ,'uniswap' AS project
-    ,'3' AS version
-    ,TRY_CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
-    ,dexs.block_time
-    ,erc20a.symbol AS token_bought_symbol
-    ,erc20b.symbol AS token_sold_symbol
 SELECT
     'arbitrum' AS blockchain -- add the blockchain name to the results
     ,'uniswap' AS project -- add the project name to the results
@@ -88,12 +65,7 @@ SELECT
     ,case
         when lower(erc20a.symbol) > lower(erc20b.symbol) then concat(erc20b.symbol, '-', erc20a.symbol)
         else concat(erc20a.symbol, '-', erc20b.symbol)
-    end as token_pair
-    ,dexs.token_bought_amount_raw / power(10, erc20a.decimals) AS token_bought_amount
-    ,dexs.token_sold_amount_raw / power(10, erc20b.decimals) AS token_sold_amount
-    ,CAST(dexs.token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw
-    ,CAST(dexs.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw
-    end as token_pair -- ordering the symbols of token0 and token1 alphabetically and concatenating them with a dash in order to create consistent token_pairs
+        end as token_pair -- ordering the symbols of token0 and token1 alphabetically and concatenating them with a dash in order to create consistent token_pairs
     ,dexs.token_bought_amount_raw / power(10, erc20a.decimals) AS token_bought_amount -- calculating the display amount of token0 that was bought
     ,dexs.token_sold_amount_raw / power(10, erc20b.decimals) AS token_sold_amount -- calculating the display amount of token1 that was sold
     ,dexs.token_bought_amount_raw 
@@ -102,20 +74,10 @@ SELECT
         dexs.amount_usd
         ,(dexs.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price
         ,(dexs.token_sold_amount_raw / power(10, p_sold.decimals)) * p_sold.price
-    ) AS amount_usd
-    ,dexs.token_bought_address
-    ,dexs.token_sold_address
-    ) AS amount_usd -- calculating the amount of USD that was bought or sold by using either the price of the token sold or the token bought from the prices.usd table
+        ) AS amount_usd -- calculating the amount of USD that was bought or sold by using either the price of the token sold or the token bought from the prices.usd table
     ,dexs.token_bought_address -- the address of the token that was bought
     ,dexs.token_sold_address -- the address of the token that was sold
     ,coalesce(dexs.taker, tx.from) AS taker -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
-    ,dexs.maker
-    ,dexs.project_contract_address
-    ,dexs.tx_hash
-    ,tx.from AS tx_from
-    ,tx.to AS tx_to
-    ,dexs.trace_address
-    ,dexs.evt_index
     ,dexs.maker 
     ,dexs.project_contract_address -- the address of the Uniswap V3 pool contract
     ,dexs.tx_hash -- the transaction in which this event was emitted
@@ -123,59 +85,19 @@ SELECT
     ,tx.to AS tx_to -- the address that received the top level call in which this transaction
     ,dexs.trace_address 
     ,dexs.evt_index -- the index of this event in the transaction
-FROM dexs
-INNER JOIN 
-    {{ source('arbitrum', 'transactions') }} tx
-    ON tx.hash = dexs.tx_hash
-    {% if not is_incremental() %}
-    AND tx.block_time >= '{{project_start_date}}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND tx.block_time >= date_trunc("day", now() - interval '1 week')
-    {% endif %}
-LEFT JOIN {{ ref('tokens_erc20') }} erc20a
-    ON erc20a.contract_address = dexs.token_bought_address 
-    AND erc20a.blockchain = 'arbitrum'
-LEFT JOIN {{ ref('tokens_erc20') }} erc20b
-    ON erc20b.contract_address = dexs.token_sold_address
-    AND erc20b.blockchain = 'arbitrum'
-LEFT JOIN {{ source('prices', 'usd') }} p_bought
-    ON p_bought.minute = date_trunc('minute', dexs.block_time)
-    AND p_bought.contract_address = dexs.token_bought_address
-    AND p_bought.blockchain = 'arbitrum'
-    {% if not is_incremental() %}
-    AND p_bought.minute >= '{{project_start_date}}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND p_bought.minute >= date_trunc("day", now() - interval '1 week')
-    {% endif %}
-LEFT JOIN {{ source('prices', 'usd') }} p_sold
-    ON p_sold.minute = date_trunc('minute', dexs.block_time)
-    AND p_sold.contract_address = dexs.token_sold_address
-    AND p_sold.blockchain = 'arbitrum'
-    {% if not is_incremental() %}
-    AND p_sold.minute >= '{{project_start_date}}'
+    FROM dexs
+    -- join the tokens_erc20 tables to get the symbol, decimals of the tokens that were bought and sold. No time element so can always do this
+    LEFT JOIN {{ ref('tokens_erc20') }} erc20a          ON erc20a.contract_address = dexs.token_bought_address      AND erc20a.blockchain = 'arbitrum'
+    LEFT JOIN {{ ref('tokens_erc20') }} erc20b          ON erc20b.contract_address = dexs.token_sold_address        AND erc20b.blockchain = 'arbitrum'
 
-    {% if not is_incremental() %} -- if the run is not incremental, join all transactions since the project start date
+    {% if not is_incremental() %} -- if the run is not incremental, join all transactions and prices since the project start date
     INNER JOIN  {{ source('arbitrum', 'transactions') }} tx ON tx.hash = dexs.tx_hash AND tx.block_time >= '{{project_start_date}}'
-    {% endif %}
-    {% if is_incremental() %}
-    AND p_sold.minute >= date_trunc("day", now() - interval '1 week')
-        {% if is_incremental() %} -- if the run is incremental, join only the transactions that happened in the last week
-        INNER JOIN  {{ source('arbitrum', 'transactions') }} tx ON tx.hash = dexs.tx_hash AND tx.block_time >= date_trunc("day", now() - interval '1 week')
-        {% endif %}    
--- join the prices.usd and tokens_erc20 tables to get the symbol, decimals and price of the tokens that were bought and sold
-LEFT JOIN {{ ref('tokens_erc20') }} erc20a          ON erc20a.contract_address = dexs.token_bought_address      AND erc20a.blockchain = 'arbitrum'
-LEFT JOIN {{ ref('tokens_erc20') }} erc20b          ON erc20b.contract_address = dexs.token_sold_address        AND erc20b.blockchain = 'arbitrum'
-
-    {% if not is_incremental() %} -- if the run is not incremental, join all prices.usd starting from the project start date
     LEFT JOIN {{ source('prices', 'usd') }} p_bought ON p_bought.minute = date_trunc('minute', dexs.block_time)  AND p_bought.contract_address = dexs.token_bought_address   AND p_bought.blockchain = 'arbitrum' AND p_bought.minute >= '{{project_start_date}}'
     LEFT JOIN {{ source('prices', 'usd') }} p_sold   ON p_sold.minute   = date_trunc('minute', dexs.block_time)  AND p_sold.contract_address   = dexs.token_bought_address   AND p_sold.blockchain   = 'arbitrum' AND p_sold.minute   >= '{{project_start_date}}'
     {% endif %}
-;
-
-            {% if is_incremental() %} -- if the run is incremental, join only the prices.usd that happened in the last week      
-            LEFT JOIN {{ source('prices', 'usd') }} p_bought ON p_bought.minute = date_trunc('minute', dexs.block_time)  AND p_bought.contract_address = dexs.token_bought_address   AND p_bought.blockchain = 'arbitrum' AND p_bought.minute >= date_trunc("day", now() - interval '1 week')
-            LEFT JOIN {{ source('prices', 'usd') }} p_sold   ON p_sold.minute   = date_trunc('minute', dexs.block_time)  AND p_sold.contract_address   = dexs.token_bought_address   AND p_sold.blockchain   = 'arbitrum' AND p_sold.minute >= date_trunc("day", now() - interval '1 week')
-            {% endif %}
-;
+            
+    {% if is_incremental() %} -- if the run is incremental, join only the transactions and prices of the last week that happened in the last week
+    INNER JOIN  {{ source('arbitrum', 'transactions') }} tx ON tx.hash = dexs.tx_hash AND tx.block_time >= date_trunc("day", now() - interval '1 week')
+    LEFT JOIN {{ source('prices', 'usd') }} p_bought ON p_bought.minute = date_trunc('minute', dexs.block_time)  AND p_bought.contract_address = dexs.token_bought_address   AND p_bought.blockchain = 'arbitrum' AND p_bought.minute >= date_trunc("day", now() - interval '1 week')
+    LEFT JOIN {{ source('prices', 'usd') }} p_sold   ON p_sold.minute   = date_trunc('minute', dexs.block_time)  AND p_sold.contract_address   = dexs.token_bought_address   AND p_sold.blockchain   = 'arbitrum' AND p_sold.minute >= date_trunc("day", now() - interval '1 week')
+    {% endif %}

--- a/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades.sql
+++ b/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades.sql
@@ -13,7 +13,7 @@
     )
 }}
 
-{% set project_start_date = '2021-06-01' %}
+{% set project_start_date = '2021-06-01' %}  -- Uniswap v3 was deployed on Arbitrum on 2021-06-01
 
 -- Uniswap v3 trades are derived from the Swap event emitted by the pool contract
 -- The Swap event contains the amount of token0 and token1 that were bought and sold

--- a/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades.sql
+++ b/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades.sql
@@ -15,6 +15,23 @@
 
 {% set project_start_date = '2021-06-01' %}
 
+-- Uniswap v3 trades are derived from the Swap event emitted by the pool contract
+-- The Swap event contains the amount of token0 and token1 that were bought and sold
+-- The Swap event also contains the address of the pool contract
+-- The pool address can be used to join with the UniswapV3Factory_evt_PoolCreated event
+-- The UniswapV3Factory_evt_PoolCreated event contains the addresses of token0 and token1
+-- The addresses of token0 and token1 can be used to join with the tokens_erc20 table
+-- The tokens_erc20 table contains the symbol and decimals of token0 and token1
+-- The symbol and decimals of token0 and token1 can be used to calculate the display amount of token0 and token1 that were bought and sold
+-- The amount of token0 and token1 that were bought and sold can be used to calculate the amount of USD that was bought and sold
+-- The amount of USD that was bought and sold can be used to calculate the price of token0 and token1
+-- The prices.usd table contains the price of token0 and token1 and is joined using the contract_address of token0 and token1
+-- The Swap event does not contain the address of the trader that bought and sold token0 and token1
+-- The address of the trader that bought and sold token0 and token1 can be derived from the transaction that emitted the Swap event
+-- The transaction that emitted the Swap event can be joined with the transactions table
+-- The transactions table contains the address of the trader that bought and sold token0 and token1
+-- The address of the trader that bought and sold token0 and token1 can be used to calculate the amount of USD that was bought and sold
+
 WITH dexs AS
 (
     --Uniswap v3
@@ -22,8 +39,10 @@ WITH dexs AS
         t.evt_block_time AS block_time
         ,t.recipient AS taker
         ,'' AS maker
+        ,'' AS maker -- Uniswap v3 does not have a maker
         ,CASE WHEN amount0 < '0' THEN abs(amount0) ELSE abs(amount1) END AS token_bought_amount_raw -- when amount0 is negative it means trader_a is buying token0 from the pool
         ,CASE WHEN amount0 < '0' THEN abs(amount1) ELSE abs(amount0) END AS token_sold_amount_raw
+        ,CASE WHEN amount0 < '0' THEN abs(amount1) ELSE abs(amount0) END AS token_sold_amount_raw -- when amount0 is negative it means trader_a is buying token1 from the pool
         ,NULL AS amount_usd
         ,CASE WHEN amount0 < '0' THEN f.token0 ELSE f.token1 END AS token_bought_address
         ,CASE WHEN amount0 < '0' THEN f.token1 ELSE f.token0 END AS token_sold_address
@@ -31,14 +50,24 @@ WITH dexs AS
         ,t.evt_tx_hash AS tx_hash
         ,'' AS trace_address
         ,t.evt_index
+        ,CASE WHEN amount0 < '0' THEN f.token0 ELSE f.token1 END AS token_bought_address -- when amount0 is negative it means trader_a is buying token0 from the pool
+        ,CASE WHEN amount0 < '0' THEN f.token1 ELSE f.token0 END AS token_sold_address -- when amount0 is negative it means trader_a is buying token1 from the pool
+        ,CAST(t.contract_address as string) as project_contract_address -- Uniswap v3 pool contract address
+        ,t.evt_tx_hash AS tx_hash -- the transaction in which this event was emitted
+        ,'' AS trace_address 
+        ,t.evt_index -- the index of this event in the transaction
     FROM
         {{ source('uniswap_v3_arbitrum', 'Pair_evt_Swap') }} t
+        uniswap_v3_arbitrum.Pair_evt_Swap t -- querying all Uniswap V3 Pools on Arbitrum
     INNER JOIN 
         {{ source('uniswap_v3_arbitrum', 'UniswapV3Factory_evt_PoolCreated') }} f
         ON f.pool = t.contract_address
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
+        uniswap_v3_arbitrum.UniswapV3Factory_evt_PoolCreated f -- Joining Uniswap V3 Factory PoolCreated event to get token0 and token1 addresses which are needed for further joins
+        ON f.pool = t.contract_address 
+
 )
 SELECT DISTINCT
     'arbitrum' AS blockchain
@@ -48,6 +77,14 @@ SELECT DISTINCT
     ,dexs.block_time
     ,erc20a.symbol AS token_bought_symbol
     ,erc20b.symbol AS token_sold_symbol
+SELECT
+    'arbitrum' AS blockchain -- add the blockchain name to the results
+    ,'uniswap' AS project -- add the project name to the results
+    ,'3' AS version -- add the version of the project to the results
+    ,TRY_CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date -- adding block_date to partition the data on
+    ,dexs.block_time 
+    ,erc20a.symbol AS token_bought_symbol -- adding the symbol of token0 to the results
+    ,erc20b.symbol AS token_sold_symbol -- adding the symbol of token1 to the results
     ,case
         when lower(erc20a.symbol) > lower(erc20b.symbol) then concat(erc20b.symbol, '-', erc20a.symbol)
         else concat(erc20a.symbol, '-', erc20b.symbol)
@@ -56,6 +93,11 @@ SELECT DISTINCT
     ,dexs.token_sold_amount_raw / power(10, erc20b.decimals) AS token_sold_amount
     ,CAST(dexs.token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw
     ,CAST(dexs.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw
+    end as token_pair -- ordering the symbols of token0 and token1 alphabetically and concatenating them with a dash in order to create consistent token_pairs
+    ,dexs.token_bought_amount_raw / power(10, erc20a.decimals) AS token_bought_amount -- calculating the display amount of token0 that was bought
+    ,dexs.token_sold_amount_raw / power(10, erc20b.decimals) AS token_sold_amount -- calculating the display amount of token1 that was sold
+    ,dexs.token_bought_amount_raw 
+    ,dexs.token_sold_amount_raw
     ,coalesce(
         dexs.amount_usd
         ,(dexs.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price
@@ -63,6 +105,9 @@ SELECT DISTINCT
     ) AS amount_usd
     ,dexs.token_bought_address
     ,dexs.token_sold_address
+    ) AS amount_usd -- calculating the amount of USD that was bought or sold by using either the price of the token sold or the token bought from the prices.usd table
+    ,dexs.token_bought_address -- the address of the token that was bought
+    ,dexs.token_sold_address -- the address of the token that was sold
     ,coalesce(dexs.taker, tx.from) AS taker -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
     ,dexs.maker
     ,dexs.project_contract_address
@@ -71,6 +116,13 @@ SELECT DISTINCT
     ,tx.to AS tx_to
     ,dexs.trace_address
     ,dexs.evt_index
+    ,dexs.maker 
+    ,dexs.project_contract_address -- the address of the Uniswap V3 pool contract
+    ,dexs.tx_hash -- the transaction in which this event was emitted
+    ,tx.from AS tx_from -- the address that initated the transaction in which this event was emitted
+    ,tx.to AS tx_to -- the address that received the top level call in which this transaction
+    ,dexs.trace_address 
+    ,dexs.evt_index -- the index of this event in the transaction
 FROM dexs
 INNER JOIN 
     {{ source('arbitrum', 'transactions') }} tx
@@ -103,8 +155,27 @@ LEFT JOIN {{ source('prices', 'usd') }} p_sold
     AND p_sold.blockchain = 'arbitrum'
     {% if not is_incremental() %}
     AND p_sold.minute >= '{{project_start_date}}'
+
+    {% if not is_incremental() %} -- if the run is not incremental, join all transactions since the project start date
+    INNER JOIN  {{ source('arbitrum', 'transactions') }} tx ON tx.hash = dexs.tx_hash AND tx.block_time >= '{{project_start_date}}'
     {% endif %}
     {% if is_incremental() %}
     AND p_sold.minute >= date_trunc("day", now() - interval '1 week')
+        {% if is_incremental() %} -- if the run is incremental, join only the transactions that happened in the last week
+        INNER JOIN  {{ source('arbitrum', 'transactions') }} tx ON tx.hash = dexs.tx_hash AND tx.block_time >= date_trunc("day", now() - interval '1 week')
+        {% endif %}    
+-- join the prices.usd and tokens_erc20 tables to get the symbol, decimals and price of the tokens that were bought and sold
+LEFT JOIN {{ ref('tokens_erc20') }} erc20a          ON erc20a.contract_address = dexs.token_bought_address      AND erc20a.blockchain = 'arbitrum'
+LEFT JOIN {{ ref('tokens_erc20') }} erc20b          ON erc20b.contract_address = dexs.token_sold_address        AND erc20b.blockchain = 'arbitrum'
+
+    {% if not is_incremental() %} -- if the run is not incremental, join all prices.usd starting from the project start date
+    LEFT JOIN {{ source('prices', 'usd') }} p_bought ON p_bought.minute = date_trunc('minute', dexs.block_time)  AND p_bought.contract_address = dexs.token_bought_address   AND p_bought.blockchain = 'arbitrum' AND p_bought.minute >= '{{project_start_date}}'
+    LEFT JOIN {{ source('prices', 'usd') }} p_sold   ON p_sold.minute   = date_trunc('minute', dexs.block_time)  AND p_sold.contract_address   = dexs.token_bought_address   AND p_sold.blockchain   = 'arbitrum' AND p_sold.minute   >= '{{project_start_date}}'
     {% endif %}
+;
+
+            {% if is_incremental() %} -- if the run is incremental, join only the prices.usd that happened in the last week      
+            LEFT JOIN {{ source('prices', 'usd') }} p_bought ON p_bought.minute = date_trunc('minute', dexs.block_time)  AND p_bought.contract_address = dexs.token_bought_address   AND p_bought.blockchain = 'arbitrum' AND p_bought.minute >= date_trunc("day", now() - interval '1 week')
+            LEFT JOIN {{ source('prices', 'usd') }} p_sold   ON p_sold.minute   = date_trunc('minute', dexs.block_time)  AND p_sold.contract_address   = dexs.token_bought_address   AND p_sold.blockchain   = 'arbitrum' AND p_sold.minute >= date_trunc("day", now() - interval '1 week')
+            {% endif %}
 ;

--- a/models/uniswap/uniswap_trades.sql
+++ b/models/uniswap/uniswap_trades.sql
@@ -7,17 +7,34 @@
         )
 }}
 
+-- defining the different uniswap models to be used in the union
+-- each model is defined in the respective chain's folder and contains all versions of the dex
 {% set uniswap_models = [
 'uniswap_ethereum_trades'
-,'uniswap_optimism_trades'
+,'uniswap_optimism_trades' 
 ,'uniswap_arbitrum_trades'
 ,'uniswap_polygon_trades'
 ] %}
 
+/*
+    This query is a union of all the uniswap models defined in the uniswap_models list
+    The union is used to combine all the different versions of the dex into one table
+
+    The query is structured as follows:
+    1. Loop through each dex model in the uniswap_models list
+    2. For each dex model, select all the columns from the model
+    3. If it is not the last iteration of the loop, add a UNION ALL to the query
+    4. If it is the last iteration of the loop, do not add a UNION ALL to the query
+    5. End the loop
+
+    The result is a single table with all the uniswap trades from all the different versions of the dex across all chains.
+
+    The query is structured this way to allow for easy addition of new dex versions and chains.
+*/
 
 SELECT *
 FROM (
-    {% for dex_model in uniswap_models %}
+    {% for dex_model in uniswap_models %} -- loop through each dex model
     SELECT
         blockchain,
         project,
@@ -29,9 +46,8 @@ FROM (
         token_pair,
         token_bought_amount,
         token_sold_amount,
-        CAST(token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw,
-        CAST(token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw,
-        amount_usd,
+        CAST(token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw, -- current DuneSQL workaround
+        CAST(token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw, -- current DuneSQL workaround
         token_bought_address,
         token_sold_address,
         taker,
@@ -43,9 +59,9 @@ FROM (
         trace_address,
         evt_index
     FROM {{ ref(dex_model) }}
-    {% if not loop.last %}
+    {% if not loop.last %} --if not loop last, union. loop last is a jinja2 variable that is true if it is the last iteration of the loop
     UNION ALL
-    {% endif %}
-    {% endfor %}
+    {% endif %} -- end if
+    {% endfor %} -- end loop
 )
 ;


### PR DESCRIPTION
A first attempt at aligning around creating proper documentations for spells.

- added in line documentation for arbitrum_v3_trades
- added readme.md documentation for both `uniswap_v3_arbitrum_trades` and `uniswap_arbitrum_trades`

Some of my thoughts around this:

1. I think I might have gone overboard with the in-line documenation in the .sql files, think a bit less would be reasonable.

2. Adding hyperlinks to other models in the readme is useful for having a more structured approach to learning and discovering spellbook content, albeit those dependencies up- and downstream can already be looked at natively in the usual spellbook documentation.

I realized we can pack multiple readme docs into one md file using the jinja template for docs, that really helps to not litter the repo with readme files.

Thinking that going forward we can probably do one for sources and one for models.

I didn't extend this to column descriptions and source descriptions yet, if we would include those as well we could build up a very relevant knowledge graph over time.


Compile the docs locally and check it out!



