### PR TITLE
Add spell for erc20 transfers on FTM

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -414,6 +414,8 @@ models:
         +schema: transfers_bnb
       arbitrum:
         +schema: transfers_arbitrum
+      fantom:
+        +schema: transfers_fantom
 
     sudoswap:
       +schema: sudoswap

--- a/models/transfers/fantom/erc20/transfers_fantom_erc20.sql
+++ b/models/transfers/fantom/erc20/transfers_fantom_erc20.sql
@@ -1,0 +1,37 @@
+{{ config(materialized='view', alias='erc20',
+        post_hook='{{ expose_spells(\'["fantom"]\',
+                                    "sector",
+                                    "transfers",
+                                    \'["soispoke", "dot2dotseurat", "tschubotz"]\') }}') }}
+
+with
+    sent_transfers as (
+        select
+            CAST('send' AS VARCHAR(4)) || CAST('-' AS VARCHAR(1)) || CAST(evt_tx_hash AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(evt_index AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(`to` AS VARCHAR(100)) as unique_transfer_id,
+            `to` as wallet_address,
+            contract_address as token_address,
+            evt_block_time,
+            value as amount_raw
+        from
+            {{ source('erc20_fantom', 'evt_transfer') }}
+    )
+
+    ,
+    received_transfers as (
+        select
+        CAST('receive' AS VARCHAR(7)) || CAST('-' AS VARCHAR(1)) || CAST(evt_tx_hash AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(evt_index AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(`from` AS VARCHAR(100)) as unique_transfer_id,
+        `from` as wallet_address,
+        contract_address as token_address,
+        evt_block_time,
+        '-' || CAST(value AS VARCHAR(100)) as amount_raw
+        from
+            {{ source('erc20_fantom', 'evt_transfer') }}
+    )
+
+-- There is no need to add wrapped FTM deposits / withdrawals since wrapped FTM on fantom triggers transfer events for both.
+    
+select unique_transfer_id, 'fantom' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100)) as amount_raw
+from sent_transfers
+union
+select unique_transfer_id, 'fantom' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100)) as amount_raw
+from received_transfers

--- a/tests/transfers/fantom/transfers_fantom_erc20_test.sql
+++ b/tests/transfers/fantom/transfers_fantom_erc20_test.sql
@@ -1,0 +1,16 @@
+-- Check that number of transfers in data range is correct
+
+with test_data as (
+    select count(*) as total
+    from {{ ref('transfers_fantom_erc20') }}
+    where evt_block_time between '2023-01-01' and '2023-02-01'
+),
+
+test_result as (
+    select case when total = 69781172 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false


### PR DESCRIPTION
Brief comments on the purpose of your changes:

- This PR adds a spell for ERC20 token transfers on Fantom.
- This PR is similar to #2949 
- It is inspired/copied from #2883 which in turn followed [transfers_ethereum_erc20.sql](https://github.com/duneanalytics/spellbook/blob/main/models/transfers/ethereum/erc20/transfers_ethereum_erc20.sql)
- **no** incremental logic used since the 2 links above don't use it either.

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:

doesn't apply.

### Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:

not used. see beginning of PR decription.



cc @MSilb7 