### PR TITLE
Change the order to determine aggregator

### DIFF
--- a/models/blur/ethereum/blur_ethereum_events.sql
+++ b/models/blur/ethereum/blur_ethereum_events.sql
@@ -53,7 +53,7 @@ SELECT
         END AS currency_contract
     , bm.contract_address AS project_contract_address
     , get_json_object(bm.buy, '$.collection') AS nft_contract_address
-    , coalesce(agg.name,agg_m.aggregator_name) AS aggregator_name
+    , coalesce(agg_m.aggregator_name, agg.name) AS aggregator_name
     , agg.contract_address AS aggregator_address
     , bm.evt_tx_hash AS tx_hash
     , et.from AS tx_from

--- a/models/opensea/ethereum/opensea_v4_ethereum_trades.sql
+++ b/models/opensea/ethereum/opensea_v4_ethereum_trades.sql
@@ -440,7 +440,7 @@ with source_ethereum_transactions as (
           ,a.platform_fee_amount_raw / power(10, e.decimals) * p.price as platform_fee_amount_usd
           ,a.creator_fee_amount_raw / power(10, e.decimals) as creator_fee_amount
           ,a.creator_fee_amount_raw / power(10, e.decimals) * p.price as creator_fee_amount_usd
-          ,coalesce(agg.name,agg_m.aggregator_name) as aggregator_name
+          ,coalesce(agg_m.aggregator_name, agg.name) as aggregator_name
           ,agg.contract_address AS aggregator_address
           ,sub_idx
   from iv_nfts a

--- a/models/sudoswap/ethereum/sudoswap_ethereum_events.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_events.sql
@@ -291,7 +291,7 @@ WITH
         SELECT
             sc.*
             , tokens.name AS collection
-            , coalesce(agg.name,agg_m.aggregator_name) as aggregator_name
+            , coalesce(agg_m.aggregator_name, agg.name) as aggregator_name
             , agg.contract_address as aggregator_address
             , sc.amount_original*pu.price as amount_usd
             , sc.pool_fee_amount*pu.price as pool_fee_amount_usd


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

Trading through the Aggregator can be used to route to the other platform's contracts. Therefore, the `right_hash` value should be applied to determine the aggregator.

Note: Seaport has the same changes, but they are not covered here as the data is large and future changes are planned.

https://dune.com/queries/2334295

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
