### PR TITLE
CI: test if all models have a custom schema set.

### DIFF
--- a/.github/workflows/dbt_precommit_hooks.yml
+++ b/.github/workflows/dbt_precommit_hooks.yml
@@ -36,6 +36,10 @@ jobs:
         run: "dbt deps"
       - name: dbt compile
         run: "dbt compile"
+      - name: check schemas
+        run: |
+          test=$(dbt --quiet --no-print ls --select config.schema:no_schema --output path)
+          [[ -z "$test" ]] && { echo "Success: All models have a custom schema"; exit 0; } || { echo "Found models without custom schema:"; echo "$test"; exit 1; }
       - uses: pre-commit/action@v3.0.0
         # Apologies for the hideously long line. Tried to get the Action to respect a multiline if but no dice.
         if: ${{ contains(steps.abc.outputs.added_modified, 'models') || contains(steps.abc.outputs.added_modified, 'test') || contains(steps.abc.outputs.added_modified, 'seeds') || contains(steps.abc.outputs.added_modified, 'macros')}}

--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -42,11 +42,6 @@ jobs:
       - name: dbt seed
         run: "dbt seed --select state:modified --state ."
 
-      - name: check schemas
-        run: |
-          test=$(dbt --quiet --no-print ls --select config.schema:no_schema --output path)
-          [[ -z "$test" ]] && { echo "Success: All models have a custom schema"; exit 0; } || { echo "Found models without custom schema:"; echo "$test"; exit 1; }
-
       - name: dbt run initial model(s)
         run: "dbt -x run --select state:modified --defer --state ."
 

--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -42,6 +42,11 @@ jobs:
       - name: dbt seed
         run: "dbt seed --select state:modified --state ."
 
+      - name: check schemas
+        run: |
+          test=$(dbt --quiet --no-print ls --select config.schema:no_schema --output path)
+          [[ -z "$test" ]] && { echo "Success: All models have a custom schema"; exit 0; } || { echo "Found models without custom schema:"; echo "$test"; exit 1; }
+
       - name: dbt run initial model(s)
         run: "dbt -x run --select state:modified --defer --state ."
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -182,8 +182,8 @@ models:
         +schema: element_avalanche_c
 
 
-    abi:
-      +schema: abi
+#    abi:
+#      +schema: abi
 
     superrare:
       +schema: superrare

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -38,6 +38,8 @@ models:
       sql: "{{ optimize_spell(this, model.config.materialized) }}"
       transaction: true
     +materialized: view
+    +schema: no_schema    # this should be overriden in model specific configs
+
     aave:
       +schema: aave
       ethereum:
@@ -120,7 +122,7 @@ models:
         +schema: uniswap_optimism
       polygon:
         +schema: uniswap_polygon
-    
+
     quickswap:
       +schema: quickswap
       polygon:
@@ -290,7 +292,7 @@ models:
         +schema: dodo_arbitrum
       optimism:
         +schema: dodo_optimism
-        
+
 
     spookyswap:
       +schema: spookyswap
@@ -453,7 +455,7 @@ models:
         +schema: trove_arbitrum
       ethereum:
         +schema: trove_ethereum
-        
+
     lifi:
       +schema: lifi
       fantom:
@@ -798,7 +800,7 @@ models:
         +schema: beethoven_x_optimism
       fantom:
         +schema: beethoven_x_fantom
-    
+
     zipswap:
       +schema: zipswap
       optimism:

--- a/models/abi/signatures.sql
+++ b/models/abi/signatures.sql
@@ -12,11 +12,20 @@
         )
 }}
 
-{% set chains = ['ethereum', 'optimism', 'arbitrum', 'avalanche_c', 'polygon', 'bnb', 'gnosis', 'fantom'] %}
+{% set chains = [
+    source('ethereum', 'signatures')
+    ,source('optimism', 'signatures')
+    ,source('arbitrum', 'signatures')
+    ,source('avalanche_c', 'signatures')
+    ,source('polygon', 'signatures')
+    ,source('bnb', 'signatures')
+    ,source('gnosis', 'signatures')
+    ,source('fantom', 'signatures')
+] %}
 
 WITH
     signatures as (
-        {% for chain in chains %}
+        {% for chain_source in chains %}
 
             SELECT
                 abi,
@@ -25,7 +34,7 @@ WITH
                 signature,
                 type,
                 concat(id, signature, type) as unique_signature_id
-            FROM {{ source(chain, 'signatures') }}
+            FROM {{ chain_source }}
 
             {% if is_incremental() %}
             WHERE created_at >= date_trunc("day", now() - interval '2 days')

--- a/models/abi/signatures.sql
+++ b/models/abi/signatures.sql
@@ -26,7 +26,7 @@ WITH
                 type,
                 concat(id, signature, type) as unique_signature_id
             FROM {{ source(chain, 'signatures') }}
-            
+
             {% if is_incremental() %}
             WHERE created_at >= date_trunc("day", now() - interval '2 days')
             {% endif %}
@@ -41,14 +41,14 @@ WITH
     SELECT
     *
     FROM (
-        SELECT 
+        SELECT
             id
             , signature
             , abi
             , type
             , created_at
             , date_trunc('month',created_at) as created_at_month
-            , unique_signature_id 
+            , unique_signature_id
             , row_number() over (partition by unique_signature_id order by created_at desc) recency
         FROM signatures
     ) a

--- a/models/abi/signatures.sql
+++ b/models/abi/signatures.sql
@@ -1,5 +1,6 @@
 {{ config(
         alias = 'signatures',
+        schema = 'abi',
         partition_by = ['created_at_month'],
         materialized = 'incremental',
         file_format = 'delta',


### PR DESCRIPTION
CI: test if all models have a custom schema set.
Works as follows:

1. In `dbt_project` we assign a `no_schema` to the top level, this applies to all models.
2. Models are expected to override this schema in their own specific config
3. we use `dbt ls --select config.schema:no_schema` to find any models that forget to do this.

This test will help us to clean up the `dbt_project` file more without the risk that models will forget to define a custom schema. 

As an example here's the test during the migration steps of the `abi` models

example test failure: https://github.com/duneanalytics/spellbook/actions/runs/4304576455/jobs/7505801192
![image](https://user-images.githubusercontent.com/83790096/222169838-0ade9865-a42c-4558-8b4e-89ba696bfb25.png)


example test passing after adding a custom schema:
https://github.com/duneanalytics/spellbook/actions/runs/4304603500/jobs/7505864079
![image](https://user-images.githubusercontent.com/83790096/222170801-20f7deef-9054-4588-8e06-4952d1f1f206.png)

