### PR TITLE
test what is casuing dex.trades to fail

### DIFF
--- a/models/dex/dex_trades.sql
+++ b/models/dex/dex_trades.sql
@@ -47,7 +47,6 @@ list of models using old generic test, due to multiple versions in one model:
 ,ref('babyswap_bnb_trades')
 ,ref('apeswap_trades')
 ,ref('ellipsis_finance_trades')
--- ,ref('spartacus_exchange_fantom_trades')
 ,ref('spookyswap_fantom_trades')
 ,ref('beethoven_x_trades')
 ,ref('rubicon_trades')
@@ -59,6 +58,7 @@ list of models using old generic test, due to multiple versions in one model:
 ,ref('spiritswap_fantom_trades')
 ] %}
 
+--,ref('spartacus_exchange_fantom_trades')
 
 SELECT *
 FROM (

--- a/models/dex/dex_trades.sql
+++ b/models/dex/dex_trades.sql
@@ -47,7 +47,7 @@ list of models using old generic test, due to multiple versions in one model:
 ,ref('babyswap_bnb_trades')
 ,ref('apeswap_trades')
 ,ref('ellipsis_finance_trades')
-,ref('spartacus_exchange_fantom_trades')
+-- ,ref('spartacus_exchange_fantom_trades')
 ,ref('spookyswap_fantom_trades')
 ,ref('beethoven_x_trades')
 ,ref('rubicon_trades')

--- a/models/spartacus_exchange/fantom/spartacus_exchange_fantom_trades.sql
+++ b/models/spartacus_exchange/fantom/spartacus_exchange_fantom_trades.sql
@@ -103,4 +103,3 @@ left join {{ source('prices', 'usd') }} p_sold
     {% if is_incremental() %}
     and p_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-;

--- a/models/spartacus_exchange/fantom/spartacus_exchange_fantom_trades.sql
+++ b/models/spartacus_exchange/fantom/spartacus_exchange_fantom_trades.sql
@@ -103,3 +103,4 @@ left join {{ source('prices', 'usd') }} p_sold
     {% if is_incremental() %}
     and p_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
+;


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
