### PR TITLE
[oneinch] fusion executors quotes fix

### DIFF
--- a/models/oneinch/oneinch_fusion_executors.sql
+++ b/models/oneinch/oneinch_fusion_executors.sql
@@ -53,11 +53,11 @@ chains as (
 , traces as (
     select 
         tx_hash
-        , "from" as resolver_address
+        , `from` as resolver_address
         , substring(input, 99, 40) as resolver_executor
         , bytea2numeric_v3(substring(input, 11, 64)) as chain_id
     from {{ source('ethereum', 'traces') }}
-    where "to" = '0xcb8308fcb7bc2f84ed1bea2c016991d34de5cc77'
+    where `to` = '0xcb8308fcb7bc2f84ed1bea2c016991d34de5cc77'
         and substring(input, 1, 10) = '0xf204bdb9'
         and block_time >= '2022-12-25'
         and tx_success
@@ -83,6 +83,8 @@ order by resolver_name, resolver_executor
 ---- TRINO QUERY -----
 
 /*
+with
+
 chains as (
     select *
     from (values

--- a/models/oneinch/oneinch_schema.yml
+++ b/models/oneinch/oneinch_schema.yml
@@ -18,9 +18,6 @@ models:
     columns:
       - &blockchain
         name: blockchain
-        tests:
-          - accepted_values:
-              values: ['ethereum','optimism','polygon','arbitrum','avalanche_c','gnosis','bnb','fantom']
       - &project
         name: project
       - &contract_name


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
