### PR TITLE
Add cUSDC price data

### DIFF
--- a/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -89,6 +89,7 @@ FROM
     ("crv-curve-dao-token", "ethereum", "CRV", "0xd533a949740bb3306d119cc777fa900ba034cd52", 18),
     ("ctxc-cortex", "ethereum", "CTXC", "0xea11755ae41d889ceec39a63e6ff75a02bc1c00d", 18),
     ("cusdt-compound-usdt", "ethereum", "cUSDT", "0xf650c3d88d12db855b8bf7d11be6c55a4e07dcc9", 8),
+    ("cusdc-compound-usdc", "ethereum", "cUSDC", "0x39aa39c021dfbae8fac545936693ac917d5e7563", 8),
     ("cvc-civic", "ethereum", "CVC", "0x41e5560054824ea6b0732e656e3ad64e20e94e45", 8),
     ("cvt-cybervein", "ethereum", "CVT", "0xbe428c3867f05dea2a89fc76a102b544eac7f772", 18),
     ("cvx-convex-finance", "ethereum", "CVX", "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b", 18),


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Add cUSDC price data.

**For Dune Engine V2**

I've checked that:
address is lowercase, api matches, address is correct, and correct number of decimals.
API is inactive, however data still gets updated and I required the historical data for a dashboard.

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
