### PR TITLE
Seaport v2 patch - add tx_hash as join key

### DIFF
--- a/models/seaport/ethereum/seaport_v2_ethereum_trades.sql
+++ b/models/seaport/ethereum/seaport_v2_ethereum_trades.sql
@@ -116,6 +116,7 @@ with source_ethereum_transactions as (
           ,b.om_order_id
       from ref_seaport_ethereum_base_pairs a
            left join iv_orders_matched b on b.om_order_hash = a.order_hash
+                                         and b.om_tx_hash = a.tx_hash  -- order_hash is not unique in itself, so must join with tx_hash
      where a.platform_contract_address = '{{c_seaport_contract_address}}'
 )
 ,iv_volume as (


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**Patch for Seaport v2.**

- when using `seaport_ethereum.Seaport_evt_OrdersMatched`, `order_hash` is not enough to keep unique, so it must be used `tx_hash` when joining, too

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
