### PR TITLE
Update tokens_arbitrum_erc20.sql

### DIFF
--- a/models/tokens/arbitrum/tokens_arbitrum_erc20.sql
+++ b/models/tokens/arbitrum/tokens_arbitrum_erc20.sql
@@ -105,4 +105,5 @@ FROM (VALUES
         ,('0xd22a58f79e9481d1a88e00c343885a588b34b68b', 'EURS', 2)
         ,('0xda492c29d88ffe9b7cbfa6dc068c2f9befae851b', 'CUSDCLP', 18)
         ,('0xb86af5eb59a8e871bfa573fa656123ea86f47c3a', 'CWETHLP', 18)
+        ,('0x1426CF37CAA89628C4DA2864e40cF75E6d66Ac6b', 'RELAY', 18)
      ) AS temp_table (contract_address, symbol, decimals)


### PR DESCRIPTION
Added Relay token

Brief comments on the purpose of your changes: Adding RELAY Token support for Arbitrum Network

**For Dune Engine V2**

I've checked that: address is lowercase, address is correct, and correct number of decimals.

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
