### PR TITLE
Add Non-App Method Lookup Table

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1370,3 +1370,6 @@ seeds:
         +column_types:
           hex: string
           dec: string
+
+    method_ids:
+      +schema: method_ids

--- a/models/method_ids/evm_non_app_method_ids.sql
+++ b/models/method_ids/evm_non_app_method_ids.sql
@@ -9,9 +9,22 @@
         )
 }}
 
--- Generic EVM methods
--- Is there a list of supported evm chains that we can pull from here?
-SELECT array('ethereum','optimism','arbitrum','polygon','gnosis','avalanche_c','fantom','goerli','bnb') as blockchains, method_id, method_descriptor
+
+{% set all_chains_array = [
+    'ethereum'
+    ,'optimism'
+    ,'arbitrum'
+    ,'polygon'
+    ,'gnosis'
+    ,'avalanche_c'
+    ,'fantom'
+    ,'goerli'
+    ,'bnb'
+    ] %}
+
+WITH aggrregate_methods AS (
+-- Generic EVM methods, we read null array as "all"
+SELECT NULL as blockchains, method_id, method_descriptor
     FROM (values
          ('0x095ea7b3','ERC20 Approval') --'ERC20 Approval'
         ,('0xa9059cbb','ERC20 Transfer') --'ERC20 Transfer'
@@ -23,7 +36,7 @@ SELECT array('ethereum','optimism','arbitrum','polygon','gnosis','avalanche_c','
         ,('0xa22cb465','ERC721/ERC1155 Approval') --'ERC721 Approval'
         ,('0x60806040','Contract Creation'), ('0x60c06040','Contract Creation') --'Contract Creation'
         ) a (method_id, method_descriptor)
-)
+
 UNION ALL --Optimism-Specific Methods
 
 SELECT array('optimism') AS blockchains, method_id, method_descriptor
@@ -44,3 +57,21 @@ SELECT array('arbitrum') AS blockchains, method_id, method_descriptor
         ,('0x7b3a3c8b','Bridge Out (L2 to L1)') --OutboundTransfer (ERC20)
         ,('0x2e567b36','Bridge In (L1 to L2)') --finalizeInboundTransfer (ERC20)
         ) a (method_id, method_descriptor)
+
+
+)
+
+
+SELECT *
+FROM (
+    {% for chain in all_chains_array %}
+    SELECT chain AS blockchain, method_id, method_descriptor
+    FROM aggrregate_methods
+    WHERE
+        blockchains IS NULL --If Null, make an entry for all chains
+        OR array_contains(blockchains,chain)
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+)

--- a/models/method_ids/evm_non_app_method_ids.sql
+++ b/models/method_ids/evm_non_app_method_ids.sql
@@ -1,7 +1,7 @@
 
 {{ config(
-        schema = 'method_ids'
-        alias ='evm_non_app_method+ids',
+        schema = 'method_ids',
+        alias ='evm_non_app_method_ids',
         post_hook='{{ expose_spells(\'["ethereum","optimism","arbitrum",  "polygon","gnosis","avalanche_c","fantom","goerli","bnb"]\',
                                 "sector",
                                 "method_ids",
@@ -9,10 +9,9 @@
         )
 }}
 
-
-{% set all_chains_array = array('ethereum','optimism','arbitrum','polygon','gnosis','avalanche_c','fantom','goerli','bnb') %}
-
-SELECT '{{all_chains_array}}' as blockchains, method_id, method_descriptor
+-- Generic EVM methods
+-- Is there a list of supported evm chains that we can pull from here?
+SELECT array('ethereum','optimism','arbitrum','polygon','gnosis','avalanche_c','fantom','goerli','bnb') as blockchains, method_id, method_descriptor
     FROM (values
          ('0x095ea7b3','ERC20 Approval') --'ERC20 Approval'
         ,('0xa9059cbb','ERC20 Transfer') --'ERC20 Transfer'
@@ -25,17 +24,17 @@ SELECT '{{all_chains_array}}' as blockchains, method_id, method_descriptor
         ,('0x60806040','Contract Creation'), ('0x60c06040','Contract Creation') --'Contract Creation'
         ) a (method_id, method_descriptor)
 )
-UNION ALL
+UNION ALL --Optimism-Specific Methods
 
 SELECT array('optimism') AS blockchains, method_id, method_descriptor
     FROM (values
-        ('0xcbd4ece9','Bridge In (L1 to L2)') --'Bridge In (L1 to L2)'
+         ('0xcbd4ece9','Bridge In (L1 to L2)') --'Bridge In (L1 to L2)'
         ,('0x32b7006d','Bridge Out (L2 to L1)') --'Bridge Out (L2 to L1)'
         ,('0xbede39b5','OVM Gas Price Oracle'), ('0xbf1fe420','OVM Gas Price Oracle') --'OVM Gas Price Oracle'
         ,('0x015d8eb9','Set L1 Block Values') -- Set L1 Block Values System Transaction (Bedrock and later)
         ) a (method_id, method_descriptor)
 
-UNION ALL
+UNION ALL --Arbitrum-Specific Methods
 
 SELECT array('arbitrum') AS blockchains, method_id, method_descriptor
     FROM (values

--- a/models/method_ids/evm_non_app_method_ids.sql
+++ b/models/method_ids/evm_non_app_method_ids.sql
@@ -1,0 +1,47 @@
+
+{{ config(
+        schema = 'method_ids'
+        alias ='evm_non_app_method+ids',
+        post_hook='{{ expose_spells(\'["ethereum","optimism","arbitrum",  "polygon","gnosis","avalanche_c","fantom","goerli","bnb"]\',
+                                "sector",
+                                "method_ids",
+                                \'["msilb7"]\') }}'
+        )
+}}
+
+
+{% set all_chains_array = array('ethereum','optimism','arbitrum','polygon','gnosis','avalanche_c','fantom','goerli','bnb') %}
+
+SELECT '{{all_chains_array}}' as blockchains, method_id, method_descriptor
+    FROM (values
+         ('0x095ea7b3','ERC20 Approval') --'ERC20 Approval'
+        ,('0xa9059cbb','ERC20 Transfer') --'ERC20 Transfer'
+        ,('0xd0e30db0','WETH Wrap') --'WETH Wrap'
+        ,('0x2e1a7d4d','WETH Unwrap') --'WETH Unwrap'
+        ,('0x42842e0e','ERC721 Transfer'), ('0x23b872dd','ERC721 Transfer') --'ERC721 Transfer' --safe transfer and transfer
+        ,('0xb88d4fde','ERC721 Transfer'), ('0xf3993d11','ERC721 Transfer')
+        ,('0xf242432a','ERC1155 Transfer'), ('0x2eb2c2d6','ERC1155 Transfer')
+        ,('0xa22cb465','ERC721/ERC1155 Approval') --'ERC721 Approval'
+        ,('0x60806040','Contract Creation'), ('0x60c06040','Contract Creation') --'Contract Creation'
+        ) a (method_id, method_descriptor)
+)
+UNION ALL
+
+SELECT array('optimism') AS blockchains, method_id, method_descriptor
+    FROM (values
+        ('0xcbd4ece9','Bridge In (L1 to L2)') --'Bridge In (L1 to L2)'
+        ,('0x32b7006d','Bridge Out (L2 to L1)') --'Bridge Out (L2 to L1)'
+        ,('0xbede39b5','OVM Gas Price Oracle'), ('0xbf1fe420','OVM Gas Price Oracle') --'OVM Gas Price Oracle'
+        ,('0x015d8eb9','Set L1 Block Values') -- Set L1 Block Values System Transaction (Bedrock and later)
+        ) a (method_id, method_descriptor)
+
+UNION ALL
+
+SELECT array('arbitrum') AS blockchains, method_id, method_descriptor
+    FROM (values
+         ('0x6bf6a42d','ARBOS System Transaction') --ARBOS System Transaction
+        ,('0xc9f95d32', 'Submit Retryable Tx') --Arb RetryableTx
+        ,('0x25e16063','Bridge Out (L2 to L1)') --WithdrawETH
+        ,('0x7b3a3c8b','Bridge Out (L2 to L1)') --OutboundTransfer (ERC20)
+        ,('0x2e567b36','Bridge In (L1 to L2)') --finalizeInboundTransfer (ERC20)
+        ) a (method_id, method_descriptor)

--- a/models/method_ids/evm_non_app_method_ids_schema.yml
+++ b/models/method_ids/evm_non_app_method_ids_schema.yml
@@ -9,15 +9,15 @@ models:
     config:
       tags: ['method_ids','methods','function','signature']
     description: >
-        A table containing mappings for method ids (function signatures) that can be considered to be non-app transactions
+        A table containing mappings for method ids (function signatures) that can be considered to be non-app transactions.  There will be one row per blockchain x method_id combination.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
               - method_id
     columns:
-      - &blockchains
-        name: blockchains
-        description: "Blockchain(s) which the method id is relevant foor"
+      - &blockchain
+        name: blockchain
+        description: "Blockchain which the method id is relevant for."
       - &method_id 
         name: method_id
         description: "Mehtod ID (first 4 bytes of calldata), in '0x....' format"

--- a/models/method_ids/evm_non_app_method_ids_schema.yml
+++ b/models/method_ids/evm_non_app_method_ids_schema.yml
@@ -1,0 +1,26 @@
+version: 2
+
+models:
+  - name: evm_non_app_method_ids
+    meta:
+      blockchain: ethereum,optimism,arbitrum,  polygon,gnosis,avalanche_c,fantom,goerli,bnb
+      project: method_ids
+      contributors: msilb7
+    config:
+      tags: ['method_ids','methods','function','signature']
+    description: >
+        A table containing mappings for method ids (function signatures) that can be considered to be non-app transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - method_id
+    columns:
+      - &blockchains
+        name: blockchains
+        description: "Blockchain(s) which the method id is relevant foor"
+      - &method_id 
+        name: method_id
+        description: "Mehtod ID (first 4 bytes of calldata), in '0x....' format"
+      - &method_descriptor 
+        name: method_descriptor
+        description: "Manual descriptor of the method ID, which should help explan why it is considered a 'non-app' method."  


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Adding a table for "non-app transaction" method ids. This is currently manually stored in a few queries - i.e.: https://dune.com/queries/451941/858996

Designed to intake chains as a query, but output with one row per chain, so it's easier to use in queries/joins by chain.

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
