### PR TITLE
Fix Perps data types for DuneSQL

### DIFF
--- a/models/perpetual_protocol/optimism/perpetual_protocol_v2_optimism_perpetual_trades.sql
+++ b/models/perpetual_protocol/optimism/perpetual_protocol_v2_optimism_perpetual_trades.sql
@@ -21,9 +21,9 @@ WITH perps AS (
 		,p.evt_block_number AS block_number
 		,p.baseToken
 		,pp.pool AS market_address
-		,ABS(cast(p.exchangedPositionNotional as double))/cast(1e18 as double) AS volume_usd
+		,ABS(p.exchangedPositionNotional)/1e18 AS volume_usd
 		,p.fee/1e18 AS fee_usd
-		,MAX(cast(co.output_0 as double))/cast(1e6 as double) AS margin_usd
+		,MAX(co.output_0)/1e6 AS margin_usd
 
 		,CASE
 		WHEN CAST(p.exchangedPositionSize AS DOUBLE) > 0 THEN 'long'

--- a/models/perpetual_protocol/optimism/perpetual_protocol_v2_optimism_perpetual_trades.sql
+++ b/models/perpetual_protocol/optimism/perpetual_protocol_v2_optimism_perpetual_trades.sql
@@ -21,9 +21,9 @@ WITH perps AS (
 		,p.evt_block_number AS block_number
 		,p.baseToken
 		,pp.pool AS market_address
-		,ABS(p.exchangedPositionNotional)/1e18 AS volume_usd
+		,ABS(cast(p.exchangedPositionNotional as double))/cast(1e18 as double) AS volume_usd
 		,p.fee/1e18 AS fee_usd
-		,MAX(co.output_0)/1e6 AS margin_usd
+		,MAX(cast(co.output_0 as double))/cast(1e6 as double) AS margin_usd
 
 		,CASE
 		WHEN CAST(p.exchangedPositionSize AS DOUBLE) > 0 THEN 'long'
@@ -35,7 +35,7 @@ WITH perps AS (
 		,'2' AS version
 		,'Perpetual' AS frontend
 		,p.trader
-		,p.exchangedPositionNotional AS volume_raw
+		,cast(p.exchangedPositionNotional as double) AS volume_raw
 		,p.evt_tx_hash AS tx_hash
 		,p.evt_index
 	FROM {{ source('perp_v2_optimism', 'ClearingHouse_evt_PositionChanged') }} AS p

--- a/models/synthetix/optimism/synthetix_v1_optimism_perpetual_trades.sql
+++ b/models/synthetix/optimism/synthetix_v1_optimism_perpetual_trades.sql
@@ -70,11 +70,10 @@ perps AS (
 
 		,DECODE(sm.marketKey, 'UTF-8') AS market
 		,s.contract_address AS market_address
-		,ABS(cast(s.tradeSize as double))/cast(1e18 as double) * p.price AS volume_usd
-		,cast(s.fee as double)/cast(1e18 as double) AS fee_usd
-		,cast(s.margin as double)/cast(1e18 as double) AS margin_usd
-		,(ABS(cast(s.tradeSize as double))/cast(1e18 as double) * p.price) 
-				/ (cast(s.margin as double)/cast(1e18 as double)) AS leverage_ratio
+		,ABS(s.tradeSize)/1e18 * p.price AS volume_usd
+		,s.fee/1e18 AS fee_usd
+		,s.margin/1e18 AS margin_usd
+		,(ABS(s.tradeSize)/1e18 * p.price) / (s.margin/1e18) AS leverage_ratio
 
 		,CASE
 		WHEN (CAST(s.margin AS DOUBLE) >= 0 AND CAST(s.size AS DOUBLE) = 0 AND CAST(s.tradeSize AS DOUBLE) < 0 AND s.size != s.tradeSize) THEN 'close'

--- a/models/synthetix/optimism/synthetix_v1_optimism_perpetual_trades.sql
+++ b/models/synthetix/optimism/synthetix_v1_optimism_perpetual_trades.sql
@@ -70,10 +70,11 @@ perps AS (
 
 		,DECODE(sm.marketKey, 'UTF-8') AS market
 		,s.contract_address AS market_address
-		,ABS(s.tradeSize)/1e18 * p.price AS volume_usd
-		,s.fee/1e18 AS fee_usd
-		,s.margin/1e18 AS margin_usd
-		,(ABS(s.tradeSize)/1e18 * p.price) / (s.margin/1e18) AS leverage_ratio
+		,ABS(cast(s.tradeSize as double))/cast(1e18 as double) * p.price AS volume_usd
+		,cast(s.fee as double)/cast(1e18 as double) AS fee_usd
+		,cast(s.margin as double)/cast(1e18 as double) AS margin_usd
+		,(ABS(cast(s.tradeSize as double))/cast(1e18 as double) * p.price) 
+				/ (cast(s.margin as double)/cast(1e18 as double)) AS leverage_ratio
 
 		,CASE
 		WHEN (CAST(s.margin AS DOUBLE) >= 0 AND CAST(s.size AS DOUBLE) = 0 AND CAST(s.tradeSize AS DOUBLE) < 0 AND s.size != s.tradeSize) THEN 'close'
@@ -87,7 +88,7 @@ perps AS (
 		,'1' AS version
 		,INITCAP(IFNULL(DECODE(UNHEX(SUBSTRING(tr.trackingCode, 3)), 'UTF-8'), 'Unspecified')) AS frontend
 		,s.account AS trader
-		,s.tradeSize AS volume_raw
+		,cast(s.tradeSize as double) AS volume_raw
 		,s.evt_tx_hash AS tx_hash
 		,s.evt_index
 	FROM {{ source('synthetix_optimism', 'FuturesMarket_evt_PositionModified') }} AS s

--- a/models/synthetix/optimism/synthetix_v2_optimism_perpetual_trades.sql
+++ b/models/synthetix/optimism/synthetix_v2_optimism_perpetual_trades.sql
@@ -70,11 +70,10 @@ perps AS (
 
 		,DECODE(sm.marketKey, 'UTF-8') AS market
 		,s.contract_address AS market_address
-		,ABS(cast(s.tradeSize as double))/cast(1e18 as double) * p.price AS volume_usd
-		,cast(s.fee as double)/cast(1e18 as double) AS fee_usd
-		,cast(s.margin as double)/cast(1e18 as double) AS margin_usd
-		,(ABS(cast(s.tradeSize as double))/cast(1e18 as double) * p.price) 
-				/ (cast(s.margin as double)/cast(1e18 as double)) AS leverage_ratio
+		,ABS(s.tradeSize)/1e18 * p.price AS volume_usd
+		,s.fee/1e18 AS fee_usd
+		,s.margin/1e18 AS margin_usd
+		,(ABS(s.tradeSize)/1e18 * p.price) / (s.margin/1e18) AS leverage_ratio
 
 		,CASE
 		WHEN (CAST(s.margin AS DOUBLE) >= 0 AND CAST(s.size AS DOUBLE) = 0 AND CAST(s.tradeSize AS DOUBLE) < 0 AND s.size != s.tradeSize) THEN 'close'

--- a/models/synthetix/optimism/synthetix_v2_optimism_perpetual_trades.sql
+++ b/models/synthetix/optimism/synthetix_v2_optimism_perpetual_trades.sql
@@ -70,10 +70,11 @@ perps AS (
 
 		,DECODE(sm.marketKey, 'UTF-8') AS market
 		,s.contract_address AS market_address
-		,ABS(s.tradeSize)/1e18 * p.price AS volume_usd
-		,s.fee/1e18 AS fee_usd
-		,s.margin/1e18 AS margin_usd
-		,(ABS(s.tradeSize)/1e18 * p.price) / (s.margin/1e18) AS leverage_ratio
+		,ABS(cast(s.tradeSize as double))/cast(1e18 as double) * p.price AS volume_usd
+		,cast(s.fee as double)/cast(1e18 as double) AS fee_usd
+		,cast(s.margin as double)/cast(1e18 as double) AS margin_usd
+		,(ABS(cast(s.tradeSize as double))/cast(1e18 as double) * p.price) 
+				/ (cast(s.margin as double)/cast(1e18 as double)) AS leverage_ratio
 
 		,CASE
 		WHEN (CAST(s.margin AS DOUBLE) >= 0 AND CAST(s.size AS DOUBLE) = 0 AND CAST(s.tradeSize AS DOUBLE) < 0 AND s.size != s.tradeSize) THEN 'close'
@@ -87,7 +88,7 @@ perps AS (
 		,'2' AS version
         ,INITCAP(IFNULL(DECODE(UNHEX(SUBSTRING(tr.trackingCode, 3)), 'UTF-8'), 'Unspecified')) AS frontend
 		,s.account AS trader
-		,s.tradeSize AS volume_raw
+		,cast(s.tradeSize as double) AS volume_raw
 		,s.evt_tx_hash AS tx_hash
 		,s.evt_index
 	FROM {{ source('synthetix_futuresmarket_optimism', 'ProxyPerpsV2_evt_PositionModified') }} AS s


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Add double casts to `volume_raw` to fix the DuneSQL issue raised here https://github.com/duneanalytics/spellbook/issues/3019

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
