### PR TITLE
Add fees to uniswap v3 trades

### DIFF
--- a/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
+++ b/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
@@ -28,6 +28,7 @@ WITH dexs AS
         ,CASE WHEN amount0 < '0' THEN f.token0 ELSE f.token1 END AS token_bought_address
         ,CASE WHEN amount0 < '0' THEN f.token1 ELSE f.token0 END AS token_sold_address
         ,CAST(t.contract_address as string) as project_contract_address
+        ,f.fee
         ,t.evt_tx_hash AS tx_hash
         ,'' AS trace_address
         ,t.evt_index
@@ -65,6 +66,7 @@ SELECT
     ,coalesce(dexs.taker, tx.from) AS taker -- subqueries rely on this COALESCE to avoid redundant joins with the transactions table
     ,dexs.maker
     ,dexs.project_contract_address
+    ,dexs.fee
     ,dexs.tx_hash
     ,tx.from AS tx_from
     ,tx.to AS tx_to

--- a/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
+++ b/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
@@ -28,7 +28,7 @@ WITH dexs AS
         ,CASE WHEN amount0 < '0' THEN f.token0 ELSE f.token1 END AS token_bought_address
         ,CASE WHEN amount0 < '0' THEN f.token1 ELSE f.token0 END AS token_sold_address
         ,CAST(t.contract_address as string) as project_contract_address
-        ,f.fee
+        ,f.fee -- field is unique to this model and will not affect downstream spells
         ,t.evt_tx_hash AS tx_hash
         ,'' AS trace_address
         ,t.evt_index
@@ -82,7 +82,7 @@ INNER JOIN {{ source('ethereum', 'transactions') }} tx
     AND tx.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
 LEFT JOIN {{ ref('tokens_erc20') }} erc20a
-    ON erc20a.contract_address = dexs.token_bought_address 
+    ON erc20a.contract_address = dexs.token_bought_address
     AND erc20a.blockchain = 'ethereum'
 LEFT JOIN {{ ref('tokens_erc20') }} erc20b
     ON erc20b.contract_address = dexs.token_sold_address


### PR DESCRIPTION
**Brief comments on the purpose of your changes:**

This makes it more convenient to query the table.

There are downstream tables that rely on the `uniswap_v3_trades` table like `uniswap.trades` and `dex.trades`. This change should not affect those tables as those tables have already specified the columns that it needs (does not use `SELECT *`).

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
