### PR TITLE
Remove AWS auth setup from upload workflow

### DIFF
--- a/.github/workflows/commit-new-manifest.yml
+++ b/.github/workflows/commit-new-manifest.yml
@@ -1,8 +1,9 @@
 name: Update Manifest
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches:
+      - main
 
 concurrency:
   group:  ${{ github.workflow }}

--- a/.github/workflows/commit-new-manifest.yml
+++ b/.github/workflows/commit-new-manifest.yml
@@ -12,9 +12,6 @@ concurrency:
 jobs:
   commit_manifest:
     runs-on: [ self-hosted, linux, spellbook ]
-    permissions:
-      id-token: write
-      contents: read
 
     steps:
     - uses: actions/setup-python@v3

--- a/.github/workflows/commit-new-manifest.yml
+++ b/.github/workflows/commit-new-manifest.yml
@@ -22,15 +22,6 @@ jobs:
       with:
         ref: main
 
-    - id: install-aws-cli
-      uses: unfor19/install-aws-cli-action@v1
-
-    - name: AWS Credentials
-      uses: aws-actions/configure-aws-credentials@master
-      with:
-        role-to-assume: arn:aws:iam::118330671040:role/spellbook-ci
-        aws-region: eu-west-1
-
     - name: dbt dependencies
       run: "dbt deps"
 


### PR DESCRIPTION
The container should already have the awscli installed and permissions are already granted. Removing these steps will allow the workflow to continue and not fail on AWS creds set up when PRs from forked branches are merged. 