### PR TITLE
Make dex_aggregator.trades DuneSQL compatible

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -184,9 +184,9 @@ valued_trades as (
                  else concat(buy_token, '-', sell_token)
                end as token_pair,
            units_sold,
-           atoms_sold,
+           CAST(atoms_sold AS DECIMAL(38,0)) AS atoms_sold,
            units_bought,
-           atoms_bought,
+           CAST(atoms_bought AS DECIMAL(38,0)) AS atoms_bought,
            (CASE
                 WHEN sell_price IS NOT NULL THEN
                     -- Choose the larger of two prices when both not null.

--- a/models/cow_protocol/gnosis/cow_protocol_gnosis_trades.sql
+++ b/models/cow_protocol/gnosis/cow_protocol_gnosis_trades.sql
@@ -167,9 +167,9 @@ valued_trades as (
                  else concat(buy_token, '-', sell_token)
                end as token_pair,
            units_sold,
-           atoms_sold,
+           CAST(atoms_sold AS DECIMAL(38,0)) AS atoms_sold,
            units_bought,
-           atoms_bought,
+           CAST(atoms_bought AS DECIMAL(38,0)) AS atoms_bought,
            (CASE
                 WHEN sell_price IS NOT NULL THEN
                     -- Choose the larger of two prices when both not null.


### PR DESCRIPTION
This PR aims to fix dev_aggregator.trades to be compatible with DuneSQL and it is unrelated to the rest of the PRs in the batch which were linked to data type changes.

Here the columns `atoms_sold` is changed from double to decimal(38,0),  and `atoms_bought` is changed from string to decimal(38,0) so that they can be correctly unioned on `dex_aggregator.trades`.

Full disclaimer: I did not fully test this, I need a refresher on how to do this (it's been a while). What I did do: I checked if other models were referring to these modified columns [here](https://dune.com/spellbook#!/model/model.spellbook.cow_protocol_ethereum_trades) and [here](https://dune.com/spellbook#!/model/model.spellbook.cow_protocol_gnosis_trades) and I didn't find any.