### PR TITLE
remove CAW from prices - permanently

### DIFF
--- a/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -1640,4 +1640,5 @@ FROM
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)
 where contract_address not in (
     '0x841fb148863454a3b3570f515414759be9091465' -- SHIH has bad price feed.
+    ,'0xf3b9569f82b18aef890de263b84189bd33ebe452' -- CAW has bad price feed.
 )


### PR DESCRIPTION
The CAW token has a price feed that includes wrong data on 27/10/2022, this inflates the usd volumes of dex trades by billions.
This PR removes the token and makes sure it doesn't come back.

It was previously already commented out here:
https://github.com/duneanalytics/spellbook/blob/712907bf4636e6722df718e2766c2dab9f0a6311/models/prices/ethereum/prices_ethereum_tokens.sql#L441
but was re-added in a more [recent PR](https://github.com/duneanalytics/spellbook/pull/3156) by @bh2smith's automatic token scripts. 

Dune queries which show the wrong prices:
https://dune.com/queries/2380231/3903027
https://dune.com/queries/2380260

We can see here that the issue has not yet been resolved by coinpaprika:
https://coinpaprika.com/coin/caw-a-hunters-dream/

cc: @aalan3