### PR TITLE
[CoW] Parse raw_internal_imbalances table

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_internal_imbalances.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_internal_imbalances.sql
@@ -1,0 +1,14 @@
+{{ config(alias='internal_imbalances',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "project",
+                                    "cow_protocol",
+                                    \'["bh2smith"]\') }}'
+)}}
+
+-- PoC Query here - https://dune.com/queries/2497645?d=11
+select
+    block_number,
+    from_hex(token) as token,
+    from_hex(tx_hash) as tx_hash,
+    cast(amount as int256) as amount
+from {{ source('cowswap', 'raw_internal_imbalance') }}

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -329,3 +329,27 @@ models:
       - &amount_usd
         name: amount_usd
 
+  - name: cow_protocol_ethereum_internal_imbalances
+    meta:
+      blockchain: ethereum
+      project: cow_protocol
+      contributors: bh2smith
+    config:
+      tags: ['ethereum','cow_protocol','solver', 'slippage', 'internalized transfers']
+    description: >
+        Solvers Optimize their transaction costs by flagging certain AMM interactions in their settlements
+        as "internalizable". This means that the settlement contract has sufficient balance "skip the pool" 
+        and utilize its own funds to facilitate trade and reduce execution costs. 
+        This results in what we refer to as "phantom transfers", which are transfers that did not happen, 
+        but would have if the settlement were not internalized. This table accounts for phantom transfers 
+        in order to give a more accurate account of "solver slippage". For more details on this project, 
+        please refer to https://github.com/cowprotocol/solver-rewards/tree/main/internal_transfers
+    columns:
+      - *block_number
+      - *tx_hash
+      - &token
+        name: token
+        description: "ERC20 token for which the imbalance occurs in"
+      - &amount
+        name: amount
+        description: "Wei amount of token imbalance (signed integer)"

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_sources.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_sources.yml
@@ -133,6 +133,12 @@ sources:
           - name: tx_hash
           - name: data
           - name: order_uid
+      - name: raw_internal_imbalance
+        columns:
+          - name: tx_hash
+          - name: block_number
+          - name: token
+          - name: amount
   - name: cow_protocol_ethereum
     description: "Ethereum decoded tables related to CoW Protocol contract's"
     tables:


### PR DESCRIPTION
Currently the types of `cowswap.raw_internal_imbalance` are inferred as strings for large integer fields and hex (like transaction hashes and addresses). We write this spell to cast the types to what one would expect so querying can be made cleaner.

Not sure yet if we can write DuneSQL in spells....

cc @olgafetisova 