### PR TITLE
Add spell for bep20 transfers on BNB

### DIFF
--- a/models/transfers/bnb/bep20/transfers_bnb_bep20.sql
+++ b/models/transfers/bnb/bep20/transfers_bnb_bep20.sql
@@ -1,0 +1,65 @@
+{{ config(materialized='view', alias='bep20',
+        post_hook='{{ expose_spells(\'["bnb"]\',
+                                    "sector",
+                                    "transfers",
+                                    \'["soispoke", "dot2dotseurat", "tschubotz"]\') }}') }}
+
+with
+    sent_transfers as (
+        select
+            CAST('send' AS VARCHAR(4)) || CAST('-' AS VARCHAR(1)) || CAST(evt_tx_hash AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(evt_index AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(`to` AS VARCHAR(100)) as unique_transfer_id,
+            `to` as wallet_address,
+            contract_address as token_address,
+            evt_block_time,
+            value as amount_raw
+        from
+            {{ source('erc20_bnb', 'evt_transfer') }}
+    )
+
+    ,
+    received_transfers as (
+        select
+        CAST('receive' AS VARCHAR(7)) || CAST('-' AS VARCHAR(1)) || CAST(evt_tx_hash AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(evt_index AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(`from` AS VARCHAR(100)) as unique_transfer_id,
+        `from` as wallet_address,
+        contract_address as token_address,
+        evt_block_time,
+        '-' || CAST(value AS VARCHAR(100)) as amount_raw
+        from
+            {{ source('erc20_bnb', 'evt_transfer') }}
+    )
+
+    ,
+    deposited_bnb as (
+        select
+            CAST('deposit' AS VARCHAR(7)) || CAST('-' AS VARCHAR(1)) || CAST(evt_tx_hash AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(evt_index AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(dst AS VARCHAR(100)) as unique_transfer_id,
+            dst as wallet_address,
+            contract_address as token_address,
+            evt_block_time,
+            wad as amount_raw
+        from
+            {{ source('bnb_bnb', 'WBNB_evt_Deposit') }}
+    )
+
+    ,
+    withdrawn_bnb as (
+        select
+            CAST('withdrawn' AS VARCHAR(9)) || CAST('-' AS VARCHAR(1)) || CAST(evt_tx_hash AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(evt_index AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(src AS VARCHAR(100)) as unique_transfer_id,
+            src as wallet_address,
+            contract_address as token_address,
+            evt_block_time,
+            '-' || CAST(wad AS VARCHAR(100)) as amount_raw
+        from
+            {{ source('bnb_bnb', 'WBNB_evt_Withdrawal') }}
+    )
+    
+select unique_transfer_id, 'bnb' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100)) as amount_raw
+from sent_transfers
+union
+select unique_transfer_id, 'bnb' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100)) as amount_raw
+from received_transfers
+union
+select unique_transfer_id, 'bnb' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100)) as amount_raw
+from deposited_bnb
+union
+select unique_transfer_id, 'bnb' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100)) as amount_raw
+from withdrawn_bnb

--- a/models/transfers/bnb/bep20/transfers_bnb_bep20.sql
+++ b/models/transfers/bnb/bep20/transfers_bnb_bep20.sql
@@ -7,8 +7,8 @@
 with
     sent_transfers as (
         select
-            CAST('send' AS VARCHAR(4)) || CAST('-' AS VARCHAR(1)) || CAST(evt_tx_hash AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(evt_index AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(`to` AS VARCHAR(100)) as unique_transfer_id,
-            `to` as wallet_address,
+            'send-' || cast(evt_tx_hash as varchar(100)) || '-' || cast (evt_index as varchar(100)) || '-' || CAST(to AS VARCHAR(100)) as unique_transfer_id,
+            to as wallet_address,
             contract_address as token_address,
             evt_block_time,
             value as amount_raw
@@ -19,8 +19,8 @@ with
     ,
     received_transfers as (
         select
-        CAST('receive' AS VARCHAR(7)) || CAST('-' AS VARCHAR(1)) || CAST(evt_tx_hash AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(evt_index AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(`from` AS VARCHAR(100)) as unique_transfer_id,
-        `from` as wallet_address,
+        'receive-' || cast(evt_tx_hash as varchar(100)) || '-' || cast (evt_index as varchar(100)) || '-' || CAST("from" AS VARCHAR(100)) as unique_transfer_id,
+        "from" as wallet_address,
         contract_address as token_address,
         evt_block_time,
         '-' || CAST(value AS VARCHAR(100)) as amount_raw
@@ -31,7 +31,7 @@ with
     ,
     deposited_bnb as (
         select
-            CAST('deposit' AS VARCHAR(7)) || CAST('-' AS VARCHAR(1)) || CAST(evt_tx_hash AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(evt_index AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(dst AS VARCHAR(100)) as unique_transfer_id,
+            'deposit-' || cast(evt_tx_hash as varchar(100)) || '-' || cast (evt_index as varchar(100)) || '-' ||  CAST(dst AS VARCHAR(100)) as unique_transfer_id,
             dst as wallet_address,
             contract_address as token_address,
             evt_block_time,
@@ -43,7 +43,7 @@ with
     ,
     withdrawn_bnb as (
         select
-            CAST('withdrawn' AS VARCHAR(9)) || CAST('-' AS VARCHAR(1)) || CAST(evt_tx_hash AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(evt_index AS VARCHAR(100)) || CAST('-' AS VARCHAR(1)) || CAST(src AS VARCHAR(100)) as unique_transfer_id,
+            'withdraw-' || cast(evt_tx_hash as varchar(100)) || '-' || cast (evt_index as varchar(100)) || '-' ||  CAST(src AS VARCHAR(100)) as unique_transfer_id,
             src as wallet_address,
             contract_address as token_address,
             evt_block_time,

--- a/models/transfers/bnb/transfers_bnb_schema.yml
+++ b/models/transfers/bnb/transfers_bnb_schema.yml
@@ -117,3 +117,23 @@ models:
       - *amount
       - *last_updated
       - *recency_index
+
+  - name: transfers_arbitrum_erc20
+    meta:
+      blockchain: arbitrum
+      sector: transfers
+      project: erc20
+      contributors: soispoke, dot2dotseurat, tschubotz
+    config:
+      tags: ['transfers', 'arbitrum', 'erc20']
+    description: "ERC20 Token Transfers on Arbitrum. This table is updated every 30 minutes."
+    columns:
+      - name: unique_transfer_id
+        description: "Unique transfer ID (used for testing for duplicates)"
+      - *blockchain
+      - *wallet_address
+      - *token_address
+      - &evt_block_time
+        name: evt_block_time
+        description: "Timestamp for block event time in UTC"
+      - *amount_raw

--- a/models/transfers/bnb/transfers_bnb_schema.yml
+++ b/models/transfers/bnb/transfers_bnb_schema.yml
@@ -118,15 +118,15 @@ models:
       - *last_updated
       - *recency_index
 
-  - name: transfers_arbitrum_erc20
+  - name: transfers_bnb_bep20
     meta:
-      blockchain: arbitrum
+      blockchain: bnb
       sector: transfers
-      project: erc20
+      project: bep20
       contributors: soispoke, dot2dotseurat, tschubotz
     config:
-      tags: ['transfers', 'arbitrum', 'erc20']
-    description: "ERC20 Token Transfers on Arbitrum. This table is updated every 30 minutes."
+      tags: ['transfers', 'bnb', 'bep20']
+    description: "BEP20 Token Transfers on bnb. This table is updated every 30 minutes."
     columns:
       - name: unique_transfer_id
         description: "Unique transfer ID (used for testing for duplicates)"

--- a/tests/transfers/bnb/transfers_bnb_bep20_test.sql
+++ b/tests/transfers/bnb/transfers_bnb_bep20_test.sql
@@ -1,0 +1,16 @@
+-- Check that number of transfers in data range is correct
+
+with test_data as (
+    select count(*) as total
+    from {{ ref('transfers_arbitrum_erc20') }}
+    where evt_block_time between '2023-01-01' and '2023-02-01'
+),
+
+test_result as (
+    select case when total = 275023459 then true else false end as success
+    from test_data
+)
+
+select *
+from test_result
+where success = false

--- a/tests/transfers/bnb/transfers_bnb_bep20_test.sql
+++ b/tests/transfers/bnb/transfers_bnb_bep20_test.sql
@@ -2,7 +2,7 @@
 
 with test_data as (
     select count(*) as total
-    from {{ ref('transfers_arbitrum_erc20') }}
+    from {{ ref('transfers_bnb_bep20') }}
     where evt_block_time between '2023-01-01' and '2023-02-01'
 ),
 


### PR DESCRIPTION
Brief comments on the purpose of your changes:

- This PR adds a spell for ERC20 token transfers on BSC.
- This PR is similar to #2949 
- It is inspired/copied from #2883 which in turn followed [transfers_ethereum_erc20.sql](https://github.com/duneanalytics/spellbook/blob/main/models/transfers/ethereum/erc20/transfers_ethereum_erc20.sql)
- **no** incremental logic used since the 2 links above don't use it either.

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:

doesn't apply.

### Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:

not used. see beginning of PR decription.
