### PR TITLE
[Easy] [Labels] Exclude double counted trades from trader_frequencies label

### DIFF
--- a/models/labels/trader_frequencies/labels_trader_frequencies.sql
+++ b/models/labels/trader_frequencies/labels_trader_frequencies.sql
@@ -14,7 +14,7 @@ with
     select
         blockchain,
         taker as address,
-        count(tx_hash) / datediff(max(block_date), min(block_date)) as trades_per_day
+        count(distinct tx_hash) / datediff(max(block_date), min(block_date)) as trades_per_day
     from (
         select blockchain, taker, block_date, tx_hash
         from {{ ref('dex_aggregator_trades') }}


### PR DESCRIPTION
Added a distinct clause to exclude double-counted trades listed from multiple different projects because an aggregator trade can show up as a DEX trade too.
