### PR TITLE
Add Event to OP Curve DEX Trades

### DIFF
--- a/models/curvefi/optimism/curvefi_optimism_sources.yml
+++ b/models/curvefi/optimism/curvefi_optimism_sources.yml
@@ -16,3 +16,5 @@ sources:
         loaded_at_field: evt_block_time
       - name: MetaPoolSwap_evt_TokenExchangeUnderlying
         loaded_at_field: evt_block_time
+      - name: MetaPoolSwap_evt_TokenExchange
+        loaded_at_field: evt_block_time

--- a/models/curvefi/optimism/curvefi_optimism_trades.sql
+++ b/models/curvefi/optimism/curvefi_optimism_trades.sql
@@ -58,7 +58,7 @@ SELECT
 
         UNION ALL
 
-        -- MetaPoolSwap
+        -- MetaPoolSwap TokenExchangeUnderlying
         SELECT
             'meta' AS pool_type, -- has implications for decimals for curve
             t.evt_block_time AS block_time,
@@ -75,6 +75,29 @@ SELECT
             bought_id, 
             sold_id
         FROM {{ source('curvefi_optimism', 'MetaPoolSwap_evt_TokenExchangeUnderlying') }} t
+        {% if is_incremental() %}
+        WHERE t.evt_block_time >= date_trunc('day', now() - interval '1 week')
+        {% endif %}
+
+        UNION ALL
+
+        -- MetaPoolSwap TokenExchang
+        SELECT
+            'meta' AS pool_type, -- has implications for decimals for curve
+            t.evt_block_time AS block_time,
+            t.evt_block_number,
+            t.buyer AS taker,
+            '' AS maker,
+            -- when amount0 is negative it means taker is buying token0 from the pool
+            tokens_bought AS token_bought_amount_raw,
+            tokens_sold AS token_sold_amount_raw,
+            t.contract_address as project_contract_address,
+            t.evt_tx_hash AS tx_hash,
+            '' AS trace_address,
+            t.evt_index, 
+            bought_id, 
+            sold_id
+        FROM {{ source('curvefi_optimism', 'MetaPoolSwap_evt_TokenExchange') }} t
         {% if is_incremental() %}
         WHERE t.evt_block_time >= date_trunc('day', now() - interval '1 week')
         {% endif %}


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Add a missing metapool event to OP DEX Trades for Curve

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
