### PR TITLE
T-22455 - Show balances_ethereum.erc721_latest

### DIFF
--- a/models/balances/ethereum/erc721/balances_ethereum_erc721_latest.sql
+++ b/models/balances/ethereum/erc721/balances_ethereum_erc721_latest.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias='erc721_latest',
-        post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
                                             "sector",
                                             "balances",
                                             \'["hildobby","soispoke","dot2dotseurat"]\') }}'


### PR DESCRIPTION
This spell can now be queried on DuneSQL - after the cluster resources adjustments + spill to disk logic that have been rolled out.

The reason why this was hidden was because querying it was resulting in `Query exceeded per-node memory` - but it's no longer happening (see [query](https://dune.com/queries/2329212))