### PR TITLE
add seaport v1.5 to seaport_v2_ethereum_trades

### DIFF
--- a/models/seaport/ethereum/seaport_v2_ethereum_trades.sql
+++ b/models/seaport/ethereum/seaport_v2_ethereum_trades.sql
@@ -17,7 +17,6 @@
 {% set c_alternative_token_address = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2" %}
 {% set c_native_symbol = "ETH" %}
 {% set c_seaport_first_date = "2023-02-01" %}
-{% set c_seaport_contract_address = "0x00000000000001ad428e4906ae43d8f9852d0dd6" %} -- v2 = Seaport v1.4
 
 
 with source_ethereum_transactions as (
@@ -74,7 +73,9 @@ with source_ethereum_transactions as (
           ,evt_index as om_evt_index
           ,posexplode(orderhashes) as (om_order_id, om_order_hash)
       from {{ source('seaport_ethereum','Seaport_evt_OrdersMatched') }}
-     where contract_address = '{{c_seaport_contract_address}}'
+     where contract_address in ('0x00000000000001ad428e4906ae43d8f9852d0dd6' -- Seaport v1.4
+                               ,'0x00000000000000adc04c56bf30ac9d3c0aaf14dc' -- Seaport v1.5
+                               ) 
 )
 ,iv_enh_base_pairs as (
     select a.block_date
@@ -117,7 +118,9 @@ with source_ethereum_transactions as (
       from ref_seaport_ethereum_base_pairs a
            left join iv_orders_matched b on b.om_order_hash = a.order_hash
                                          and b.om_tx_hash = a.tx_hash  -- order_hash is not unique in itself, so must join with tx_hash
-     where a.platform_contract_address = '{{c_seaport_contract_address}}'
+     where a.platform_contract_address in ('0x00000000000001ad428e4906ae43d8f9852d0dd6' -- Seaport v1.4
+                                          ,'0x00000000000000adc04c56bf30ac9d3c0aaf14dc' -- Seaport v1.5
+                                          ) 
 )
 ,iv_volume as (
   select block_date


### PR DESCRIPTION
Brief comments on the purpose of your changes:

• Adding in Seaport v1.5 which was recently deployed: `0x00000000000000adc04c56bf30ac9d3c0aaf14dc`

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
