### PR TITLE
Update lido decoded table name

### DIFF
--- a/models/lido/ethereum/lido_ethereum_accounting_revenue.sql
+++ b/models/lido/ethereum/lido_ethereum_accounting_revenue.sql
@@ -17,7 +17,7 @@ with oracle_txns AS (
         evt_block_time AS period,
         (CAST(postTotalPooledEther AS DOUBLE)-CAST(preTotalPooledEther AS DOUBLE)) lido_rewards,
         evt_tx_hash
-    FROM {{source('lido_ethereum','LidoOracle_evt_PostTotalShares')}}
+    FROM {{source('lido_ethereum','LegacyOracle_evt_PostTotalShares')}}
     ORDER BY 1 DESC
 ),
 

--- a/models/lido/ethereum/lido_ethereum_sources.yml
+++ b/models/lido/ethereum/lido_ethereum_sources.yml
@@ -10,7 +10,7 @@ sources:
     tables:
       - name: AllowedRecipientsRegistry_evt_RecipientAdded
       - name: AllowedRecipientsRegistry_evt_RecipientRemoved
-      - name: LidoOracle_evt_PostTotalShares
+      - name: LegacyOracle_evt_PostTotalShares
       - name: steth_evt_FeeSet
       - name: steth_evt_FeeDistributionSet
       - name: LDO_evt_Transfer


### PR DESCRIPTION
Simple change updating the table name from `lido_ethereum.LidoOracle` to `lido_ethereum.LegacyOracle`. Both names exist on Dune now, but I'll delete the old one after we merge this PR 🪄 