### PR TITLE
Add Safe txs spell for optimism

### DIFF
--- a/models/safe/optimism/safe_optimism_schema.yml
+++ b/models/safe/optimism/safe_optimism_schema.yml
@@ -68,7 +68,9 @@ models:
         name: block_number
         description: "Number of block"
       - *tx_hash
-      - *address
+      - &safe_address
+        name: safe_address
+        description: "Safe contract address"
       - &to
         name: to
         description: "Destination address"

--- a/models/safe/optimism/safe_optimism_schema.yml
+++ b/models/safe/optimism/safe_optimism_schema.yml
@@ -68,8 +68,7 @@ models:
         name: block_number
         description: "Number of block"
       - *tx_hash
-      - &safe_address
-        name: safe_address
+      - name: address
         description: "Safe contract address"
       - &to
         name: to

--- a/models/safe/optimism/safe_optimism_schema.yml
+++ b/models/safe/optimism/safe_optimism_schema.yml
@@ -46,3 +46,62 @@ models:
         tests:
           - unique
           - not_null
+
+  - name: safe_optimism_transactions
+    meta:
+      blockchain: optimism
+      project: safe
+      contributors: tschubotz
+    freshness:
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    config:
+      tags: ['safe', 'optimism']
+    description: "Safe transactions"
+    columns:
+      - *blockchain
+      - *block_date
+      - &block_time
+        name: block_time
+        description: "Datetime of block"
+      - &block_number
+        name: block_number
+        description: "Number of block"
+      - *tx_hash
+      - *address
+      - &to
+        name: to
+        description: "Destination address"
+      - &value
+        name: value
+        description: "Value of transaction"
+      - &gas
+        name: gas 
+        description: "Gas limit set for transaction"
+      - &gas_used
+        name: gas_used
+        description: "Gas used during transaction"
+      - &tx_index
+        name: tx_index
+        description: "Transaction index"
+      - &sub_traces
+        name: sub_traces
+        description: "Number of sub traces"
+      - &trace_address
+        name: trace_address
+        description: ""
+      - &success
+        name: success
+        description: "Success state of transaction"
+      - &error
+        name: error
+        description: "Error of transaction if any"
+      - &code
+        name: code
+        description: "Code"
+      - &input
+        name: input
+        description: "Input data"
+      - &output
+        name: output
+        description: "Output data"

--- a/models/safe/optimism/safe_optimism_transactions.sql
+++ b/models/safe/optimism/safe_optimism_transactions.sql
@@ -4,7 +4,7 @@
         alias='safe_transactions_optimism',
         partition_by = ['block_date'],
         unique_key = ['block_date', 'tx_hash', 'trace_address'], 
-        on_schema_change='full_refresh',
+        on_schema_change='fail',
         file_format ='delta',
         incremental_strategy='merge',
         post_hook='{{ expose_spells(\'["optimism"]\',

--- a/models/safe/optimism/safe_optimism_transactions.sql
+++ b/models/safe/optimism/safe_optimism_transactions.sql
@@ -1,10 +1,9 @@
 {{ 
     config(
         materialized='incremental',
-        alias='safe_transactions_optimism',
+        alias='safe_optimism_transactions',
         partition_by = ['block_date'],
         unique_key = ['block_date', 'tx_hash', 'trace_address'], 
-        on_schema_change='fail',
         file_format ='delta',
         incremental_strategy='merge',
         post_hook='{{ expose_spells(\'["optimism"]\',

--- a/models/safe/optimism/safe_optimism_transactions.sql
+++ b/models/safe/optimism/safe_optimism_transactions.sql
@@ -20,7 +20,7 @@ select
     tr.block_time,
     tr.block_number,
     tr.tx_hash,
-    s.address as safe_address,
+    s.address,
     tr.to,
     tr.value,
     tr.gas,

--- a/models/safe/optimism/safe_optimism_transactions.sql
+++ b/models/safe/optimism/safe_optimism_transactions.sql
@@ -1,7 +1,7 @@
 {{ 
     config(
         materialized='incremental',
-        alias='safe_optimism_transactions',
+        alias='transactions',
         partition_by = ['block_date'],
         unique_key = ['block_date', 'tx_hash', 'trace_address'], 
         file_format ='delta',

--- a/models/safe/optimism/safe_optimism_transactions.sql
+++ b/models/safe/optimism/safe_optimism_transactions.sql
@@ -4,7 +4,7 @@
         alias='safe_transactions_optimism',
         partition_by = ['block_date'],
         unique_key = ['block_date', 'tx_hash', 'trace_address'], 
-        on_schema_change='fail',
+        on_schema_change='full_refresh',
         file_format ='delta',
         incremental_strategy='merge',
         post_hook='{{ expose_spells(\'["optimism"]\',

--- a/models/safe/optimism/safe_optimism_transactions.sql
+++ b/models/safe/optimism/safe_optimism_transactions.sql
@@ -1,0 +1,58 @@
+{{ 
+    config(
+        materialized='incremental',
+        alias='safe_transactions_optimism',
+        partition_by = ['block_date'],
+        unique_key = ['block_date', 'tx_hash', 'trace_address'], 
+        on_schema_change='fail',
+        file_format ='delta',
+        incremental_strategy='merge',
+        post_hook='{{ expose_spells(\'["optimism"]\',
+                                    "project",
+                                    "safe",
+                                    \'["tschubotz"]\') }}'
+    ) 
+}}
+
+select 
+    'optimism' as blockchain,
+    try_cast(date_trunc('day', tr.block_time) as date) as block_date,
+    tr.block_time,
+    tr.block_number,
+    tr.tx_hash,
+    s.address,
+    tr.to,
+    tr.value,
+    tr.gas,
+    tr.gas_used,
+    tr.tx_index,
+    tr.sub_traces,
+    tr.trace_address,
+    tr.success,
+    tr.error,
+    tr.code,
+    tr.input,
+    tr.output,
+    case 
+        when substring(tr.input, 0, 10) = '0x6a761202' then 'execTransaction'
+        when substring(tr.input, 0, 10) = '0x468721a7' then 'execTransactionFromModule'
+        when substring(tr.input, 0, 10) = '0x5229073f' then 'execTransactionFromModuleReturnData'
+        else 'unknown'
+    end as method
+from {{ source('optimism', 'traces') }} tr 
+join {{ ref('safe_optimism_safes') }} s
+    on s.address = tr.from
+join {{ ref('safe_optimism_singletons') }} ss
+    on tr.to = ss.address
+where substring(tr.input, 0, 10) in (
+        '0x6a761202', -- execTransaction
+        '0x468721a7', -- execTransactionFromModule
+        '0x5229073f' -- execTransactionFromModuleReturnData
+    )
+    and tr.call_type = 'delegatecall'
+    {% if not is_incremental() %}
+    and tr.block_time > '2021-11-17' -- for initial query optimisation    
+    {% endif %}
+    {% if is_incremental() %}
+    and tr.block_time > date_trunc("day", now() - interval '1 week')
+    {% endif %}

--- a/models/safe/optimism/safe_optimism_transactions.sql
+++ b/models/safe/optimism/safe_optimism_transactions.sql
@@ -20,7 +20,7 @@ select
     tr.block_time,
     tr.block_number,
     tr.tx_hash,
-    s.address,
+    s.address as safe_address,
     tr.to,
     tr.value,
     tr.gas,

--- a/tests/safe/optimism/safe_optimism_transactions_test.sql
+++ b/tests/safe/optimism/safe_optimism_transactions_test.sql
@@ -1,0 +1,17 @@
+-- Check that number of Safe transactions in specific date range is correct.
+
+with test_data as (
+    select count(*) as total
+    from {{ ref('safe_optimism_transactions') }}
+    where block_time > '2023-01-01'
+        and block_time < '2023-02-01'
+),
+
+test_result as (
+    select case when total = 34650 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false


### PR DESCRIPTION
Brief comments on the purpose of your changes:
- Adds a spell for Safe transactions for OP
- This PR is split out of #2754 

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
