### PR TITLE
Please update safe_polygon_safes

### DIFF
--- a/models/safe/polygon/safe_polygon_safes.sql
+++ b/models/safe/polygon/safe_polygon_safes.sql
@@ -49,3 +49,5 @@ where et.success = true
     {% if is_incremental() %}
     and et.block_time > date_trunc("day", now() - interval '1 week')
     {% endif %}
+    
+-- this spell ends till 10th March 2023.

--- a/models/safe/polygon/safe_polygon_schema.yml
+++ b/models/safe/polygon/safe_polygon_schema.yml
@@ -31,6 +31,11 @@ models:
     config:
       tags: ['safe', 'polygon']
     description: "Safe addresses"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+            - block_date
     columns:
       - &blockchain
         name: blockchain


### PR DESCRIPTION
Hi @jeff-dude, this spell for Polygon is only updated up till 10th March 2023. Can you please fix this?

Thanks!

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
