### PR TITLE
exclude eth nft wash trades

### DIFF
--- a/models/nft/ethereum/nft_ethereum_wash_trades.sql
+++ b/models/nft/ethereum/nft_ethereum_wash_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+        tags=['prod_exclude'],
         alias ='wash_trades',
         partition_by='block_date',
         materialized='incremental',


### PR DESCRIPTION
cc @hildobby @0xRobin
 
not 100% sure what upstream dependency is causing duplicates, but merge is failing i need to exclude for now to get prod running

best guess is seaport/opensea bugs recently, but i did do a full refresh on `nft_events` and all downstream (i.e. `dbt run --select nft_events+ --full-refresh`), and then dupes still appeared