### PR TITLE
Revert "Dagster Deploy w/ manifest management (#2818)"

### DIFF
--- a/.github/workflows/commit-new-manifest.yml
+++ b/.github/workflows/commit-new-manifest.yml
@@ -1,0 +1,33 @@
+name: Update Manifest
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group:  ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  commit_manifest:
+    runs-on: [ self-hosted, linux, spellbook ]
+
+    steps:
+    - uses: actions/setup-python@v3
+    - name: Checkout main branch
+      uses: actions/checkout@v2
+      with:
+        ref: main
+        
+    - name: Add git_sha to schema
+      run: "/runner/change_schema.sh wizard"
+
+    - name: dbt dependencies
+      run: "dbt deps"
+
+    - name: dbt compile to create prod manifest from main
+      run: "dbt compile --target-path ."
+
+    - name: upload manifest
+      run: "aws s3 cp manifest.json s3://manifest-spellbook/manifest.json"

--- a/.github/workflows/dagster_deploy.yml
+++ b/.github/workflows/dagster_deploy.yml
@@ -3,31 +3,14 @@ on:
     branches:
       - "main"
 
+concurrency:
+  group:  ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   dispatch:
     runs-on: [ self-hosted, linux, spellbook ]
     steps:
-    - uses: actions/setup-python@v3
-    - name: Checkout main branch
-      uses: actions/checkout@v2
-      with:
-        ref: main
-
-    - name: Add git_sha to schema
-      run: "/runner/change_schema.sh wizard"
-
-    - name: copy old manifest to new file
-      run: "aws s3 cp s3://manifest-spellbook/manifest.json s3://manifest-spellbook/previous_manifest.json"
-
-    - name: dbt dependencies
-      run: "dbt deps"
-
-    - name: dbt compile to create prod manifest from main
-      run: "dbt compile --target-path ."
-
-    - name: upload manifest
-      run: "aws s3 cp manifest.json s3://manifest-spellbook/manifest.json"
-
     - name: Set pat token
       id: set-pat-token
       run: |


### PR DESCRIPTION
This reverts commit 72f59b2c8c3cf2f47b8c7f818fa760da692dc287.

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
