### PR TITLE
wsteth kyber pools arbitrum/optimism

### DIFF
--- a/models/lido/lido_liquidity.sql
+++ b/models/lido/lido_liquidity.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='liquidity',
-        post_hook='{{ expose_spells(\'["ethereum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "arbitrum", "optimism"]\',
                                 "project",
                                 "lido_liquidity",
                                 \'["ppclunghe", "gregshestakovlido", "hosuke"]\') }}'
@@ -8,7 +8,9 @@
 }}
 
 {% set lido_liquidity_models = [
- ref('lido_liquidity_ethereum_kyberswap_pools')
+ ref('lido_liquidity_ethereum_kyberswap_pools'),
+ ref('lido_liquidity_arbitrum_kyberswap_pools'),
+ ref('lido_liquidity_optimism_kyberswap_pools')
 ] %}
 
 

--- a/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_pools.sql
+++ b/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_pools.sql
@@ -1,0 +1,277 @@
+{{ config(
+    schema='lido_liquidity_arbitrum',
+    alias = 'kyberswap_pools',
+    partition_by = ['time'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['pool', 'time'],
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "lido_liquidity",
+                                \'["ppclunghe", "gregshestakovlido"]\') }}'
+    )
+}}
+
+{% set project_start_date = '2022-02-11' %} 
+
+with dates as (
+select explode(sequence(to_date('{{ project_start_date }}'), now(), interval 1 hour)) as hour
+)
+ 
+, pools as (
+select pool as address, 'arbitrum' as blockchain, 'kyberswap' as project, swapFeeUnits/1000 as fee
+from {{ source('kyber_arbitrum', 'Elastic_Factory_evt_PoolCreated') }}
+where token0 = lower('0x5979D7b546E38E414F7E9822514be443A4800529') or token1 = lower('0x5979D7b546E38E414F7E9822514be443A4800529')
+
+)
+
+, tokens_mapping as (
+select * from (values 
+    (LOWER('0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32'), LOWER('0x13ad51ed4f1b7e9dc168d8a00cb3f4ddd85efa60')), --LDO
+    (LOWER('0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'), LOWER('0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f')),   --WBTC
+    (LOWER('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'), LOWER('0xff970a61a04b1ca14834a43f5de4533ebddb5cc8')),   --USDC
+    (LOWER('0xdeFA4e8a7bcBA345F687a2f1456F5Edd9CE97202'), LOWER('0xe4dddfe67e7164b0fe14e218d80dc4c08edc01cb')), -- KNC
+    (LOWER('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'), LOWER('0x82af49447d8a07e3bd95bd0d56f35241523fbab1')),   --WETH
+    (LOWER('0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1'), LOWER('0x912ce59144191c1204e64559fe8253a0e49e6548')),   --ARB
+    (LOWER('0x514910771AF9Ca656af840dff83E8264EcF986CA'), LOWER('0xf97f4df75117a78c1a5a0dbb814af92458539fb4')),  --LINK
+    (LOWER('0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'), LOWER('0x5979d7b546e38e414f7e9822514be443a4800529')) --wstETH
+) as tokens(address_l1, address_l2)
+)
+
+, tokens as (
+select distinct token as address, pt.symbol, pt.decimals, tm.address_l1 
+from (
+select token1 as token
+from {{ source('kyber_arbitrum', 'Elastic_Factory_evt_PoolCreated') }}
+where token0 = lower('0x5979D7b546E38E414F7E9822514be443A4800529') 
+union
+select token0
+from {{ source('kyber_arbitrum', 'Elastic_Factory_evt_PoolCreated') }}
+where token1 = lower('0x5979D7b546E38E414F7E9822514be443A4800529') 
+union 
+select lower('0x5979D7b546E38E414F7E9822514be443A4800529') 
+) t
+left join {{ref('prices_tokens')}} pt on ((t.token !=  lower('0x5979d7b546e38e414f7e9822514be443a4800529') and t.token = pt.contract_address) or
+                               (t.token  =  lower('0x5979d7b546e38e414f7e9822514be443a4800529')  and pt.contract_address =  lower('0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0')))
+left join tokens_mapping tm on t.token = tm.address_l2                                    
+)
+
+
+, tokens_prices_daily AS (
+    SELECT distinct
+        DATE_TRUNC('day', minute) AS time,
+        tokens_mapping.address_l2 as token,
+        avg(price) AS price
+    FROM {{ source('prices', 'usd') }}
+    left join tokens_mapping on prices.usd.contract_address = tokens_mapping.address_l1
+    {% if is_incremental() %}
+    WHERE date_trunc('day', minute) >= date_trunc("day", now() - interval '1 week') and date_trunc('day', minute) < date_trunc('day', now())
+    {% else %}
+    WHERE date_trunc('day', minute) >= '{{ project_start_date }}' and date_trunc('day', minute) < date_trunc('day', now())
+    {% endif %}
+    and blockchain = 'ethereum'
+    and contract_address in (select address_l1 from tokens)
+    group by 1,2
+    union all
+    SELECT distinct
+        DATE_TRUNC('day', minute), 
+        tokens_mapping.address_l2 as token,
+        last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
+    FROM {{ source('prices', 'usd') }}
+    left join tokens_mapping on prices.usd.contract_address = tokens_mapping.address_l1
+    WHERE date_trunc('day', minute) = date_trunc('day', now())
+    and blockchain = 'ethereum'
+    and contract_address in (select address_l1 from tokens)
+)
+
+
+, tokens_prices_hourly AS (
+    select time, lead(time,1, DATE_TRUNC('hour', now() + interval '1 hour')) over (partition by token order by time) as next_time, token, price
+    from (
+    SELECT distinct
+        DATE_TRUNC('hour', minute) time, 
+        contract_address as token,
+        last_value(price) over (partition by DATE_TRUNC('hour', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
+    FROM {{ source('prices', 'usd') }}
+    {% if is_incremental() %}
+    WHERE date_trunc('hour', minute) >= date_trunc("hour", now() - interval '7 days')
+    {% else %}
+    WHERE date_trunc('hour', minute) >= '{{ project_start_date }}' 
+    {% endif %} 
+    and blockchain = 'ethereum'
+    and contract_address in (select address from tokens)   
+) p
+)
+
+, swap_events as (
+    select 
+        date_trunc('day', sw.evt_block_time) as time,
+        sw.contract_address as pool,
+        cr.token0, cr.token1,
+        sum(cast(deltaQty0 as DOUBLE)) as amount0,
+        sum(cast(deltaQty1 as DOUBLE)) as amount1
+        
+    from {{ source('kyber_arbitrum', 'Elastic_Pool_evt_swap') }} sw
+    left join {{ source('kyber_arbitrum', 'Elastic_Factory_evt_PoolCreated') }} cr on sw.contract_address = cr.pool
+    {% if is_incremental() %}
+    WHERE date_trunc('day', sw.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    {% else %}
+    WHERE date_trunc('day', sw.evt_block_time) >= '{{ project_start_date }}'
+    {% endif %} 
+    and sw.contract_address in (select address from pools)
+    group by 1,2,3,4
+) 
+    
+, mint_events as (
+    select 
+        date_trunc('day', mt.evt_block_time) as time,
+        mt.contract_address as pool,
+        cr.token0, cr.token1,
+        sum(cast(qty0 as DOUBLE)) as amount0,
+        sum(cast(qty1 as DOUBLE)) as amount1
+    from {{ source('kyber_arbitrum', 'Elastic_Pool_evt_Mint') }} mt
+    left join {{ source('kyber_arbitrum', 'Elastic_Factory_evt_PoolCreated') }} cr on mt.contract_address = cr.pool
+    {% if is_incremental() %}
+    WHERE date_trunc('day', mt.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    {% else %}
+    WHERE date_trunc('day', mt.evt_block_time) >= '{{ project_start_date }}'
+    {% endif %}
+    and mt.contract_address  in (select address from pools)
+    group by 1,2,3,4
+    union all
+    select d.day as time, cr.pool, cr.token0, cr.token1, 0, 0
+    from (select distinct date_trunc('day', hour) as day from dates) d
+    left join {{ source('kyber_arbitrum', 'Elastic_Factory_evt_PoolCreated') }} cr on 1 = 1
+    where cr.pool in (select address from pools)
+)
+
+
+
+
+, burn_events as (
+    select 
+        date_trunc('day', bn.evt_block_time) as time,
+        bn.contract_address as pool,
+        cr.token0, cr.token1,
+        (-1)*sum(cast(qty0 as DOUBLE)) as amount0,
+        (-1)*sum(cast(qty1 as DOUBLE)) as amount1
+    from {{ source('kyber_arbitrum', 'Elastic_Pool_evt_Burn') }} bn
+    left join {{ source('kyber_arbitrum', 'Elastic_Factory_evt_PoolCreated') }} cr on bn.contract_address = cr.pool
+    {% if is_incremental() %}
+    WHERE date_trunc('day', bn.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    {% else %}
+    WHERE date_trunc('day', bn.evt_block_time) >= '{{ project_start_date }}'
+    {% endif %}
+    and bn.contract_address  in (select address from pools)
+    group by 1,2,3,4
+
+    union all
+
+    select 
+        date_trunc('day', bn.evt_block_time), 
+        bn.contract_address as pool,
+        cr.token0, cr.token1,
+        (-1) * sum(cast(qty0 as double)) as amount0, 
+        (-1) * sum(cast(qty1 as double)) as amount1 
+    from {{ source('kyber_arbitrum', 'Elastic_Pool_evt_BurnRTokens') }} bn
+    left join {{ source('kyber_arbitrum', 'Elastic_Factory_evt_PoolCreated') }} cr on bn.contract_address = cr.pool
+    {% if is_incremental() %}
+    WHERE date_trunc('day', bn.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    {% else %}
+    WHERE date_trunc('day', bn.evt_block_time) >= '{{ project_start_date }}'
+    {% endif %}
+    and bn.contract_address  in (select address from pools)
+    group by 1,2,3,4
+)
+
+
+    
+, daily_delta_balance as (
+    select time, pool, token0, token1, sum(coalesce(amount0, 0)) as amount0, sum(coalesce(amount1, 0)) as amount1
+    from ( 
+    select time, pool, token0, token1, amount0, amount1 
+    from swap_events
+    union all
+    select time, pool, token0, token1, amount0, amount1 
+    from mint_events
+    union all
+    select time, pool, token0, token1, amount0, amount1 
+    from burn_events
+    ) balance
+    group by 1,2,3,4
+)
+  
+, pool_liquidity as (
+    select  time, lead(time, 1, current_date + interval '1 day') over (order by time) as next_time, 
+            pool, token0, token1, sum(amount0) over(partition by pool order by time) as amount0, 
+            sum(amount1)  over(partition by pool order by time) as amount1
+    from daily_delta_balance
+)
+
+
+, swap_events_hourly as (
+    select hour, pool, token0, token1, sum(amount0) as amount0, sum(amount1) as amount1 from (
+    select 
+        d.hour,
+        sw.contract_address as pool,
+        cr.token0, cr.token1,
+        coalesce(sum(cast(abs(deltaQty0) as DOUBLE)),0) as amount0,
+        coalesce(sum(cast(abs(deltaQty1) as DOUBLE)),0) as amount1
+        
+    from dates d
+    left join {{source('kyber_arbitrum','Elastic_Pool_evt_swap')}} sw on d.hour = date_trunc('hour', sw.evt_block_time)
+    left join {{source('kyber_arbitrum','Elastic_Factory_evt_PoolCreated')}} cr on sw.contract_address = cr.pool
+    {% if is_incremental() %}
+    WHERE date_trunc('day', sw.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    {% else %}
+    WHERE date_trunc('day', sw.evt_block_time) >= '{{ project_start_date }}'
+    {% endif %}
+    and sw.contract_address in (select address from pools)
+    group by 1,2,3,4
+    union all
+    select d.hour,
+        cr.pool as pool,
+        cr.token0, cr.token1, 0, 0
+    from dates d
+    left join {{source('kyber_arbitrum','Elastic_Factory_evt_PoolCreated')}} cr on 1 = 1
+    where cr.pool in (select address from pools)  
+      ) a group by 1,2,3,4
+) 
+
+, trading_volume_hourly as (
+    select hour as time, pool, token0, amount0, p.price, coalesce(p.price*amount0/power(10, t.decimals),0) as volume
+    from swap_events_hourly s 
+    left join tokens t on s.token0 = t.address
+    left join tokens_prices_hourly p on  s.hour >= p.time and s.hour < p.next_time  and s.token0 = p.token
+   
+)
+
+, trading_volume as (
+select  distinct date_trunc('day', time) as time, pool, sum(volume) as volume
+from trading_volume_hourly
+group by 1,2
+)
+
+, all_metrics as (
+select l.pool, pools.blockchain, pools.project, pools.fee, l.time, 
+    case when token0 = LOWER('0x5979D7b546E38E414F7E9822514be443A4800529') then token0 else token1 end main_token,
+    case when token0 = LOWER('0x5979D7b546E38E414F7E9822514be443A4800529') then t0.symbol else t1.symbol end main_token_symbol,
+    case when token0 = LOWER('0x5979D7b546E38E414F7E9822514be443A4800529') then token1 else token0 end paired_token,
+    case when token0 = LOWER('0x5979D7b546E38E414F7E9822514be443A4800529') then t1.symbol else t0.symbol end paired_token_symbol, 
+    case when token0 = LOWER('0x5979D7b546E38E414F7E9822514be443A4800529') then amount0/power(10, t0.decimals)  else amount1/power(10, t1.decimals)  end main_token_reserve,
+    case when token0 = LOWER('0x5979D7b546E38E414F7E9822514be443A4800529') then amount1/power(10, t1.decimals)  else amount0/power(10, t0.decimals)  end paired_token_reserve,
+    case when token0 = LOWER('0x5979D7b546E38E414F7E9822514be443A4800529') then p0.price*amount0/power(10, t0.decimals) else p1.price*amount1/power(10, t1.decimals) end as main_token_usd_reserve,
+    case when token0 = LOWER('0x5979D7b546E38E414F7E9822514be443A4800529') then p1.price*amount1/power(10, t1.decimals) else p0.price*amount0/power(10, t0.decimals) end as paired_token_usd_reserve,
+    volume as trading_volume
+from pool_liquidity l 
+left join pools on l.pool = pools.address
+left join tokens t0 on l.token0 = t0.address
+left join tokens t1 on l.token1 = t1.address
+left join tokens_prices_daily p0 on l.time = p0.time and l.token0 = p0.token
+left join tokens_prices_daily p1 on l.time = p1.time and l.token1 = p1.token
+left join trading_volume tv on l.time = tv.time and l.pool = tv.pool
+) 
+
+select CONCAT(CONCAT(CONCAT(CONCAT(CONCAT(blockchain,CONCAT(' ', project)) ,' '), paired_token_symbol),':') , main_token_symbol, ' ', fee) as pool_name,* 
+from all_metrics

--- a/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_schema.yml
+++ b/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_schema.yml
@@ -1,0 +1,64 @@
+version: 2
+
+models:
+  - name: lido_liquidity_arbitrum_kyberswap_pools
+    meta:
+      blockchain: arbitrum
+      project: lido
+      contributors: gregshestakovlido, ppclunghe
+    config:
+      tags: ['arbitrum','lido','liquidity']
+    description: 
+        Lido wstETH liquidity pools on Kyberswap Arbitrum
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - pool
+            - blockchain
+            - time
+    columns:
+      - &pool_name
+        name: pool_name
+        description: "Liquidity pool's name consisting of the its blockchain, DEX project, symbols of tokens and fee value"
+      - &pool
+        name: pool
+        description: "Liquidity pool's address"
+      - &blockchain
+        name: blockchain
+        description: "Blockchain which the DEX is deployed"
+      - &project
+        name: project
+        description: "Project name of the DEX"
+      - &fee
+        name: fee
+        description: "Liquidity pool's trading fee"
+      - &time
+        name: time
+        description: "UTC event block date truncated to the day mark"
+      - &main_token
+        name: main_token
+        description: "Main token's address"
+      - &main_token_symbol
+        name: main_token_symbol
+        description: "Token symbol for main pool's token"
+      - &paired_token
+        name: paired_token
+        description: "Paired token's address"
+      - &paired_token_symbol
+        name: paired_token_symbol
+        description: "Token symbol for paired pool's token"
+      - &main_token_reserve
+        name: main_token_reserve
+        description: "Liquidity reserve of the main token in the pool"
+      - &paired_token_reserve
+        name: paired_token_reserve
+        description: "Liquidity reserve of the paired token in the pool"
+      - &main_token_usd_reserve
+        name: main_token_usd_reserve
+        description: "Liquidity of the main token in the pool in USD"
+      - &paired_token_usd_reserve
+        name: paired_token_usd_reserve
+        description: "Liquidity of the paired token in the pool in USD"
+      - &trading_volume
+        name: trading_volume
+        description: "USD value of the trade"

--- a/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_sources.yml
+++ b/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_sources.yml
@@ -1,0 +1,15 @@
+version: 2
+
+sources:    
+  - name: kyber_arbitrum
+    description: "Arbitrum decoded tables related to Kyberswap contract"
+    freshness: # default freshness
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    tables:
+      - name: Elastic_Pool_evt_Mint
+        loaded_at_field: evt_block_time
+      - name: Elastic_Pool_evt_Burn
+        loaded_at_field: evt_block_time
+      - name: Elastic_Pool_evt_BurnRTokens
+        loaded_at_field: evt_block_time  

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_sources.yml
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_sources.yml
@@ -13,6 +13,7 @@ sources:
         loaded_at_field: evt_block_time
       - name: Elastic_Pool_evt_BurnRTokens
         loaded_at_field: evt_block_time
+      
   - name: prices
     description: "Prices tables across blockchains"
     freshness:

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_kyberswap_pools.sql
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_kyberswap_pools.sql
@@ -1,0 +1,271 @@
+{{ config(
+    schema='lido_liquidity_optimism',
+    alias = 'kyberswap_pools',
+    partition_by = ['time'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['pool', 'time'],
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "lido_liquidity",
+                                \'["ppclunghe", "gregshestakovlido"]\') }}'
+    )
+}}
+
+{% set project_start_date = '2022-10-01' %} 
+
+with dates as (
+select explode(sequence(to_date('{{ project_start_date }}'), now(), interval 1 hour)) as hour
+)
+ 
+, pools as (
+select pool as address, 'optimism' as blockchain, 'kyberswap' as project, swapFeeUnits/1000 as fee
+from {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }}
+where token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') or token1 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
+)
+
+
+, tokens_mapping as (
+select distinct address_l1, address_l2 from (
+select l1_token as address_l1, l2_token as address_l2 from tokens_optimism.erc20_bridged_mapping 
+union all 
+select lower('0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8'),lower('0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed') 
+union all 
+select lower('0x8D6CeBD76f18E1558D4DB88138e2DeFB3909fAD6'),  lower('0xdfa46478f9e5ea86d57387849598dbfb2e964b02')
+))
+
+, tokens_mapping as (
+select distinct address_l1, address_l2 from (
+select l1_token as address_l1, l2_token as address_l2 from tokens_optimism.erc20_bridged_mapping 
+union all 
+select lower('0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8'),lower('0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed') 
+union all 
+select lower('0x8D6CeBD76f18E1558D4DB88138e2DeFB3909fAD6'),  lower('0xdfa46478f9e5ea86d57387849598dbfb2e964b02')
+))
+
+, tokens as (
+select distinct token as address, pt.symbol, pt.decimals, tm.address_l1
+from (
+select token1 as token
+from {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }}
+where token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') 
+union
+select token0
+from {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }}
+where token1 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') 
+union 
+select lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') 
+) t
+left join prices.tokens pt on ((t.token !=  lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') and t.token = pt.contract_address) or
+                               (t.token  =  lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')  and pt.contract_address =  lower('0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0')))
+left join tokens_mapping tm on t.token = tm.address_l2                                    
+)
+
+, tokens_prices_daily AS (
+    SELECT distinct
+        DATE_TRUNC('day', minute) AS time,
+        tokens_mapping.address_l2 as token,
+        avg(price) AS price
+    FROM {{ source('prices', 'usd') }}
+    left join tokens_mapping on prices.usd.contract_address = tokens_mapping.address_l1
+    {% if is_incremental() %}
+    WHERE date_trunc('day', minute) >= date_trunc("day", now() - interval '1 week') and date_trunc('day', minute) < date_trunc('day', now())
+    {% else %}
+    WHERE date_trunc('day', minute) >= '{{ project_start_date }}' and date_trunc('day', minute) < date_trunc('day', now())
+    {% endif %}
+    and blockchain = 'ethereum'
+    and contract_address in (select address_l1 from tokens)
+    group by 1,2
+    union all
+    SELECT distinct
+        DATE_TRUNC('day', minute), 
+        tokens_mapping.address_l2 as token,
+        last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
+    FROM {{ source('prices', 'usd') }}
+    left join tokens_mapping on prices.usd.contract_address = tokens_mapping.address_l1
+    WHERE date_trunc('day', minute) = date_trunc('day', now())
+    and blockchain = 'ethereum'
+    and contract_address in (select address_l1 from tokens)
+)
+
+, tokens_prices_hourly AS (
+    select time, lead(time,1, DATE_TRUNC('hour', now() + interval '1 hour')) over (partition by token order by time) as next_time, token, price
+    from (
+    SELECT distinct
+        DATE_TRUNC('hour', minute) time, 
+        tokens_mapping.address_l2 as token,
+        last_value(price) over (partition by DATE_TRUNC('hour', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
+    FROM {{ source('prices', 'usd') }}
+    left join tokens_mapping on prices.usd.contract_address = tokens_mapping.address_l1
+    {% if is_incremental() %}
+    WHERE date_trunc('hour', minute) >= date_trunc("hour", now() - interval '7 days')
+    {% else %}
+    WHERE date_trunc('hour', minute) >= '{{ project_start_date }}' 
+    {% endif %} 
+    and blockchain = 'ethereum'
+    and contract_address in (select address_l1 from tokens)) p
+)
+
+, swap_events as (
+    select 
+        date_trunc('day', sw.evt_block_time) as time,
+        sw.contract_address as pool,
+        cr.token0, cr.token1,
+        sum(cast(deltaQty0 as DOUBLE)) as amount0,
+        sum(cast(deltaQty1 as DOUBLE)) as amount1
+        
+    from {{ source('kyber_optimism', 'Elastic_Pool_evt_swap') }} sw
+    left join {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }} cr on sw.contract_address = cr.pool
+    {% if is_incremental() %}
+    WHERE date_trunc('day', sw.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    {% else %}
+    WHERE date_trunc('day', sw.evt_block_time) >= '{{ project_start_date }}'
+    {% endif %} 
+    and sw.contract_address in (select address from pools)   
+    group by 1,2,3,4
+) 
+    
+, mint_events as (
+    select 
+        date_trunc('day', mt.evt_block_time) as time,
+        mt.contract_address as pool,
+        cr.token0, cr.token1,
+        sum(cast(qty0 as DOUBLE)) as amount0,
+        sum(cast(qty1 as DOUBLE)) as amount1
+    from {{ source('kyber_optimism', 'Elastic_Pool_evt_Mint') }} mt
+    left join {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }} cr on mt.contract_address = cr.pool
+    {% if is_incremental() %}
+    WHERE date_trunc('day', mt.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    {% else %}
+    WHERE date_trunc('day', mt.evt_block_time) >= '{{ project_start_date }}'
+    {% endif %}
+    and mt.contract_address in (select address from pools)    
+    group by 1,2,3,4
+    union all
+    select d.day as time, cr.pool, cr.token0, cr.token1, 0, 0
+    from (select distinct date_trunc('day', hour) as day from dates) d
+    left join {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }} cr on 1 = 1
+    where cr.pool in (select address from pools)
+)
+    
+, burn_events as (
+    select 
+        date_trunc('day', bn.evt_block_time) as time,
+        bn.contract_address as pool,
+        cr.token0, cr.token1,
+        (-1)*sum(cast(qty0 as DOUBLE)) as amount0,
+        (-1)*sum(cast(qty1 as DOUBLE)) as amount1
+    from {{ source('kyber_optimism', 'Elastic_Pool_evt_Burn') }} bn
+    left join {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }} cr on bn.contract_address = cr.pool
+    {% if is_incremental() %}
+    WHERE date_trunc('day', bn.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    {% else %}
+    WHERE date_trunc('day', bn.evt_block_time) >= '{{ project_start_date }}'
+    {% endif %}
+    and bn.contract_address in (select address from pools)    
+    group by 1,2,3,4
+
+    union all
+
+    select 
+        date_trunc('day', bn.evt_block_time), 
+        bn.contract_address as pool,
+        cr.token0, cr.token1,
+        (-1) * sum(cast(qty0 as double)) as amount0, 
+        (-1) * sum(cast(qty1 as double)) as amount1 
+    from {{ source('kyber_optimism', 'Elastic_Pool_evt_BurnRTokens') }} bn
+    left join {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }} cr on bn.contract_address = cr.pool
+    {% if is_incremental() %}
+    WHERE date_trunc('day', bn.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    {% else %}
+    WHERE date_trunc('day', bn.evt_block_time) >= '{{ project_start_date }}'
+    {% endif %}
+    and bn.contract_address in (select address from pools)    
+    group by 1,2,3,4
+)
+
+    
+, daily_delta_balance as (
+    select time, pool, token0, token1, sum(coalesce(amount0, 0)) as amount0, sum(coalesce(amount1, 0)) as amount1
+    from ( 
+    select time, pool, token0, token1, amount0, amount1 
+    from swap_events
+    union all
+    select time, pool, token0, token1, amount0, amount1 
+    from mint_events
+    union all
+    select time, pool, token0, token1, amount0, amount1 
+    from burn_events
+    ) balance
+    group by 1,2,3,4
+)
+  
+, pool_liquidity as (
+    select  time, lead(time, 1, current_date + interval '1 day') over (order by time) as next_time, 
+            pool, token0, token1, sum(amount0) over(partition by pool order by time) as amount0, sum(amount1)  over(partition by pool order by time) as amount1
+    from daily_delta_balance
+)
+
+
+, swap_events_hourly as (
+    select hour, pool, token0, token1, sum(amount0) as amount0, sum(amount1) as amount1 from (
+    select 
+        d.hour,
+        sw.contract_address as pool,
+        cr.token0, cr.token1,
+        coalesce(sum(cast(abs(deltaQty0) as DOUBLE)),0) as amount0,
+        coalesce(sum(cast(abs(deltaQty1) as DOUBLE)),0) as amount1
+        
+    from dates d
+    left join {{source('kyber_optimism','Elastic_Pool_evt_swap')}} sw on d.hour = date_trunc('hour', sw.evt_block_time)
+    left join {{source('kyber_optimism','Elastic_Factory_evt_PoolCreated')}} cr on sw.contract_address = cr.pool
+    where sw.contract_address in (select address from pools)
+    group by 1,2,3,4
+    union all
+    select d.hour,
+        cr.pool as pool,
+        cr.token0, cr.token1, 0, 0
+    from dates d
+    left join {{source('kyber_optimism','Elastic_Factory_evt_PoolCreated')}} cr on 1 = 1
+    where cr.pool in (select address from pools)  
+      ) a group by 1,2,3,4
+) 
+
+, trading_volume_hourly as (
+    select hour as time, pool, token0, amount0, p.price, coalesce(p.price*amount0/power(10, t.decimals),0) as volume
+    from swap_events_hourly s 
+    left join tokens t on s.token0 = t.address
+    left join tokens_prices_hourly p on  s.hour >= p.time and s.hour < p.next_time  and s.token0 = p.token
+   
+)
+
+, trading_volume as (
+select  distinct date_trunc('day', time) as time, pool, sum(volume) as volume
+from trading_volume_hourly
+group by 1,2
+)
+
+, all_metrics as (
+select l.pool, pools.chain, pools.project, pools.fee, l.time, 
+    case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then token0 else token1 end main_token,
+    case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then t0.symbol else t1.symbol end main_token_symbol,
+    case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then token1 else token0 end paired_token,
+    case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then t1.symbol else t0.symbol end paired_token_symbol, 
+    case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then coalesce(amount0/power(10, t0.decimals),0)  else coalesce(amount1/power(10, t1.decimals),0)  end main_token_reserve,
+    case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then coalesce(amount1/power(10, t1.decimals),0)  else coalesce(amount0/power(10, t0.decimals),0)  end paired_token_reserve,
+    case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then coalesce(p0.price*amount0/power(10, t0.decimals),0) else coalesce(p1.price*amount1/power(10, t1.decimals),0) end as main_token_usd_reserve,
+    case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then coalesce(p1.price*amount1/power(10, t1.decimals),0) else coalesce(p0.price*amount0/power(10, t0.decimals),0) end as paired_token_usd_reserve,
+    coalesce(volume,0) as trading_volume
+from pool_liquidity l 
+left join pools on l.pool = pools.address
+left join tokens t0 on l.token0 = t0.address
+left join tokens t1 on l.token1 = t1.address
+left join tokens_prices_daily p0 on l.time = p0.time and l.token0 = p0.token
+left join tokens_prices_daily p1 on l.time = p1.time and l.token1 = p1.token
+left join trading_volume tv on l.time = tv.time and l.pool = tv.pool
+
+) 
+
+select CONCAT(CONCAT(CONCAT(CONCAT(CONCAT(blockchain,CONCAT(' ', project)) ,' '), paired_token_symbol),':') , main_token_symbol, ' ', fee) as pool_name,* 
+from all_metrics

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_schema.yml
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_schema.yml
@@ -1,0 +1,64 @@
+version: 2
+
+models:
+  - name: lido_liquidity_optimism_kyberswap_pools
+    meta:
+      blockchain: optimism
+      project: lido
+      contributors: gregshestakovlido, ppclunghe
+    config:
+      tags: ['optimism','lido','liquidity']
+    description: 
+        Lido wstETH liquidity pools on Kyberswap Optimism
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - pool
+            - blockchain
+            - time
+    columns:
+      - &pool_name
+        name: pool_name
+        description: "Liquidity pool's name consisting of the its blockchain, DEX project, symbols of tokens and fee value"
+      - &pool
+        name: pool
+        description: "Liquidity pool's address"
+      - &blockchain
+        name: blockchain
+        description: "Blockchain which the DEX is deployed"
+      - &project
+        name: project
+        description: "Project name of the DEX"
+      - &fee
+        name: fee
+        description: "Liquidity pool's trading fee"
+      - &time
+        name: time
+        description: "UTC event block date truncated to the day mark"
+      - &main_token
+        name: main_token
+        description: "Main token's address"
+      - &main_token_symbol
+        name: main_token_symbol
+        description: "Token symbol for main pool's token"
+      - &paired_token
+        name: paired_token
+        description: "Paired token's address"
+      - &paired_token_symbol
+        name: paired_token_symbol
+        description: "Token symbol for paired pool's token"
+      - &main_token_reserve
+        name: main_token_reserve
+        description: "Liquidity reserve of the main token in the pool"
+      - &paired_token_reserve
+        name: paired_token_reserve
+        description: "Liquidity reserve of the paired token in the pool"
+      - &main_token_usd_reserve
+        name: main_token_usd_reserve
+        description: "Liquidity of the main token in the pool in USD"
+      - &paired_token_usd_reserve
+        name: paired_token_usd_reserve
+        description: "Liquidity of the paired token in the pool in USD"
+      - &trading_volume
+        name: trading_volume
+        description: "USD value of the trade"

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_sources.yml
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_sources.yml
@@ -1,0 +1,15 @@
+version: 2
+
+sources:    
+  - name: kyber_optimism
+    description: "Optimism decoded tables related to Kyberswap contract"
+    freshness: # default freshness
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    tables:
+      - name: Elastic_Pool_evt_Mint
+        loaded_at_field: evt_block_time
+      - name: Elastic_Pool_evt_Burn
+        loaded_at_field: evt_block_time
+      - name: Elastic_Pool_evt_BurnRTokens
+        loaded_at_field: evt_block_time  


### PR DESCRIPTION
Brief comments on the purpose of your changes:
Adding Kyber wstETH pools on Arbitrum/Optimism to lido_liquidity model
**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [x] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
