### PR TITLE
[oneinch] add oneinch_fusion_executors and fix naming in oneinch_contract_addresses

### DIFF
--- a/models/oneinch/oneinch_contract_addresses.sql
+++ b/models/oneinch/oneinch_contract_addresses.sql
@@ -177,7 +177,7 @@ with routers as (
         , project
         , contract_name
         , contract_type
-        , address)
+        , contract_address)
 ) 
 
 select 
@@ -185,5 +185,5 @@ select
   , project
   , contract_name
   , contract_type
-  , lower(address) as address
+  , lower(contract_address) as contract_address
 from routers

--- a/models/oneinch/oneinch_fusion_executors.sql
+++ b/models/oneinch/oneinch_fusion_executors.sql
@@ -1,0 +1,151 @@
+{{
+    config(
+        schema='oneinch',
+        alias='fusion_executors',
+        materialized='table',
+        file_format='delta',
+        unique_key = ['resolver_executor', 'chain_id']
+    )
+}}
+
+
+---- SPARK QUERY ------
+with
+
+chains as (
+    select *
+    from (values
+        ('ethereum', 1), -- mainnet
+        ('bnb', 56),
+        ('ethereum_kovan', 42), -- kovan
+        ('optimism', 10), -- optimistic
+        ('polygon', 137), -- matic
+        ('arbitrum', 42161),
+        ('gnosis', 100), -- xdai
+        ('avalanche_c', 43114), -- avax
+        ('fantom', 250),
+        ('aurora', 1313161554),
+        ('klaytn', 8217)
+    ) as t(chain, chain_id)
+)
+
+, names as (
+    select *
+    from (values
+        ('0xf63392356a985ead50b767a3e97a253ff870e91a', '1inch Labs', true),
+        ('0xa260f8b7c8f37c2f1bc11b04c19902829de6ac8a', 'Arctic Bastion', true),
+        ('0xcfa62f77920d6383be12c91c71bd403599e1116f', 'The Open DAO resolver', true),
+        ('0xe023f53f735c196e4a028233c2ee425957812a41', 'Seawise', true),
+        ('0x754bcbaf851f94ca0065d0d06d53b168daab17b8', 'Alpha', false),
+        ('0xb2153caa185484fd377f488d89143a7fd76695ce', 'Laertes', true),
+        ('0xc975671642534f407ebdcaef2428d355ede16a2c', 'OTEX', true),
+        ('0xd7f6f541d4210550ca56f7b4c4a549efd4cafb49', 'The T Resolver', true),
+        ('0x21b7db78e76dcd100f717206ee655daab2de118c', 'Spider Labs', true),
+        ('0x12e5ceb5c14f3a1a9971da154f6530c1cf7274ac', 'Rosato LLC', true),
+        ('0xee230dd7519bc5d0c9899e8704ffdc80560e8509', 'Kinetex Labs Resolver', true),
+        ('0xaf3803348f4f1f527a8b6f611c30c8702bacd2af', 'Resolver 0xaf38..d2af', true),
+        ('0xa6219c7d74edeb12d74a3c664f7aaeb7d01ab902', 'Resolver 0xa621..b902', false),
+        ('0x74c629c4096e234029c78c7760dc0aadb717adb0', 'Resolver 0x74c6..adb0', false),
+        ('0x7c7047337995c338c1682f12bc38d4e4108309bb', 'Resolver 0x7c70..09bb', false)
+    ) as t(resolver_address, resolver_name, kyc)
+)
+
+, traces as (
+    select 
+        tx_hash
+        , "from" as resolver_address
+        , substring(input, 49, 20) as resolver_executor
+        , cast(bytea2numeric(substring(input, 5, 32)) as double) as chain_id
+    from ethereum.traces
+    where "to" = '0xcb8308fcb7bc2f84ed1bea2c016991d34de5cc77'
+        and substring(input, 1, 4) = '0xf204bdb9'
+        and block_time >= timestamp '2022-12-25'
+        and tx_success
+        and success
+)
+
+select distinct
+    resolver_address
+    , resolver_executor
+    , coalesce(chain, cast(chain_id as string)) as blockchain
+    , chain_id
+    , resolver_name
+    , kyc
+    , max(tx_hash) over(partition by resolver_executor, chain_id) as tx_hash_example
+from traces
+left join names using(resolver_address)
+left join chains using(chain_id)
+order by resolver_name, resolver_executor
+
+
+
+
+---- TRINO QUERY -----
+
+/*
+chains as (
+    select *
+    from (values
+        ('ethereum', 1), -- mainnet
+        ('bnb', 56),
+        ('ethereum_kovan', 42), -- kovan
+        ('optimism', 10), -- optimistic
+        ('polygon', 137), -- matic
+        ('arbitrum', 42161),
+        ('gnosis', 100), -- xdai
+        ('avalanche_c', 43114), -- avax
+        ('fantom', 250),
+        ('aurora', 1313161554),
+        ('klaytn', 8217)
+    ) as t(chain, chain_id)
+)
+
+, names as (
+    select *
+    from (values
+        (0xf63392356a985ead50b767a3e97a253ff870e91a, '1inch Labs', true),
+        (0xa260f8b7c8f37c2f1bc11b04c19902829de6ac8a, 'Arctic Bastion', true),
+        (0xcfa62f77920d6383be12c91c71bd403599e1116f, 'The Open DAO resolver', true),
+        (0xe023f53f735c196e4a028233c2ee425957812a41, 'Seawise', true),
+        (0x754bcbaf851f94ca0065d0d06d53b168daab17b8, 'Alpha', false),
+        (0xb2153caa185484fd377f488d89143a7fd76695ce, 'Laertes', true),
+        (0xc975671642534f407ebdcaef2428d355ede16a2c, 'OTEX', true),
+        (0xd7f6f541d4210550ca56f7b4c4a549efd4cafb49, 'The T Resolver', true),
+        (0x21b7db78e76dcd100f717206ee655daab2de118c, 'Spider Labs', true),
+        (0x12e5ceb5c14f3a1a9971da154f6530c1cf7274ac, 'Rosato LLC', true),
+        (0xee230dd7519bc5d0c9899e8704ffdc80560e8509, 'Kinetex Labs Resolver', true),
+        (0xaf3803348f4f1f527a8b6f611c30c8702bacd2af, 'Resolver 0xaf38..d2af', true),
+        (0xa6219c7d74edeb12d74a3c664f7aaeb7d01ab902, 'Resolver 0xa621..b902', false),
+        (0x74c629c4096e234029c78c7760dc0aadb717adb0, 'Resolver 0x74c6..adb0', false),
+        (0x7c7047337995c338c1682f12bc38d4e4108309bb, 'Resolver 0x7c70..09bb', false)
+    ) as t(resolver_address, resolver_name, kyc)
+)
+
+, traces as (
+    select 
+        tx_hash
+        , "from" as resolver_address
+        , substr(input, 49, 20) as resolver_executor
+        , cast(bytearray_to_uint256(substr(input, 5, 32)) as double) as chain_id
+    from ethereum.traces
+    where "to" = 0xcb8308fcb7bc2f84ed1bea2c016991d34de5cc77
+        and substr(input, 1, 4) = 0xf204bdb9
+        and block_time >= timestamp '2022-12-25'
+        and tx_success
+        and success
+)
+
+
+select distinct 
+    resolver_address
+    , resolver_executor
+    , coalesce(chain, cast(chain_id as varchar)) as blockchain
+    , chain_id
+    , resolver_name
+    , kyc
+    , max(tx_hash) over(partition by resolver_executor, chain_id) as tx_hash_example
+from traces
+left join names using(resolver_address)
+left join chains using(chain_id)
+order by resolver_name, resolver_executor
+*/

--- a/models/oneinch/oneinch_fusion_executors.sql
+++ b/models/oneinch/oneinch_fusion_executors.sql
@@ -54,12 +54,12 @@ chains as (
     select 
         tx_hash
         , "from" as resolver_address
-        , substring(input, 49, 20) as resolver_executor
-        , cast(bytea2numeric_v3(substring(input, 5, 32)) as double) as chain_id
+        , substring(input, 99, 40) as resolver_executor
+        , bytea2numeric_v3(substring(input, 11, 64)) as chain_id
     from {{ source('ethereum', 'traces') }}
     where "to" = '0xcb8308fcb7bc2f84ed1bea2c016991d34de5cc77'
-        and substring(input, 1, 4) = '0xf204bdb9'
-        and block_time >= timestamp '2022-12-25'
+        and substring(input, 1, 10) = '0xf204bdb9'
+        and block_time >= '2022-12-25'
         and tx_success
         and success
 )
@@ -127,7 +127,7 @@ chains as (
         , "from" as resolver_address
         , substr(input, 49, 20) as resolver_executor
         , cast(bytearray_to_uint256(substr(input, 5, 32)) as double) as chain_id
-    from ethereum.traces
+    from {{ source('ethereum', 'traces') }}
     where "to" = 0xcb8308fcb7bc2f84ed1bea2c016991d34de5cc77
         and substr(input, 1, 4) = 0xf204bdb9
         and block_time >= timestamp '2022-12-25'

--- a/models/oneinch/oneinch_fusion_executors.sql
+++ b/models/oneinch/oneinch_fusion_executors.sql
@@ -55,8 +55,8 @@ chains as (
         tx_hash
         , "from" as resolver_address
         , substring(input, 49, 20) as resolver_executor
-        , cast(bytea2numeric(substring(input, 5, 32)) as double) as chain_id
-    from ethereum.traces
+        , cast(bytea2numeric_v3(substring(input, 5, 32)) as double) as chain_id
+    from {{ source('ethereum', 'traces') }}
     where "to" = '0xcb8308fcb7bc2f84ed1bea2c016991d34de5cc77'
         and substring(input, 1, 4) = '0xf204bdb9'
         and block_time >= timestamp '2022-12-25'

--- a/models/oneinch/oneinch_schema.yml
+++ b/models/oneinch/oneinch_schema.yml
@@ -14,7 +14,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - blockchain
-            - address
+            - contract_address
     columns:
       - &blockchain
         name: blockchain
@@ -27,5 +27,34 @@ models:
         name: contract_name
       - &contract_type
         name: contract_type
-      - &address
-        name: address
+      - &contract_address
+        name: contract_address
+
+  - name: oneinch_fusion_executors
+    meta:
+      blockchain: ['ethereum','optimism','polygon','arbitrum','avalanche_c','gnosis','bnb','fantom']
+      sector: oneinch
+      contributors: [grkhr]
+    config:
+      tags: ['oneinch', 'metadata']
+    description: >
+        fusion resolvers and executors
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - chain_id
+            - resolver_executor
+    columns:
+      - &resolver_address
+        name: resolver_address
+      - &resolver_executor
+        name: resolver_executor
+      - *blockchain
+      - &chain_id
+        name: chain_id
+      - &resolver_name
+        name: resolver_name
+      - &kyc
+        name: kyc
+      - &tx_hash_example
+        name: tx_hash_example


### PR DESCRIPTION
…ract_addresses

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
