### PR TITLE
[hotfix] OP - Self-Destruct uniqueness

### DIFF
--- a/models/contracts/optimism/contracts_optimism_self_destruct_contracts.sql
+++ b/models/contracts/optimism/contracts_optimism_self_destruct_contracts.sql
@@ -28,20 +28,26 @@ with creates as (
       {% endif %}
 )
 
-select
-  cr.created_time 
-  ,cr.creation_tx_hash 
-  ,cr.contract_address 
-  ,cr.trace_element
-from creates as cr
-join {{ source('optimism', 'traces') }} as sd
-  on cr.creation_tx_hash = sd.tx_hash
-  and cr.created_time = sd.block_time
-  and cr.trace_element = sd.trace_address[0]
-  and sd.`type` = 'suicide'
-  {% if is_incremental() %}
-  and sd.block_time >= date_trunc('day', now() - interval '1 week')
-  and cr.contract_address NOT IN (SELECT contract_address FROM {{this}} ) --ensure no duplicates
-  {% endif %}
-group by 1, 2, 3, 4
+SELECT
+created_time, creation_tx_hash, contract_address, trace_element
+FROM (
+  select
+    cr.created_time 
+    ,cr.creation_tx_hash 
+    ,cr.contract_address 
+    ,cr.trace_element
+    , ROW_NUMBER() OVER (PARTITION BY cr.contract_address ORDER BY created_time ASC) as rn
+  from creates as cr
+  join {{ source('optimism', 'traces') }} as sd
+    on cr.creation_tx_hash = sd.tx_hash
+    and cr.created_time = sd.block_time
+    and cr.trace_element = sd.trace_address[0]
+    and sd.`type` = 'suicide'
+    {% if is_incremental() %}
+    and sd.block_time >= date_trunc('day', now() - interval '1 week')
+    and cr.contract_address NOT IN (SELECT contract_address FROM {{this}} ) --ensure no duplicates
+    {% endif %}
+  group by 1, 2, 3, 4
+) a 
+WHERE rn = 1
 ;

--- a/models/contracts/optimism/contracts_optimism_self_destruct_contracts.sql
+++ b/models/contracts/optimism/contracts_optimism_self_destruct_contracts.sql
@@ -27,6 +27,7 @@ with creates as (
       and block_time >= date_trunc('day', now() - interval '1 week')
       {% endif %}
 )
+
 select
   cr.created_time 
   ,cr.creation_tx_hash 
@@ -40,6 +41,7 @@ join {{ source('optimism', 'traces') }} as sd
   and sd.`type` = 'suicide'
   {% if is_incremental() %}
   and sd.block_time >= date_trunc('day', now() - interval '1 week')
+  and cr.contract_address NOT IN (SELECT contract_address FROM {{this}} ) --ensure no duplicates
   {% endif %}
 group by 1, 2, 3, 4
 ;


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Changes to prevent duplicates - re: https://github.com/duneanalytics/spellbook/pull/3504
- Checks if the contract already exists in the selfdestruct table
- Ensures that each contract is only included once in the incremental pulls

cc @jeff-dude 

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
