### PR TITLE
Update tokens_bnb_bep20.sql

### DIFF
--- a/models/tokens/bnb/tokens_bnb_bep20.sql
+++ b/models/tokens/bnb/tokens_bnb_bep20.sql
@@ -5529,4 +5529,5 @@ SELECT LOWER(contract_address) AS contract_address, symbol, decimals
 ,('0x4268b8f0b87b6eae5d897996e6b845ddbd99adf3', 'axlUSDC', 6)     
 ,('0xc2E9d07F66A89c44062459A47a0D2Dc038E4fb16', 'stkBNB', 18)
 ,('0x2dfF88A56767223A5529eA5960Da7A3F5f766406', 'ID', 18)
+,('0xb64e280e9d1b5dbec4accedb2257a87b400db149', 'LVL', 18)
 ) AS temp_table (contract_address, symbol, decimals)


### PR DESCRIPTION
Please add LVL to prices.usd table
https://bscscan.com/token/0xB64E280e9D1B5DbEc4AcceDb2257A87b400DB149 
https://coinpaprika.com/coin/lvl-level/

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
