### PR TITLE
[Bug] Fix Trade Surplus for Partial Fills

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trades.sql
@@ -236,5 +236,5 @@ valued_trades as (
 select *,
   -- Relative surplus (in %) is the difference between limit price and executed price as a ratio of the limit price.
   -- Absolute surplus (in USD) is relative surplus multiplied with the value of the trade
-  fill_proportion * usd_value * (atoms_bought * limit_sell_amount - atoms_sold * limit_buy_amount) / (atoms_bought * limit_sell_amount) as surplus_usd
+  usd_value * (atoms_bought * limit_sell_amount - atoms_sold * limit_buy_amount) / (atoms_bought * limit_sell_amount) as surplus_usd
 from valued_trades


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Fixing a bug for surplus calculation.
The fix adjusts the surplus that has been previously computed wrongly.

The current calculation already includes the filled proportion amount and doesn't need to be multiplied again by the proportion fill.

Brief comments on the purpose of your changes:
Example:
This [transaction](https://explorer.cow.fi/orders/0x1bcbe704226db32ab68b39d13b8650a1cb3ec4518d9516b92b8e4d1649b037477f2a72b087939917caa1011de5a18302b3f21d0a646a7739/?tab=fills) has approximately 109 ICSA in surplus, which is ~$54, our previous calculation was giving only a percentage of that value due to the fact that the order has been filled in 2 transactions.

**For Dune Engine V2**

I've checked that:

### General checks:
* [X] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
