### PR TITLE
Labels Hackathon: Add Lens posts label

### DIFF
--- a/models/labels/social/labels_social.sql
+++ b/models/labels/social/labels_social.sql
@@ -10,6 +10,7 @@
 
 {% set social_models = [
  ref('labels_ens')
+ ,ref('labels_lens_poster_frequencies')
 ] %}
 
 SELECT *

--- a/models/labels/social/labels_social_schema.yml
+++ b/models/labels/social/labels_social_schema.yml
@@ -8,7 +8,7 @@ models:
       category: social
       contributors: ilemi
     config:
-      tags: ['labels', 'social','ens']
+      tags: ['labels', 'social','ens','lens']
     description: "all social labels"
     columns:
       - &blockchain

--- a/models/labels/social/usage/lens/poster_frequencies/labels_lens_poster_frequencies.sql
+++ b/models/labels/social/usage/lens/poster_frequencies/labels_lens_poster_frequencies.sql
@@ -13,10 +13,7 @@ WITH lens_addresses as
        ,CAST (profileId AS string) AS profileId
 FROM {{ source('lens_polygon','LensHub_evt_ProfileCreated') }} pc 
 
--- {% if is_incremental() %}
--- WHERE 1=1
--- AND pc.evt_block_time >= date_trunc('day', now() - interval '1 week')
--- {% endif %}
+
 
 )
 
@@ -28,10 +25,7 @@ FROM {{ source('lens_polygon','LensHub_evt_ProfileCreated') }} pc
  
     FROM {{ source('lens_polygon','LensHub_call_post') }} cp1
     
-    -- {% if is_incremental() %}
-    -- WHERE 1=1
-    -- AND cp.call_block_time >= date_trunc('day', now() - interval '1 week')
-    -- {% endif %}
+ 
     WHERE 1=1
     AND call_success = true
 
@@ -44,10 +38,7 @@ FROM {{ source('lens_polygon','LensHub_evt_ProfileCreated') }} pc
         ,CAST(get_json_object(vars, '$.profileId') AS string) as profileId
     FROM {{ source('lens_polygon','LensHub_call_postWithSig') }} cp2
 
-    -- -- {% if is_incremental() %}
-    -- WHERE 1=1
-    -- -- AND cp2.call_block_time >= date_trunc('day', now() - interval '1 week')
-    -- -- {% endif %}
+  
     WHERE 1=1
     AND call_success = true
 )

--- a/models/labels/social/usage/lens/poster_frequencies/labels_lens_poster_frequencies.sql
+++ b/models/labels/social/usage/lens/poster_frequencies/labels_lens_poster_frequencies.sql
@@ -1,0 +1,95 @@
+{{config(alias='lens_poster_frequencies'
+
+    ,post_hook='{{ expose_spells(\'["polygon"]\',
+                                    "sector",
+                                    "labels",
+                                    \'["scoffie"]\') }}')
+}}
+
+WITH lens_addresses as 
+
+(SELECT to as address
+       ,handle as name
+       ,CAST (profileId AS string) AS profileId
+FROM {{ source('lens_polygon','LensHub_evt_ProfileCreated') }} pc 
+
+-- {% if is_incremental() %}
+-- WHERE 1=1
+-- AND pc.evt_block_time >= date_trunc('day', now() - interval '1 week')
+-- {% endif %}
+
+)
+
+,post_data as
+ (
+    SELECT
+         output_0 as post_id
+         ,CAST(get_json_object(vars, '$.profileId') AS string) as profileId
+ 
+    FROM {{ source('lens_polygon','LensHub_call_post') }} cp1
+    
+    -- {% if is_incremental() %}
+    -- WHERE 1=1
+    -- AND cp.call_block_time >= date_trunc('day', now() - interval '1 week')
+    -- {% endif %}
+    WHERE 1=1
+    AND call_success = true
+
+    
+    union all
+
+    
+    SELECT
+        output_0 as post_id
+        ,CAST(get_json_object(vars, '$.profileId') AS string) as profileId
+    FROM {{ source('lens_polygon','LensHub_call_postWithSig') }} cp2
+
+    -- -- {% if is_incremental() %}
+    -- WHERE 1=1
+    -- -- AND cp2.call_block_time >= date_trunc('day', now() - interval '1 week')
+    -- -- {% endif %}
+    WHERE 1=1
+    AND call_success = true
+)
+
+,post_count as 
+(SELECT  distinct profileId 
+       ,COUNT(post_id) as posts_count
+FROM post_data
+GROUP BY 1
+)
+,percentile as 
+(SELECT approx_percentile(posts_count, 0.99) as p99
+        ,approx_percentile(posts_count, 0.95) as p95
+        ,approx_percentile(posts_count, 0.90) as p90
+        ,approx_percentile(posts_count, 0.80) as p80
+        ,approx_percentile(posts_count, 0.5) as p50
+FROM  post_count
+)
+
+SELECT 
+'polygon' as blockchain 
+,address
+,CASE WHEN posts_count >= (select p99 from percentile) THEN 'top 1% lens poster'
+      WHEN posts_count >= (select p95 from percentile) THEN 'top 5% lens poster'
+      WHEN posts_count >= (select p90 from percentile) THEN 'top 10% lens poster'
+      WHEN posts_count >= (select p80 from percentile) THEN 'top 20% lens poster'
+      WHEN posts_count <= (select p50 from percentile) THEN 'bottom 50% lens poster'
+      ELSE 'between 50% to 80% lens posters' END AS name
+
+ ,'social' AS category
+ ,'scoffie' AS contributor
+ ,'query' AS source
+ ,timestamp('2023-03-17') as created_at
+ ,now() as updated_at
+ ,'lens_poster_frequencies' as model_name
+ ,'usage' as label_type
+FROM lens_addresses la
+
+INNER JOIN post_count  pc 
+ON la.profileId=pc.profileId 
+
+
+
+
+

--- a/models/labels/social/usage/lens/poster_frequencies/labels_lens_poster_frequencies_schema.yml
+++ b/models/labels/social/usage/lens/poster_frequencies/labels_lens_poster_frequencies_schema.yml
@@ -1,7 +1,7 @@
 version: 2
 
 models:
-  - name: labels_lens
+  - name: labels_lens_poster_frequencies
     meta:
       blockchain: polygon
       sector: labels

--- a/models/labels/social/usage/lens/poster_frequencies/labels_lens_poster_frequencies_schema.yml
+++ b/models/labels/social/usage/lens/poster_frequencies/labels_lens_poster_frequencies_schema.yml
@@ -1,0 +1,33 @@
+version: 2
+
+models:
+  - name: labels_lens
+    meta:
+      blockchain: polygon
+      sector: labels
+      category: social
+      contributors:  scoffie
+    config:
+      tags: ['query','labels', 'polygon', 'lens']
+    description: "Lens labels"
+    columns:
+      - name: blockchain
+        description: "Blockchain"
+      - name: address
+        description: "Lens address"
+      - name: name
+        description: "Describes the category a lens poster falls under in terms of number of posts"
+      - name: category
+        description: "Label category"
+      - name: contributor
+        description: "Wizard(s) contributing to labels"
+      - name: source
+        description: "How were labels generated (could be static or query)"
+      - name: created_at
+        description: "When were labels created"
+      - name: updated_at
+        description: "When were labels updated for the last time"
+      - name: model_name
+        description: "Name of the label model sourced from"
+      - name: label_type
+        description: "Type of label (see labels overall readme)"

--- a/models/labels/social/usage/lens/poster_frequencies/labels_lens_poster_frequencies_sources.yml
+++ b/models/labels/social/usage/lens/poster_frequencies/labels_lens_poster_frequencies_sources.yml
@@ -1,0 +1,24 @@
+version: 2
+
+sources:
+  - name: lens_polygon
+    description: >
+      Decoded tables related to lens protocol. The web3 social platform
+    freshness:
+      warn_after: { count: 12, period: hour }
+    tables:
+      - name: LensHub_evt_ProfileCreated
+        description: >
+          table related to the lens profiles created and the addresses associated with the profiles.
+        loaded_at_field: evt_block_time
+      - name: LensHub_call_post
+        description: >
+          table related to addresses on lens profile that call the post function when they want to post content on lens profile.
+        loaded_at_field: call_block_time
+      - name: LensHub_call_postWithSig
+        description: >
+          table related to addresses on lens profile that call the post function of behalf of other addresses 
+          when they want to post content on lens profile.
+        loaded_at_field: call_block_time
+
+


### PR DESCRIPTION
Brief comments on the purpose of your changes:

This PR adds lens posting frequency labels to the labels table.
**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
