### PR TITLE
fix nft.events and nft.fees on DuneSQL

### DIFF
--- a/models/fractal/polygon/fractal_polygon_events.sql
+++ b/models/fractal/polygon/fractal_polygon_events.sql
@@ -153,7 +153,7 @@ SELECT
     CAST(coalesce(s.royalty_fee_amount_raw,0) / power(10, erc.decimals) AS double) AS royalty_fee_amount,
     CAST(coalesce(s.royalty_fee_amount_raw,0) / power(10, erc.decimals) * p.price AS double) AS royalty_fee_amount_usd,
     CAST(coalesce(s.royalty_fee_amount_raw,0) / s.amount_raw * 100 AS double) AS royalty_fee_percentage,
-    CAST(NULL AS double) AS royalty_fee_receive_address,
+    CAST(NULL AS varchar(5)) AS royalty_fee_receive_address,
     CAST(NULL AS string) AS royalty_fee_currency_symbol,
     a.evt_tx_hash || '-' || a.evt_type || '-' || a.evt_index || '-' || a.token_id  AS unique_trade_id
 FROM trades a

--- a/models/rarible/polygon/rarible_polygon_events.sql
+++ b/models/rarible/polygon/rarible_polygon_events.sql
@@ -164,7 +164,7 @@ SELECT
   CAST(coalesce(s.royalty_fee_amount_raw,0) / power(10, erc.decimals) as double) AS royalty_fee_amount,
   CAST(coalesce(s.royalty_fee_amount_raw,0) / power(10, erc.decimals) * p.price AS double) AS royalty_fee_amount_usd,
   CAST(coalesce(s.royalty_fee_amount_raw,0) / s.amount_raw * 100 AS double) AS royalty_fee_percentage,
-  CAST(NULL AS double) AS royalty_fee_receive_address,
+  CAST(NULL AS varchar(5)) AS royalty_fee_receive_address,
   CAST(NULL AS string)  AS royalty_fee_currency_symbol,
   a.evt_tx_hash || '-' || a.evt_type || '-' || a.evt_index || '-' || a.token_id || '-' || CAST(a.number_of_items AS string)  AS unique_trade_id
 FROM trades a


### PR DESCRIPTION
`royalty_fee_receive_address` was being incorrectly cast to double