### PR TITLE
[CoW] ETH Flow - add column environment

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_eth_flow_orders.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_eth_flow_orders.sql
@@ -22,6 +22,12 @@ eth_flow_orders as (
         evt_block_time as block_time,
         evt_block_number as block_number,
         evt_tx_hash as tx_hash,
+        case
+            when event.contract_address = '0x40a50cf069e992aa4536211b23f286ef88752187'
+                then 'prod'
+            when event.contract_address = '0xd02de8da0b71e1b59489794f423fabba2adc4d93'
+                then 'barn'
+        end as environment,
         -- This validity is always infinite. Instead we unpack this from the data field.
         -- from_unixtime(get_json_object(event.order, '$.validTo')) as valid_to,
         from_unixtime(conv(substring(data, 19, 8), 16, 10)) as valid_to,

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -16,7 +16,7 @@ models:
         description: "Solver's wallet address"
       - &environment
         name: environment
-        description: "Solver's environment"
+        description: "Development environment"
       - &name
         name: name
         description: "Solver's name"
@@ -255,9 +255,7 @@ models:
       - *block_time
       - *block_number
       - *tx_hash
-      - &environment
-        name: environment
-        description: string representing the development environment the order was placed (prod or barn)
+      - *environment
       - *valid_to
       - &quote_id
         name: quote_id

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -255,6 +255,9 @@ models:
       - *block_time
       - *block_number
       - *tx_hash
+      - &environment
+        name: environment
+        description: string representing the development environment the order was placed (prod or barn)
       - *valid_to
       - &quote_id
         name: quote_id


### PR DESCRIPTION
Adding a column which distinguishes between the different development environments eth flow orders are placed. 
Note that "barn" is analogous to "staging" since its a "CoW" protocol.

cc @gentrexha, @nlordell and @fedgiac 

for internal review.

This change will be used to update our "Missing Refund" Alert based on [this query](https://dune.com/queries/1944598?StartTime=2023-05-07+19%3A00%3A25.343000&GracePeriod=10&EndTime=2023-05-07+20%3A00%3A25.343000&category=abstraction&namespace=cow_protocol&table=eth_flow_orders&blockchains=ethereum) by adding a parameter to the query as follows

An alternative to this is to just add a contract_address to the orders table, but I can't see any other reason/purpose for them.

```sql
where environment = '{{DevEnv}}'
```