### PR TITLE
Clean up AAVE sub-models from data explorer

### DIFF
--- a/models/aave/ethereum/aave_ethereum_supply.sql
+++ b/models/aave/ethereum/aave_ethereum_supply.sql
@@ -3,7 +3,7 @@
       , post_hook='{{ expose_spells(\'["ethereum"]\',
                                   "project",
                                   "aave",
-                                  \'["batwayne", "chuxin"]\') }}'
+                                  \'["batwayne", "chuxin", "hildobby"]\') }}'
   )
 }}
 

--- a/models/aave/ethereum/aave_v1_ethereum_borrow.sql
+++ b/models/aave/ethereum/aave_v1_ethereum_borrow.sql
@@ -1,10 +1,6 @@
 {{ config(
     schema = 'aave_v1_ethereum'
     , alias='borrow'
-    , post_hook='{{ expose_spells(\'["ethereum"]\',
-                                  "project",
-                                  "aave_v1",
-                                  \'["batwayne", "chuxin"]\') }}'
   )
 }}
 

--- a/models/aave/ethereum/aave_v1_ethereum_flashloans.sql
+++ b/models/aave/ethereum/aave_v1_ethereum_flashloans.sql
@@ -5,10 +5,6 @@
     , file_format = 'delta'
     , incremental_strategy = 'merge'
     , unique_key = ['tx_hash', 'evt_index']
-    , post_hook='{{ expose_spells(\'["ethereum"]\',
-                                  "project",
-                                  "aave_v1",
-                                  \'["hildobby"]\') }}'
   )
 }}
 

--- a/models/aave/ethereum/aave_v1_ethereum_supply.sql
+++ b/models/aave/ethereum/aave_v1_ethereum_supply.sql
@@ -1,10 +1,6 @@
 {{ config(
     schema = 'aave_v1_ethereum'
     , alias='supply'
-    , post_hook='{{ expose_spells(\'["ethereum"]\',
-                                  "project",
-                                  "aave_v1",
-                                  \'["batwayne", "chuxin"]\') }}'
   )
 }}
 

--- a/models/aave/ethereum/aave_v2_ethereum_borrow.sql
+++ b/models/aave/ethereum/aave_v2_ethereum_borrow.sql
@@ -1,10 +1,6 @@
 {{ config(
     schema = 'aave_v2_ethereum'
     , alias='borrow'
-    , post_hook='{{ expose_spells(\'["ethereum"]\',
-                                  "project",
-                                  "aave_v2",
-                                  \'["batwayne", "chuxin"]\') }}'
   )
 }}
 

--- a/models/aave/ethereum/aave_v2_ethereum_flashloans.sql
+++ b/models/aave/ethereum/aave_v2_ethereum_flashloans.sql
@@ -5,10 +5,6 @@
     , file_format = 'delta'
     , incremental_strategy = 'merge'
     , unique_key = ['tx_hash', 'evt_index']
-    , post_hook='{{ expose_spells(\'["ethereum"]\',
-                                  "project",
-                                  "aave_v2",
-                                  \'["hildobby"]\') }}'
   )
 }}
 

--- a/models/aave/ethereum/aave_v2_ethereum_interest_rates.sql
+++ b/models/aave/ethereum/aave_v2_ethereum_interest_rates.sql
@@ -1,10 +1,6 @@
 {{ config(
   schema = 'aave_v2_ethereum'
   , alias='interest'
-  , post_hook='{{ expose_spells(\'["ethereum"]\',
-                                  "project",
-                                  "aave_v2",
-                                  \'["batwayne", "chuxin"]\') }}'
   )
 }}
 

--- a/models/aave/ethereum/aave_v2_ethereum_supply.sql
+++ b/models/aave/ethereum/aave_v2_ethereum_supply.sql
@@ -1,10 +1,6 @@
 {{ config(
     schema = 'aave_v2_ethereum'
     , alias='supply'
-    , post_hook='{{ expose_spells(\'["ethereum"]\',
-                                  "project",
-                                  "aave_v2",
-                                  \'["batwayne", "chuxin"]\') }}'
   )
 }}
 

--- a/models/aave/ethereum/aave_v3_ethereum_flashloans.sql
+++ b/models/aave/ethereum/aave_v3_ethereum_flashloans.sql
@@ -5,10 +5,6 @@
     , file_format = 'delta'
     , incremental_strategy = 'merge'
     , unique_key = ['tx_hash', 'evt_index']
-    , post_hook='{{ expose_spells(\'["ethereum"]\',
-                                  "project",
-                                  "aave_v3",
-                                  \'["hildobby"]\') }}'
   )
 }}
 


### PR DESCRIPTION
Very simple change, to remove aave_v1, v2, etc. from being treated as separate models by the data explorer, exposing only the top level project spell as we do across spellbook.