### PR TITLE
trade_type column typo fix for liquidifty_bnb_trades and liquidifty_ethereum_trades

### DIFF
--- a/models/liquidifty/bnb/liquidifty_bnb_trades.sql
+++ b/models/liquidifty/bnb/liquidifty_bnb_trades.sql
@@ -90,7 +90,7 @@ stack as (
         evt_block_time as block_time,
         cast(null as varchar(5)) as token_id,
         'erc721' as token_standard,
-        'Bundle Item Trade' as trade_type,
+        'Bundle Trade' as trade_type,
         CAST(amount as decimal(38,0)) as number_of_items,
         'Buy' as trade_category,
         owner as seller,

--- a/models/liquidifty/ethereum/liquidifty_ethereum_trades.sql
+++ b/models/liquidifty/ethereum/liquidifty_ethereum_trades.sql
@@ -50,7 +50,7 @@ stack as (
         evt_block_time as block_time,
         cast(null as varchar(5)) as token_id,
         'erc721' as token_standard,
-        'Bundle Item Trade' as trade_type,
+        'Bundle Trade' as trade_type,
         CAST(amount as decimal(38,0)) as number_of_items,
         'Buy' as trade_category,
         owner as seller,


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Fixed typo to conform with trade_type standard across nft.trades.

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
