### PR TITLE
[oneinch] add new views & fix old one

### DIFF
--- a/models/oneinch/oneinch_contract_addresses.sql
+++ b/models/oneinch/oneinch_contract_addresses.sql
@@ -177,7 +177,7 @@ with routers as (
         , project
         , contract_name
         , contract_type
-        , address)
+        , contract_address)
 ) 
 
 select 
@@ -185,5 +185,5 @@ select
   , project
   , contract_name
   , contract_type
-  , lower(address) as address
+  , lower(contract_address) as contract_address
 from routers

--- a/models/oneinch/oneinch_filter_tokens.sql
+++ b/models/oneinch/oneinch_filter_tokens.sql
@@ -1,0 +1,43 @@
+{{ config(materialized='view', alias='filter_tokens') }}
+
+-- last updated 2023-04-17
+with broken_prices as (
+    select * 
+    from (
+        values
+            ('0xfb5453340c03db5ade474b27e68b6a9c6b2823eb', 'ethereum', 'ROBOT'), 
+            ('0x12b6893ce26ea6341919fe289212ef77e51688c8', 'ethereum', 'TAMA'), 
+            ('0x841fb148863454a3b3570f515414759be9091465', 'ethereum', 'SHIH'), 
+            ('0xf3b9569f82b18aef890de263b84189bd33ebe452', 'ethereum', 'CAW'), 
+            ('0x7815bda662050d84718b988735218cffd32f75ea', 'ethereum', 'YEL'), 
+            ('0x22acaee85ddb83a3a33b7f0928a0e2c3bfdb6a4f', 'ethereum', 'PRXY'), 
+            ('0x5d858bcd53e085920620549214a8b27ce2f04670', 'ethereum', 'POP'), 
+            ('0x090185f2135308bad17527004364ebcc2d37e5f6', 'ethereum', 'SPELL'), 
+            ('0xc5b3d3231001a776123194cf1290068e8b0c783b', 'ethereum', 'LIT'), 
+            ('0xdb4d1099d53e92593430e33483db41c63525f55f', 'ethereum', 'JOY'), 
+            ('0xe94b97b6b43639e238c851a7e693f50033efd75c', 'ethereum', 'RNBW'),
+            ('0xd2877702675e6ceb975b4a1dff9fb7baf4c91ea9', 'ethereum', 'LUNC'),
+            ('0x8e6cd950ad6ba651f6dd608dc70e5886b1aa6b24', 'ethereum', 'STARL'),
+            ('0xbd2f0cd039e0bfcf88901c98c0bfac5ab27566e3', 'ethereum', 'DSD'),
+            ('0x55d398326f99059ff775485246999027b3197955', 'bnb', 'Binance PEG BSC-USD'),
+            ('0x43f3918ff115081cfbfb256a5bde1e8d181f2907', 'bnb', 'ANT'), 
+            ('0x587c16b84c64751760f6e3e7e32f896634704352', 'bnb', 'WHALE'),
+            ('0xe76804b43f17fc41f226d63fd2a676df409d4678', 'bnb', 'BAT'),
+            ('0xa4b6e76bba7413b9b4bd83f4e3aa63cc181d869f', 'bnb', 'FTM'),
+            ('0xf50155cffd6c9a3634edfd6a00850016fe02c4dc', 'bnb', 'MED'), 
+            ('0xe85afccdafbe7f2b096f268e31cce3da8da2990a', 'bnb', 'aBNBc'),
+            ('0xa19d3f4219e2ed6dc1cb595db20f70b8b6866734', 'bnb', 'WIRTUAL'),
+            ('0x7ae97042a4a0eb4d1eb370c34bfec71042a056b7', 'optimism', 'UNLOCK') 
+    )
+    as t (
+        contract_address
+        , blockchain
+        , symbol
+    )
+) 
+
+select 
+    lower(contract_address) as contract_address
+    , blockchain
+    , symbol
+from broken_prices

--- a/models/oneinch/oneinch_fusion_resolvers.sql
+++ b/models/oneinch/oneinch_fusion_resolvers.sql
@@ -1,0 +1,40 @@
+{{ config(materialized='view', alias='fusion_resolvers') }}
+
+with resolvers as (
+    select * 
+    from (
+        values
+        ('1inch Labs', '0x55dcad916750c19c4ec69d65ff0317767b36ce90'),
+        ('1inch Labs', '0x3169de0e661d684e0d235f19cf72327173e0be11'),
+        ('1inch Labs', '0x8acdb3bcc5101b1ba8a5070f003a77a2da376fe8'),
+        ('1inch Labs', '0x84d99aa569d93a9ca187d83734c8c4a519c4e9b1'),
+        ('1inch Labs', '0xb33839e05ce9fc53236ae325324a27612f4d110d'),
+
+        ('Laertes', '0x9108813f22637385228a1c621c1904bbbc50dc25'),
+
+        ('Arctic Bastion', '0x2eb393fbac8aaa16047d4242033a25486e14f345'),
+        ('Arctic Bastion', '0x7636a5bfd763cefec2da9858c459f2a9b0fe8a6c'),
+        ('Arctic Bastion', '0xf1b2e1fef70e0383ef29618d02d0dd503ae239ae'),
+        ('Arctic Bastion', '0x377a1286ff83df266ff11bede2ef600044f3626b'),
+        ('Arctic Bastion', '0xe16e2f35da363a4bd330812e7cffb3f51a97c7d1'),
+
+        ('The Open DAO resolver', '0xcfa62f77920d6383be12c91c71bd403599e1116f'),
+
+        ('Seawise', '0xad7149152a65e6ec97add7b1b1f917dcafcf9b21'),
+        ('Seawise', '0xd1742b3c4fbb096990c8950fa635aec75b30781a'),
+        ('Seawise', '0xa9ff271ee217dc1c9ce3f7ebf0d6f096842cd82f'),
+
+        ('The T Resolver', '0xc6c7565644ea1893ad29182f7b6961aab7edfed0'),
+
+        ('Resolver 8', '0x69313aec23db7e4e8788b942850202bcb6038734'),
+
+        ('Kinetex Labs Resolver', '0xee230dd7519bc5d0c9899e8704ffdc80560e8509')
+    ) as t(
+        resolver_name, resolver_address
+    )
+)
+
+select 
+    lower(resolver_address) as resolver_address
+    , resolver_name
+from resolvers

--- a/models/oneinch/oneinch_schema.yml
+++ b/models/oneinch/oneinch_schema.yml
@@ -59,11 +59,6 @@ models:
       tags: ['oneinch', 'metadata']
     description: >
         (dictionary) fusion resolvers names
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - contract_address
-            - blockchain
     columns:
       - &resolver_address
         name: resolver_address

--- a/models/oneinch/oneinch_schema.yml
+++ b/models/oneinch/oneinch_schema.yml
@@ -27,5 +27,47 @@ models:
         name: contract_name
       - &contract_type
         name: contract_type
-      - &address
-        name: address
+      - &contract_address
+        name: contract_address
+
+  - name: oneinch_filter_tokens
+    meta:
+      blockchain: ['ethereum','optimism','polygon','arbitrum','avalanche_c','gnosis','bnb','fantom']
+      sector: oneinch
+      contributors: [grkhr]
+    config:
+      tags: ['oneinch', 'metadata']
+    description: >
+        (dictionary) tokens with broken prices to filter further
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - contract_address
+            - blockchain
+    columns:
+      - *contract_address
+      - *blockchain
+      - &symbol
+        name: symbol
+
+  - name: oneinch_fusion_resolvers
+    meta:
+      blockchain: ['ethereum','optimism','polygon','arbitrum','avalanche_c','gnosis','bnb','fantom']
+      sector: oneinch
+      contributors: [grkhr]
+    config:
+      tags: ['oneinch', 'metadata']
+    description: >
+        (dictionary) fusion resolvers names
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - contract_address
+            - blockchain
+    columns:
+      - &resolver_address
+        name: resolver_address
+        tests:
+          - unique
+      - &resolver_name
+        name: resolver_name

--- a/models/oneinch/oneinch_schema.yml
+++ b/models/oneinch/oneinch_schema.yml
@@ -14,7 +14,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - blockchain
-            - address
+            - contract_address
     columns:
       - &blockchain
         name: blockchain


### PR DESCRIPTION
new:
- oneinch_filter_tokens
- oneinch_fusion_resolvers

old:
- address → contract_address in oneinch_contract_addresses

---

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
