### PR TITLE
[Easy] [Safe] Fixed wrong type for substring and string comparison for safe signer threshold spell

### DIFF
--- a/models/safe/ethereum/safe_ethereum_signer_thresholds.sql
+++ b/models/safe/ethereum/safe_ethereum_signer_thresholds.sql
@@ -18,9 +18,9 @@ with safes as (
     where
         s.call_success = true
         and et.success = true
-        AND substring(et.input, 0, 4) in ('0x0ec78d9e') -- setup methods of v0_1_0
+        AND substring(cast(et.input as varchar), 0, 4) in ('0x0ec78d9e') -- setup methods of v0_1_0
         AND et.call_type = 'delegatecall' -- the delegate call to the master copy is the Safe address
-        AND et.to in ('0x8942595A2dC5181Df0465AF0D7be08c8f23C93af') -- mastercopy address v0_1_0
+        AND cast(et.to as varchar) in ('0x8942595A2dC5181Df0465AF0D7be08c8f23C93af') -- mastercopy address v0_1_0
     union all
     select
         call_block_time as block_time,


### PR DESCRIPTION
#2929 introduced a safe signer threshold spell and there are some wrong types in there which are fixed by this PR
