### PR TITLE
modified the logic in the case statement - zeroex fills

### DIFF
--- a/models/zeroex/ethereum/zeroex_ethereum_api_fills.sql
+++ b/models/zeroex/ethereum/zeroex_ethereum_api_fills.sql
@@ -311,19 +311,19 @@ direct_uniswapv2 AS (
             swap.contract_address AS maker,
             LAST_VALUE(swap.to) OVER ( PARTITION BY swap.evt_tx_hash ORDER BY swap.evt_index) AS taker,
             CASE
-                WHEN swap.amount0In::float > swap.amount0Out::float THEN pair.token0
+                WHEN CAST(swap.amount0In AS float) > CAST(swap.amount0Out AS float) THEN pair.token0
                 ELSE pair.token1
             END AS taker_token,
             CASE
-                WHEN swap.amount0In::float > swap.amount0Out::float THEN pair.token1
+                WHEN CAST(swap.amount0In AS float) > CAST(swap.amount0Out AS float) THEN pair.token1
                 ELSE pair.token0
             END AS maker_token,
             CASE
-                WHEN swap.amount0In::float > swap.amount0Out::float THEN swap.amount0In - swap.amount0Out
+                WHEN CAST(swap.amount0In AS float) > CAST(swap.amount0Out AS float) THEN swap.amount0In - swap.amount0Out
                 ELSE swap.amount1In - swap.amount1Out
             END AS taker_token_amount_raw,
             CASE
-                WHEN swap.amount0In::float > swap.amount0Out::float THEN swap.amount1Out - swap.amount1In
+                WHEN CAST(swap.amount0In AS float) > CAST(swap.amount0Out AS float) THEN swap.amount1Out - swap.amount1In
                 ELSE swap.amount0Out - swap.amount0In
             END AS maker_token_amount_raw,
             'Uniswap V2 Direct' AS type,
@@ -352,19 +352,19 @@ direct_sushiswap AS (
             swap.contract_address AS maker,
             LAST_VALUE(swap.to) OVER (PARTITION BY swap.evt_tx_hash ORDER BY swap.evt_index) AS taker,
             CASE
-                WHEN swap.amount0In::float > swap.amount0Out::float THEN pair.token0
+                WHEN CAST(swap.amount0In AS float) > CAST(swap.amount0Out AS float) THEN pair.token0
                 ELSE pair.token1
             END AS taker_token,
             CASE
-                WHEN swap.amount0In::float > swap.amount0Out::float THEN pair.token1
+                WHEN CAST(swap.amount0In AS float) > CAST(swap.amount0Out AS float) THEN pair.token1
                 ELSE pair.token0
             END AS maker_token,
             CASE
-                WHEN swap.amount0In::float > swap.amount0Out::float THEN swap.amount0In - swap.amount0Out
+                WHEN CAST(swap.amount0In AS float) > CAST(swap.amount0Out AS float) THEN swap.amount0In - swap.amount0Out
                 ELSE swap.amount1In - swap.amount1Out
             END AS taker_token_amount_raw,
             CASE
-                WHEN swap.amount0In::float > swap.amount0Out::float THEN swap.amount1Out - swap.amount1In
+                WHEN CAST(swap.amount0In AS float) > CAST(swap.amount0Out AS float) THEN swap.amount1Out - swap.amount1In
                 ELSE swap.amount0Out - swap.amount0In
             END AS maker_token_amount_raw,
             'Sushiswap Direct' AS type,

--- a/models/zeroex/ethereum/zeroex_ethereum_api_fills.sql
+++ b/models/zeroex/ethereum/zeroex_ethereum_api_fills.sql
@@ -311,19 +311,19 @@ direct_uniswapv2 AS (
             swap.contract_address AS maker,
             LAST_VALUE(swap.to) OVER ( PARTITION BY swap.evt_tx_hash ORDER BY swap.evt_index) AS taker,
             CASE
-                WHEN swap.amount0In > swap.amount0Out THEN pair.token0
+                WHEN swap.amount0In::float > swap.amount0Out::float THEN pair.token0
                 ELSE pair.token1
             END AS taker_token,
             CASE
-                WHEN swap.amount0In > swap.amount0Out THEN pair.token1
+                WHEN swap.amount0In::float > swap.amount0Out::float THEN pair.token1
                 ELSE pair.token0
             END AS maker_token,
             CASE
-                WHEN swap.amount0In > swap.amount0Out THEN swap.amount0In - swap.amount0Out
+                WHEN swap.amount0In::float > swap.amount0Out::float THEN swap.amount0In - swap.amount0Out
                 ELSE swap.amount1In - swap.amount1Out
             END AS taker_token_amount_raw,
             CASE
-                WHEN swap.amount0In > swap.amount0Out THEN swap.amount1Out - swap.amount1In
+                WHEN swap.amount0In::float > swap.amount0Out::float THEN swap.amount1Out - swap.amount1In
                 ELSE swap.amount0Out - swap.amount0In
             END AS maker_token_amount_raw,
             'Uniswap V2 Direct' AS type,
@@ -352,19 +352,19 @@ direct_sushiswap AS (
             swap.contract_address AS maker,
             LAST_VALUE(swap.to) OVER (PARTITION BY swap.evt_tx_hash ORDER BY swap.evt_index) AS taker,
             CASE
-                WHEN swap.amount0In > swap.amount0Out THEN pair.token0
+                WHEN swap.amount0In::float > swap.amount0Out::float THEN pair.token0
                 ELSE pair.token1
             END AS taker_token,
             CASE
-                WHEN swap.amount0In > swap.amount0Out THEN pair.token1
+                WHEN swap.amount0In::float > swap.amount0Out::float THEN pair.token1
                 ELSE pair.token0
             END AS maker_token,
             CASE
-                WHEN swap.amount0In > swap.amount0Out THEN swap.amount0In - swap.amount0Out
+                WHEN swap.amount0In::float > swap.amount0Out::float THEN swap.amount0In - swap.amount0Out
                 ELSE swap.amount1In - swap.amount1Out
             END AS taker_token_amount_raw,
             CASE
-                WHEN swap.amount0In > swap.amount0Out THEN swap.amount1Out - swap.amount1In
+                WHEN swap.amount0In::float > swap.amount0Out::float THEN swap.amount1Out - swap.amount1In
                 ELSE swap.amount0Out - swap.amount0In
             END AS maker_token_amount_raw,
             'Sushiswap Direct' AS type,

--- a/tests/generic/ethereum/zeroex_ethereum_fills_test.sql
+++ b/tests/generic/ethereum/zeroex_ethereum_fills_test.sql
@@ -1,20 +1,14 @@
 {% test zeroex_ethereum_fills_test(model, column_name, seed_file) %}
-
-
-WITH unit_tests AS
-(
-    SELECT 
-        CASE WHEN 
-            fills.{{ column_name }} = fills_sample.{{ column_name }}
-            THEN True ELSE False END 
-        AS amount_test
-    FROM {{ model }} fills
-    JOIN {{ seed_file }} fills_sample 
-        ON fills.tx_hash = fills_sample.tx_hash
-        AND fills.evt_index = fills_sample.evt_index
+WITH unit_tests as
+(SELECT case when test.maker_token = actual.maker_token 
+                and test.taker = actual.taker 
+                and test.taker_token = actual.taker_token
+then True else False end as test
+FROM {{ ref('zeroex_ethereum_api_fills') }} actual
+JOIN {{ ref('zeroex_ethereum_api_fills_sample') }} test 
+    ON test.tx_hash = actual.tx_hash AND test.evt_index = actual.evt_index
 )
-select *
-    from unit_tests
-    where amount_test = False
-
+select count(case when test = false then 1 else null end)/count(*) as pct_mismatch, count(*) as count_rows
+from unit_tests
+having count(case when test = false then 1 else null end) > count(*)*0.1
 {% endtest %}

--- a/tests/generic/ethereum/zeroex_ethereum_fills_test.sql
+++ b/tests/generic/ethereum/zeroex_ethereum_fills_test.sql
@@ -1,12 +1,20 @@
-WITH unit_tests as
-(SELECT case when test.maker_token = actual.maker_token 
-               
-                and test.taker_token = actual.taker_token
-then True else False end as test
-FROM {{ ref('zeroex_ethereum_api_fills') }} actual
-JOIN {{ ref('zeroex_ethereum_api_fills_sample') }} test
-    ON test.tx_hash = actual.tx_hash AND test.evt_index = actual.evt_index
+{% test zeroex_ethereum_fills_test(model, column_name, seed_file) %}
+
+
+WITH unit_tests AS
+(
+    SELECT 
+        CASE WHEN 
+            fills.{{ column_name }} = fills_sample.{{ column_name }}
+            THEN True ELSE False END 
+        AS amount_test
+    FROM {{ model }} fills
+    JOIN {{ seed_file }} fills_sample 
+        ON fills.tx_hash = fills_sample.tx_hash
+        AND fills.evt_index = fills_sample.evt_index
 )
-select count(case when test = false then 1 else null end)/count(*) as pct_mismatch, count(*) as count_rows
-from unit_tests
-having count(case when test = false then 1 else null end) > count(*)*0.1
+select *
+    from unit_tests
+    where amount_test = False
+
+{% endtest %}

--- a/tests/generic/ethereum/zeroex_ethereum_fills_test.sql
+++ b/tests/generic/ethereum/zeroex_ethereum_fills_test.sql
@@ -1,20 +1,12 @@
-{% test zeroex_ethereum_fills_test(model, column_name, seed_file) %}
-
-
-WITH unit_tests AS
-(
-    SELECT 
-        CASE WHEN 
-            fills.{{ column_name }} = fills_sample.{{ column_name }}
-            THEN True ELSE False END 
-        AS amount_test
-    FROM {{ model }} fills
-    JOIN {{ seed_file }} fills_sample 
-        ON fills.tx_hash = fills_sample.tx_hash
-        AND fills.evt_index = fills_sample.evt_index
+WITH unit_tests as
+(SELECT case when test.maker_token = actual.maker_token 
+               
+                and test.taker_token = actual.taker_token
+then True else False end as test
+FROM {{ ref('zeroex_ethereum_api_fills') }} actual
+JOIN {{ ref('zeroex_ethereum_api_fills_sample') }} test
+    ON test.tx_hash = actual.tx_hash AND test.evt_index = actual.evt_index
 )
-select *
-    from unit_tests
-    where amount_test = False
-
-{% endtest %}
+select count(case when test = false then 1 else null end)/count(*) as pct_mismatch, count(*) as count_rows
+from unit_tests
+having count(case when test = false then 1 else null end) > count(*)*0.1


### PR DESCRIPTION
A minor change was made by modifying the logic in the base model **_zeroex_ethereum_api_fills_**. The case statement was comparing strings, but it should have compared numbers instead.

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [x] `coin_id` represents the ID of the coin on coinpaprika.com
* [x] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
