### PR TITLE
Add new pool to timeswap 

### DIFF
--- a/models/timeswap/polygon/timeswap_polygon_pools.sql
+++ b/models/timeswap/polygon/timeswap_polygon_pools.sql
@@ -107,6 +107,20 @@ FROM
                 'Polygon',
                 '0xb9385AfC6Ddf565C0256116Aa3415EfdFca1E872',
                 '0x880D3fc39683Ecbfd7636cc48D5FCc34508ca7c3'
+            ),
+            (
+                'USDC',
+                'stMATIC',
+                '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+                '0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4',
+                6,
+                18,
+                '261755666862260356510288159562898624196923076923076',
+                '1688126400',
+                'USDC-stMATIC',
+                'Polygon',
+                '0xb9385AfC6Ddf565C0256116Aa3415EfdFca1E872',
+                '0x880D3fc39683Ecbfd7636cc48D5FCc34508ca7c3'
             )
     ) AS temp_table (
         token0_symbol,


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
