### PR TITLE
[CoW Protocol] Implement partial fill into cow_protocol ethereum trades

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -138,7 +138,7 @@ models:
         description: "SELL/BUY string indicating if the trade was a sell or buy order"
       - &partial_fill
         name: partial_fill
-        description: "Boolean indicating if the order was partially filled"
+        description: "Boolean indicating if the order is partially fill-able"
 
   - name: cow_protocol_ethereum_batches
     meta:

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -136,6 +136,9 @@ models:
       - &order_type
         name: order_type
         description: "SELL/BUY string indicating if the trade was a sell or buy order"
+      - &partial_fill
+        name: partial_fill
+        description: "Boolean indicating if the order was partially filled"
 
   - name: cow_protocol_ethereum_batches
     meta:

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -221,7 +221,7 @@ valued_trades as (
            valid_to,
            flags,
            case when (flags % 2) = 0 then 'SELL' else 'BUY' end as order_type,
-           case when ((flags / 2) % 2) = 0 then 'Not partially fillable' else 'Partially fillable' end as partial_fill
+           case when ((flags / 2) % 2) = 0 then false else true end as partial_fill
     FROM trades_with_token_units trades
     JOIN uid_to_app_id
         ON uid = order_uid

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -220,7 +220,8 @@ valued_trades as (
            limit_buy_amount,
            valid_to,
            flags,
-           case when (flags % 2) = 0 then 'SELL' else 'BUY' end as order_type
+           case when (flags % 2) = 0 then 'SELL' else 'BUY' end as order_type,
+           case when ((flags / 2) % 2) = 0 then 'Not partially fillable' else 'Partially fillable' end as partial_fill
     FROM trades_with_token_units trades
     JOIN uid_to_app_id
         ON uid = order_uid

--- a/tests/cow_protocol/ethereum/cow_protocol_ethereum_assert_partial_fill.sql
+++ b/tests/cow_protocol/ethereum/cow_protocol_ethereum_assert_partial_fill.sql
@@ -1,0 +1,37 @@
+-- Given a list of trades, when we look at their partial_fill, based on the type of the trade we expect partial_fill to behave differently
+WITH unit_test1 AS
+(
+    SELECT
+        *
+    FROM
+        {{ ref('cow_protocol_ethereum_trades') }}
+    WHERE
+        order_uid = '0xaa1568c867c991bd462bcb6ee5939e4e01144d4e9e29bb74c2fa8d50b3afc92c519b70055af55a007110b4ff99b0ea33071c720a64289604'
+        and partial_fill != 'Partially fillable'
+),
+
+    unit_test2 AS
+(
+    SELECT
+        *
+    FROM
+        {{ ref('cow_protocol_ethereum_trades') }}
+    WHERE
+        order_uid = '0xb431b648f44c8c988c417044ecdbfecf9785e177be12f600de467989284842ef40a50cf069e992aa4536211b23f286ef88752187ffffffff'
+        and partial_fill != 'Not partially fillable'
+)
+
+SELECT
+        *
+FROM
+    (
+        SELECT
+            *
+        FROM
+            unit_test1
+        UNION
+        SELECT
+            *
+        FROM
+            unit_test2
+    )

--- a/tests/cow_protocol/ethereum/cow_protocol_ethereum_assert_partial_fill.sql
+++ b/tests/cow_protocol/ethereum/cow_protocol_ethereum_assert_partial_fill.sql
@@ -7,7 +7,7 @@ WITH unit_test1 AS
         {{ ref('cow_protocol_ethereum_trades') }}
     WHERE
         order_uid = '0xaa1568c867c991bd462bcb6ee5939e4e01144d4e9e29bb74c2fa8d50b3afc92c519b70055af55a007110b4ff99b0ea33071c720a64289604'
-        and partial_fill != 'Partially fillable'
+        and partial_fill != true
 ),
 
     unit_test2 AS
@@ -18,7 +18,7 @@ WITH unit_test1 AS
         {{ ref('cow_protocol_ethereum_trades') }}
     WHERE
         order_uid = '0xb431b648f44c8c988c417044ecdbfecf9785e177be12f600de467989284842ef40a50cf069e992aa4536211b23f286ef88752187ffffffff'
-        and partial_fill != 'Not partially fillable'
+        and partial_fill != false
 )
 
 SELECT


### PR DESCRIPTION
Brief comments on the purpose of your changes:

For the launch of partial fill orders, we're adding a partial_fill column to our trades label to differentiate between these types of trades.

cc @bh2smith for internal review

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

