### PR TITLE
Fix OP ERC20 Bridged Mapping Duplicate

### DIFF
--- a/models/ovm/optimism/ovm_optimism_l2_token_factory.sql
+++ b/models/ovm/optimism/ovm_optimism_l2_token_factory.sql
@@ -13,7 +13,7 @@
   )
 }}
 
-SELECT distinct
+SELECT 
 contract_address AS factory_address,
 _l1Token AS l1_token,
 _l2Token AS l2_token,

--- a/models/ovm/optimism/ovm_optimism_l2_token_factory.sql
+++ b/models/ovm/optimism/ovm_optimism_l2_token_factory.sql
@@ -13,7 +13,7 @@
   )
 }}
 
-SELECT 
+SELECT distinct
 contract_address AS factory_address,
 _l1Token AS l1_token,
 _l2Token AS l2_token,

--- a/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping.sql
@@ -25,6 +25,7 @@ FROM (
 
         SELECT _l1Token AS l1_token, _l2Token AS l2_token, NULL AS symbol, NULL AS decimals
             FROM {{source( 'optimism_ethereum', 'L1StandardBridge_evt_ERC20DepositInitiated' ) }}
+        WHERE evt_tx_hash != '0x460965f169a99b3d372cd749621a3652ad232d1b1580fd77424eacc2e973b672' --bad event emitted
         {% if is_incremental() %}
         WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}   

--- a/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping.sql
@@ -27,7 +27,7 @@ FROM (
             FROM {{source( 'optimism_ethereum', 'L1StandardBridge_evt_ERC20DepositInitiated' ) }}
         WHERE evt_tx_hash != '0x460965f169a99b3d372cd749621a3652ad232d1b1580fd77424eacc2e973b672' --bad event emitted
         {% if is_incremental() %}
-        WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')
+        AND evt_block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}   
         GROUP BY 1,2
         

--- a/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping.sql
@@ -20,7 +20,7 @@ SELECT l1_token, l2_token
     , COALESCE(map.symbol, et.symbol) AS l1_symbol --select token factory, else eth
     , COALESCE(et.decimals, map.decimals) AS l1_decimals --select eth mapping, else token factory
     , ROW_NUMBER() OVER (PARTITION BY l1_token, l2_token
-        ORDER BY COALESCE(et.decimals, map.decimals) ASC, COALESCE(map.symbol, et.symbol) DESC NULLS LAST) AS rnk
+        ORDER BY COALESCE(et.decimals, map.decimals) ASC, lower( COALESCE(map.symbol, et.symbol) ) DESC NULLS LAST) AS rnk
 FROM (
 
         SELECT _l1Token AS l1_token, _l2Token AS l2_token, NULL AS symbol, NULL AS decimals

--- a/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping.sql
@@ -20,7 +20,7 @@ SELECT l1_token, l2_token
     , COALESCE(map.symbol, et.symbol) AS l1_symbol --select token factory, else eth
     , COALESCE(et.decimals, map.decimals) AS l1_decimals --select eth mapping, else token factory
     , ROW_NUMBER() OVER (PARTITION BY l1_token, l2_token
-        ORDER BY COALESCE(et.decimals, map.decimals) ASC, lower( COALESCE(map.symbol, et.symbol) ) DESC NULLS LAST) AS rnk
+        ORDER BY COALESCE(et.decimals, map.decimals) ASC, COALESCE(map.symbol, et.symbol) DESC NULLS LAST) AS rnk
 FROM (
 
         SELECT _l1Token AS l1_token, _l2Token AS l2_token, NULL AS symbol, NULL AS decimals

--- a/models/tokens/optimism/tokens_optimism_erc20_generated.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20_generated.sql
@@ -58,7 +58,7 @@ SELECT LOWER(contract_address) AS contract_address
     FROM (
       SELECT contract_address, symbol, decimals, token_type, token_mapping_source,
       -- ensure we don't have dupes with different symbols
-        ROW_NUMBER() OVER (PARTITION BY contract_address ORDER BY symbol ASC NULLS LAST) AS token_rank
+        ROW_NUMBER() OVER (PARTITION BY contract_address ORDER BY decimals ASC NULLS LAST, symbol ASC NULLS LAST) AS token_rank
         FROM generated_tokens_list  
     ) a
   WHERE token_rank = 1

--- a/models/tokens/optimism/tokens_optimism_erc20_generated.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20_generated.sql
@@ -16,6 +16,7 @@ FROM (
     , 'underlying' as token_type, 'l2 bridge mapping' AS token_mapping_source
     FROM {{ ref('tokens_optimism_erc20_bridged_mapping') }}
     WHERE l1_symbol IS NOT NULL
+    GROUP BY 1,2,3
 
     UNION ALL
 
@@ -24,6 +25,7 @@ FROM (
     , 'receipt' as token_type, 'aave factory' AS token_mapping_source
     FROM {{ ref('aave_v3_tokens') }}
       WHERE blockchain = 'optimism'
+    GROUP BY 1,2,3
     
     UNION ALL
 
@@ -32,6 +34,7 @@ FROM (
     , 'receipt' as token_type, 'the granary factory' AS token_mapping_source
     FROM {{ ref('the_granary_optimism_tokens') }}
       WHERE blockchain = 'optimism'
+    GROUP BY 1,2,3
     
     UNION ALL
 
@@ -40,6 +43,7 @@ FROM (
     , 'receipt' as token_type, 'yearn vault factory' AS token_mapping_source
     FROM {{ ref('yearn_optimism_vaults') }}
       WHERE blockchain = 'optimism'
+    GROUP BY 1,2,3
     
   ) a
   GROUP BY contract_address, symbol, token_type, token_mapping_source --get uniques & handle if L2 token factory gets decimals wrong
@@ -52,6 +56,9 @@ SELECT LOWER(contract_address) AS contract_address
       , token_mapping_source
 
     FROM (
-      SELECT contract_address, symbol, decimals, token_type, token_mapping_source
+      SELECT contract_address, symbol, decimals, token_type, token_mapping_source,
+      -- ensure we don't have dupes with different symbols
+        ROW_NUMBER() OVER (PARTITION BY contract_address ORDER BY symbol ASC NULLS LAST) AS token_rank
         FROM generated_tokens_list  
     ) a
+  WHERE token_rank = 1


### PR DESCRIPTION
Brief comments on the purpose of your changes:

ref: https://github.com/duneanalytics/spellbook/pull/3465 & https://github.com/duneanalytics/spellbook/pull/3460

The issue was that the generated ERC20s weren't checking on unique L2 token addresses for the bridge mappings. In cases where multiple L1 tokens are joined to the same L2 token, and each has a different symbol (i.e. rETH vs RETH), we were getting suplicated.

We now have a check that makes sure we only get 1 of each L2 token contract address (row number over symbol).

cc @jeff-dude 

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
