### PR TITLE
Fix missing 0x prefix on taker address

### DIFF
--- a/models/curvefi/optimism/curvefi_optimism_trades.sql
+++ b/models/curvefi/optimism/curvefi_optimism_trades.sql
@@ -88,7 +88,7 @@ SELECT
             'basic' as pool_type,
             block_time,
             block_number,
-            substring(topic2,25,40) AS taker,
+            concat('0x',substring(topic2,27,40)) AS taker,
             '' AS maker,
             conv(substring(data,3+64*3,64),16,10) as token_bought_amount_raw, --2nd bought
             conv(substring(data,3+64*1,64),16,10) as token_sold_amount_raw, --1st sold


### PR DESCRIPTION
We found exactly 3 trades on dex.trades that had a misformated taker address (starting with '00' instead of '0x', which breaks some explicit type casts allowing DSQL to treat these as varbinary (=faster and happier).

I applied this fix which seems fairly naive, I understand `topic2` supports binary values larger than an address, so the raw field has many more leading zeroes. Assuming this is true, I just changed the string manipulation to get a correct address hex string.

If any of this is wrong pls flag. cc  @MSilb7 @Hosuke (fyi @jeff-dude)