### PR TITLE
remove ANT from bnb feed

### DIFF
--- a/models/prices/bnb/prices_bnb_tokens.sql
+++ b/models/prices/bnb/prices_bnb_tokens.sql
@@ -23,7 +23,6 @@ FROM
     ("adx-adex", "bnb", "ADX", "0x6bff4fb161347ad7de4a625ae5aa3a1ca7077819", 18),
     ("aggl-aggleio", "bnb", "AGGL", "0x1042aa383cab145dc77121ca75650804a5c134ff", 18),
     ("ankr-ankr-network", "bnb", "ANKR", "0xf307910a4c7bbc79691fd374889b36d8531b08e3", 18),
-    -- ("ant-aragon", "bnb", "ANT", "0x43f3918ff115081cfbfb256a5bde1e8d181f2907", 18), -- removed due to issue
     ("atom-cosmos", "bnb", "ATOM", "0x0eb3a705fc54725037cc9e008bdede697f62f335", 18),
     ("auto-auto", "bnb", "AUTO", "0x1cff458b364d0d328d4c9d59d10be7d22d01953d", 18),
     ("axlusdc-axelar-usd-coin", "bnb", "axlUSDC", "0x4268b8f0b87b6eae5d897996e6b845ddbd99adf3", 6),

--- a/models/prices/bnb/prices_bnb_tokens.sql
+++ b/models/prices/bnb/prices_bnb_tokens.sql
@@ -202,5 +202,6 @@ FROM
     ("oath-oath","bnb","OATH","0xd3c6ceedd1cc7bd4304f72b011d53441d631e662",18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)
 where contract_address not in (
-    '0x2ab0e9e4ee70fff1fb9d67031e44f6410170d00e' -- bXEN has bad price feed.
+    '0x2ab0e9e4ee70fff1fb9d67031e44f6410170d00e', -- bXEN has bad price feed.
+    '0x43f3918ff115081cfbfb256a5bde1e8d181f2907' -- ANT (aragon) doesn't exists on BSC, it's a scam-token address.
 )

--- a/models/prices/bnb/prices_bnb_tokens.sql
+++ b/models/prices/bnb/prices_bnb_tokens.sql
@@ -23,7 +23,7 @@ FROM
     ("adx-adex", "bnb", "ADX", "0x6bff4fb161347ad7de4a625ae5aa3a1ca7077819", 18),
     ("aggl-aggleio", "bnb", "AGGL", "0x1042aa383cab145dc77121ca75650804a5c134ff", 18),
     ("ankr-ankr-network", "bnb", "ANKR", "0xf307910a4c7bbc79691fd374889b36d8531b08e3", 18),
-    ("ant-aragon", "bnb", "ANT", "0x43f3918ff115081cfbfb256a5bde1e8d181f2907", 18),
+    -- ("ant-aragon", "bnb", "ANT", "0x43f3918ff115081cfbfb256a5bde1e8d181f2907", 18), -- removed due to issue
     ("atom-cosmos", "bnb", "ATOM", "0x0eb3a705fc54725037cc9e008bdede697f62f335", 18),
     ("auto-auto", "bnb", "AUTO", "0x1cff458b364d0d328d4c9d59d10be7d22d01953d", 18),
     ("axlusdc-axelar-usd-coin", "bnb", "axlUSDC", "0x4268b8f0b87b6eae5d897996e6b845ddbd99adf3", 6),


### PR DESCRIPTION
**ANT** (aragon) `0x43f3918ff115081cfbfb256a5bde1e8d181f2907` doesn't exist on BSC. Seems like a scam-token (and mismatch on coinpaprika side).

Proofs:
- Liquidity is superlow on pools and price divergence from original ANT is huge ([pool $0.000054](https://dexscreener.com/bsc/0x6630e4c50258f762ea5eaa8ece26650b9baf7aaf) vs [cmc $3.5](https://coinmarketcap.com/currencies/aragon/))
- No contract address specified on [CMC](https://coinmarketcap.com/currencies/aragon/) and [CG](https://www.coingecko.com/en/coins/aragon)
- It's another name on [bscscan](https://bscscan.com/token/0x43f3918ff115081cfbfb256a5bde1e8d181f2907) (AntCoin)
