### PR TITLE
Make opensea_v3_ethereum.trades DuneSQL compatible

### DIFF
--- a/models/opensea/ethereum/opensea_v3_ethereum_trades.sql
+++ b/models/opensea/ethereum/opensea_v3_ethereum_trades.sql
@@ -58,9 +58,9 @@ select blockchain
       ,zone_address
       ,estimated_price
       ,is_private
-      ,'seaport-' || tx_hash || '-' || cast(evt_index as VARCHAR(10)) || '-' || nft_contract_address || '-' || cast(token_id as VARCHAR(10)) || '-' || cast(sub_idx as VARCHAR(10)) as unique_trade_id
+      ,'seaport-' || CAST(tx_hash AS VARCHAR(100)) || '-' || cast(evt_index as VARCHAR(10)) || '-' || CAST(nft_contract_address AS VARCHAR(100)) || '-' || cast(token_id as VARCHAR(10)) || '-' || cast(sub_idx as VARCHAR(10)) as unique_trade_id
   from {{ ref('seaport_ethereum_trades') }}
- where zone_address in ('0xf397619df7bfd4d1657ea9bdd9df7ff888731a11'
+ where CAST(zone_address AS VARCHAR(100)) in ('0xf397619df7bfd4d1657ea9bdd9df7ff888731a11'
                        ,'0x9b814233894cd227f561b78cc65891aa55c62ad2'
                        ,'0x004c00500000ad104d7dbd00e3ae0a5c00560c00'
                        ,'0x110b2b128a9ed1be5ef3232d8e4e41640df5c2cd'


### PR DESCRIPTION
No resulting column types are changed, only explicit casting to varchar is applied to perform in filters and to concat values.