### PR TITLE
T-25470 - Fix aave_ethereum.borrow

### DIFF
--- a/models/aave/ethereum/aave_v1_ethereum_borrow.sql
+++ b/models/aave/ethereum/aave_v1_ethereum_borrow.sql
@@ -31,14 +31,14 @@ SELECT
     '1' AS version,
     'borrow' AS transaction_type,
     CASE 
-        WHEN _borrowRateMode = '1' THEN 'stable'
-        WHEN _borrowRateMode = '2' THEN 'variable'
+        WHEN CAST(_borrowRateMode AS VARCHAR(100)) = '1' THEN 'stable'
+        WHEN CAST(_borrowRateMode AS VARCHAR(100)) = '2' THEN 'variable'
     END AS loan_type,
     CASE
-        WHEN _reserve = '{{aave_mock_address}}' THEN '{{weth_address}}' --Using WETH instead of Aave "mock" address
-        ELSE _reserve
+        WHEN CAST(_reserve AS VARCHAR(100)) = '{{aave_mock_address}}' THEN '{{weth_address}}' --Using WETH instead of Aave "mock" address
+        ELSE CAST(_reserve AS VARCHAR(100))
     END AS token,
-    _user AS borrower,
+    CAST(_user AS VARCHAR(100)) AS borrower,
     CAST(NULL AS VARCHAR(5)) AS repayer,
     CAST(NULL AS VARCHAR(5)) AS liquidator,
     CAST(_amount AS DECIMAL(38,0)) AS amount,
@@ -53,11 +53,11 @@ SELECT
     'repay' AS transaction_type,
     NULL AS loan_type,
     CASE
-        WHEN _reserve = '{{aave_mock_address}}' THEN '{{weth_address}}' --Using WETH instead of Aave "mock" address
-        ELSE _reserve
+        WHEN CAST(_reserve AS VARCHAR(100)) = '{{aave_mock_address}}' THEN '{{weth_address}}' --Using WETH instead of Aave "mock" address
+        ELSE CAST(_reserve AS VARCHAR(100))
     END AS token,
-    _user AS borrower,
-    _repayer AS repayer,
+    CAST(_user AS VARCHAR(100)) AS borrower,
+    CAST(_repayer AS VARCHAR(100)) AS repayer,
     CAST(NULL AS VARCHAR(5)) AS liquidator,
     - CAST(_amountMinusFees AS DECIMAL(38,0)) AS amount,
     evt_tx_hash,
@@ -71,12 +71,12 @@ SELECT
     'borrow_liquidation' AS transaction_type,
     NULL AS loan_type,
     CASE
-        WHEN _reserve = '{{aave_mock_address}}' THEN '{{weth_address}}' --Using WETH instead of Aave "mock" address
-        ELSE _reserve
+        WHEN CAST(_reserve AS VARCHAR(100)) = '{{aave_mock_address}}' THEN '{{weth_address}}' --Using WETH instead of Aave "mock" address
+        ELSE CAST(_reserve AS VARCHAR(100))
     END AS token,
-    _user AS borrower,
-    _liquidator AS repayer,
-    _liquidator AS liquidator,
+    CAST(_user AS VARCHAR(100)) AS borrower,
+    CAST(_liquidator AS VARCHAR(100)) AS repayer,
+    CAST(_liquidator AS VARCHAR(100)) AS liquidator,
     - CAST(_purchaseAmount AS DECIMAL(38,0)) AS amount,
     evt_tx_hash,
     evt_index,

--- a/models/aave/ethereum/aave_v2_ethereum_borrow.sql
+++ b/models/aave/ethereum/aave_v2_ethereum_borrow.sql
@@ -28,11 +28,11 @@ SELECT
     '2' AS version,
     'borrow' AS transaction_type,
     CASE 
-        WHEN borrowRateMode = '1' THEN 'stable'
-        WHEN borrowRateMode = '2' THEN 'variable'
+        WHEN CAST(borrowRateMode AS VARCHAR(100)) = '1' THEN 'stable'
+        WHEN CAST(borrowRateMode AS VARCHAR(100)) = '2' THEN 'variable'
     END AS loan_type,
-    reserve AS token,
-    user AS borrower, 
+    CAST(reserve AS VARCHAR(100)) AS token,
+    CAST(user AS VARCHAR(100)) AS borrower, 
     CAST(NULL AS VARCHAR(5)) AS repayer,
     CAST(NULL AS VARCHAR(5)) AS liquidator,
     CAST(amount AS DECIMAL(38,0)) AS amount,
@@ -46,9 +46,9 @@ SELECT
     '2' AS version,
     'repay' AS transaction_type,
     NULL AS loan_type,
-    reserve AS token,
-    user AS borrower,
-    repayer AS repayer,
+    CAST(reserve AS VARCHAR(100)) AS token,
+    CAST(user AS VARCHAR(100)) AS borrower,
+    CAST(repayer AS VARCHAR(100)) AS repayer,
     CAST(NULL AS VARCHAR(5)) AS liquidator,
     - CAST(amount AS DECIMAL(38,0)) AS amount,
     evt_tx_hash,
@@ -61,9 +61,9 @@ SELECT
     '2' AS version,
     'borrow_liquidation' AS transaction_type,
     NULL AS loan_type,
-    debtAsset AS token,
-    user AS borrower,
-    liquidator AS repayer,
+    CAST(debtAsset AS VARCHAR(100)) AS token,
+    CAST(user AS VARCHAR(100)) AS borrower,
+    CAST(liquidator AS VARCHAR(100)) AS repayer,
     liquidator AS liquidator,
     - CAST(debtToCover AS DECIMAL(38, 0)) AS amount,
     evt_tx_hash,


### PR DESCRIPTION
Explicit casting on the select clause to fix DuneSQL issues that appeared in Dev after the data type breaking changes.

This does not change any final column types on the model, what was a varchar remains a varchar :)