### PR TITLE
Edit workflow ignore paths

### DIFF
--- a/.github/workflows/dbt_precommit_hooks.yml
+++ b/.github/workflows/dbt_precommit_hooks.yml
@@ -9,6 +9,7 @@ on:
       - 'scripts/**'
       - 'Pipfile'
       - '.gitignore'
+      - '.github/**'
   push:
     branches:
       - 'main'

--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -9,6 +9,7 @@ on:
       - 'scripts/**'
       - 'Pipfile'
       - '.gitignore'
+      - '.github/**'
   push:
     branches:
       - 'main'

--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -9,7 +9,7 @@ on:
       - 'scripts/**'
       - 'Pipfile'
       - '.gitignore'
-      - '.github/**'
+      - '.github/workflows/dbt_slim_ci.yml'
   push:
     branches:
       - 'main'

--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -9,7 +9,7 @@ on:
       - 'scripts/**'
       - 'Pipfile'
       - '.gitignore'
-      - '.github/workflows/dbt_slim_ci.yml'
+      - '.github/**'
   push:
     branches:
       - 'main'


### PR DESCRIPTION
This change adds an ignore path to the slim ci workflow file. The expected change is that edits to only workflow files will not trigger the slim ci from running. We could also add only this file to the ignore path but I can't think of any reason to trigger this workflow as a result of only changes to other workflows. Note that with this change, removing or changing the timeout will not trigger a run of the CI. That may mean the action needs to be triggered manually or an additional commit will be required. 