### PR TITLE
temp fix to hide double stealer

### DIFF
--- a/models/stealcam/arbitrum/stealcam_arbitrum_events.sql
+++ b/models/stealcam/arbitrum/stealcam_arbitrum_events.sql
@@ -104,3 +104,4 @@ WHERE sc.evt_block_time >= date_trunc("day", now() - interval '1 week')
 {% if not is_incremental() %}
 WHERE sc.evt_block_time >= '{{project_start_date}}'
 {% endif %}
+AND sc.to != '0xfd5caed0be9e2a62b5887676ff79466c5437f898' -- temp fix to hide duplicates


### PR DESCRIPTION
`stealcam_arbitrum_events` is blocking the hourly job due to merge conflicts.
Core of the issue is a smart contract that executes 2 steals in 1 transaction.
ex: https://arbiscan.io/tx/0xefa9927f3d19bfc30a596ac7d1a9a775582768fb81ce45f10dbeee77f7f28fbf

This PR hides those steals because the joins with the raw traces produce duplicates in those cases. 

cc: @hildobby if you have time to look at a fix to resolve the issue.