### PR TITLE
add dragon blood DB to price.usd

### DIFF
--- a/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -96,6 +96,7 @@ FROM
     ("dac-davinci-coin", "ethereum", "DAC", "0xaad54c9f27b876d2538455dda69207279ff673a5", 18),
     ("dai-dai", "ethereum", "DAI", "0x6b175474e89094c44da98b954eedeac495271d0f", 18),
     ("data-streamr-datacoin", "ethereum", "DATA", "0x0cf0ee63788a0849fe5297f3407f701e122cc023", 18),
+    ("db-dragon-blood", "ethereum", "DB", "0x5423a6a06dd64480ad17c46e42b95827da2719d9", 18),
     ("dent-dent", "ethereum", "DENT", "0x3597bfd533a99c9aa083587b074434e61eb0a258", 8),
     ("dfx-dfx-finance", "ethereum", "DFX", "0x888888435fde8e7d4c54cab67f206e4199454c60", 18),
     ("dgd-digixdao", "ethereum", "DGD", "0xe0b7927c4af23765cb51314a0e0521a9645f0e2a", 9),


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

Add Dragon Blood (DB) token to price.usd.

Coinpaprika: https://coinpaprika.com/coin/db-dragon-blood/
Etherscan: https://etherscan.io/token/0x5423a6a06dd64480ad17c46e42b95827da2719d9#readContract


I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
