### PR TITLE
order matters lol

### DIFF
--- a/models/labels/nft/usage/transaction_numbers/labels_nft_traders_transactions.sql
+++ b/models/labels/nft/usage/transaction_numbers/labels_nft_traders_transactions.sql
@@ -38,10 +38,10 @@ SELECT * FROM (
     'nft' AS category,
     'soispoke' AS contributor,
     'query' AS source,
-    'nft_traders_transactions' as model_name,
-    'usage' as label_type,
     timestamp('2022-08-24') as created_at,
-    now() as updated_at
+    now() as updated_at,
+    'nft_traders_transactions' as model_name,
+    'usage' as label_type
     FROM nft_trades
       JOIN total on total.address = nft_trades.address
     WHERE nft_trades.address is not null


### PR DESCRIPTION
accidently switched order of `model_name` and `label_type` with `created_at` and `updated_at` so the table populated wrong for nft volume transactions.