### PR TITLE
Adds an ERC20 token to Arbitrum token table

### DIFF
--- a/models/tokens/arbitrum/tokens_arbitrum_erc20.sql
+++ b/models/tokens/arbitrum/tokens_arbitrum_erc20.sql
@@ -115,4 +115,5 @@ FROM (VALUES
         ,('0x07e49d5de43dda6162fa28d24d5935c151875283', 'GOVI', 18)
         ,('0x65c936f008bc34fe819bce9fa5afd9dc2d49977f', 'Y2K', 18)
         ,('0xda51015b73ce11f77a115bb1b8a7049e02ddecf0', 'NEU', 18)
+        ,('0x088cd8f5eF3652623c22D48b1605DCfE860Cd704', 'VELA', 18)
      ) AS temp_table (contract_address, symbol, decimals)


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')

### Changes:
Added the missing erc20 token (VELA token) details to arbitrum token table.
