### PR TITLE
revert eth erc20 price

### DIFF
--- a/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -15,7 +15,6 @@ SELECT
 FROM
 (
     VALUES
-    ("eth-ethereum","ethereum","ETH","{{ var('ETH_ERC20_ADDRESS') }}",18),
     ("0xbtc-0xbitcoin", "ethereum", "0xBTC", "0xb6ed7644c69416d67b522e20bc294a9a9b405b31", 8),
     ("1inch-1inch", "ethereum", "1INCH", "0x111111111117dc0aa78b770fa6a738034120c302", 18),
     ("aave-new", "ethereum", "AAVE", "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9", 18),


### PR DESCRIPTION
fyi @0xRobin 
this addition has caused duplicates in:
- x2y2 events
- zora events
- looksrare v2 events
- blur events

quick look into compiling those models (i used looksrare v2) showed the `OR` statement in the price forward fill join started to return duplicates. to be clear, there were no dupes if i comment out the `OR` portion, there were dupes with it active. prod has been failing since merge.