### PR TITLE
T-26215 - Fix opensea_v3_ethereum.events in DuneSQL

### DIFF
--- a/models/opensea/ethereum/opensea_v3_ethereum_trades.sql
+++ b/models/opensea/ethereum/opensea_v3_ethereum_trades.sql
@@ -58,7 +58,7 @@ select blockchain
       ,zone_address
       ,estimated_price
       ,is_private
-      ,'seaport-' || CAST(tx_hash AS VARCHAR(100)) || '-' || cast(evt_index as VARCHAR(10)) || '-' || CAST(nft_contract_address AS VARCHAR(100)) || '-' || cast(token_id as VARCHAR(10)) || '-' || cast(sub_idx as VARCHAR(10)) as unique_trade_id
+      ,'seaport-' || CAST(tx_hash AS VARCHAR(100)) || '-' || cast(evt_index as VARCHAR(100)) || '-' || CAST(nft_contract_address AS VARCHAR(100)) || '-' || cast(token_id as VARCHAR(100)) || '-' || cast(sub_idx as VARCHAR(100)) as unique_trade_id
   from {{ ref('seaport_ethereum_trades') }}
  where CAST(zone_address AS VARCHAR(100)) in ('0xf397619df7bfd4d1657ea9bdd9df7ff888731a11'
                        ,'0x9b814233894cd227f561b78cc65891aa55c62ad2'


### PR DESCRIPTION
The fix for concat introduced in https://github.com/duneanalytics/spellbook/pull/2433 to make opensea_v3_ethereum.events DuneSQL compatible does not work, it fails with `Error: Value cannot be represented as Varchar(10)` (see query example [here](https://dune.com/queries/2235147?d=11)).

This PR aims to fix that.

