### PR TITLE
Fix bug in partial_fill column flag unpacking and update cow_protocol_ethereum_trades.sql

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -220,8 +220,8 @@ valued_trades as (
            limit_buy_amount,
            valid_to,
            flags,
-           case when (flags % 2) = 0 then 'SELL' else 'BUY' end as order_type,
-           case when ((flags / 2) % 2) = 0 then false else true end as partial_fill
+           case when (bitwise_and(cast(flags as bigint),1)) = 0 then 'SELL' else 'BUY' end as order_type,
+           case when (bitwise_and(cast(flags as bigint),2)) = 0 then false else true end as partial_fill
     FROM trades_with_token_units trades
     JOIN uid_to_app_id
         ON uid = order_uid


### PR DESCRIPTION
Fix bug in partial_fill column flag unpacking

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
