### PR TITLE
Fix labels project wallets

### DIFF
--- a/models/addresses/optimism/addresses_optimism_grants_funding.sql
+++ b/models/addresses/optimism/addresses_optimism_grants_funding.sql
@@ -131,8 +131,9 @@ FROM (VALUES
 SELECT
    category
    , entries.address
-   , coalesce(cast(wallets.project_name as varchar(100)), cast(entries.proposal_name as varchar(100))) as project_name
+   , cast(coalesce(pnm.project_name, entries.proposal_name) as varchar(100)) as project_name
    , cast(entries.proposal_name as varchar(100)) as proposal_name
    , cast(entries.funding_source as varchar(100)) as funding_source
 FROM entries
-LEFT JOIN {{ ref('op_token_distributions_optimism_project_wallets') }} wallets on entries.proposal_name = wallets.proposal_name
+LEFT JOIN {{ ref('op_token_distributions_optimism_project_name_mapping') }} pnm
+        ON pnm.proposal_name = entries.proposal_name

--- a/models/addresses/optimism/addresses_optimism_grants_funding.sql
+++ b/models/addresses/optimism/addresses_optimism_grants_funding.sql
@@ -4,10 +4,12 @@
 		"addresses",
 		\'["msilb7"]\') }}')}}
 
+WITH entries AS (
 SELECT
-	category, lower(address) AS address
-	, cast(proposal_name as varchar(100)) AS proposal_name
-	, cast(funding_source as varchar(100)) AS funding_source
+	category
+	, lower(address) AS address
+	, proposal_name
+	, funding_source
 
 FROM (VALUES
 
@@ -123,3 +125,14 @@ FROM (VALUES
 
 
    ) AS x (category, address, proposal_name, funding_source)
+
+)
+
+SELECT
+   category
+   , entries.address
+   , coalesce(cast(wallets.project_name as varchar(100)), cast(entries.proposal_name as varchar(100))) as project_name
+   , cast(entries.proposal_name as varchar(100)) as proposal_name
+   , cast(entries.funding_source as varchar(100)) as funding_source
+FROM entries
+LEFT JOIN {{ ref('op_token_distributions_optimism_project_wallets') }} wallets on entries.proposal_name = wallets.proposal_name

--- a/models/addresses/optimism/addresses_optimism_schema.yml
+++ b/models/addresses/optimism/addresses_optimism_schema.yml
@@ -40,6 +40,8 @@ models:
         description: "What type of address is this (i.e. Optimism vs Project)."
       - name: address
         description: "Address of the project's grant receiver address."
+      - name: project_name
+        description: "Proposal name mapped to a project name, if relevant."
       - name: proposal_name
         description: "The project name on the proposal mapping to the grant."
       - name: funding_source


### PR DESCRIPTION
Fix for following bug:
the labels_project_wallets file tries to get the column project_name from addresses_optimism_grants_funding, but this column was removed earlier this week in this PR:
https://github.com/duneanalytics/spellbook/pull/2751/files#diff-ea031d3129a72af68fb2fc6a316d555fefb2dd75f7597ecb01dcf3d2c637735d

solution suggested by @MSilb7 