### PR TITLE
change the order to determine aggregator (Blur)

### DIFF
--- a/models/blur/ethereum/blur_ethereum_events.sql
+++ b/models/blur/ethereum/blur_ethereum_events.sql
@@ -53,7 +53,7 @@ SELECT
         END AS currency_contract
     , bm.contract_address AS project_contract_address
     , get_json_object(bm.buy, '$.collection') AS nft_contract_address
-    , coalesce(agg.name,agg_m.aggregator_name) AS aggregator_name
+    , coalesce(agg_m.aggregator_name, agg.name) AS aggregator_name
     , agg.contract_address AS aggregator_address
     , bm.evt_tx_hash AS tx_hash
     , et.from AS tx_from


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

**split PR from** https://github.com/duneanalytics/spellbook/pull/3136

Trading through the Aggregator can be used to route to the other platform's contracts. Therefore, the right_hash value should be applied to determine the aggregator.

https://dune.com/queries/2334295

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
