### PR TITLE
Revert CI timeout to 90min

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dbt-test:
     runs-on: [ self-hosted, linux, spellbook ]
-    timeout-minutes: 180
+    timeout-minutes: 90
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
A timeout change to 3h was merged in the big NFT cleanup PR. 
This reverts it to the previous value. 