### PR TITLE
Add Fee Segments to gas_optimism_fees

### DIFF
--- a/models/gas/optimism/gas_optimism_schema.yml
+++ b/models/gas/optimism/gas_optimism_schema.yml
@@ -103,3 +103,21 @@ models:
       - &type
         name: type
         description: "Transaction type: Legacy (Pre EIP 1559) or DynamicFee (Post EIP-1559)"
+      - &l1_data_fee_native
+        name: l1_data_fee_native
+        description: "Gas Used for L1 Data Gas (data availability fee) in ETH"
+      - &l1_data_fee_usd
+        name: l1_data_fee_usd
+        description: "Gas Used for L1 Data Gas (data availability fee) in USD"
+      - &l2_base_fee_native
+        name: l2_base_fee_native
+        description: "Gas Used for L2 Execution Gas from the base fee gas price in ETH"
+      - &l2_base_fee_usd
+        name: l2_base_fee_usd
+        description: "Gas Used for L2 Execution Gas from the base fee gas price in USD"
+      - &l2_priority_fee_native
+        name: l2_priority_fee_native
+        description: "Gas Used for L2 Execution Gas from the priority fee paid in ETH"
+      - &l2_priority_fee_usd
+        name: l2_priority_fee_usd
+        description: "Gas Used for L2 Execution Gas from the priority fee paid in USD"

--- a/models/gas/optimism/gas_optimism_schema.yml
+++ b/models/gas/optimism/gas_optimism_schema.yml
@@ -5,7 +5,7 @@ models:
     meta:
       blockchain: optimism
       sector: gas
-      contributors: soispoke
+      contributors: soispoke, msilb7
     config:
       tags: ['optimism', 'gas', 'fees']
     description: >


### PR DESCRIPTION
Brief comments on the purpose of your changes:

Add gas fee segmentation to `gas_optimism_fees`:

- l1_data_fee: Gas paid for submitting data to L2
- l2_base_fee: Gas paid for L2 execution gas (per the base fee per gas)
- l2_priority_fee: Gas paid for priority L2 execution gas

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
