### PR TITLE
Add zone address to distinguish OpenSea trades

### DIFF
--- a/models/opensea/ethereum/opensea_v4_ethereum_trades.sql
+++ b/models/opensea/ethereum/opensea_v4_ethereum_trades.sql
@@ -60,7 +60,7 @@ select blockchain
       ,is_private
       ,'seaport-' || tx_hash || '-' || cast(evt_index as VARCHAR(10)) || '-' || nft_contract_address || '-' || cast(token_id as VARCHAR(10)) || '-' || cast(sub_idx as VARCHAR(10)) as unique_trade_id
   from {{ ref('seaport_ethereum_trades') }}
- where zone_address in ('0xf397619df7bfd4d1657ea9bdd9df7ff888731a11'
+ where CAST(zone_address AS VARCHAR(100)) in ('0xf397619df7bfd4d1657ea9bdd9df7ff888731a11'
                        ,'0x9b814233894cd227f561b78cc65891aa55c62ad2'
                        ,'0x004c00500000ad104d7dbd00e3ae0a5c00560c00'
                        ,'0x110b2b128a9ed1be5ef3232d8e4e41640df5c2cd'

--- a/models/opensea/ethereum/opensea_v4_ethereum_trades.sql
+++ b/models/opensea/ethereum/opensea_v4_ethereum_trades.sql
@@ -60,4 +60,10 @@ select blockchain
       ,is_private
       ,'seaport-' || tx_hash || '-' || cast(evt_index as VARCHAR(10)) || '-' || nft_contract_address || '-' || cast(token_id as VARCHAR(10)) || '-' || cast(sub_idx as VARCHAR(10)) as unique_trade_id
   from {{ ref('seaport_ethereum_trades') }}
- where version = 'v2'                       
+ where zone_address in ('0xf397619df7bfd4d1657ea9bdd9df7ff888731a11'
+                       ,'0x9b814233894cd227f561b78cc65891aa55c62ad2'
+                       ,'0x004c00500000ad104d7dbd00e3ae0a5c00560c00'
+                       ,'0x110b2b128a9ed1be5ef3232d8e4e41640df5c2cd'
+                       ,'0x000000e7ec00e7b300774b00001314b8610022b8' -- newly added on Seaport v1.4
+                       )
+   and version = 'v2'                       


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

Add zone address to distinguish OpenSea trades

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
