### PR TITLE
T-25470 - Fix transfers_ethereum.erc20

### DIFF
--- a/models/transfers/ethereum/erc20/transfers_ethereum_erc20.sql
+++ b/models/transfers/ethereum/erc20/transfers_ethereum_erc20.sql
@@ -23,7 +23,7 @@ with
         `from` as wallet_address,
         contract_address as token_address,
         evt_block_time,
-        '-' || value as amount_raw
+        '-' || CAST(value AS VARCHAR(100)) as amount_raw
         from
             {{ source('erc20_ethereum', 'evt_transfer') }}
     )
@@ -47,19 +47,19 @@ with
             src as wallet_address,
             contract_address as token_address,
             evt_block_time,
-            '-' || wad as amount_raw
+            '-' || CAST(wad AS VARCHAR(100)) as amount_raw
         from
             {{ source('zeroex_ethereum', 'weth9_evt_withdrawal') }}
     )
     
-select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100))
 from sent_transfers
 union
-select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100))
 from received_transfers
 union
-select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100))
 from deposited_weth
 union
-select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, amount_raw
+select unique_transfer_id, 'ethereum' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100))
 from withdrawn_weth


### PR DESCRIPTION
Explicit casting on a few concat operations and on the select clause, to fix DuneSQL issues that appeared in Dev after the data type breaking changes.

This does not change any final column types on the model, what was a varchar remains a varchar :) 