### PR TITLE
remove @ in seed step of ci test

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: "dbt compile"
 
       - name: dbt seed
-        run: "dbt seed --select @state:modified --state ."
+        run: "dbt seed --select state:modified --state ."
 
       - name: dbt run initial model(s)
         run: "dbt -x run --select state:modified --exclude tag:prod_exclude --defer --state ."


### PR DESCRIPTION
@0xRobin it looks like [this pr](https://github.com/duneanalytics/spellbook/commit/3ffc84ac4564d68ca6a909406b4a65caca1dde6b) added `@` to the `state:modified` piece of the seed step. what exactly does that do? i've noticed on other PRs now, all seeds run each time, not just modified. i'm proposing to remove that here.