### PR TITLE
Added opensea_v4_ethereum.trades to opensea_ethereum.events

### DIFF
--- a/models/opensea/ethereum/opensea_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_ethereum_events.sql
@@ -86,4 +86,45 @@ FROM
                 ,currency_symbol as royalty_fee_currency_symbol
                 ,unique_trade_id
           FROM {{ ref('opensea_v3_ethereum_events') }}
+        UNION ALL
+        SELECT   blockchain
+                ,project
+                ,version
+                ,block_time
+                ,token_id
+                ,collection
+                ,amount_usd
+                ,token_standard
+                ,case when trade_type <> 'Bundle Trade' and count(1) over (partition by tx_hash) > 1 then 'Bulk Purchase'
+                      else trade_type
+                 end as trade_type
+                ,CAST(number_of_items AS DECIMAL(38,0)) number_of_items
+                ,case when is_private then 'Private Sale' else trade_category end as trade_category -- Private sale can be purchasd by Buy/Offer accepted, but we surpress when it is Private sale here 
+                ,evt_type
+                ,seller
+                ,buyer
+                ,amount_original
+                ,CAST(amount_raw AS DECIMAL(38,0)) amount_raw
+                ,currency_symbol
+                ,currency_contract
+                ,nft_contract_address
+                ,project_contract_address
+                ,aggregator_name
+                ,aggregator_address
+                ,tx_hash
+                ,block_number
+                ,tx_from
+                ,tx_to
+                ,platform_fee_amount_raw
+                ,platform_fee_amount
+                ,platform_fee_amount_usd
+                ,case when amount_raw > 0 then CAST ((platform_fee_amount_raw / amount_raw * 100) AS DOUBLE) end platform_fee_percentage
+                ,royalty_fee_amount_raw
+                ,royalty_fee_amount
+                ,royalty_fee_amount_usd
+                ,case when amount_raw > 0 then CAST((royalty_fee_amount_raw / amount_raw * 100) AS DOUBLE) end royalty_fee_percentage
+                ,royalty_fee_receive_address
+                ,currency_symbol as royalty_fee_currency_symbol
+                ,unique_trade_id
+          FROM {{ ref('opensea_v4_ethereum_events') }}
 )

--- a/models/opensea/ethereum/opensea_ethereum_schema.yml
+++ b/models/opensea/ethereum/opensea_ethereum_schema.yml
@@ -233,11 +233,7 @@ models:
       - *royalty_fee_amount_usd
       - *royalty_fee_receive_address
       - *royalty_fee_currency_symbol
-      - &unique_trade_id
-        name: unique_trade_id
-        description:  "Unique trade ID"
-        tests:
-          - unique
+      - *unique_trade_id
 
   - name: opensea_v3_ethereum_trades
     meta:

--- a/models/opensea/ethereum/opensea_ethereum_schema.yml
+++ b/models/opensea/ethereum/opensea_ethereum_schema.yml
@@ -189,6 +189,56 @@ models:
         tests:
           - unique
 
+  - name: opensea_v4_ethereum_events
+    meta:
+      blockchain: ethereum
+      project: opensea
+      contributors: [sohwak]
+    config:
+      tags: ['ethereum','opensea','v4','events']
+    description: >
+        OpenSea V4 events on Ethereum
+    columns:
+      - *blockchain
+      - *project
+      - *version
+      - *block_time
+      - *token_id
+      - *collection
+      - *amount_usd
+      - *token_standard
+      - *trade_type
+      - *number_of_items
+      - *trade_category
+      - *evt_type
+      - *seller
+      - *buyer
+      - *amount_original
+      - *amount_raw
+      - *currency_symbol
+      - *currency_contract
+      - *nft_contract_address
+      - *project_contract_address
+      - *aggregator_name
+      - *aggregator_address
+      - *tx_hash
+      - *block_number
+      - *tx_from
+      - *tx_to
+      - *platform_fee_amount_raw
+      - *platform_fee_amount
+      - *platform_fee_amount_usd
+      - *royalty_fee_amount_raw
+      - *royalty_fee_amount
+      - *royalty_fee_amount_usd
+      - *royalty_fee_receive_address
+      - *royalty_fee_currency_symbol
+      - &unique_trade_id
+        name: unique_trade_id
+        description:  "Unique trade ID"
+        tests:
+          - unique
+
   - name: opensea_v3_ethereum_trades
     meta:
       blockchain: ethereum

--- a/models/opensea/ethereum/opensea_v4_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v4_ethereum_events.sql
@@ -1,0 +1,60 @@
+{{ config(schema='opensea_v3_ethereum'
+         ,alias='events') 
+}}
+
+-- opensea.events is compose of mint, burn, and trades. 
+-- but now there are only trades.
+-- materialize : view
+
+select blockchain    
+      ,'opensea' as project
+      ,'v3' as version
+      ,block_date
+      ,block_time
+      ,seller
+      ,buyer
+      ,trade_type
+      ,trade_category
+      ,evt_type
+      ,nft_contract_address
+      ,collection
+      ,token_id
+      ,number_of_items
+      ,token_standard
+      ,amount_original
+      ,amount_raw
+      ,amount_usd
+      ,currency_symbol
+      ,currency_contract
+      ,original_currency_contract
+      ,currency_decimals   
+      ,project_contract_address
+      ,platform_fee_receive_address
+      ,platform_fee_amount_raw
+      ,platform_fee_amount
+      ,platform_fee_amount_usd
+      ,royalty_fee_receive_address
+      ,royalty_fee_amount_raw
+      ,royalty_fee_amount
+      ,royalty_fee_amount_usd
+      ,royalty_fee_receive_address_1
+      ,royalty_fee_receive_address_2
+      ,royalty_fee_receive_address_3
+      ,royalty_fee_receive_address_4
+      ,royalty_fee_amount_raw_1
+      ,royalty_fee_amount_raw_2
+      ,royalty_fee_amount_raw_3
+      ,royalty_fee_amount_raw_4
+      ,aggregator_name
+      ,aggregator_address
+      ,block_number
+      ,tx_hash
+      ,evt_index
+      ,tx_from
+      ,tx_to
+      ,right_hash
+      ,zone_address
+      ,estimated_price
+      ,is_private
+      ,unique_trade_id
+  from {{ ref('opensea_v3_ethereum_trades') }}

--- a/models/opensea/ethereum/opensea_v4_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v4_ethereum_events.sql
@@ -1,4 +1,4 @@
-{{ config(schema='opensea_v3_ethereum'
+{{ config(schema='opensea_v4_ethereum'
          ,alias='events') 
 }}
 
@@ -8,7 +8,7 @@
 
 select blockchain    
       ,'opensea' as project
-      ,'v3' as version
+      ,'v4' as version
       ,block_date
       ,block_time
       ,seller
@@ -57,4 +57,4 @@ select blockchain
       ,estimated_price
       ,is_private
       ,unique_trade_id
-  from {{ ref('opensea_v3_ethereum_trades') }}
+  from {{ ref('opensea_v4_ethereum_trades') }}


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Added `opensea_v4_ethereum.trades` to `opensea_ethereum.events`

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
