### PR TITLE
Balancer arbitrum gauges label hotfix

### DIFF
--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_gauges_arbitrum.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_gauges_arbitrum.sql
@@ -4,36 +4,40 @@
                                     "labels",
                                     \'["jacektrocinski"]\') }}')}}
 
-SELECT
-    'arbitrum' AS blockchain,
-    gauge.gauge AS address,
-    'arb:' || pools.name AS name,
-    'balancer_v2_gauges' AS category,
-    'balancerlabs' AS contributor,
-    'query' AS source,
-    TIMESTAMP('2022-01-13') AS created_at,
-    NOW() AS updated_at,
-    'balancer_v2_gauges_arbitrum' AS model_name,
-    'identifier' AS label_type
-FROM
-    {{ source('balancer_ethereum', 'ArbitrumRootGaugeFactory_evt_ArbitrumRootGaugeCreated') }} gauge
-    LEFT JOIN {{ source('balancer_arbitrum', 'ChildChainLiquidityGaugeFactory_evt_RewardsOnlyGaugeCreated') }} streamer ON gauge.recipient = streamer.streamer
-    LEFT JOIN {{ ref('labels_balancer_v2_pools_arbitrum') }} pools ON pools.address = streamer.pool
-UNION ALL
-SELECT
-    'arbitrum' AS blockchain,
-    gauge.gauge AS address,
-    'arb:' || pools.name AS name,
-    'balancer_v2_gauges' AS category,
-    'balancerlabs' AS contributor,
-    'query' AS source,
-    TIMESTAMP('2022-01-13') AS created_at,
-    NOW() AS updated_at,
-    'balancer_v2_gauges_arbitrum' AS model_name,
-    'identifier' AS label_type
-FROM
-    {{ source('balancer_ethereum', 'CappedArbitrumRootGaugeFactory_evt_GaugeCreated') }} gauge
-    INNER JOIN {{ source('balancer_ethereum', 'CappedArbitrumRootGaugeFactory_call_create') }} call ON call.call_tx_hash = gauge.evt_tx_hash
-    LEFT JOIN {{ source('balancer_arbitrum', 'ChildChainLiquidityGaugeFactory_evt_RewardsOnlyGaugeCreated') }} streamer ON streamer.streamer = call.recipient
-    LEFT JOIN {{ ref('labels_balancer_v2_pools_arbitrum') }} pools ON pools.address = streamer.pool;
+WITH data AS (
+        SELECT
+        'arbitrum' AS blockchain,
+        gauge.gauge AS address,
+        'arb:' || pools.name AS name,
+        'balancer_v2_gauges' AS category,
+        'balancerlabs' AS contributor,
+        'query' AS source,
+        TIMESTAMP('2022-01-13') AS created_at,
+        NOW() AS updated_at,
+        'balancer_v2_gauges_arbitrum' AS model_name,
+        'identifier' AS label_type
+    FROM
+        {{ source('balancer_ethereum', 'ArbitrumRootGaugeFactory_evt_ArbitrumRootGaugeCreated') }} gauge
+        LEFT JOIN {{ source('balancer_arbitrum', 'ChildChainLiquidityGaugeFactory_evt_RewardsOnlyGaugeCreated') }} streamer ON gauge.recipient = streamer.streamer
+        LEFT JOIN {{ ref('labels_balancer_v2_pools_arbitrum') }} pools ON pools.address = streamer.pool
+    UNION ALL
+    SELECT
+        'arbitrum' AS blockchain,
+        gauge.gauge AS address,
+        'arb:' || pools.name AS name,
+        'balancer_v2_gauges' AS category,
+        'balancerlabs' AS contributor,
+        'query' AS source,
+        TIMESTAMP('2022-01-13') AS created_at,
+        NOW() AS updated_at,
+        'balancer_v2_gauges_arbitrum' AS model_name,
+        'identifier' AS label_type
+    FROM
+        {{ source('balancer_ethereum', 'CappedArbitrumRootGaugeFactory_evt_GaugeCreated') }} gauge
+        INNER JOIN {{ source('balancer_ethereum', 'CappedArbitrumRootGaugeFactory_call_create') }} call ON call.call_tx_hash = gauge.evt_tx_hash
+        LEFT JOIN {{ source('balancer_arbitrum', 'ChildChainLiquidityGaugeFactory_evt_RewardsOnlyGaugeCreated') }} streamer ON streamer.streamer = call.recipient
+        LEFT JOIN {{ ref('labels_balancer_v2_pools_arbitrum') }} pools ON pools.address = streamer.pool;
+    )
 
+SELECT distinct *
+FROM data

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_gauges_arbitrum.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_gauges_arbitrum.sql
@@ -36,3 +36,4 @@ FROM
     INNER JOIN {{ source('balancer_ethereum', 'CappedArbitrumRootGaugeFactory_call_create') }} call ON call.call_tx_hash = gauge.evt_tx_hash
     LEFT JOIN {{ source('balancer_arbitrum', 'ChildChainLiquidityGaugeFactory_evt_RewardsOnlyGaugeCreated') }} streamer ON streamer.streamer = call.recipient
     LEFT JOIN {{ ref('labels_balancer_v2_pools_arbitrum') }} pools ON pools.address = streamer.pool;
+    

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_gauges_arbitrum.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_gauges_arbitrum.sql
@@ -4,40 +4,35 @@
                                     "labels",
                                     \'["jacektrocinski"]\') }}')}}
 
-WITH data AS (
-        SELECT
-        'arbitrum' AS blockchain,
-        gauge.gauge AS address,
-        'arb:' || pools.name AS name,
-        'balancer_v2_gauges' AS category,
-        'balancerlabs' AS contributor,
-        'query' AS source,
-        TIMESTAMP('2022-01-13') AS created_at,
-        NOW() AS updated_at,
-        'balancer_v2_gauges_arbitrum' AS model_name,
-        'identifier' AS label_type
-    FROM
-        {{ source('balancer_ethereum', 'ArbitrumRootGaugeFactory_evt_ArbitrumRootGaugeCreated') }} gauge
-        LEFT JOIN {{ source('balancer_arbitrum', 'ChildChainLiquidityGaugeFactory_evt_RewardsOnlyGaugeCreated') }} streamer ON gauge.recipient = streamer.streamer
-        LEFT JOIN {{ ref('labels_balancer_v2_pools_arbitrum') }} pools ON pools.address = streamer.pool
-    UNION ALL
-    SELECT
-        'arbitrum' AS blockchain,
-        gauge.gauge AS address,
-        'arb:' || pools.name AS name,
-        'balancer_v2_gauges' AS category,
-        'balancerlabs' AS contributor,
-        'query' AS source,
-        TIMESTAMP('2022-01-13') AS created_at,
-        NOW() AS updated_at,
-        'balancer_v2_gauges_arbitrum' AS model_name,
-        'identifier' AS label_type
-    FROM
-        {{ source('balancer_ethereum', 'CappedArbitrumRootGaugeFactory_evt_GaugeCreated') }} gauge
-        INNER JOIN {{ source('balancer_ethereum', 'CappedArbitrumRootGaugeFactory_call_create') }} call ON call.call_tx_hash = gauge.evt_tx_hash
-        LEFT JOIN {{ source('balancer_arbitrum', 'ChildChainLiquidityGaugeFactory_evt_RewardsOnlyGaugeCreated') }} streamer ON streamer.streamer = call.recipient
-        LEFT JOIN {{ ref('labels_balancer_v2_pools_arbitrum') }} pools ON pools.address = streamer.pool;
-    )
-
-SELECT distinct *
-FROM data
+    SELECT distinct
+    'arbitrum' AS blockchain,
+    gauge.gauge AS address,
+    'arb:' || pools.name AS name,
+    'balancer_v2_gauges' AS category,
+    'balancerlabs' AS contributor,
+    'query' AS source,
+    TIMESTAMP('2022-01-13') AS created_at,
+    NOW() AS updated_at,
+    'balancer_v2_gauges_arbitrum' AS model_name,
+    'identifier' AS label_type
+FROM
+    {{ source('balancer_ethereum', 'ArbitrumRootGaugeFactory_evt_ArbitrumRootGaugeCreated') }} gauge
+    LEFT JOIN {{ source('balancer_arbitrum', 'ChildChainLiquidityGaugeFactory_evt_RewardsOnlyGaugeCreated') }} streamer ON gauge.recipient = streamer.streamer
+    LEFT JOIN {{ ref('labels_balancer_v2_pools_arbitrum') }} pools ON pools.address = streamer.pool
+UNION ALL
+SELECT distinct
+    'arbitrum' AS blockchain,
+    gauge.gauge AS address,
+    'arb:' || pools.name AS name,
+    'balancer_v2_gauges' AS category,
+    'balancerlabs' AS contributor,
+    'query' AS source,
+    TIMESTAMP('2022-01-13') AS created_at,
+    NOW() AS updated_at,
+    'balancer_v2_gauges_arbitrum' AS model_name,
+    'identifier' AS label_type
+FROM
+    {{ source('balancer_ethereum', 'CappedArbitrumRootGaugeFactory_evt_GaugeCreated') }} gauge
+    INNER JOIN {{ source('balancer_ethereum', 'CappedArbitrumRootGaugeFactory_call_create') }} call ON call.call_tx_hash = gauge.evt_tx_hash
+    LEFT JOIN {{ source('balancer_arbitrum', 'ChildChainLiquidityGaugeFactory_evt_RewardsOnlyGaugeCreated') }} streamer ON streamer.streamer = call.recipient
+    LEFT JOIN {{ ref('labels_balancer_v2_pools_arbitrum') }} pools ON pools.address = streamer.pool;


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
