### PR TITLE
[CoW] Trade Slippage for Partially Fillable Orders

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -305,6 +305,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - order_uid
+            - block_number
     columns:
       - *order_uid
       - *block_time
@@ -317,6 +318,8 @@ models:
         name: tolerance_bips
       - &trade_usd_value
         name: trade_usd_value
+      - &fill_proportion
+        name: fill_proportion
       - &amount_atoms
         name: amount_atoms
       - &amount_percentage

--- a/tests/cow_protocol/ethereum/cow_protocol_ethereum_assert_slippage.sql
+++ b/tests/cow_protocol/ethereum/cow_protocol_ethereum_assert_slippage.sql
@@ -1,0 +1,17 @@
+WITH test_1 AS
+(
+    SELECT * FROM {{ ref('cow_protocol_ethereum_trade_slippage') }}
+    WHERE order_uid = '0x514a80473dc24034a1983ec831603f2f100ad7defd1578b077c637f73f3b92ecffab14b181409170378471b13ff2bff5be012c646434b605'
+    AND block_number = 16975171
+    AND (
+        abs(amount_percentage) > 3.3
+       OR
+        abs(amount_atoms) > 10471539
+       OR
+        abs(amount_usd) > 10.5
+    )
+)
+
+SELECT * FROM (
+    SELECT * FROM test_1
+)


### PR DESCRIPTION
Previously we did not account for partially fillable orders in our computation of trade slippage. This PR rectifies that!


cc @olgafetisova for internal review!
## Test Plan

[PoC Query](https://dune.com/queries/2279196?sidebar=none) accurately reflects the intended changes (cf. record with `order_uid = 0x514a80473dc24034a1983ec831603f2f100ad7defd1578b077c637f73f3b92ecffab14b181409170378471b13ff2bff5be012c646434b605`)
