### PR TITLE
Fixup: add missing coma in metadata

### DIFF
--- a/models/fractal/polygon/fractal_polygon_events.sql
+++ b/models/fractal/polygon/fractal_polygon_events.sql
@@ -6,7 +6,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_time', 'unique_trade_id'],
-    post_hook='{{ expose_spells(\'["polygon"]\'
+    post_hook='{{ expose_spells(\'["polygon"]\',
                               "project",
                               "fractal",
                               \'["springzh"]\') }}'

--- a/models/magiceden/polygon/magiceden_polygon_events.sql
+++ b/models/magiceden/polygon/magiceden_polygon_events.sql
@@ -6,7 +6,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_date', 'unique_trade_id'],
-    post_hook='{{ expose_spells(\'["polygon"]\'
+    post_hook='{{ expose_spells(\'["polygon"]\',
                               "project",
                               "magiceden",
                               \'["springzh"]\') }}'

--- a/models/rarible/polygon/rarible_polygon_events.sql
+++ b/models/rarible/polygon/rarible_polygon_events.sql
@@ -6,7 +6,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_time', 'unique_trade_id'],
-    post_hook='{{ expose_spells(\'["polygon"]\'
+    post_hook='{{ expose_spells(\'["polygon"]\',
                               "project",
                               "rarible",
                               \'["springzh"]\') }}'


### PR DESCRIPTION
Affected tables:
  - `fractal_polygon.events`
  - `magiceden_polygon.events`
  - `rarible_polygon.events`