### PR TITLE
add PancakeSwap Token on Ethereum

### DIFF
--- a/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -72,6 +72,7 @@ FROM
     ("btt-bittorrent", "ethereum", "BTT", "0xfa456cf55250a839088b27ee32a424d7dacb54ff", 18),
     ("btu-btu-protocol", "ethereum", "BTU", "0xb683d83a532e2cb7dfa5275eed3698436371cc9f", 18),
     ("busd-binance-usd", "ethereum", "BUSD", "0x4fabb145d64652a948d72533023f6e7a623c7c53", 18),
+    ("cake-pancakeswap", "ethereum", "CAKE", "0x152649ea73beab28c5b49b26eb48f7ead6d4c898", 18),
     ("cel-celsius", "ethereum", "CEL", "0xaaaebe6fe48e54f431b0c390cfaf0b017d09d42d", 4),
     ("celr-celer-network", "ethereum", "CELR", "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667", 18),
     ("cennz-centrality", "ethereum", "CENNZ", "0x1122b6a0e00dce0563082b6e2953f3a943855c1f", 18),


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:
address is lowercase, api is from coinpaprika & copied correct, number of decimals is correct, ticker is same as coinpaprika.

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
