### PR TITLE
Make `prices.usd_forward_fill` DuneSQL compatible

### DIFF
--- a/models/prices/prices_schema.yml
+++ b/models/prices/prices_schema.yml
@@ -78,7 +78,7 @@ models:
   - name: prices_usd_forward_fill
     meta:
       sector: prices
-      contributors: 0xRob
+      contributors: 0xRob, hildobby
     config:
       tags: [ 'prices', 'usd', 'forward_fill' ]
     description: "View on prices that does a forward fill on the last 24h till the current timestamp"

--- a/models/prices/prices_usd_forward_fill.sql
+++ b/models/prices/prices_usd_forward_fill.sql
@@ -4,32 +4,32 @@
         post_hook='{{ expose_spells_hide_trino(\'["ethereum", "solana", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c", "polygon"]\',
                                     "sector",
                                     "prices",
-                                    \'["0xRob"]\') }}'
+                                    \'["0xRob", "hildobby"]\') }}'
         )
 }}
 
 -- how much time we look back, anything before is considered finalized, anything after is forward filled.
 -- we could decrease this to optimize query performance but it's a tradeoff with resiliency to lateness.
-{%- set lookback_interval = '2 day' %}
+{%- set lookback_interval = '2' %}
 
 
 WITH
   finalized as (
     select *
     FROM {{ source('prices', 'usd') }}
-    where minute <= now() - interval {{lookback_interval}}
+    where minute <= now() - interval {{lookback_interval}} day
 )
 
 , unfinalized as (
     select *,
         lead(minute) over (partition by blockchain,contract_address,decimals,symbol order by minute asc) as next_update_minute
     FROM {{ source('prices', 'usd') }}
-    where minute > now() - interval {{lookback_interval}}
+    where minute > now() - interval {{lookback_interval}} day
 )
 
 , timeseries as (
     select explode(sequence(
-        date_trunc('minute', now() - interval {{lookback_interval}})
+        date_trunc('minute', now() - interval {{lookback_interval}} day)
         ,date_trunc('minute', now())
         ,interval 1 minute)) as minute
 )


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
