### PR TITLE
change blank string to null

### DIFF
--- a/models/superrare/superrare_ethereum_events.sql
+++ b/models/superrare/superrare_ethereum_events.sql
@@ -215,7 +215,7 @@ SELECT distinct
     cast(date_trunc('day', a.evt_block_time) AS date) AS block_date,
     a.evt_block_time as block_time,
     a.tokenId as token_id,
-    '' as collection,
+    cast(NULL as varchar(1)) as collection,
     case
     when a.currencyAddress = '0xba5bde662c17e2adff1075610382b9b691296350' then (a.amount / 1e18) * average_price_that_day_eth_per_rare * ep.price
     else (a.amount / 1e18) * ep.price
@@ -241,9 +241,9 @@ SELECT distinct
     else '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
     end as currency_contract,
     a.contract_address as nft_contract_address,
-    '' as project_contract_address,
-    '' as aggregator_name,
-    '' as aggregator_address,
+    cast(NULL as varchar(1)) as project_contract_address,
+    cast(NULL as varchar(1)) as aggregator_name,
+    cast(NULL as varchar(1)) as aggregator_address,
     a.evt_tx_hash as tx_hash,
     t.block_number as block_number,
     t.from as tx_from,


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

- Undetermined values should be NULL.
- In most databases, the 0-length string `''` and `NULL` may be treated differently.
- So it can be filtered with `collection = ''`. It is preferable that undetermined values are unified by `collection is null`.

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
