### PR TITLE
T-26530 Revert "T-23515 enable dunesql check"

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -62,3 +62,4 @@ jobs:
 
       - name: Run DuneSQL Check
         run: "/runner/dunesql_check.py --schema test_schema --pr_schema git_$GIT_SHA"
+        continue-on-error: true


### PR DESCRIPTION
Reverts duneanalytics/spellbook#3027 due to T-26530

From @0xRobin's findings:

> Simple scenario:
> You have some base models A en B and a UNION view U on top of them.
> You then add a new base model C and include it in the U view.
> 
> Models that are modified in this change are C and U.
> These are checked by the DuneSQL check, but if these models contain any type override in Trino the check will fail.
> The check on U is combining base A and B (with override) with base C (without override) and complains about a type mismatch..
> Here's a simple PR demonstrating the issue:
> https://github.com/duneanalytics/spellbook/pull/3083