### PR TITLE
T-25470 - Fix aave_ethereum.interest

### DIFF
--- a/models/aave/ethereum/aave_v2_ethereum_interest_rates.sql
+++ b/models/aave/ethereum/aave_v2_ethereum_interest_rates.sql
@@ -17,6 +17,6 @@ select
   avg(CAST(a.variableBorrowRate AS DOUBLE)) / 1e27 as variable_borrow_apy
 from {{ source('aave_v2_ethereum', 'LendingPool_evt_ReserveDataUpdated') }} a
 left join {{ ref('tokens_ethereum_erc20') }} t
-on a.reserve=t.contract_address
+on CAST(a.reserve AS VARCHAR(100)) = t.contract_address
 group by 1,2,3
 ;


### PR DESCRIPTION
Explicit casting on the select clause to fix DuneSQL issues that appeared in Dev after the data type breaking changes.

This does not change any final column types on the model, what was a varchar remains a varchar :)