### PR TITLE
add prod_exclude tags for models to disable in production

### DIFF
--- a/models/airswap/ethereum/airswap_ethereum_trades.sql
+++ b/models/airswap/ethereum/airswap_ethereum_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags=['prod_exclude'],
     alias ='trades',
     partition_by = ['block_date'],
     materialized = 'incremental',

--- a/models/hashflow/ethereum/hashflow_ethereum_raw_trades.sql
+++ b/models/hashflow/ethereum/hashflow_ethereum_raw_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags=['prod_exclude'],
     alias = 'raw_trades',
     partition_by = ['block_date'],
     materialized = 'incremental',

--- a/models/odos/avalanche_c/odos_avalanche_c_trades.sql
+++ b/models/odos/avalanche_c/odos_avalanche_c_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags=['prod_exclude'],
     alias = 'trades',
     partition_by = ['block_date'],
     materialized = 'incremental',


### PR DESCRIPTION
fyi @0xRobin -- trying out something new for excluding in prod to keep orchestration side clean. there are a few ways to achieve this, but it's a quick and clean one.