### PR TITLE
[EASY]type fix of amount_original & amount_usd column

### DIFF
--- a/models/stealcam/arbitrum/stealcam_arbitrum_events.sql
+++ b/models/stealcam/arbitrum/stealcam_arbitrum_events.sql
@@ -8,7 +8,7 @@
     post_hook='{{ expose_spells(\'["arbitrum"]\',
                                 "project",
                                 "stealcam",
-                                \'["hildobby"]\') }}')
+                                \'["hildobby","pandajackson42"]\') }}')
 }}
 
 
@@ -33,8 +33,8 @@ SELECT 'arbitrum' AS blockchain
 , '0x82af49447d8a07e3bd95bd0d56f35241523fbab1' AS currency_contract
 , 'ETH' AS currency_symbol
 , CAST(sc.value AS DECIMAL(38,0)) AS amount_raw
-, CAST(sc.value/POWER(10, 18) AS DECIMAL(38,0)) AS amount_original
-, CAST(pu.price*sc.value/POWER(10, 18) AS DECIMAL(38,0)) AS amount_usd
+, CAST(sc.value/POWER(10, 18) AS DOUBLE) AS amount_original
+, CAST(pu.price*sc.value/POWER(10, 18) AS DOUBLE) AS amount_usd
 , sc.contract_address AS project_contract_address
 , CAST(NULL AS string) AS aggregator_name
 , CAST(NULL AS string) AS aggregator_address


### PR DESCRIPTION
Because of the wrong type, the fraction part of amount_original & amount_usd all deprecated. 
Changing type from `DECIMAL(38,0)` to `DOUBLE` solve this issue.

Current output: https://dune.com/queries/2299972
![image](https://user-images.githubusercontent.com/114440592/229101227-bda70412-34c3-481f-9f7e-77c8628c8ae2.png)

Expected output: https://dune.com/queries/2243141
![image](https://user-images.githubusercontent.com/114440592/229101546-63d0ac17-ad27-440a-a613-a07422fbe587.png)


