### PR TITLE
OP Aggregated Traces

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1208,3 +1208,7 @@ models:
 
     time_utils:
       +schema: time_utils
+    
+    traces:
+      optimism:
+        +schema: traces_optimism

--- a/models/traces/optimism/traces_optimism_aggregated_traces.sql
+++ b/models/traces/optimism/traces_optimism_aggregated_traces.sql
@@ -1,0 +1,92 @@
+{{ config(
+	alias = 'aggregated_traces',
+	partition_by = ['block_date'],
+	materialized = 'incremental',
+	file_format = 'delta',
+	incremental_strategy = 'merge',
+	unique_key = ['block_time', 'block_number', 'tx_hash', 'tx_from', 'tx_to', 'tx_method_id', 'tx_value'
+			,'tx_l2_gas_used', 'trace_from', 'trace_to','trace_method_id', 'call_type']
+	)
+}}
+
+SELECT
+DATE_TRUNC('day', block_time) AS block_date
+, block_time, block_number, tx_hash
+, tx_from, tx_to, tx_method_id, tx_value, tx_l2_gas_used
+, trace_from, trace_to, trace_method_id, call_type
+, tx_l1_gas_used, tx_l1_gas_price, tx_l1_fee
+, tx_l2_gas_price, tx_l2_base_fee_price, tx_l2_priority_fee_price, tx_gas_fee_eth
+
+, SUM(trace_value) AS trace_value
+, SUM(top_level_trace_gas_used) AS top_level_trace_gas_used
+, SUM(trace_gas_used) AS trace_gas_used
+, cast(SUM(trace_gas_used) as double) / cast(tx_l2_gas_used AS double) AS pct_tx_trace_gas_used
+, COUNT(*) AS num_traces
+
+FROM (
+
+	SELECT
+
+        , t.block_time
+        , t.block_number
+        , t.hash AS tx_hash
+    
+	, t."from" AS tx_from
+	, t.to AS tx_to
+	, substring(t.data,1,10) AS tx_method_id --dunesql: bytearray_substring(t.data,1,4)
+	, t.value AS tx_value
+	, t.gas_used AS tx_l2_gas_used
+
+	, r."from" AS trace_from
+	, r.to AS trace_to
+	, substring(r.input,1,10) AS trace_method_id --dunesql: bytearray_substring(r.input,1,4)
+	, r.value AS trace_value
+	, r.type AS call_type
+	, r.gas_used AS top_level_trace_gas_used
+	, r.gas_used - sub_tr.gas_used AS trace_gas_used
+
+	, t.l1_gas_used AS tx_l1_gas_used
+	, t.l1_gas_price AS tx_l1_gas_price
+	, t.l1_fee AS tx_l1_fee
+	, t.gas_price AS tx_l2_gas_price
+	, COALESCE( cast(b.base_fee_per_gas as double), cast(t.gas_price as double) ) AS tx_l2_base_fee_price --use gas price pre-Bedrock
+	, CASE WHEN b.base_fee_per_gas IS NULL THEN 0 ELSE
+		cast(t.gas_price as double) - cast(b.base_fee_per_gas as double)
+		END AS tx_l2_priority_fee_price
+	, case when t.gas_price = cast(0 as uint256) THEN 0 ELSE
+		cast(t.l1_fee + (t.gas_used * cast(t.gas_price as double)) as double)
+		END AS tx_gas_fee_eth
+    
+	FROM {{ source('optimism', 'traces') }} r
+    
+        INNER JOIN {{ source('optimism', 'transactions') }} t
+        	ON t.hash = r.tx_hash
+		AND t.block_time = r.block_time
+		AND t.block_number = r.block_number
+		{% if is_incremental() %}
+        	AND r.block_time >= date_trunc('day', now() - interval '1 week')
+        	{% endif %}
+
+        INNER JOIN {{ source('optimism', 'blocks') }} b
+		ON  t.block_time = b.time
+		AND t.block_number = b.number
+		{% if is_incremental() %}
+        	AND b.time >= date_trunc('day', now() - interval '1 week')
+        	{% endif %}
+            
+        LEFT JOIN {{ source('optimism', 'traces') }} sub_tr
+		ON r.tx_hash = sub_tr.tx_hash
+		AND r.block_number = sub_tr.block_number
+		AND r.block_time = sub_tr.block_time
+		AND r.trace_address = (CASE WHEN cardinality(sub_tr.trace_address) =0 THEN array[-1] ELSE slice(sub_tr.trace_address, 1, cardinality(sub_tr.trace_address) - 1) END)
+		{% if is_incremental() %}
+        	AND sub_tr.block_time >= date_trunc('day', now() - interval '1 week')
+        	{% endif %}
+        
+	{% if is_incremental() %}
+	WHERE t.block_time >= date_trunc('day', now() - interval '1 week')
+	{% endif %}
+
+) a
+
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19

--- a/models/traces/optimism/traces_optimism_aggregated_traces.sql
+++ b/models/traces/optimism/traces_optimism_aggregated_traces.sql
@@ -43,7 +43,7 @@ FROM (
 	, r.value AS trace_value
 	, r.type AS call_type
 	, r.gas_used AS top_level_trace_gas_used
-	, r.gas_used - sub_tr.gas_used AS trace_gas_used
+	, COALESCE( r.gas_used - sub_tr.gas_used , r.gas_used)	AS trace_gas_used --if no sub traces, then it's the lowest level trace
 
 	, t.l1_gas_used AS tx_l1_gas_used
 	, t.l1_gas_price AS tx_l1_gas_price

--- a/models/traces/optimism/traces_optimism_aggregated_traces_schema.yml
+++ b/models/traces/optimism/traces_optimism_aggregated_traces_schema.yml
@@ -1,0 +1,103 @@
+version: 2
+
+models:
+  - name: traces_optimism_aggregated_traces
+    meta:
+      blockchain: optimism
+      project: traces
+      contributors: msilb7
+    config:
+      tags: ['optimism','traces','gas','aggregate']
+    description: >
+        A table containing trace data on Optimism, grouped by trace and transaction metadata, and with accurate gas per trace tracking. This table used for attirbuting gas usage by transaction and use case within a transaction, as well as providing a ~50% smaller trace table for runtime.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - block_time
+              - block_number
+              - tx_hash
+              - tx_from
+              - tx_to
+              - tx_method_id
+              - tx_value
+              - tx_gas_used
+              - trace_from
+              - trace_to
+              - trace_method_id
+              - call_type
+    columns:
+      - &block_date
+        name: block_date
+        description: "Date of the block that the transaction was included in"
+      - &block_time
+        name: block_time
+        description: "Time of the block that the transaction was included in"
+      - &block_number
+        name: block_number
+        description: "Block Number that the transaction was included in"
+      - &tx_hash
+        name: tx_hash
+        description: "Transaction hash"
+      - &tx_from
+        name: tx_from
+        description: "Transaction sender address"
+      - &tx_to
+        name: tx_to
+        description:  "Transaction to address. When this is a contract, it's the contract that the user directly interacts with."
+      - &tx_method_id
+        name: tx_method_id
+        description: "First 4 bytes of transaction data. THe function called by the transaction."
+      - &tx_value
+        name: tx_value
+        description: "ETH Transferred in the transaction"
+      - &tx_l2_gas_used
+        name: tx_l2_gas_used
+        description: "Gas used by the transaction"
+      - &trace_from
+        name: trace_from
+        description: "Trace sender - what is calling the contract in trace_to"
+      - &trace_to
+        name: trace_to
+        description: "Trace to address - what contract is being called"
+      - &trace_method_id
+        name: trace_method_id
+        description: "First 4 bytes of trace input. THe function called in the trace."
+      - &call_type
+        name: call_type
+        description: "Call type"
+      - &tx_l1_gas_used
+        name: l1_gas_used
+        description: "L1 Gas Used + Overhead by the transaction"
+      - &tx_l1_gas_price
+        name: l1_gas_price
+        description: "L1 Gas Price at the time of the transaction"
+      - &tx_l1_fee
+        name: tx_l1_fee
+        description: "L1 Data Fee charged in the transaction (wei)"
+      - &tx_l2_gas_price
+        name: tx_l2_gas_price
+        description: "L2 Gas Price at the time of the transaction (wei)"
+      - &tx_l2_base_fee_price
+        name: tx_l2_base_fee_price
+        description: "Base Fee for L2 gas at the time of the transaction (wei)"
+      - &tx_l2_priority_fee_price
+        name: tx_l2_priority_fee_price
+        description: "Priority Fee paid by the user for L2 gas (wei)"
+      - &tx_gas_fee_eth
+        name: tx_gas_fee_eth
+        description: "Transaction total gas fee in ETH"
+      - &trace_value
+        name: trace_value
+        description: "ETH Transferred in the trace"
+      - &top_level_trace_gas_used
+        name: top_level_trace_gas_used
+        description: "How much gas the trace used, including all sub-traces (Note: This is NOT a true segment of toal gas)"
+      - &trace_gas_used
+        name: trace_gas_used
+        description: "How much gas the trace used, excluding all sub-traces. This is a better measure of how much gas each contract used."
+      - &pct_tx_trace_gas_used
+        name: pct_tx_trace_gas_used
+        description: "Pct of the total transaction's gas was used by the trace_gas_used"
+      - &num_traces
+        name: num_traces
+        description: "How many traces are summed together in this row"


### PR DESCRIPTION
Brief comments on the purpose of your changes:

This creates an aggregates traces table for Optimism, which:
1. Incorporates better gas usage per trace attribution (see: https://github.com/duneanalytics/spellbook/pull/3457)
2. Groups traces by trace and transaction-level data, which cuts down the size of the table to [40% of the original](https://dune.com/queries/2629847).

This can be used for simpler trace <> contract gas usage attribution and help with query execution time. Once @hildobby 's gas traces PRs are merged, we can read from there versus re-creating the gas mapping here.

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
