### PR TITLE
[CoW] Add batch_rewards view

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_batch_rewards.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_batch_rewards.sql
@@ -1,0 +1,23 @@
+{{ config(alias='batch_rewards',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "project",
+                                    "cow_protocol",
+                                    \'["bh2smith"]\') }}'
+)}}
+
+-- PoC Query here - https://dune.com/queries/2247554
+select
+    block_deadline,
+    block_number, -- Null here means the settlement did not occur.
+    from_hex(solver) as winning_solver,
+    from_hex(tx_hash) as tx_hash,
+    -- Unpacking the data
+    data.winning_score,
+    data.reference_score,
+    data.surplus,
+    data.fee,
+    data.execution_cost,
+    data.uncapped_payment_eth,
+    data.capped_payment,
+    transform(data.participating_solvers, x -> from_hex(x)) as participating_solvers
+from {{ source('cowswap', 'raw_batch_rewards') }}

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -359,7 +359,7 @@ models:
       - &uncapped_payment_eth
         name: uncapped_payment_eth
         description: the (uncapped) payment (in ETH) to be awarded to the winning solver for the batch.
-      - &uncapped_payment_eth
+      - &capped_payment
         name: capped_payment
         description: the payment (in ETH) to be awarded to the winning solver for the batch.
       - &participating_solvers

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -352,9 +352,7 @@ models:
       - &surplus
         name: surplus
         description: Total surplus achieved (in ETH) for the batch. Zero when tx_hash is Null.
-      - &fee
-        name: fee
-        description: total fee (in ETH) collected for the batch. Zero when tx_hash is Null.
+      - *fee
       - &execution_cost
         name: execution_cost
         description: execution cost of the batch (can also be acquired from `ethereum.transactions`)

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -338,7 +338,7 @@ models:
       - *block_number
       - &block_deadline
         name: block_deadline
-        description: latest block for which winning solver must submit their solution. After this block, the payment is ZERO.
+        description: Latest block for which winning solver must submit their solution. After this block, the payment is ZERO.
       - &winning_solver
         name: winning_solver
         description: Solver which won the auction (i.e. the right to execute the batch)
@@ -355,13 +355,13 @@ models:
       - *fee
       - &execution_cost
         name: execution_cost
-        description: execution cost of the batch (can also be acquired from `ethereum.transactions`)
+        description: Execution cost of the batch (can also be acquired from `ethereum.transactions`)
       - &uncapped_payment_eth
         name: uncapped_payment_eth
-        description: the (uncapped) payment (in ETH) to be awarded to the winning solver for the batch.
+        description: The (uncapped) payment (in ETH) to be awarded to the winning solver for the batch.
       - &capped_payment
         name: capped_payment
-        description: the payment (in ETH) to be awarded to the winning solver for the batch.
+        description: The payment (in ETH) to be awarded to the winning solver for the batch.
       - &participating_solvers
         name: participating_solvers
-        description: an array of solvers who submitted a valid score/solution for the batch. Used to compute participation/secondary rewards
+        description: An array of solvers who submitted a valid score/solution for the batch. Used to compute participation/secondary rewards

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -320,4 +320,50 @@ models:
         name: amount_percentage
       - &amount_usd
         name: amount_usd
-
+  - name: cow_protocol_ethereum_batch_rewards
+    meta:
+      blockchain: ethereum
+      project: cow_protocol
+      contributors: bh2smith
+    config:
+      tags: ['ethereum','cow_protocol','app_data', "metadata"]
+    description: >
+      Batch Rewards contains the data necessary to compute Weekly Solver Payouts.
+      In particular, how much COW token solvers are entitled for each settled order.
+      Furthermore, since the introduction of limit orders into the protocol, 
+      this table also contains the surplus fee.
+      The specification for Batch Reward data can be found at 
+      [Snapshot CIP-20](https://snapshot.org/#/cow.eth/proposal/0x2d3f9bd1ea72dca84b03e97dda3efc1f4a42a772c54bd2037e8b62e7d09a491f)
+    columns:
+      - *block_number
+      - &block_deadline
+        name: block_deadline
+        description: latest block for which winning solver must submit their solution. After this block, the payment is ZERO.
+      - &winning_solver
+        name: winning_solver
+        description: Solver which won the auction (i.e. the right to execute the batch)
+      - *tx_hash
+      - &winning_score
+        name: winning_score
+        description: Score submitted by the winning solver
+      - &reference_score
+        name: reference_score
+        description: Second highest score (used to evaluate the winning solver's payment - as a second price auction)
+      - &surplus
+        name: surplus
+        description: Total surplus achieved (in ETH) for the batch. Zero when tx_hash is Null.
+      - &fee
+        name: fee
+        description: total fee (in ETH) collected for the batch. Zero when tx_hash is Null.
+      - &execution_cost
+        name: execution_cost
+        description: execution cost of the batch (can also be acquired from `ethereum.transactions`)
+      - &uncapped_payment_eth
+        name: uncapped_payment_eth
+        description: the (uncapped) payment (in ETH) to be awarded to the winning solver for the batch.
+      - &uncapped_payment_eth
+        name: capped_payment
+        description: the payment (in ETH) to be awarded to the winning solver for the batch.
+      - &participating_solvers
+        name: participating_solvers
+        description: an array of solvers who submitted a valid score/solution for the batch. Used to compute participation/secondary rewards

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_sources.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_sources.yml
@@ -133,6 +133,13 @@ sources:
           - name: tx_hash
           - name: data
           - name: order_uid
+      - name: raw_batch_rewards
+        columns:
+          - name: block_number
+          - name: block_deadline
+          - name: solver
+          - name: tx_hash
+          - name: data
   - name: cow_protocol_ethereum
     description: "Ethereum decoded tables related to CoW Protocol contract's"
     tables:


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Parsing/unpacking the data field from the raw community source table `cowswap.raw_batch_rewards`. Very similar to PR #2303 which parses `raw_order_rewards`.

PoC Query: https://dune.com/queries/2247554

cc 
- @dsalv -- as participant in construction of community source table.
and
- @gentrexha for internal review


I am a bit worried about all this type casting in a view and hope it does not affect query performance too much.


**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)
