### PR TITLE
Fix eth erc20 address

### DIFF
--- a/models/_sector/nft/trades/nft_ethereum_trades_beta.sql
+++ b/models/_sector/nft/trades/nft_ethereum_trades_beta.sql
@@ -24,7 +24,7 @@ WITH cte_prices_patch as (
     {% endif %}
     UNION ALL
     SELECT
-        '{{ var(ETH_ERC20_ADDRESS) }}' as contract_address
+        '{{ var("ETH_ERC20_ADDRESS") }}' as contract_address
         ,'ethereum' as blockchain
         ,18 as decimals
         ,p.minute

--- a/models/_sector/nft/trades/nft_ethereum_trades_beta.sql
+++ b/models/_sector/nft/trades/nft_ethereum_trades_beta.sql
@@ -15,6 +15,27 @@
     ,('foundation',    'v1',   ref('foundation_ethereum_base_trades'))
 ] %}
 
+-- We should remove this CTE and include ETH into the general prices table once everything is migrated
+WITH cte_prices_patch as (
+    SELECT * FROM ref('prices_usd_forward_fill')
+    WHERE blockchain = 'ethereum'
+    {% if is_incremental() %}
+    AND p.minute >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
+    UNION ALL
+    SELECT
+        '{{ var(ETH_ERC20_ADDRESS) }}' as contract_address
+        ,'ethereum' as blockchain
+        ,18 as decimals
+        ,p.minute
+        ,p.price
+        ,'ETH' as symbol
+    FROM ref('prices_usd_forward_fill') p
+    WHERE blockchain is null AND symbol = 'ETH'
+    {% if is_incremental() %}
+    AND p.minute >= date_trunc("day", now() - interval '1 week')
+    {% endif %}
+)
 
 -- macros/models/sector/nft
 {{
@@ -24,7 +45,7 @@
         transactions_model=source('ethereum','transactions'),
         tokens_nft_model=ref('tokens_ethereum_nft'),
         tokens_erc20_model=ref('tokens_ethereum_erc20'),
-        prices_model=ref('prices_usd_forward_fill'),
+        prices_model=cte_prices_patch,
         aggregators=ref('nft_ethereum_aggregators'),
         aggregator_markers=ref('nft_ethereum_aggregators_markers')
     )


### PR DESCRIPTION
Follow up PR to https://github.com/duneanalytics/spellbook/pull/3271
This re-enables the ETH ERC20 address functionality for the restructured models without impacting existing ones. 