### PR TITLE
Add price feedsfrom coinpaprika

### DIFF
--- a/models/prices/arbitrum/prices_arbitrum_tokens.sql
+++ b/models/prices/arbitrum/prices_arbitrum_tokens.sql
@@ -16,6 +16,7 @@ FROM
 (
     VALUES
 
+    ("arb-arbitrum","arbitrum","ARB","0x912ce59144191c1204e64559fe8253a0e49e6548",18),
     ("0xbtc-0xbitcoin","arbitrum","0xBTC","0x7cb16cb78ea464ad35c8a50abf95dff3c9e09d5d",8),
     ("aave-new","arbitrum","AAVE","0xba5ddd1f9d7f570dc94a51479a000e3bce967196",18),
     ("ageur-ageur","arbitrum","agEUR","0xfa5ed56a203466cbbc2430a43c66b9d8723528e7",18),

--- a/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -1316,6 +1316,13 @@ FROM
     ("vra-verasity", "ethereum", "VRA", "0xf411903cbc70a74d22900a5de66a2dda66507255", 18),
     ("gt-gatechain-token","ethereum", "GT", "0xe66747a101bff2dba3697199dcce5b743b454759",18),
     ("stg-stargatetoken","ethereum","STG","0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",18),
-    ("ico-axelar", "ethereum", "AXL", "0x467719ad09025fcc6cf6f8311755809d45a5e5f3", 6)
+    ("ico-axelar", "ethereum", "AXL", "0x467719ad09025fcc6cf6f8311755809d45a5e5f3", 6),
+    ("cmp-component", "ethereum", "CMP", "0x9f20ed5f919dc1c1695042542c13adcfc100dcab", 18),
+    ("gas-gas-dao", "ethereum", "GAS", "0x6bba316c48b49bd1eac44573c5c871ff02958469", 18),
+    ("fort-forta", "ethereum", "FORT", "0x41545f8b9472d758bb669ed8eaeeecd7a9c4ec29", 18),
+    ("tknfy-tokenfy", "ethereum", "TKNFY", "0xa6dd98031551c23bb4a2fbe2c4d524e8f737c6f7", 18),
+    ("ff-forefront", "ethereum", "FF", "0x7e9d8f07a64e363e97a648904a89fb4cd5fb94cd", 18),
+    ("pal-paladin-eth", "ethereum", "PAL", "0xab846fb6c81370327e784ae7cbb6d6a6af6ff4bf", 18),
+    ("sudo-sudo-governance-token", "ethereum", "SUDO", "0x3446dd70b2d52a6bf4a5a192d9b0a161295ab7f9", 18)
 
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/models/prices/optimism/prices_optimism_tokens.sql
+++ b/models/prices/optimism/prices_optimism_tokens.sql
@@ -17,6 +17,7 @@ FROM
     VALUES
     
     --tokens not yet supported or are not active on coinpaprika are commented out
+    ("op-optimism", "optimism", "OP", "0x4200000000000000000000000000000000000042", 18),
     ("eth-ethereum", "optimism", "ETH", "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", 18),
     ("eth-ethereum", "optimism","ETH", "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000",18),
     ("dai-dai", "optimism", "DAI", "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1", 18),


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
