### PR TITLE
Fix Types for DuneSQL compatibility across dex trades models 

### DIFF
--- a/models/babyswap/bnb/babyswap_bnb_trades.sql
+++ b/models/babyswap/bnb/babyswap_bnb_trades.sql
@@ -51,8 +51,8 @@ SELECT 'bnb'                                                             AS bloc
            END                                                           AS token_pair,
        babyswap_dex.token_bought_amount_raw / power(10, erc20a.decimals) AS token_bought_amount,
        babyswap_dex.token_sold_amount_raw / power(10, erc20b.decimals)   AS token_sold_amount,
-       babyswap_dex.token_bought_amount_raw,
-       babyswap_dex.token_sold_amount_raw,
+       CAST(babyswap_dex.token_bought_amount_raw  AS DECIMAL(38,0)) AS token_bought_amount_raw,
+       CAST(babyswap_dex.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw,
        coalesce(
                babyswap_dex.amount_usd
            , (babyswap_dex.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price

--- a/models/iziswap/bnb/iziswap_bnb_trades.sql
+++ b/models/iziswap/bnb/iziswap_bnb_trades.sql
@@ -36,8 +36,8 @@ select
 	, '1' as version
 	, date_trunc('DAY', s.evt_block_time) as block_date
 	, s.evt_block_time as block_time
-	, s.token_bought_amount_raw as token_bought_amount_raw
-	, s.token_sold_amount_raw as token_sold_amount_raw
+    , CAST(s.token_bought_amount_raw  AS DECIMAL(38,0)) AS token_bought_amount_raw
+    , CAST(s.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw
     , coalesce(
         (s.token_bought_amount_raw / power(10, prices_b.decimals)) * prices_b.price
         ,(s.token_sold_amount_raw / power(10, prices_s.decimals)) * prices_s.price

--- a/models/mdex/bnb/mdex_bnb_trades.sql
+++ b/models/mdex/bnb/mdex_bnb_trades.sql
@@ -52,8 +52,8 @@ SELECT
         END                                                       AS token_pair,
     mdex_dex.token_bought_amount_raw / power(10, erc20a.decimals) AS token_bought_amount,
     mdex_dex.token_sold_amount_raw / power(10, erc20b.decimals)   AS token_sold_amount,
-    mdex_dex.token_bought_amount_raw,
-    mdex_dex.token_sold_amount_raw,
+    CAST(mdex_dex.token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw,
+    CAST(mdex_dex.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw,
     coalesce(
             mdex_dex.amount_usd
         , (mdex_dex.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price

--- a/models/nomiswap/bnb/nomiswap_bnb_trades.sql
+++ b/models/nomiswap/bnb/nomiswap_bnb_trades.sql
@@ -52,8 +52,8 @@ SELECT
         END                                                           AS token_pair,
     nomiswap_dex.token_bought_amount_raw / power(10, erc20a.decimals) AS token_bought_amount,
     nomiswap_dex.token_sold_amount_raw / power(10, erc20b.decimals)   AS token_sold_amount,
-    nomiswap_dex.token_bought_amount_raw,
-    nomiswap_dex.token_sold_amount_raw,
+    CAST(nomiswap_dex.token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw,
+    CAST(nomiswap_dex.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw,
     coalesce(
            nomiswap_dex.amount_usd
         , (nomiswap_dex.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price

--- a/models/platypus_finance/avalanche_c/platypus_finance_avalanche_c_trades.sql
+++ b/models/platypus_finance/avalanche_c/platypus_finance_avalanche_c_trades.sql
@@ -35,14 +35,6 @@ select
 	, '1' as version
 	, date_trunc('DAY', s.evt_block_time) as block_date
 	, s.evt_block_time as block_time
-	, CAST(s.toAmount AS DECIMAL(38,0)) as token_bought_amount_raw
-	, CAST(s.fromAmount AS DECIMAL(38,0)) as token_sold_amount_raw
-    , coalesce(
-        (s.toAmount / power(10, prices_b.decimals)) * prices_b.price
-        ,(s.fromAmount / power(10, prices_s.decimals)) * prices_s.price
-    ) as amount_usd	
-	, s.toToken as token_bought_address
-	, s.fromToken as token_sold_address
 	, erc20_b.symbol as token_bought_symbol
 	, erc20_s.symbol as token_sold_symbol
 	, case
@@ -51,6 +43,14 @@ select
     end as token_pair
 	, s.toAmount / power(10, erc20_b.decimals) as token_bought_amount
 	, s.fromAmount / power(10, erc20_s.decimals) as token_sold_amount
+	, CAST(s.toAmount AS DECIMAL(38,0)) as token_bought_amount_raw
+	, CAST(s.fromAmount AS DECIMAL(38,0)) as token_sold_amount_raw
+    , coalesce(
+        (s.toAmount / power(10, prices_b.decimals)) * prices_b.price
+        ,(s.fromAmount / power(10, prices_s.decimals)) * prices_s.price
+    ) as amount_usd	
+	, s.toToken as token_bought_address
+	, s.fromToken as token_sold_address
     , coalesce(s.`to`, tx.from) AS taker
 	, '' as maker
 	, cast(s.contract_address as string) as project_contract_address

--- a/models/trader_joe/avalanche_c/trader_joe_avalanche_c_trades.sql
+++ b/models/trader_joe/avalanche_c/trader_joe_avalanche_c_trades.sql
@@ -51,8 +51,8 @@ SELECT
     end as token_pair
     ,dexs.token_bought_amount_raw / power(10, erc20a.decimals) AS token_bought_amount
     ,dexs.token_sold_amount_raw / power(10, erc20b.decimals) AS token_sold_amount
-    ,dexs.token_bought_amount_raw
-    ,dexs.token_sold_amount_raw
+    ,CAST(dexs.token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw
+    ,CAST(dexs.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw
     ,coalesce(
         dexs.amount_usd
         ,(dexs.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price

--- a/models/velodrome/optimism/velodrome_optimism_trades.sql
+++ b/models/velodrome/optimism/velodrome_optimism_trades.sql
@@ -54,8 +54,8 @@ SELECT
     end as token_pair
     ,dexs.token_bought_amount_raw / power(10, erc20a.decimals) AS token_bought_amount
     ,dexs.token_sold_amount_raw / power(10, erc20b.decimals) AS token_sold_amount
-    ,dexs.token_bought_amount_raw
-    ,dexs.token_sold_amount_raw
+    ,CAST(dexs.token_bought_amount_raw AS DECIMAL(38,0)) AS token_bought_amount_raw
+    ,CAST(dexs.token_sold_amount_raw AS DECIMAL(38,0)) AS token_sold_amount_raw
     ,coalesce(
         dexs.amount_usd
         ,(dexs.token_bought_amount_raw / power(10, p_bought.decimals)) * p_bought.price

--- a/models/wombat/bnb/wombat_bnb_trades.sql
+++ b/models/wombat/bnb/wombat_bnb_trades.sql
@@ -51,8 +51,8 @@ select
 	, '1' as version
 	, date_trunc('DAY', s.evt_block_time) as block_date
 	, s.evt_block_time as block_time
-	, s.toAmount as token_bought_amount_raw
-	, s.fromAmount as token_sold_amount_raw
+    , CAST(s.toAmount AS DECIMAL(38,0)) AS token_bought_amount_raw
+    , CAST(s.fromAmount AS DECIMAL(38,0)) AS token_sold_amount_raw
     , coalesce(
         (s.toAmount / power(10, prices_b.decimals)) * prices_b.price
         ,(s.fromAmount / power(10, prices_s.decimals)) * prices_s.price


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
