### PR TITLE
Add spell for ETH transfers of Safes on Arbitrum

### DIFF
--- a/models/safe/arbitrum/safe_arbitrum_eth_transfers.sql
+++ b/models/safe/arbitrum/safe_arbitrum_eth_transfers.sql
@@ -1,0 +1,59 @@
+{{ 
+    config(
+        materialized='incremental',
+        alias='eth_transfers',
+        partition_by = ['block_date'],
+        unique_key = ['block_date', 'tx_hash', 'trace_address', 'amount_raw'],
+        on_schema_change='fail',
+        file_format ='delta',
+        incremental_strategy='merge',
+        post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                    "project",
+                                    "safe",
+                                    \'["tschubotz"]\') }}'
+    ) 
+}}
+
+select 
+    s.address,
+    try_cast(date_trunc('day', et.block_time) as date) as block_date,
+    et.block_time,
+    -et.value as amount_raw,
+    et.tx_hash,
+    array_join(et.trace_address, ',') as trace_address
+from {{ source('arbitrum', 'traces') }} et
+join {{ ref('safe_arbitrum_safes') }} s on et.from = s.address
+    and et.from != et.to -- exclude calls to self to guarantee unique key property
+    and et.success = true
+    and (lower(et.call_type) not in ('delegatecall', 'callcode', 'staticcall') or et.call_type is null)
+    and et.value > '0' -- value is of type string. exclude 0 value traces
+{% if not is_incremental() %}
+where et.block_time > '2021-06-20' -- for initial query optimisation    
+{% endif %}
+{% if is_incremental() %}
+-- to prevent potential counterfactual safe deployment issues we take a bigger interval
+where et.block_time > date_trunc("day", now() - interval '10 days')
+{% endif %}
+        
+union all
+    
+select 
+    s.address, 
+    try_cast(date_trunc('day', et.block_time) as date) as block_date,
+    et.block_time,
+    et.value as amount_raw,
+    et.tx_hash,
+    array_join(et.trace_address, ',') as trace_address
+from {{ source('arbitrum', 'traces') }} et
+join {{ ref('safe_arbitrum_safes') }} s on et.to = s.address
+    and et.from != et.to -- exclude calls to self to guarantee unique key property
+    and et.success = true
+    and (lower(et.call_type) not in ('delegatecall', 'callcode', 'staticcall') or et.call_type is null)
+    and et.value > '0' -- value is of type string. exclude 0 value traces
+{% if not is_incremental() %}
+where et.block_time > '2021-06-20' -- for initial query optimisation      
+{% endif %}
+{% if is_incremental() %}
+-- to prevent potential counterfactual safe deployment issues we take a bigger interval
+where et.block_time > date_trunc("day", now() - interval '10 days')
+{% endif %}

--- a/models/safe/arbitrum/safe_arbitrum_schema.yml
+++ b/models/safe/arbitrum/safe_arbitrum_schema.yml
@@ -106,3 +106,24 @@ models:
       - &output
         name: output
         description: "Output data"
+
+  - name: safe_arbitrum_eth_transfers
+    meta:
+      blockchain: arbitrum
+      project: safe
+      contributors: tschubotz
+    freshness:
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    config:
+      tags: ['safe', 'transfers', 'arbitrum']
+    description: "ETH transfers into or out of Safes"
+    columns:
+      - *address
+      - *block_date
+      - *block_time
+      - &amount_raw
+        name: amount_raw
+        description: "Raw amount of transferred ETH"
+      - *tx_hash
+      - *trace_address

--- a/tests/safe/arbitrum/safe_arbitrum_eth_transfers_test.sql
+++ b/tests/safe/arbitrum/safe_arbitrum_eth_transfers_test.sql
@@ -1,0 +1,16 @@
+-- Check that SUM of ETH transfers during specific time frame is correct.
+
+with test_data as (
+    select round(sum(amount_raw) / 1e18, 0) as total
+    from {{ ref('safe_arbitrum_safes') }}
+    where block_time between '2022-11-01' and '2022-11-03'
+),
+
+test_result as (
+    select case when total = -15 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false


### PR DESCRIPTION
Brief comments on the purpose of your changes:

- Add spell for ETH transfers of Safes on Arbitrum
- (There's a similar spell for this on Ethereum already)

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
