### PR TITLE
add buffer flow to the model, fix revenue

### DIFF
--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_buffer_inflow.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_buffer_inflow.sql
@@ -1,0 +1,27 @@
+{{ config(
+        alias ='buffer_inflow',
+        partition_by = ['period'],
+        materialized = 'table',
+        file_format = 'delta',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "lido_accounting",
+                                \'["gregshestakovlido", "ppclunghe", "xadcv"]\') }}'
+        )
+}}
+--https://dune.com/queries/2488514
+--ref{{'lido_accounting_ethereum_buffer_inflow'}}
+
+
+SELECT  evt_block_time as period, amount as amount,lower('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2') as token, evt_tx_hash
+FROM {{source('lido_ethereum','steth_evt_Submitted')}}
+
+union all
+
+SELECT evt_block_time, amount, lower('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'), evt_tx_hash
+FROM {{source('lido_ethereum','steth_evt_ELRewardsReceived')}}
+
+union all 
+
+SELECT evt_block_time, amount , lower('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'), evt_tx_hash
+FROM {{source('lido_ethereum','steth_evt_WithdrawalsReceived')}}

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_buffer_outflow.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_buffer_outflow.sql
@@ -1,0 +1,16 @@
+{{ config(
+        alias ='buffer_outflow',
+        partition_by = ['period'],
+        materialized = 'table',
+        file_format = 'delta',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "lido_accounting",
+                                \'["gregshestakovlido", "ppclunghe", "xadcv"]\') }}'
+        )
+}}
+--https://dune.com/queries/2488552
+--ref{{'lido_accounting_ethereum_buffer_outflow'}}
+
+SELECT evt_block_time as period, amountOfETHLocked as amount, LOWER('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2') AS token,  evt_tx_hash
+FROM {{source('lido_ethereum','WithdrawalQueueERC721_evt_WithdrawalsFinalized')}}

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_revenue.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_revenue.sql
@@ -1,0 +1,107 @@
+{{ config(
+        alias ='revenue',
+        partition_by = ['period'],
+        materialized = 'table',
+        file_format = 'delta',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "lido_accounting",
+                                \'["pipistrella", "adcv", "zergil1397", "lido"]\') }}'
+        )
+}}
+
+--https://dune.com/queries/2011922
+--ref{{'lido_accounting_revenue'}}
+
+with 
+addresses AS (
+select * from (values
+(LOWER('0x3e40d73eb977dc6a537af587d48316fee66e9c8c'), 'Aragon'),
+(LOWER('0x55032650b14df07b85bF18A3a3eC8E0Af2e028d5'),  'NO'),
+(LOWER('0x8B3f33234ABD88493c0Cd28De33D583B70beDe35'),  'InsuranceFund')
+) as list(address, name)
+ ),
+
+oracle_txns AS ( 
+    SELECT
+        evt_block_time AS period,
+        (CAST(postTotalPooledEther AS DOUBLE)-CAST(preTotalPooledEther AS DOUBLE)) lido_rewards,
+        evt_tx_hash
+    FROM {{source('lido_ethereum','LegacyOracle_evt_PostTotalShares')}}
+    WHERE evt_block_time <= '2023-05-16 00:00' 
+    ORDER BY 1 DESC
+),
+
+
+oraclev2_txns as (  
+    SELECT period, sum(treasury_revenue) as treasury_revenue, sum(operators_revenue) as operators_revenue, sum(insurance_revenue) as insurance_revenue, evt_tx_hash 
+    FROM (
+    SELECT 
+        o.evt_block_time as period,
+        case when t.to in  (select address from addresses where name = 'Aragon') then t.value else 0 end AS treasury_revenue,
+        case when t.to in  (select address from addresses where name = 'NO') then t.value else 0 end AS operators_revenue,
+        case when t.to in  (select address from addresses where name = 'InsuranceFund') then t.value else 0 end as insurance_revenue,
+        o.evt_tx_hash
+    FROM {{source('lido_ethereum','AccountingOracle_evt_ProcessingStarted')}} o
+    left join {{source('lido_ethereum','steth_evt_Transfer')}} t on o.evt_tx_hash = t.evt_tx_hash 
+            and t.`from` = '0x0000000000000000000000000000000000000000' 
+            and `to` in (select address from addresses)
+    ) group by 1,5
+),
+
+
+protocol_fee AS (
+    SELECT 
+        DATE_TRUNC('day', evt_block_time) AS period, 
+        LEAD(DATE_TRUNC('day', evt_block_time), 1, NOW()) OVER (ORDER BY DATE_TRUNC('day', evt_block_time)) AS next_period,
+        CAST(feeBasisPoints AS DOUBLE)/10000 AS points
+    FROM {{source('lido_ethereum','steth_evt_FeeSet')}}
+),
+
+protocol_fee_distribution AS (
+    SELECT 
+        DATE_TRUNC('day', evt_block_time) AS period, 
+        LEAD(DATE_TRUNC('day', evt_block_time), 1, NOW()) OVER (ORDER BY DATE_TRUNC('day', evt_block_time)) AS next_period,
+        CAST(insuranceFeeBasisPoints AS DOUBLE)/10000 AS insurance_points,
+        CAST(operatorsFeeBasisPoints AS DOUBLE)/10000 AS operators_points,
+        CAST(treasuryFeeBasisPoints AS DOUBLE)/10000 AS treasury_points
+    FROM {{source('lido_ethereum','steth_evt_FeeDistributionSet')}}
+)
+
+
+    SELECT  
+        oracle_txns.period AS period, 
+        oracle_txns.evt_tx_hash,
+        LOWER('0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84') AS token,
+        lido_rewards AS total,
+        protocol_fee.points AS protocol_fee,
+        protocol_fee_distribution.insurance_points AS insurance_fee,
+        protocol_fee_distribution.operators_points AS operators_fee,
+        protocol_fee_distribution.treasury_points AS treasury_fee,
+        (1 - protocol_fee.points)*lido_rewards AS depositors_revenue,
+        protocol_fee.points*protocol_fee_distribution.treasury_points*lido_rewards AS treasury_revenue,
+        protocol_fee.points*protocol_fee_distribution.insurance_points*lido_rewards AS insurance_revenue,
+        protocol_fee.points*protocol_fee_distribution.operators_points*lido_rewards AS operators_revenue
+    FROM oracle_txns
+    LEFT JOIN protocol_fee ON DATE_TRUNC('day', oracle_txns.period) >= protocol_fee.period AND DATE_TRUNC('day', oracle_txns.period) < protocol_fee.next_period
+    LEFT JOIN protocol_fee_distribution ON DATE_TRUNC('day', oracle_txns.period) >= protocol_fee_distribution.period AND DATE_TRUNC('day', oracle_txns.period) < protocol_fee_distribution.next_period
+
+    union all
+
+    SELECT  
+        oracle_txns.period AS period, 
+        oracle_txns.evt_tx_hash,
+        LOWER('0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84') AS token,
+        oracle_txns.treasury_revenue + oracle_txns.operators_revenue + 	oracle_txns.insurance_revenue AS total,
+        protocol_fee.points AS protocol_fee,
+        protocol_fee_distribution.insurance_points AS insurance_fee,
+        protocol_fee_distribution.operators_points AS operators_fee,
+        protocol_fee_distribution.treasury_points AS treasury_fee,
+        10*(1 - protocol_fee.points)*(oracle_txns.treasury_revenue + oracle_txns.operators_revenue + 	oracle_txns.insurance_revenue) AS depositors_revenue,
+        oracle_txns.treasury_revenue AS treasury_revenue,
+        oracle_txns.insurance_revenue AS insurance_revenue,
+        oracle_txns.operators_revenue AS operators_revenue
+    FROM oraclev2_txns oracle_txns
+    LEFT JOIN protocol_fee ON DATE_TRUNC('day', oracle_txns.period) >= protocol_fee.period AND DATE_TRUNC('day', oracle_txns.period) < protocol_fee.next_period
+    LEFT JOIN protocol_fee_distribution ON DATE_TRUNC('day', oracle_txns.period) >= protocol_fee_distribution.period AND DATE_TRUNC('day', oracle_txns.period) < protocol_fee_distribution.next_period
+

--- a/models/lido/ethereum/accounting/lido_ethereum_accounting_buffer_inflow.sql
+++ b/models/lido/ethereum/accounting/lido_ethereum_accounting_buffer_inflow.sql
@@ -1,0 +1,27 @@
+{{ config(
+        alias ='buffer_inflow',
+        partition_by = ['period'],
+        materialized = 'table',
+        file_format = 'delta',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "lido",
+                                \'["gregshestakovlido", "ppclunghe", "xadcv"]\') }}'
+        )
+}}
+--https://dune.com/queries/2488514
+--ref{{'lido_ethereum_accounting_buffer_inflow'}}
+
+
+SELECT  evt_block_time as period, amount as amount,lower('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2') as token, evt_tx_hash
+FROM {{source('lido_ethereum','steth_evt_Submitted')}}
+
+union all
+
+SELECT evt_block_time, amount, lower('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'), evt_tx_hash
+FROM {{source('lido_ethereum','steth_evt_ELRewardsReceived')}}
+
+union all 
+
+SELECT evt_block_time, amount , lower('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'), evt_tx_hash
+FROM {{source('lido_ethereum','steth_evt_WithdrawalsReceived')}}

--- a/models/lido/ethereum/accounting/lido_ethereum_accounting_buffer_outflow.sql
+++ b/models/lido/ethereum/accounting/lido_ethereum_accounting_buffer_outflow.sql
@@ -12,5 +12,5 @@
 --https://dune.com/queries/2488552
 --ref{{'lido_ethereum_accounting_buffer_outflow'}}
 
-SELECT evt_block_time, amountOfETHLocked as amount, LOWER('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2') AS token,  evt_tx_hash
+SELECT evt_block_time as period, amountOfETHLocked as amount, LOWER('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2') AS token,  evt_tx_hash
 FROM {{source('lido_ethereum','WithdrawalQueueERC721_evt_WithdrawalsFinalized')}}

--- a/models/lido/ethereum/accounting/lido_ethereum_accounting_buffer_outflow.sql
+++ b/models/lido/ethereum/accounting/lido_ethereum_accounting_buffer_outflow.sql
@@ -1,0 +1,16 @@
+{{ config(
+        alias ='buffer_outflow',
+        partition_by = ['period'],
+        materialized = 'table',
+        file_format = 'delta',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "lido",
+                                \'["gregshestakovlido", "ppclunghe", "xadcv"]\') }}'
+        )
+}}
+--https://dune.com/queries/2488552
+--ref{{'lido_ethereum_accounting_buffer_outflow'}}
+
+SELECT evt_block_time, amountOfETHLocked as amount, LOWER('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2') AS token,  evt_tx_hash
+FROM {{source('lido_ethereum','WithdrawalQueueERC721_evt_WithdrawalsFinalized')}}

--- a/models/lido/ethereum/accounting/lido_ethereum_accounting_revenue.sql
+++ b/models/lido/ethereum/accounting/lido_ethereum_accounting_revenue.sql
@@ -6,7 +6,7 @@
         post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "project",
                                 "lido",
-                                \'["pipistrella", "adcv", "zergil1397", "lido"]\') }}'
+                                \'["gregshestakovlido", "ppclunghe", "xadcv"]\') }}'
         )
 }}
 
@@ -97,7 +97,7 @@ protocol_fee_distribution AS (
         protocol_fee_distribution.insurance_points AS insurance_fee,
         protocol_fee_distribution.operators_points AS operators_fee,
         protocol_fee_distribution.treasury_points AS treasury_fee,
-        (1 - protocol_fee.points)*(oracle_txns.treasury_revenue + oracle_txns.operators_revenue + 	oracle_txns.insurance_revenue) AS depositors_revenue,
+        10*(1 - protocol_fee.points)*(oracle_txns.treasury_revenue + oracle_txns.operators_revenue + 	oracle_txns.insurance_revenue) AS depositors_revenue,
         oracle_txns.treasury_revenue AS treasury_revenue,
         oracle_txns.insurance_revenue AS insurance_revenue,
         oracle_txns.operators_revenue AS operators_revenue

--- a/models/lido/ethereum/accounting/lido_ethereum_accounting_schema.yml
+++ b/models/lido/ethereum/accounting/lido_ethereum_accounting_schema.yml
@@ -6,7 +6,7 @@ models:
       blockchain: ethereum
       sector: liquid_staking
       project: lido
-      contributors: [ pipistrella, adcv, zergil1397,lido ]
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
     config:
       tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
     description: "Amount of DAI spend on referral programm"
@@ -25,7 +25,7 @@ models:
       blockchain: ethereum
       sector: liquid_staking
       project: lido
-      contributors: [ pipistrella, adcv, zergil1397,lido ]
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
     config:
       tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
     description: "ETH deposits to Lido"
@@ -44,7 +44,7 @@ models:
       blockchain: ethereum
       sector: liquid_staking
       project: lido
-      contributors: [ pipistrella, adcv, zergil1397,lido ]
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
     config:
       tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
     description: "Fundraised Lido funds"
@@ -63,7 +63,7 @@ models:
       blockchain: ethereum
       sector: liquid_staking
       project: lido
-      contributors: [ pipistrella, adcv, zergil1397,lido ]
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
     config:
       tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
     description: "LDO spent on refferral payments"
@@ -82,7 +82,7 @@ models:
       blockchain: ethereum
       sector: liquid_staking
       project: lido
-      contributors: [ pipistrella, adcv, zergil1397,lido ]
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
     config:
       tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
     description: "LEGO expenses"
@@ -101,7 +101,7 @@ models:
       blockchain: ethereum
       sector: liquid_staking
       project: lido
-      contributors: [ pipistrella, adcv, zergil1397,lido ]
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
     config:
       tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
     description: "Amount of tokens spent on incentives"
@@ -120,7 +120,7 @@ models:
       blockchain: ethereum
       sector: liquid_staking
       project: lido
-      contributors: [ pipistrella, adcv, zergil1397,lido ]
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
     config:
       tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
     description: "Incentives spend on lox"
@@ -139,7 +139,7 @@ models:
       blockchain: ethereum
       sector: liquid_staking
       project: lido
-      contributors: [ pipistrella, adcv, zergil1397,lido ]
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
     config:
       tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
     description: "Operating expenses"
@@ -158,7 +158,7 @@ models:
       blockchain: ethereum
       sector: liquid_staking
       project: lido
-      contributors: [ pipistrella, adcv, zergil1397,lido ]
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
     config:
       tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
     description: "Other expenses"
@@ -177,7 +177,7 @@ models:
       blockchain: ethereum
       sector: liquid_staking
       project: lido
-      contributors: [ pipistrella, adcv, zergil1397,lido ]
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
     config:
       tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
     description: "Other income"
@@ -196,7 +196,7 @@ models:
       blockchain: ethereum
       sector: liquid_staking
       project: lido
-      contributors: [ pipistrella, adcv, zergil1397,lido ]
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
     config:
       tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
     description: "Raw revenue"
@@ -240,7 +240,7 @@ models:
       blockchain: ethereum
       sector: liquid_staking
       project: lido
-      contributors: [ pipistrella, adcv, zergil1397,lido ]
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
     config:
       tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
     description: "Trp expenses"
@@ -254,3 +254,40 @@ models:
       - name: evt_tx_hash,
         description: "Transaction hash"
 
+  - name: lido_ethereum_accounting_buffer_inflow
+    meta:
+      blockchain: ethereum
+      sector: liquid_staking
+      project: lido
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
+    config:
+      tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
+    description: "Protocol buffer ETH inflow"
+    columns:
+      - name: period
+        description: "Timestamp of the accounting entry"
+      - name: token
+        description: "Token name"
+      - name: amount
+        description: "Token amount"
+      - name: evt_tx_hash,
+        description: "Transaction hash"
+
+  - name: lido_ethereum_accounting_buffer_outflow
+    meta:
+      blockchain: ethereum
+      sector: liquid_staking
+      project: lido
+      contributors: [ gregshestakovlido, ppclunghe, xadcv ]
+    config:
+      tags: [ 'ethereum', 'lido', 'staking', 'accounting' ]
+    description: "Protocol buffer ETH outflow"
+    columns:
+      - name: period
+        description: "Timestamp of the accounting entry"
+      - name: token
+        description: "Token name"
+      - name: amount
+        description: "Token amount"
+      - name: evt_tx_hash,
+        description: "Transaction hash"

--- a/models/lido/ethereum/accounting/lido_ethereum_accounting_sources.yml
+++ b/models/lido/ethereum/accounting/lido_ethereum_accounting_sources.yml
@@ -16,4 +16,7 @@ sources:
       - name: steth_evt_Transfer
       - name: LDO_evt_Transfer
       - name: AccountingOracle_evt_ProcessingStarted
-      
+      - name: steth_evt_Submitted
+      - name: steth_evt_ELRewardsReceived
+      - name: steth_evt_WithdrawalsReceived
+      - name: WithdrawalQueueERC721_evt_WithdrawalsFinalized


### PR DESCRIPTION
Brief comments on the purpose of your changes:

After Lido V2 upgrade we want to make the bunch of changes in accounting model, in this update we add ETH inflow/outflow for protocol buffer

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [x] `coin_id` represents the ID of the coin on coinpaprika.com
* [x] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
