### PR TITLE
[Bug] Fix Trade Surplus for Partial Fills

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -139,6 +139,8 @@ models:
       - &partial_fill
         name: partial_fill
         description: "Boolean indicating if the order is partially fill-able"
+      - &fill_proportion
+        name: fill_proportion
 
   - name: cow_protocol_ethereum_batches
     meta:

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -321,8 +321,7 @@ models:
         name: tolerance_bips
       - &trade_usd_value
         name: trade_usd_value
-      - &fill_proportion
-        name: fill_proportion
+      - *fill_proportion
       - &amount_atoms
         name: amount_atoms
       - &amount_percentage


### PR DESCRIPTION
There were two issues here (not using fill proportion) and some overflow issues related to the large integer arithmetic that were solved by simply rearranging the surplus equation.

cc @olgafetisova 