### PR TITLE
exclude failing lido model

### DIFF
--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_kyberswap_pools.sql
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_kyberswap_pools.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema='lido_liquidity_optimism',
     alias = 'kyberswap_pools',
     partition_by = ['time'],
@@ -13,12 +14,12 @@
     )
 }}
 
-{% set project_start_date = '2022-10-01' %} 
+{% set project_start_date = '2022-10-01' %}
 
 with dates as (
 select explode(sequence(to_date('{{ project_start_date }}'), now(), interval 1 hour)) as hour
 )
- 
+
 , pools as (
 select pool as address, 'optimism' as blockchain, 'kyberswap' as project, swapFeeUnits/1000 as fee
 from {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }}
@@ -28,10 +29,10 @@ where token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') or token1 = l
 
 , tokens_mapping as (
 select distinct address_l1, address_l2 from (
-select l1_token as address_l1, l2_token as address_l2 from tokens_optimism.erc20_bridged_mapping 
-union all 
-select lower('0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8'),lower('0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed') 
-union all 
+select l1_token as address_l1, l2_token as address_l2 from tokens_optimism.erc20_bridged_mapping
+union all
+select lower('0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8'),lower('0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed')
+union all
 select lower('0x8D6CeBD76f18E1558D4DB88138e2DeFB3909fAD6'),  lower('0xdfa46478f9e5ea86d57387849598dbfb2e964b02')
 ))
 
@@ -40,17 +41,17 @@ select distinct lower(token) as address, pt.symbol, pt.decimals, tm.address_l1
 from (
 select token1 as token
 from {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }}
-where token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') 
+where token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
 union
 select token0
 from {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }}
-where token1 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') 
-union 
-select lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') 
+where token1 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
+union
+select lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
 ) t
 left join prices.tokens pt on ((t.token !=  lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') and t.token = pt.contract_address) or
                                (t.token  =  lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')  and pt.contract_address =  lower('0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0')))
-left join tokens_mapping tm on t.token = tm.address_l2                                    
+left join tokens_mapping tm on t.token = tm.address_l2
 )
 
 , tokens_prices_daily AS (
@@ -70,7 +71,7 @@ left join tokens_mapping tm on t.token = tm.address_l2
     group by 1,2
     union all
     SELECT distinct
-        DATE_TRUNC('day', minute), 
+        DATE_TRUNC('day', minute),
         tokens_mapping.address_l2 as token,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }}
@@ -84,7 +85,7 @@ left join tokens_mapping tm on t.token = tm.address_l2
     select time, lead(time,1, DATE_TRUNC('hour', now() + interval '1 hour')) over (partition by token order by time) as next_time, token, price
     from (
     SELECT distinct
-        DATE_TRUNC('hour', minute) time, 
+        DATE_TRUNC('hour', minute) time,
         tokens_mapping.address_l2 as token,
         last_value(price) over (partition by DATE_TRUNC('hour', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }}
@@ -92,33 +93,33 @@ left join tokens_mapping tm on t.token = tm.address_l2
     {% if is_incremental() %}
     WHERE date_trunc('hour', minute) >= date_trunc("hour", now() - interval '7 days')
     {% else %}
-    WHERE date_trunc('hour', minute) >= '{{ project_start_date }}' 
-    {% endif %} 
+    WHERE date_trunc('hour', minute) >= '{{ project_start_date }}'
+    {% endif %}
     and blockchain = 'ethereum'
     and contract_address in (select address_l1 from tokens)) p
 )
 
 , swap_events as (
-    select 
+    select
         date_trunc('day', sw.evt_block_time) as time,
         sw.contract_address as pool,
         cr.token0, cr.token1,
         sum(cast(deltaQty0 as DOUBLE)) as amount0,
         sum(cast(deltaQty1 as DOUBLE)) as amount1
-        
+
     from {{ source('kyber_optimism', 'Elastic_Pool_evt_swap') }} sw
     left join {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }} cr on sw.contract_address = cr.pool
     {% if is_incremental() %}
-    WHERE date_trunc('day', sw.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    WHERE date_trunc('day', sw.evt_block_time) >= date_trunc("day", now() - interval '1 week')
     {% else %}
     WHERE date_trunc('day', sw.evt_block_time) >= '{{ project_start_date }}'
-    {% endif %} 
-    and sw.contract_address in (select address from pools)   
+    {% endif %}
+    and sw.contract_address in (select address from pools)
     group by 1,2,3,4
-) 
-    
+)
+
 , mint_events as (
-    select 
+    select
         date_trunc('day', mt.evt_block_time) as time,
         mt.contract_address as pool,
         cr.token0, cr.token1,
@@ -127,11 +128,11 @@ left join tokens_mapping tm on t.token = tm.address_l2
     from {{ source('kyber_optimism', 'Elastic_Pool_evt_Mint') }} mt
     left join {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }} cr on mt.contract_address = cr.pool
     {% if is_incremental() %}
-    WHERE date_trunc('day', mt.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    WHERE date_trunc('day', mt.evt_block_time) >= date_trunc("day", now() - interval '1 week')
     {% else %}
     WHERE date_trunc('day', mt.evt_block_time) >= '{{ project_start_date }}'
     {% endif %}
-    and mt.contract_address in (select address from pools)    
+    and mt.contract_address in (select address from pools)
     group by 1,2,3,4
     union all
     select d.day as time, cr.pool, cr.token0, cr.token1, 0, 0
@@ -139,9 +140,9 @@ left join tokens_mapping tm on t.token = tm.address_l2
     left join {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }} cr on 1 = 1
     where cr.pool in (select address from pools)
 )
-    
+
 , burn_events as (
-    select 
+    select
         date_trunc('day', bn.evt_block_time) as time,
         bn.contract_address as pool,
         cr.token0, cr.token1,
@@ -150,50 +151,50 @@ left join tokens_mapping tm on t.token = tm.address_l2
     from {{ source('kyber_optimism', 'Elastic_Pool_evt_Burn') }} bn
     left join {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }} cr on bn.contract_address = cr.pool
     {% if is_incremental() %}
-    WHERE date_trunc('day', bn.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    WHERE date_trunc('day', bn.evt_block_time) >= date_trunc("day", now() - interval '1 week')
     {% else %}
     WHERE date_trunc('day', bn.evt_block_time) >= '{{ project_start_date }}'
     {% endif %}
-    and bn.contract_address in (select address from pools)    
+    and bn.contract_address in (select address from pools)
     group by 1,2,3,4
 
     union all
 
-    select 
-        date_trunc('day', bn.evt_block_time), 
+    select
+        date_trunc('day', bn.evt_block_time),
         bn.contract_address as pool,
         cr.token0, cr.token1,
-        (-1) * sum(cast(qty0 as double)) as amount0, 
-        (-1) * sum(cast(qty1 as double)) as amount1 
+        (-1) * sum(cast(qty0 as double)) as amount0,
+        (-1) * sum(cast(qty1 as double)) as amount1
     from {{ source('kyber_optimism', 'Elastic_Pool_evt_BurnRTokens') }} bn
     left join {{ source('kyber_optimism', 'Elastic_Factory_evt_PoolCreated') }} cr on bn.contract_address = cr.pool
     {% if is_incremental() %}
-    WHERE date_trunc('day', bn.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+    WHERE date_trunc('day', bn.evt_block_time) >= date_trunc("day", now() - interval '1 week')
     {% else %}
     WHERE date_trunc('day', bn.evt_block_time) >= '{{ project_start_date }}'
     {% endif %}
-    and bn.contract_address in (select address from pools)    
+    and bn.contract_address in (select address from pools)
     group by 1,2,3,4
 )
 
-    
+
 , daily_delta_balance as (
     select time, pool, token0, token1, sum(coalesce(amount0, 0)) as amount0, sum(coalesce(amount1, 0)) as amount1
-    from ( 
-    select time, pool, token0, token1, amount0, amount1 
+    from (
+    select time, pool, token0, token1, amount0, amount1
     from swap_events
     union all
-    select time, pool, token0, token1, amount0, amount1 
+    select time, pool, token0, token1, amount0, amount1
     from mint_events
     union all
-    select time, pool, token0, token1, amount0, amount1 
+    select time, pool, token0, token1, amount0, amount1
     from burn_events
     ) balance
     group by 1,2,3,4
 )
-  
+
 , pool_liquidity as (
-    select  time, lead(time, 1, current_date + interval '1 day') over (order by time) as next_time, 
+    select  time, lead(time, 1, current_date + interval '1 day') over (order by time) as next_time,
             pool, token0, token1, sum(amount0) over(partition by pool order by time) as amount0, sum(amount1)  over(partition by pool order by time) as amount1
     from daily_delta_balance
 )
@@ -201,13 +202,13 @@ left join tokens_mapping tm on t.token = tm.address_l2
 
 , swap_events_hourly as (
     select hour, pool, token0, token1, sum(amount0) as amount0, sum(amount1) as amount1 from (
-    select 
+    select
         d.hour,
         sw.contract_address as pool,
         cr.token0, cr.token1,
         coalesce(sum(cast(abs(deltaQty0) as DOUBLE)),0) as amount0,
         coalesce(sum(cast(abs(deltaQty1) as DOUBLE)),0) as amount1
-        
+
     from dates d
     left join {{source('kyber_optimism','Elastic_Pool_evt_swap')}} sw on d.hour = date_trunc('hour', sw.evt_block_time)
     left join {{source('kyber_optimism','Elastic_Factory_evt_PoolCreated')}} cr on sw.contract_address = cr.pool
@@ -219,16 +220,16 @@ left join tokens_mapping tm on t.token = tm.address_l2
         cr.token0, cr.token1, 0, 0
     from dates d
     left join {{source('kyber_optimism','Elastic_Factory_evt_PoolCreated')}} cr on 1 = 1
-    where cr.pool in (select address from pools)  
+    where cr.pool in (select address from pools)
       ) a group by 1,2,3,4
-) 
+)
 
 , trading_volume_hourly as (
     select hour as time, pool, token0, amount0, p.price, coalesce(p.price*amount0/power(10, t.decimals),0) as volume
-    from swap_events_hourly s 
+    from swap_events_hourly s
     left join tokens t on s.token0 = t.address
     left join tokens_prices_hourly p on  s.hour >= p.time and s.hour < p.next_time  and s.token0 = p.token
-   
+
 )
 
 , trading_volume as (
@@ -238,17 +239,17 @@ group by 1,2
 )
 
 , all_metrics as (
-select l.pool, pools.blockchain, pools.project, pools.fee, l.time, 
+select l.pool, pools.blockchain, pools.project, pools.fee, l.time,
     case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then token0 else token1 end main_token,
     case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then t0.symbol else t1.symbol end main_token_symbol,
     case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then token1 else token0 end paired_token,
-    case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then t1.symbol else t0.symbol end paired_token_symbol, 
+    case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then t1.symbol else t0.symbol end paired_token_symbol,
     case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then coalesce(amount0/power(10, t0.decimals),0)  else coalesce(amount1/power(10, t1.decimals),0)  end main_token_reserve,
     case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then coalesce(amount1/power(10, t1.decimals),0)  else coalesce(amount0/power(10, t0.decimals),0)  end paired_token_reserve,
     case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then coalesce(p0.price*amount0/power(10, t0.decimals),0) else coalesce(p1.price*amount1/power(10, t1.decimals),0) end as main_token_usd_reserve,
     case when token0 = LOWER('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then coalesce(p1.price*amount1/power(10, t1.decimals),0) else coalesce(p0.price*amount0/power(10, t0.decimals),0) end as paired_token_usd_reserve,
     coalesce(volume,0) as trading_volume
-from pool_liquidity l 
+from pool_liquidity l
 left join pools on l.pool = pools.address
 left join tokens t0 on l.token0 = t0.address
 left join tokens t1 on l.token1 = t1.address
@@ -256,7 +257,7 @@ left join tokens_prices_daily p0 on l.time = p0.time and l.token0 = p0.token
 left join tokens_prices_daily p1 on l.time = p1.time and l.token1 = p1.token
 left join trading_volume tv on l.time = tv.time and l.pool = tv.pool
 
-) 
+)
 
-select CONCAT(CONCAT(CONCAT(CONCAT(CONCAT(blockchain,CONCAT(' ', project)) ,' '), paired_token_symbol),':') , main_token_symbol, ' ', fee) as pool_name,* 
+select CONCAT(CONCAT(CONCAT(CONCAT(CONCAT(blockchain,CONCAT(' ', project)) ,' '), paired_token_symbol),':') , main_token_symbol, ' ', fee) as pool_name,*
 from all_metrics


### PR DESCRIPTION
This PR excludes the `lido_liquidity_optimism_kyberswap_pools` model which has been failing on duplicates.

CC: @ppclunghe @gregshestakovlido 
When this is merged the model won't receive any hourly updates anymore, are you able to review the model and adapt so the uniqueness test on `[pool, time]` does not produce any failures?