### PR TITLE
[Easy] Fix Blur

### DIFF
--- a/models/blur/ethereum/blur_ethereum_events.sql
+++ b/models/blur/ethereum/blur_ethereum_events.sql
@@ -14,7 +14,7 @@
 {% set project_start_date = '2022-10-18' %}
 {% set seaport_usage_start_date = '2023-01-25' %}
 
-SELECT
+SELECT distinct
     CAST('ethereum' AS string) AS blockchain
     , CAST('blur' AS string) AS project
     , CAST('v1' AS string) AS version
@@ -139,7 +139,7 @@ WHERE bm.evt_block_time >= date_trunc("day", now() - interval '1 week')
 UNION ALL
 
 SELECT distinct
-    'ethereum' AS blockchain
+    CAST('ethereum' AS string) AS blockchain
     , CAST('blur' AS string) AS project
     , CAST('v1' AS string) AS version
     , CAST(date_trunc('day', s.evt_block_time) AS timestamp) AS block_date

--- a/models/blur/ethereum/blur_ethereum_events.sql
+++ b/models/blur/ethereum/blur_ethereum_events.sql
@@ -139,7 +139,7 @@ WHERE bm.evt_block_time >= date_trunc("day", now() - interval '1 week')
 UNION ALL
 
 SELECT distinct
-    CAST('ethereum' AS string) AS blockchain
+    'ethereum' AS blockchain
     , CAST('blur' AS string) AS project
     , CAST('v1' AS string) AS version
     , CAST(date_trunc('day', s.evt_block_time) AS timestamp) AS block_date


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Current issue is caused by this: https://twitter.com/hildobby_/status/1625510856523145226?s=20

I fixed it last week for the seaport part of blur's abstraction hoping it would also be needed here too but now we've had those be transacted 2d ago through blur's direct marketplace contract which broke the model, so here is the fix.
I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
