### PR TITLE
Revert "Enable vacuum on spells (#3392)"

### DIFF
--- a/macros/expose_spells.sql
+++ b/macros/expose_spells.sql
@@ -7,8 +7,7 @@
         'dune.data_explorer.category'='abstraction',
         'dune.data_explorer.abstraction.type'= '{{ spell_type }}', -- 'project' or 'sector'
         'dune.data_explorer.abstraction.name'= '{{ spell_name }}', -- 'aave' or 'uniswap'
-        'dune.data_explorer.contributors'= '{{ contributors }}',   -- e.g., ["soispoke","jeff_dude"]
-        'dune.vacuum' = '{"enabled":true}'
+        'dune.data_explorer.contributors'= '{{ contributors }}'   -- e.g., ["soispoke","jeff_dude"]
         )
 {%- else -%}
 {%- endif -%}

--- a/macros/expose_spells_hide_trino.sql
+++ b/macros/expose_spells_hide_trino.sql
@@ -8,8 +8,7 @@
         'dune.data_explorer.category'='abstraction',
         'dune.data_explorer.abstraction.type'= '{{ spell_type }}', -- 'project' or 'sector'
         'dune.data_explorer.abstraction.name'= '{{ spell_name }}', -- 'aave' or 'uniswap'
-        'dune.data_explorer.contributors'= '{{ contributors }}',   -- e.g., ["soispoke","jeff_dude"]
-        'dune.vacuum' = '{"enabled":true}'
+        'dune.data_explorer.contributors'= '{{ contributors }}'   -- e.g., ["soispoke","jeff_dude"]
         )
 {%- else -%}
 {%- endif -%}


### PR DESCRIPTION
fyi @a-monteiro -- reverting this as it forces a full refresh on all spells that use the macro and the endpoint times out. we will need to upgrade the endpoint prior to merging this back in. we can coordinate tomorrow.