### PR TITLE
catalog override

### DIFF
--- a/macros/dune/macros_schema.yml
+++ b/macros/dune/macros_schema.yml
@@ -45,3 +45,8 @@ macros:
       Overrides the core is_incremental marco to allow the usage of a force-incremental command line variable.
       This enables us to easily get the compiled incremental models. 
       Example usage: dbt compile --vars '{force-incremental: True}'
+
+  - name: ref
+    description: >
+      Overrides the builtin ref macro to force the use of "delta_prod" as the database (or catalog)
+

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -1,0 +1,7 @@
+{% macro ref(model_name) %}
+
+  {% set rel = builtins.ref(model_name) %}
+  {% set newrel = rel.replace_path(database="delta_prod") %}
+  {% do return(newrel) %}
+
+{% endmacro %}


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Override the ref built in to use `delta_prod` as the catalog/database. The ref macro is used to render the table/view names for spells. Because the decoded and raw tables will be in the `hive` catalog, we define the profiles.yml file with the hive catalog and then override the catalog for the spells to `delta_prod`

Example:
Without this change -> hive.nft.trades
With this change -> delta_prod.nft.trades

This change was validated by running `dbt_compile` and reviewing some rendered SQL in the target/models directory.