### PR TITLE
Add Safe transactions spells for all available chains

### DIFF
--- a/models/safe/arbitrum/safe_arbitrum_schema.yml
+++ b/models/safe/arbitrum/safe_arbitrum_schema.yml
@@ -46,3 +46,62 @@ models:
         description: "Datetime of Safe creation"
       - &tx_hash
         name: tx_hash
+
+  - name: safe_arbitrum_transactions
+    meta:
+      blockchain: arbitrum
+      project: safe
+      contributors: tschubotz
+    freshness:
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    config:
+      tags: ['safe', 'arbitrum']
+    description: "Safe transactions"
+    columns:
+      - *blockchain
+      - *block_date
+      - &block_time
+        name: block_time
+        description: "Datetime of block"
+      - &block_number
+        name: block_number
+        description: "Number of block"
+      - *tx_hash
+      - *address
+      - &to
+        name: to
+        description: "Destination address"
+      - &value
+        name: value
+        description: "Value of transaction"
+      - &gas
+        name: gas 
+        description: "Gas limit set for transaction"
+      - &gas_used
+        name: gas_used
+        description: "Gas used during transaction"
+      - &tx_index
+        name: tx_index
+        description: "Transaction index"
+      - &sub_traces
+        name: sub_traces
+        description: "Number of sub traces"
+      - &trace_address
+        name: trace_address
+        description: ""
+      - &success
+        name: success
+        description: "Success state of transaction"
+      - &error
+        name: error
+        description: "Error of transaction if any"
+      - &code
+        name: code
+        description: "Code"
+      - &input
+        name: input
+        description: "Input data"
+      - &output
+        name: output
+        description: "Output data"

--- a/models/safe/arbitrum/safe_arbitrum_transactions.sql
+++ b/models/safe/arbitrum/safe_arbitrum_transactions.sql
@@ -1,0 +1,58 @@
+{{ 
+    config(
+        materialized='incremental',
+        alias='safe_transactions_arbitrum',
+        partition_by = ['block_date'],
+        unique_key = ['block_date', 'tx_hash', 'trace_address'], 
+        on_schema_change='fail',
+        file_format ='delta',
+        incremental_strategy='merge',
+        post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                    "project",
+                                    "safe",
+                                    \'["tschubotz"]\') }}'
+    ) 
+}}
+
+select 
+    'arbitrum' as blockchain,
+    try_cast(date_trunc('day', tr.block_time) as date) as block_date,
+    tr.block_time,
+    tr.block_number,
+    tr.tx_hash,
+    s.address,
+    tr.to,
+    tr.value,
+    tr.gas,
+    tr.gas_used,
+    tr.tx_index,
+    tr.sub_traces,
+    tr.trace_address,
+    tr.success,
+    tr.error,
+    tr.code,
+    tr.input,
+    tr.output,
+    case 
+        when substring(tr.input, 0, 10) = '0x6a761202' then 'execTransaction'
+        when substring(tr.input, 0, 10) = '0x468721a7' then 'execTransactionFromModule'
+        when substring(tr.input, 0, 10) = '0x5229073f' then 'execTransactionFromModuleReturnData'
+        else 'unknown'
+    end as method
+from {{ source('arbitrum', 'traces') }} tr 
+join {{ ref('safe_arbitrum_safes') }} s
+    on s.address = tr.from
+join {{ ref('safe_arbitrum_singletons') }} ss
+    on tr.to = ss.address
+where substring(tr.input, 0, 10) in (
+        '0x6a761202', -- execTransaction
+        '0x468721a7', -- execTransactionFromModule
+        '0x5229073f' -- execTransactionFromModuleReturnData
+    )
+    and tr.call_type = 'delegatecall'
+    {% if not is_incremental() %}
+    and tr.block_time > '2021-06-20' -- for initial query optimisation  
+    {% endif %}
+    {% if is_incremental() %}
+    and tr.block_time > date_trunc("day", now() - interval '1 week')
+    {% endif %}

--- a/models/safe/avalanche_c/safe_avalanche_c_schema.yml
+++ b/models/safe/avalanche_c/safe_avalanche_c_schema.yml
@@ -46,3 +46,62 @@ models:
         description: "Datetime of Safe creation"
       - &tx_hash
         name: tx_hash
+
+  - name: safe_avalanche_c_transactions
+    meta:
+      blockchain: avalanche_c
+      project: safe
+      contributors: tschubotz
+    freshness:
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    config:
+      tags: ['safe', 'avalanche_c']
+    description: "Safe transactions"
+    columns:
+      - *blockchain
+      - *block_date
+      - &block_time
+        name: block_time
+        description: "Datetime of block"
+      - &block_number
+        name: block_number
+        description: "Number of block"
+      - *tx_hash
+      - *address
+      - &to
+        name: to
+        description: "Destination address"
+      - &value
+        name: value
+        description: "Value of transaction"
+      - &gas
+        name: gas 
+        description: "Gas limit set for transaction"
+      - &gas_used
+        name: gas_used
+        description: "Gas used during transaction"
+      - &tx_index
+        name: tx_index
+        description: "Transaction index"
+      - &sub_traces
+        name: sub_traces
+        description: "Number of sub traces"
+      - &trace_address
+        name: trace_address
+        description: ""
+      - &success
+        name: success
+        description: "Success state of transaction"
+      - &error
+        name: error
+        description: "Error of transaction if any"
+      - &code
+        name: code
+        description: "Code"
+      - &input
+        name: input
+        description: "Input data"
+      - &output
+        name: output
+        description: "Output data"

--- a/models/safe/avalanche_c/safe_avalanche_c_transactions.sql
+++ b/models/safe/avalanche_c/safe_avalanche_c_transactions.sql
@@ -1,0 +1,58 @@
+{{ 
+    config(
+        materialized='incremental',
+        alias='safe_transactions_avalanche_c',
+        partition_by = ['block_date'],
+        unique_key = ['block_date', 'tx_hash', 'trace_address'], 
+        on_schema_change='fail',
+        file_format ='delta',
+        incremental_strategy='merge',
+        post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                    "project",
+                                    "safe",
+                                    \'["tschubotz"]\') }}'
+    ) 
+}}
+
+select 
+    'avalanche_c' as blockchain,
+    try_cast(date_trunc('day', tr.block_time) as date) as block_date,
+    tr.block_time,
+    tr.block_number,
+    tr.tx_hash,
+    s.address,
+    tr.to,
+    tr.value,
+    tr.gas,
+    tr.gas_used,
+    tr.tx_index,
+    tr.sub_traces,
+    tr.trace_address,
+    tr.success,
+    tr.error,
+    tr.code,
+    tr.input,
+    tr.output,
+    case 
+        when substring(tr.input, 0, 10) = '0x6a761202' then 'execTransaction'
+        when substring(tr.input, 0, 10) = '0x468721a7' then 'execTransactionFromModule'
+        when substring(tr.input, 0, 10) = '0x5229073f' then 'execTransactionFromModuleReturnData'
+        else 'unknown'
+    end as method
+from {{ source('avalanche_c', 'traces') }} tr 
+join {{ ref('safe_avalanche_c_safes') }} s
+    on s.address = tr.from
+join {{ ref('safe_avalanche_c_singletons') }} ss
+    on tr.to = ss.address
+where substring(tr.input, 0, 10) in (
+        '0x6a761202', -- execTransaction
+        '0x468721a7', -- execTransactionFromModule
+        '0x5229073f' -- execTransactionFromModuleReturnData
+    )
+    and tr.call_type = 'delegatecall'
+    {% if not is_incremental() %}
+    and tr.block_time > '2021-10-05' -- for initial query optimisation    
+    {% endif %}
+    {% if is_incremental() %}
+    and tr.block_time > date_trunc("day", now() - interval '1 week')
+    {% endif %}

--- a/models/safe/bnb/safe_bnb_schema.yml
+++ b/models/safe/bnb/safe_bnb_schema.yml
@@ -46,3 +46,62 @@ models:
         description: "Datetime of Safe creation"
       - &tx_hash
         name: tx_hash
+
+  - name: safe_bnb_transactions
+    meta:
+      blockchain: bnb
+      project: safe
+      contributors: tschubotz
+    freshness:
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    config:
+      tags: ['safe', 'bnb']
+    description: "Safe transactions"
+    columns:
+      - *blockchain
+      - *block_date
+      - &block_time
+        name: block_time
+        description: "Datetime of block"
+      - &block_number
+        name: block_number
+        description: "Number of block"
+      - *tx_hash
+      - *address
+      - &to
+        name: to
+        description: "Destination address"
+      - &value
+        name: value
+        description: "Value of transaction"
+      - &gas
+        name: gas 
+        description: "Gas limit set for transaction"
+      - &gas_used
+        name: gas_used
+        description: "Gas used during transaction"
+      - &tx_index
+        name: tx_index
+        description: "Transaction index"
+      - &sub_traces
+        name: sub_traces
+        description: "Number of sub traces"
+      - &trace_address
+        name: trace_address
+        description: ""
+      - &success
+        name: success
+        description: "Success state of transaction"
+      - &error
+        name: error
+        description: "Error of transaction if any"
+      - &code
+        name: code
+        description: "Code"
+      - &input
+        name: input
+        description: "Input data"
+      - &output
+        name: output
+        description: "Output data"

--- a/models/safe/bnb/safe_bnb_transactions.sql
+++ b/models/safe/bnb/safe_bnb_transactions.sql
@@ -1,0 +1,58 @@
+{{ 
+    config(
+        materialized='incremental',
+        alias='safe_transactions_bnb',
+        partition_by = ['block_date'],
+        unique_key = ['block_date', 'tx_hash', 'trace_address'], 
+        on_schema_change='fail',
+        file_format ='delta',
+        incremental_strategy='merge',
+        post_hook='{{ expose_spells(\'["bnb"]\',
+                                    "project",
+                                    "safe",
+                                    \'["tschubotz"]\') }}'
+    ) 
+}}
+
+select 
+    'bnb' as blockchain,
+    try_cast(date_trunc('day', tr.block_time) as date) as block_date,
+    tr.block_time,
+    tr.block_number,
+    tr.tx_hash,
+    s.address,
+    tr.to,
+    tr.value,
+    tr.gas,
+    tr.gas_used,
+    tr.tx_index,
+    tr.sub_traces,
+    tr.trace_address,
+    tr.success,
+    tr.error,
+    tr.code,
+    tr.input,
+    tr.output,
+    case 
+        when substring(tr.input, 0, 10) = '0x6a761202' then 'execTransaction'
+        when substring(tr.input, 0, 10) = '0x468721a7' then 'execTransactionFromModule'
+        when substring(tr.input, 0, 10) = '0x5229073f' then 'execTransactionFromModuleReturnData'
+        else 'unknown'
+    end as method
+from {{ source('bnb', 'traces') }} tr 
+join {{ ref('safe_bnb_safes') }} s
+    on s.address = tr.from
+join {{ ref('safe_bnb_singletons') }} ss
+    on tr.to = ss.address
+where substring(tr.input, 0, 10) in (
+        '0x6a761202', -- execTransaction
+        '0x468721a7', -- execTransactionFromModule
+        '0x5229073f' -- execTransactionFromModuleReturnData
+    )
+    and tr.call_type = 'delegatecall'
+    {% if not is_incremental() %}
+    and tr.block_time > '2021-01-26' -- for initial query optimisation     
+    {% endif %}
+    {% if is_incremental() %}
+    and tr.block_time > date_trunc("day", now() - interval '1 week')
+    {% endif %}

--- a/models/safe/ethereum/safe_ethereum_schema.yml
+++ b/models/safe/ethereum/safe_ethereum_schema.yml
@@ -71,3 +71,58 @@ models:
         tests:
           - unique
           - not_null
+
+  - name: safe_ethereum_transactions
+    meta:
+      blockchain: ethereum
+      project: safe
+      contributors: tschubotz
+    freshness:
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    config:
+      tags: ['safe', 'ethereum']
+    description: "Safe transactions"
+    columns:
+      - *blockchain
+      - *block_date
+      - *block_time
+      - &block_number
+        name: block_number
+        description: "Number of block"
+      - *tx_hash
+      - *address
+      - &to
+        name: to
+        description: "Destination address"
+      - &value
+        name: value
+        description: "Value of transaction"
+      - &gas
+        name: gas 
+        description: "Gas limit set for transaction"
+      - &gas_used
+        name: gas_used
+        description: "Gas used during transaction"
+      - &tx_index
+        name: tx_index
+        description: "Transaction index"
+      - &sub_traces
+        name: sub_traces
+        description: "Number of sub traces"
+      - *trace_address
+      - &success
+        name: success
+        description: "Success state of transaction"
+      - &error
+        name: error
+        description: "Error of transaction if any"
+      - &code
+        name: code
+        description: "Code"
+      - &input
+        name: input
+        description: "Input data"
+      - &output
+        name: output
+        description: "Output data"

--- a/models/safe/ethereum/safe_ethereum_transactions.sql
+++ b/models/safe/ethereum/safe_ethereum_transactions.sql
@@ -1,0 +1,58 @@
+{{ 
+    config(
+        materialized='incremental',
+        alias='safe_transactions_ethereum',
+        partition_by = ['block_date'],
+        unique_key = ['block_date', 'tx_hash', 'trace_address'], 
+        on_schema_change='fail',
+        file_format ='delta',
+        incremental_strategy='merge',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "project",
+                                    "safe",
+                                    \'["tschubotz"]\') }}'
+    ) 
+}}
+
+select 
+    'ethereum' as blockchain,
+    try_cast(date_trunc('day', tr.block_time) as date) as block_date,
+    tr.block_time,
+    tr.block_number,
+    tr.tx_hash,
+    s.address,
+    tr.to,
+    tr.value,
+    tr.gas,
+    tr.gas_used,
+    tr.tx_index,
+    tr.sub_traces,
+    tr.trace_address,
+    tr.success,
+    tr.error,
+    tr.code,
+    tr.input,
+    tr.output,
+    case 
+        when substring(tr.input, 0, 10) = '0x6a761202' then 'execTransaction'
+        when substring(tr.input, 0, 10) = '0x468721a7' then 'execTransactionFromModule'
+        when substring(tr.input, 0, 10) = '0x5229073f' then 'execTransactionFromModuleReturnData'
+        else 'unknown'
+    end as method
+from {{ source('ethereum', 'traces') }} tr 
+join {{ ref('safe_ethereum_safes') }} s
+    on s.address = tr.from
+join {{ ref('safe_ethereum_singletons') }} ss
+    on tr.to = ss.address
+where substring(tr.input, 0, 10) in (
+        '0x6a761202', -- execTransaction
+        '0x468721a7', -- execTransactionFromModule
+        '0x5229073f' -- execTransactionFromModuleReturnData
+    )
+    and tr.call_type = 'delegatecall'
+    {% if not is_incremental() %}
+    and tr.block_time > '2018-11-24' -- for initial query optimisation    
+    {% endif %}
+    {% if is_incremental() %}
+    and tr.block_time > date_trunc("day", now() - interval '1 week')
+    {% endif %}

--- a/models/safe/fantom/safe_fantom_schema.yml
+++ b/models/safe/fantom/safe_fantom_schema.yml
@@ -46,3 +46,62 @@ models:
         description: "Datetime of Safe creation"
       - &tx_hash
         name: tx_hash
+
+  - name: safe_fantom_transactions
+    meta:
+      blockchain: fantom
+      project: safe
+      contributors: tschubotz
+    freshness:
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    config:
+      tags: ['safe', 'fantom']
+    description: "Safe transactions"
+    columns:
+      - *blockchain
+      - *block_date
+      - &block_time
+        name: block_time
+        description: "Datetime of block"
+      - &block_number
+        name: block_number
+        description: "Number of block"
+      - *tx_hash
+      - *address
+      - &to
+        name: to
+        description: "Destination address"
+      - &value
+        name: value
+        description: "Value of transaction"
+      - &gas
+        name: gas 
+        description: "Gas limit set for transaction"
+      - &gas_used
+        name: gas_used
+        description: "Gas used during transaction"
+      - &tx_index
+        name: tx_index
+        description: "Transaction index"
+      - &sub_traces
+        name: sub_traces
+        description: "Number of sub traces"
+      - &trace_address
+        name: trace_address
+        description: ""
+      - &success
+        name: success
+        description: "Success state of transaction"
+      - &error
+        name: error
+        description: "Error of transaction if any"
+      - &code
+        name: code
+        description: "Code"
+      - &input
+        name: input
+        description: "Input data"
+      - &output
+        name: output
+        description: "Output data"

--- a/models/safe/fantom/safe_fantom_transactions.sql
+++ b/models/safe/fantom/safe_fantom_transactions.sql
@@ -1,0 +1,58 @@
+{{ 
+    config(
+        materialized='incremental',
+        alias='safe_transactions_fantom',
+        partition_by = ['block_date'],
+        unique_key = ['block_date', 'tx_hash', 'trace_address'], 
+        on_schema_change='fail',
+        file_format ='delta',
+        incremental_strategy='merge',
+        post_hook='{{ expose_spells(\'["fantom"]\',
+                                    "project",
+                                    "safe",
+                                    \'["tschubotz"]\') }}'
+    ) 
+}}
+
+select 
+    'fantom' as blockchain,
+    try_cast(date_trunc('day', tr.block_time) as date) as block_date,
+    tr.block_time,
+    tr.block_number,
+    tr.tx_hash,
+    s.address,
+    tr.to,
+    tr.value,
+    tr.gas,
+    tr.gas_used,
+    tr.tx_index,
+    tr.sub_traces,
+    tr.trace_address,
+    tr.success,
+    tr.error,
+    tr.code,
+    tr.input,
+    tr.output,
+    case 
+        when substring(tr.input, 0, 10) = '0x6a761202' then 'execTransaction'
+        when substring(tr.input, 0, 10) = '0x468721a7' then 'execTransactionFromModule'
+        when substring(tr.input, 0, 10) = '0x5229073f' then 'execTransactionFromModuleReturnData'
+        else 'unknown'
+    end as method
+from {{ source('fantom', 'traces') }} tr 
+join {{ ref('safe_fantom_safes') }} s
+    on s.address = tr.from
+join {{ ref('safe_fantom_singletons') }} ss
+    on tr.to = ss.address
+where substring(tr.input, 0, 10) in (
+        '0x6a761202', -- execTransaction
+        '0x468721a7', -- execTransactionFromModule
+        '0x5229073f' -- execTransactionFromModuleReturnData
+    )
+    and tr.call_type = 'delegatecall'
+    {% if not is_incremental() %}
+    and tr.block_time > '2021-11-25' -- for initial query optimisation    
+    {% endif %}
+    {% if is_incremental() %}
+    and tr.block_time > date_trunc("day", now() - interval '1 week')
+    {% endif %}

--- a/models/safe/gnosis/safe_gnosis_schema.yml
+++ b/models/safe/gnosis/safe_gnosis_schema.yml
@@ -46,3 +46,62 @@ models:
         description: "Datetime of Safe creation"
       - &tx_hash
         name: tx_hash
+
+  - name: safe_gnosis_transactions
+    meta:
+      blockchain: gnosis
+      project: safe
+      contributors: tschubotz
+    freshness:
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    config:
+      tags: ['safe', 'gnosis']
+    description: "Safe transactions"
+    columns:
+      - *blockchain
+      - *block_date
+      - &block_time
+        name: block_time
+        description: "Datetime of block"
+      - &block_number
+        name: block_number
+        description: "Number of block"
+      - *tx_hash
+      - *address
+      - &to
+        name: to
+        description: "Destination address"
+      - &value
+        name: value
+        description: "Value of transaction"
+      - &gas
+        name: gas 
+        description: "Gas limit set for transaction"
+      - &gas_used
+        name: gas_used
+        description: "Gas used during transaction"
+      - &tx_index
+        name: tx_index
+        description: "Transaction index"
+      - &sub_traces
+        name: sub_traces
+        description: "Number of sub traces"
+      - &trace_address
+        name: trace_address
+        description: ""
+      - &success
+        name: success
+        description: "Success state of transaction"
+      - &error
+        name: error
+        description: "Error of transaction if any"
+      - &code
+        name: code
+        description: "Code"
+      - &input
+        name: input
+        description: "Input data"
+      - &output
+        name: output
+        description: "Output data"

--- a/models/safe/gnosis/safe_gnosis_transactions.sql
+++ b/models/safe/gnosis/safe_gnosis_transactions.sql
@@ -1,0 +1,58 @@
+{{ 
+    config(
+        materialized='incremental',
+        alias='safe_transactions_gnosis',
+        partition_by = ['block_date'],
+        unique_key = ['block_date', 'tx_hash', 'trace_address'], 
+        on_schema_change='fail',
+        file_format ='delta',
+        incremental_strategy='merge',
+        post_hook='{{ expose_spells(\'["gnosis"]\',
+                                    "project",
+                                    "safe",
+                                    \'["tschubotz"]\') }}'
+    ) 
+}}
+
+select 
+    'gnosis' as blockchain,
+    try_cast(date_trunc('day', tr.block_time) as date) as block_date,
+    tr.block_time,
+    tr.block_number,
+    tr.tx_hash,
+    s.address,
+    tr.to,
+    tr.value,
+    tr.gas,
+    tr.gas_used,
+    tr.tx_index,
+    tr.sub_traces,
+    tr.trace_address,
+    tr.success,
+    tr.error,
+    tr.code,
+    tr.input,
+    tr.output,
+    case 
+        when substring(tr.input, 0, 10) = '0x6a761202' then 'execTransaction'
+        when substring(tr.input, 0, 10) = '0x468721a7' then 'execTransactionFromModule'
+        when substring(tr.input, 0, 10) = '0x5229073f' then 'execTransactionFromModuleReturnData'
+        else 'unknown'
+    end as method
+from {{ source('gnosis', 'traces') }} tr 
+join {{ ref('safe_gnosis_safes') }} s
+    on s.address = tr.from
+join {{ ref('safe_gnosis_singletons') }} ss
+    on tr.to = ss.address
+where substring(tr.input, 0, 10) in (
+        '0x6a761202', -- execTransaction
+        '0x468721a7', -- execTransactionFromModule
+        '0x5229073f' -- execTransactionFromModuleReturnData
+    )
+    and tr.call_type = 'delegatecall'
+    {% if not is_incremental() %}
+    and tr.block_time > '2020-05-21' -- for initial query optimisation    
+    {% endif %}
+    {% if is_incremental() %}
+    and tr.block_time > date_trunc("day", now() - interval '1 week')
+    {% endif %}

--- a/models/safe/goerli/safe_goerli_schema.yml
+++ b/models/safe/goerli/safe_goerli_schema.yml
@@ -46,3 +46,62 @@ models:
         description: "Datetime of Safe creation"
       - &tx_hash
         name: tx_hash
+
+  - name: safe_goerli_transactions
+    meta:
+      blockchain: goerli
+      project: safe
+      contributors: tschubotz
+    freshness:
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    config:
+      tags: ['safe', 'goerli']
+    description: "Safe transactions"
+    columns:
+      - *blockchain
+      - *block_date
+      - &block_time
+        name: block_time
+        description: "Datetime of block"
+      - &block_number
+        name: block_number
+        description: "Number of block"
+      - *tx_hash
+      - *address
+      - &to
+        name: to
+        description: "Destination address"
+      - &value
+        name: value
+        description: "Value of transaction"
+      - &gas
+        name: gas 
+        description: "Gas limit set for transaction"
+      - &gas_used
+        name: gas_used
+        description: "Gas used during transaction"
+      - &tx_index
+        name: tx_index
+        description: "Transaction index"
+      - &sub_traces
+        name: sub_traces
+        description: "Number of sub traces"
+      - &trace_address
+        name: trace_address
+        description: ""
+      - &success
+        name: success
+        description: "Success state of transaction"
+      - &error
+        name: error
+        description: "Error of transaction if any"
+      - &code
+        name: code
+        description: "Code"
+      - &input
+        name: input
+        description: "Input data"
+      - &output
+        name: output
+        description: "Output data"

--- a/models/safe/goerli/safe_goerli_transactions.sql
+++ b/models/safe/goerli/safe_goerli_transactions.sql
@@ -1,0 +1,58 @@
+{{ 
+    config(
+        materialized='incremental',
+        alias='safe_transactions_goerli',
+        partition_by = ['block_date'],
+        unique_key = ['block_date', 'tx_hash', 'trace_address'], 
+        on_schema_change='fail',
+        file_format ='delta',
+        incremental_strategy='merge',
+        post_hook='{{ expose_spells(\'["goerli"]\',
+                                    "project",
+                                    "safe",
+                                    \'["tschubotz"]\') }}'
+    ) 
+}}
+
+select 
+    'goerli' as blockchain,
+    try_cast(date_trunc('day', tr.block_time) as date) as block_date,
+    tr.block_time,
+    tr.block_number,
+    tr.tx_hash,
+    s.address,
+    tr.to,
+    tr.value,
+    tr.gas,
+    tr.gas_used,
+    tr.tx_index,
+    tr.sub_traces,
+    tr.trace_address,
+    tr.success,
+    tr.error,
+    tr.code,
+    tr.input,
+    tr.output,
+    case 
+        when substring(tr.input, 0, 10) = '0x6a761202' then 'execTransaction'
+        when substring(tr.input, 0, 10) = '0x468721a7' then 'execTransactionFromModule'
+        when substring(tr.input, 0, 10) = '0x5229073f' then 'execTransactionFromModuleReturnData'
+        else 'unknown'
+    end as method
+from {{ source('goerli', 'traces') }} tr 
+join {{ ref('safe_goerli_safes') }} s
+    on s.address = tr.from
+join {{ ref('safe_goerli_singletons') }} ss
+    on tr.to = ss.address
+where substring(tr.input, 0, 10) in (
+        '0x6a761202', -- execTransaction
+        '0x468721a7', -- execTransactionFromModule
+        '0x5229073f' -- execTransactionFromModuleReturnData
+    )
+    and tr.call_type = 'delegatecall'
+    {% if not is_incremental() %}
+    and tr.block_time > '2019-09-03' -- for initial query optimisation    
+    {% endif %}
+    {% if is_incremental() %}
+    and tr.block_time > date_trunc("day", now() - interval '1 week')
+    {% endif %}

--- a/models/safe/optimism/safe_optimism_schema.yml
+++ b/models/safe/optimism/safe_optimism_schema.yml
@@ -46,3 +46,62 @@ models:
         tests:
           - unique
           - not_null
+
+  - name: safe_optimism_transactions
+    meta:
+      blockchain: optimism
+      project: safe
+      contributors: tschubotz
+    freshness:
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    config:
+      tags: ['safe', 'optimism']
+    description: "Safe transactions"
+    columns:
+      - *blockchain
+      - *block_date
+      - &block_time
+        name: block_time
+        description: "Datetime of block"
+      - &block_number
+        name: block_number
+        description: "Number of block"
+      - *tx_hash
+      - *address
+      - &to
+        name: to
+        description: "Destination address"
+      - &value
+        name: value
+        description: "Value of transaction"
+      - &gas
+        name: gas 
+        description: "Gas limit set for transaction"
+      - &gas_used
+        name: gas_used
+        description: "Gas used during transaction"
+      - &tx_index
+        name: tx_index
+        description: "Transaction index"
+      - &sub_traces
+        name: sub_traces
+        description: "Number of sub traces"
+      - &trace_address
+        name: trace_address
+        description: ""
+      - &success
+        name: success
+        description: "Success state of transaction"
+      - &error
+        name: error
+        description: "Error of transaction if any"
+      - &code
+        name: code
+        description: "Code"
+      - &input
+        name: input
+        description: "Input data"
+      - &output
+        name: output
+        description: "Output data"

--- a/models/safe/optimism/safe_optimism_transactions.sql
+++ b/models/safe/optimism/safe_optimism_transactions.sql
@@ -1,0 +1,58 @@
+{{ 
+    config(
+        materialized='incremental',
+        alias='safe_transactions_optimism',
+        partition_by = ['block_date'],
+        unique_key = ['block_date', 'tx_hash', 'trace_address'], 
+        on_schema_change='fail',
+        file_format ='delta',
+        incremental_strategy='merge',
+        post_hook='{{ expose_spells(\'["optimism"]\',
+                                    "project",
+                                    "safe",
+                                    \'["tschubotz"]\') }}'
+    ) 
+}}
+
+select 
+    'optimism' as blockchain,
+    try_cast(date_trunc('day', tr.block_time) as date) as block_date,
+    tr.block_time,
+    tr.block_number,
+    tr.tx_hash,
+    s.address,
+    tr.to,
+    tr.value,
+    tr.gas,
+    tr.gas_used,
+    tr.tx_index,
+    tr.sub_traces,
+    tr.trace_address,
+    tr.success,
+    tr.error,
+    tr.code,
+    tr.input,
+    tr.output,
+    case 
+        when substring(tr.input, 0, 10) = '0x6a761202' then 'execTransaction'
+        when substring(tr.input, 0, 10) = '0x468721a7' then 'execTransactionFromModule'
+        when substring(tr.input, 0, 10) = '0x5229073f' then 'execTransactionFromModuleReturnData'
+        else 'unknown'
+    end as method
+from {{ source('optimism', 'traces') }} tr 
+join {{ ref('safe_optimism_safes') }} s
+    on s.address = tr.from
+join {{ ref('safe_optimism_singletons') }} ss
+    on tr.to = ss.address
+where substring(tr.input, 0, 10) in (
+        '0x6a761202', -- execTransaction
+        '0x468721a7', -- execTransactionFromModule
+        '0x5229073f' -- execTransactionFromModuleReturnData
+    )
+    and tr.call_type = 'delegatecall'
+    {% if not is_incremental() %}
+    and tr.block_time > '2021-11-17' -- for initial query optimisation    
+    {% endif %}
+    {% if is_incremental() %}
+    and tr.block_time > date_trunc("day", now() - interval '1 week')
+    {% endif %}

--- a/models/safe/polygon/safe_polygon_schema.yml
+++ b/models/safe/polygon/safe_polygon_schema.yml
@@ -46,3 +46,63 @@ models:
         description: "Datetime of Safe creation"
       - &tx_hash
         name: tx_hash
+
+
+  - name: safe_polygon_transactions
+    meta:
+      blockchain: polygon
+      project: safe
+      contributors: tschubotz
+    freshness:
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    config:
+      tags: ['safe', 'polygon']
+    description: "Safe transactions"
+    columns:
+      - *blockchain
+      - *block_date
+      - &block_time
+        name: block_time
+        description: "Datetime of block"
+      - &block_number
+        name: block_number
+        description: "Number of block"
+      - *tx_hash
+      - *address
+      - &to
+        name: to
+        description: "Destination address"
+      - &value
+        name: value
+        description: "Value of transaction"
+      - &gas
+        name: gas 
+        description: "Gas limit set for transaction"
+      - &gas_used
+        name: gas_used
+        description: "Gas used during transaction"
+      - &tx_index
+        name: tx_index
+        description: "Transaction index"
+      - &sub_traces
+        name: sub_traces
+        description: "Number of sub traces"
+      - &trace_address
+        name: trace_address
+        description: ""
+      - &success
+        name: success
+        description: "Success state of transaction"
+      - &error
+        name: error
+        description: "Error of transaction if any"
+      - &code
+        name: code
+        description: "Code"
+      - &input
+        name: input
+        description: "Input data"
+      - &output
+        name: output
+        description: "Output data"

--- a/models/safe/polygon/safe_polygon_transactions.sql
+++ b/models/safe/polygon/safe_polygon_transactions.sql
@@ -1,0 +1,58 @@
+{{ 
+    config(
+        materialized='incremental',
+        alias='safe_transactions_polygon',
+        partition_by = ['block_date'],
+        unique_key = ['block_date', 'tx_hash', 'trace_address'], 
+        on_schema_change='fail',
+        file_format ='delta',
+        incremental_strategy='merge',
+        post_hook='{{ expose_spells(\'["polygon"]\',
+                                    "project",
+                                    "safe",
+                                    \'["tschubotz"]\') }}'
+    ) 
+}}
+
+select 
+    'polygon' as blockchain,
+    try_cast(date_trunc('day', tr.block_time) as date) as block_date,
+    tr.block_time,
+    tr.block_number,
+    tr.tx_hash,
+    s.address,
+    tr.to,
+    tr.value,
+    tr.gas,
+    tr.gas_used,
+    tr.tx_index,
+    tr.sub_traces,
+    tr.trace_address,
+    tr.success,
+    tr.error,
+    tr.code,
+    tr.input,
+    tr.output,
+    case 
+        when substring(tr.input, 0, 10) = '0x6a761202' then 'execTransaction'
+        when substring(tr.input, 0, 10) = '0x468721a7' then 'execTransactionFromModule'
+        when substring(tr.input, 0, 10) = '0x5229073f' then 'execTransactionFromModuleReturnData'
+        else 'unknown'
+    end as method
+from {{ source('polygon', 'traces') }} tr 
+join {{ ref('safe_polygon_safes') }} s
+    on s.address = tr.from
+join {{ ref('safe_polygon_singletons') }} ss
+    on tr.to = ss.address
+where substring(tr.input, 0, 10) in (
+        '0x6a761202', -- execTransaction
+        '0x468721a7', -- execTransactionFromModule
+        '0x5229073f' -- execTransactionFromModuleReturnData
+    )
+    AND tr.call_type = 'delegatecall'
+    {% if not is_incremental() %}
+    and tr.block_time > '2021-03-07' -- for initial query optimisation    
+    {% endif %}
+    {% if is_incremental() %}
+    and tr.block_time > date_trunc("day", now() - interval '1 week')
+    {% endif %}

--- a/tests/safe/arbitrum/safe_arbitrum_transactions_test.sql
+++ b/tests/safe/arbitrum/safe_arbitrum_transactions_test.sql
@@ -1,0 +1,17 @@
+-- Check that number of Safe transactions in specific date range is correct.
+
+with test_data as (
+    select count(*) as total
+    from {{ ref('safe_avalanche_c_transactions') }}
+    where block_time > '2023-01-01'
+        and block_time < '2023-02-01'
+),
+
+test_result as (
+    select case when total = 49838 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false

--- a/tests/safe/avalanche_c/safe_avalanche_c_transactions_test.sql
+++ b/tests/safe/avalanche_c/safe_avalanche_c_transactions_test.sql
@@ -1,0 +1,17 @@
+-- Check that number of Safe transactions in specific date range is correct.
+
+with test_data as (
+    select count(*) as total
+    from {{ ref('safe_arbitrum_transactions') }}
+    where block_time > '2023-01-01'
+        and block_time < '2023-02-01'
+),
+
+test_result as (
+    select case when total = 3618 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false

--- a/tests/safe/bnb/safe_bnb_transactions_test.sql
+++ b/tests/safe/bnb/safe_bnb_transactions_test.sql
@@ -1,0 +1,17 @@
+-- Check that number of Safe transactions in specific date range is correct.
+
+with test_data as (
+    select count(*) as total
+    from {{ ref('safe_bnb_transactions') }}
+    where block_time > '2023-01-01'
+        and block_time < '2023-02-01'
+),
+
+test_result as (
+    select case when total = 14009 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false

--- a/tests/safe/ethereum/safe_ethereum_transactions_test.sql
+++ b/tests/safe/ethereum/safe_ethereum_transactions_test.sql
@@ -1,0 +1,17 @@
+-- Check that number of Safe transactions in specific date range is correct.
+
+with test_data as (
+    select count(*) as total
+    from {{ ref('safe_ethereum_transactions') }}
+    where block_time > '2023-01-01'
+        and block_time < '2023-02-01'
+),
+
+test_result as (
+    select case when total = 54809 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false

--- a/tests/safe/fantom/safe_fantom_transactions_test.sql
+++ b/tests/safe/fantom/safe_fantom_transactions_test.sql
@@ -1,0 +1,17 @@
+-- Check that number of Safe transactions in specific date range is correct.
+
+with test_data as (
+    select count(*) as total
+    from {{ ref('safe_fantom_transactions') }}
+    where block_time > '2023-01-01'
+        and block_time < '2023-02-01'
+),
+
+test_result as (
+    select case when total = 689 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false

--- a/tests/safe/gnosis/safe_gnosis_transactions_test.sql
+++ b/tests/safe/gnosis/safe_gnosis_transactions_test.sql
@@ -1,0 +1,17 @@
+-- Check that number of Safe transactions in specific date range is correct.
+
+with test_data as (
+    select count(*) as total
+    from {{ ref('safe_gnosis_transactions') }}
+    where block_time > '2023-01-01'
+        and block_time < '2023-02-01'
+),
+
+test_result as (
+    select case when total = 21535 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false

--- a/tests/safe/goerli/safe_goerli_transactions_test.sql
+++ b/tests/safe/goerli/safe_goerli_transactions_test.sql
@@ -1,0 +1,17 @@
+-- Check that number of Safe transactions in specific date range is correct.
+
+with test_data as (
+    select count(*) as total
+    from {{ ref('safe_goerli_transactions') }}
+    where block_time > '2023-01-01'
+        and block_time < '2023-02-01'
+),
+
+test_result as (
+    select case when total = 13954 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false

--- a/tests/safe/optimism/safe_optimism_transactions_test.sql
+++ b/tests/safe/optimism/safe_optimism_transactions_test.sql
@@ -1,0 +1,17 @@
+-- Check that number of Safe transactions in specific date range is correct.
+
+with test_data as (
+    select count(*) as total
+    from {{ ref('safe_optimism_transactions') }}
+    where block_time > '2023-01-01'
+        and block_time < '2023-02-01'
+),
+
+test_result as (
+    select case when total = 34650 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false

--- a/tests/safe/polygon/safe_polygon_transactions_test.sql
+++ b/tests/safe/polygon/safe_polygon_transactions_test.sql
@@ -1,0 +1,17 @@
+-- Check that number of Safe transactions in specific date range is correct.
+
+with test_data as (
+    select count(*) as total
+    from {{ ref('safe_polygon_transactions') }}
+    where block_time > '2023-01-01'
+        and block_time < '2023-02-01'
+),
+
+test_result as (
+    select case when total = 479688 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false


### PR DESCRIPTION
Brief comments on the purpose of your changes:
- Adds a spell for Safe transactions for Arbitrum, Avax, BNB, ETH, FTM, GNO, Goerli, OP, and Polygon.

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
