### PR TITLE
[EASY] Adding WSTETH in prices.usd

### DIFF
--- a/models/prices/polygon/prices_polygon_tokens.sql
+++ b/models/prices/polygon/prices_polygon_tokens.sql
@@ -54,6 +54,7 @@ FROM
     ("ico-axelar", "polygon", "AXL", "0x6e4e624106cb12e168e6533f8ec7c82263358940", 6),
     ("frax-frax", "polygon", "FRAX", "0x45c32fa6df82ead1e2ef74d17b76547eddfaff89", 18),
     ("fxs-frax-share", "polygon", "FXS", "0x1a3acf6D19267E2d3e7f898f42803e90C9219062", 18),
-    ("sand-the-sandbox", "polygon", "SAND", "0xbbba073c31bf03b8acf7c28ef0738decf3695683", 18)
+    ("sand-the-sandbox", "polygon", "SAND", "0xbbba073c31bf03b8acf7c28ef0738decf3695683", 18),
+    ("wsteth-wrapped-liquid-staked-ether-20",   "polygon","0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd", 18)
     
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)


### PR DESCRIPTION
adding wsteth for polygon in prices.usd

https://api.coinpaprika.com/v1/coins/wsteth-wrapped-liquid-staked-ether-20

https://polygonscan.com/token/0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
