### PR TITLE
OP Contract Mapping - Types

### DIFF
--- a/models/contracts/optimism/contracts_optimism_contract_mapping.sql
+++ b/models/contracts/optimism/contracts_optimism_contract_mapping.sql
@@ -265,7 +265,7 @@ with base_level as (
 )
 select 
   c.contract_address
-  ,initcap(
+  ,cast(initcap(
       replace(
       -- priority order: Override name, Mapped vs Dune, Raw/Actual names
         coalesce(
@@ -277,9 +277,9 @@ select
       '_',
       ' '
     )
-   ) as contract_project
+   ) as varchar) as contract_project
   ,c.token_symbol
-  ,coalesce(co.contract_name, c.contract_name) as contract_name
+  ,cast( coalesce(co.contract_name, c.contract_name) as varchar) as contract_name
   ,coalesce(c.creator_address, ovm1c.creator_address) as creator_address
   ,coalesce(c.created_time, to_timestamp(ovm1c.created_time)) as created_time
   ,coalesce(c.contract_factory, 

--- a/models/contracts/optimism/contracts_optimism_contract_mapping.sql
+++ b/models/contracts/optimism/contracts_optimism_contract_mapping.sql
@@ -277,9 +277,9 @@ select
       '_',
       ' '
     )
-   ) as varchar) as contract_project
+   ) as varchar(250)) as contract_project
   ,c.token_symbol
-  ,cast( coalesce(co.contract_name, c.contract_name) as varchar) as contract_name
+  ,cast( coalesce(co.contract_name, c.contract_name) as varchar(250)) as contract_name
   ,coalesce(c.creator_address, ovm1c.creator_address) as creator_address
   ,coalesce(c.created_time, to_timestamp(ovm1c.created_time)) as created_time
   ,coalesce(c.contract_factory, 


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Having an error in DuneSQL where contract project names are being read as varbinary (maybe because of 0x). So adding a forced varchar cast.

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
