### PR TITLE
Fix curvefi pools duplicates

### DIFF
--- a/models/curvefi/optimism/curvefi_optimism_pools.sql
+++ b/models/curvefi/optimism/curvefi_optimism_pools.sql
@@ -26,7 +26,7 @@ WITH base_pools AS (
         , output_0 AS token
         , contract_address AS pool
     FROM {{ source('curvefi_optimism', 'StableSwap_call_coins') }}
-    WHERE call_success
+    WHERE call_success and output_0 is not null
     GROUP BY
         arg0, output_0, contract_address --unique
 )

--- a/models/curvefi/optimism/curvefi_optimism_pools.sql
+++ b/models/curvefi/optimism/curvefi_optimism_pools.sql
@@ -15,7 +15,6 @@
 -- Original Ref - Dune v1 Abstraction: https://github.com/duneanalytics/spellbook/blob/main/deprecated-dune-v1-abstractions/optimism2/dex/insert_curve.sql
 -- Start Time
 -- SELECT MIN(call_block_time) FROM curvefi_optimism.StableSwap_call_coins
--- test CI
 {% set project_start_date = '2022-01-17' %}
 
 

--- a/models/curvefi/optimism/curvefi_optimism_pools.sql
+++ b/models/curvefi/optimism/curvefi_optimism_pools.sql
@@ -15,6 +15,7 @@
 -- Original Ref - Dune v1 Abstraction: https://github.com/duneanalytics/spellbook/blob/main/deprecated-dune-v1-abstractions/optimism2/dex/insert_curve.sql
 -- Start Time
 -- SELECT MIN(call_block_time) FROM curvefi_optimism.StableSwap_call_coins
+-- test CI
 {% set project_start_date = '2022-01-17' %}
 
 
@@ -50,9 +51,9 @@ WITH base_pools AS (
         {% endif %}
         GROUP BY
             mp.evt_tx_hash, (bp.tokenid + 1), bp.token, mp.evt_block_number --unique
-    
+
         UNION ALL
-        
+
         SELECT
             mp.evt_tx_hash
             , 0 AS tokenid
@@ -90,7 +91,7 @@ WITH base_pools AS (
         , pool
     FROM
     (
-        SELECT 
+        SELECT
             posexplode(_coins)
             , output_0 AS pool
         FROM {{ source('curvefi_optimism', 'PoolFactory_call_deploy_plain_pool') }}
@@ -119,7 +120,7 @@ WITH base_pools AS (
             ,('Basic Pool','0','0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9','0x54dcfe120d608551f9010d3b66620d230fd5c11b')
             ,('Basic Pool','1','0x29A3d66B30Bc4AD674A4FDAF27578B64f6afbFe7','0x54dcfe120d608551f9010d3b66620d230fd5c11b')
         ) a (version, tokenid, token, pool)
-    
+
     )
 
 , agg_pools AS (
@@ -127,14 +128,14 @@ WITH base_pools AS (
         version
         , cast(tokenid as int) AS tokenid
         , token
-        , pool 
+        , pool
     FROM
     (
         SELECT
             'Base Pool' AS version
             , tokenid
             , token
-            , pool 
+            , pool
         FROM base_pools
         UNION ALL
         SELECT

--- a/models/curvefi/optimism/curvefi_optimism_trades.sql
+++ b/models/curvefi/optimism/curvefi_optimism_trades.sql
@@ -14,7 +14,6 @@
 -- SELECT MIN(evt_block_time) FROM curvefi_optimism.StableSwap_evt_TokenExchange
 -- UNION ALL
 -- SELECT MIN(evt_block_time) FROM curvefi_optimism.MetaPoolSwap_evt_TokenExchange
--- test CI
 {% set project_start_date = '2022-01-17' %}
 
 with dexs as

--- a/models/curvefi/optimism/curvefi_optimism_trades.sql
+++ b/models/curvefi/optimism/curvefi_optimism_trades.sql
@@ -14,6 +14,7 @@
 -- SELECT MIN(evt_block_time) FROM curvefi_optimism.StableSwap_evt_TokenExchange
 -- UNION ALL
 -- SELECT MIN(evt_block_time) FROM curvefi_optimism.MetaPoolSwap_evt_TokenExchange
+-- test CI
 {% set project_start_date = '2022-01-17' %}
 
 with dexs as
@@ -48,8 +49,8 @@ SELECT
             t.contract_address as project_contract_address,
             t.evt_tx_hash AS tx_hash,
             '' AS trace_address,
-            t.evt_index, 
-            bought_id, 
+            t.evt_index,
+            bought_id,
             sold_id
         FROM {{ source('curvefi_optimism', 'StableSwap_evt_TokenExchange') }} t
         {% if is_incremental() %}
@@ -71,14 +72,14 @@ SELECT
             t.contract_address as project_contract_address,
             t.evt_tx_hash AS tx_hash,
             '' AS trace_address,
-            t.evt_index, 
-            bought_id, 
+            t.evt_index,
+            bought_id,
             sold_id
         FROM {{ source('curvefi_optimism', 'MetaPoolSwap_evt_TokenExchangeUnderlying') }} t
         {% if is_incremental() %}
         WHERE t.evt_block_time >= date_trunc('day', now() - interval '1 week')
         {% endif %}
-    
+
 
         UNION ALL
 


### PR DESCRIPTION
Root cause:
There are cases where `output_0` (which represents the token address) from `StableSwap_call_coins` is null for the following pool.
https://optimistic.etherscan.io/address/0x13d81435e76b684bfd65a0b4a62bd101dc712ed4

This fix filters out those calls. 