### PR TITLE
[Quickfix] Fix wrong selection

### DIFF
--- a/models/labels/addresses/dex/usage/trader_kyt/labels_trader_kyt.sql
+++ b/models/labels/addresses/dex/usage/trader_kyt/labels_trader_kyt.sql
@@ -85,7 +85,7 @@ from (select t1.`from`, date_trunc('month', t1.block_time) AS month, count(*) AS
             select address
             from {{ ref('labels_cex') }}
             union all 
-            select miner as address
+            select address
             from {{ ref('labels_miners') }}
             union all
             select


### PR DESCRIPTION
Fix the following issue:
```
00:33:05  Runtime Error in model labels_trader_kyt (models/labels/addresses/dex/usage/trader_kyt/labels_trader_kyt.sql)
00:33:05    [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name miner cannot be resolved. Did you mean one of the following? [hive_metastore.labels.miners.name, hive_metastore.labels.miners.source, hive_metastore.labels.miners.address, hive_metastore.labels.miners.category, hive_metastore.labels.miners.blockchain]; line 95 pos 19
```