### PR TITLE
OP Contracts - Remove 0x name entirely

### DIFF
--- a/models/contracts/optimism/contracts_optimism_contract_creator_address_list.sql
+++ b/models/contracts/optimism/contracts_optimism_contract_creator_address_list.sql
@@ -344,7 +344,7 @@ FROM (
       ,('0x11F11121DF7256C40339393b0FB045321022ce44', 'LiFi')
       ,('0xcde47c1a5e2d60b9ff262b0a3b6d486048575ad9', 'OP')
       ,('0x59ca05674f5073f95f292aaca2d28a7dc80f12d6', 'Mirror')
-      ,('0xedcd79f34db8b78cd7a55e04dbf991ecd1a5c0f4', 'Zeroex (0x)')
+      ,('0xedcd79f34db8b78cd7a55e04dbf991ecd1a5c0f4', 'Zeroex')
       ,('0x48cff7ff77b2bf83e4a6f843b5b1709601671e83', 'Clipper')
       ,('0x1a3daa6f487a480c1ad312b90fd0244871940b66', 'Quix')
       ,('0x8df57e3d9ddde355dce1adb19ebce93419ffa0fb', 'Revert Finance')

--- a/models/contracts/optimism/contracts_optimism_project_name_mappings.sql
+++ b/models/contracts/optimism/contracts_optimism_project_name_mappings.sql
@@ -19,7 +19,7 @@ from (
     ,('aave_v3', 'Aave')
     ,('perp_v2', 'Perpetual Protocol')
     ,('synthetix_futures', 'Kwenta')
-    ,('zeroex', 'Zeroex (0x)' )
+    ,('zeroex', 'Zeroex' )
     ,('uniswap_v3', 'Uniswap')
     ,('Uniswap V3', 'Uniswap')
     ,('oneinch', '1inch')


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Remove '0x' entirely from project names, revert to 'Zeroex'. This ~should be temporary. Ideally we can show names which include '0x'

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
