### PR TITLE
lido liquidity velodrome

### DIFF
--- a/models/lido/lido_liquidity.sql
+++ b/models/lido/lido_liquidity.sql
@@ -18,7 +18,8 @@
  ref('lido_liquidity_arbitrum_balancer_pools'),
  ref('lido_liquidity_optimism_balancer_pools'),
  ref('lido_liquidity_arbitrum_curve_pools'),
- ref('lido_liquidity_optimism_curve_pools')
+ ref('lido_liquidity_optimism_curve_pools'),
+ ref('lido_liquidity_optimism_velodrome_pools')
 ] %}
 
 

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_schema.yml
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_schema.yml
@@ -158,3 +158,35 @@ models:
       - *main_token_usd_reserve
       - *paired_token_usd_reserve
       - *trading_volume            
+
+  - name: lido_liquidity_optimism_velodrome_pools
+    meta:
+      blockchain: optimism
+      project: lido
+      contributors: ppclunghe
+    config:
+      tags: ['optimism','lido','liquidity']
+    description: 
+        Lido wstETH liquidity pools on Velodrome Optimism
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - pool
+            - blockchain
+            - time
+    columns:
+      - *pool_name
+      - *pool
+      - *blockchain
+      - *project
+      - *fee
+      - *time
+      - *main_token
+      - *main_token_symbol
+      - *paired_token
+      - *paired_token_symbol
+      - *main_token_reserve
+      - *paired_token_reserve
+      - *main_token_usd_reserve
+      - *paired_token_usd_reserve
+      - *trading_volume       

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_sources.yml
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_sources.yml
@@ -52,3 +52,17 @@ sources:
     tables:
       - name: wstETH_evt_Transfer
         loaded_at_field: evt_block_time                
+
+  - name: velodrome_optimism
+    description: "Optimism decoded tables related to Velodrome pools contracts"
+    freshness: # default freshness
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    tables:
+      - name: Pair_evt_Mint
+        loaded_at_field: evt_block_time
+      - name: Pair_evt_Burn
+        loaded_at_field: evt_block_time          
+      - name: Pair_evt_Fees
+        loaded_at_field: evt_block_time          
+       

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_velodrome_pools.sql
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_velodrome_pools.sql
@@ -1,0 +1,302 @@
+{{ config(
+    schema='lido_liquidity_optimism',
+    alias = 'velodrome_pools',
+    partition_by = ['time'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['pool', 'time'],
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "lido_liquidity",
+                                \'["ppclunghe"]\') }}'
+    )
+}}
+
+{% set project_start_date = '2022-09-14' %}
+
+
+
+with dates AS (
+        SELECT explode(sequence(to_date('{{ project_start_date }}'), CURRENT_DATE, interval 1 day)) AS day
+    )
+
+
+, pools as (
+select pair AS address,
+      'optimism' AS blockchain,
+      'velodrome' AS project,
+      case when stable then 'stable' else 'volatile' end AS pool_type,
+      0.02 as fee
+from {{source('velodrome_optimism','PairFactory_evt_PairCreated')}}
+where token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
+      OR token1 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
+)      
+
+, tokens as (
+ select distinct token, pt.symbol, pt.decimals
+ from (
+ select token0 as token
+ from {{source('velodrome_optimism','PairFactory_evt_PairCreated')}}
+ where token1 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
+ union all
+ select token1
+ from {{source('velodrome_optimism','PairFactory_evt_PairCreated')}}
+ where token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
+ union all
+ select lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
+ ) t
+ left join {{source('prices','tokens')}} AS pt ON t.token = pt.contract_address
+ )
+ 
+ 
+ , tokens_prices_daily as (     
+select distinct 
+      DATE_TRUNC('day', minute) AS time,
+      contract_address AS token,
+      AVG(price) AS price
+FROM {{source('prices','usd')}}
+    {% if is_incremental() %}
+    WHERE date_trunc('day', minute) >= date_trunc("day", now() - interval '1 week') and date_trunc('day', minute) < date_trunc('day', now())
+    {% else %}
+    WHERE date_trunc('day', minute) >= '{{ project_start_date }}' and date_trunc('day', minute) < date_trunc('day', now())
+    {% endif %}
+      and blockchain = 'optimism'
+  and contract_address IN (select token from tokens)
+group by 1,2
+union all
+select distinct
+      DATE_TRUNC('day', minute),
+      contract_address AS token,
+      LAST_VALUE(price) OVER (PARTITION BY DATE_TRUNC('day', minute),contract_address  ORDER BY minute NULLS FIRST range BETWEEN UNBOUNDED preceding AND UNBOUNDED following) AS price
+    FROM
+      {{source('prices','usd')}}
+    WHERE
+      DATE_TRUNC('day', minute) = DATE_TRUNC('day', NOW())
+      and blockchain = 'optimism'
+  and contract_address IN (select token from tokens) 
+ )
+ 
+ , wsteth_prices_hourly AS (
+    SELECT distinct
+        DATE_TRUNC('hour', minute) time, 
+        contract_address as token,
+        last_value(price) over (partition by DATE_TRUNC('hour', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
+    FROM {{ source('prices', 'usd') }}
+    {% if is_incremental() %}
+    WHERE date_trunc('hour', minute) >= date_trunc("hour", now() - interval '7 days')
+    {% else %}
+    WHERE date_trunc('hour', minute) >= '{{ project_start_date }}' 
+    {% endif %} 
+      and blockchain = 'optimism' and contract_address = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
+    
+)
+
+, wsteth_prices_hourly_with_lead AS (
+select time, lead(time, 1, date_trunc('hour', now() + interval '1'  hour)) over (order by time) as next_time, price
+from wsteth_prices_hourly
+)
+
+
+, mint_events AS (
+ select DATE_TRUNC('day', m.evt_block_time) AS time,
+      m.contract_address AS pool,
+      cr.token0,
+      cr.token1,
+      SUM(TRY_CAST(amount0 AS DOUBLE)) AS amount0,
+      SUM(TRY_CAST(amount1 AS DOUBLE)) AS amount1
+ from {{source('velodrome_optimism','Pair_evt_Mint')}} m
+ left join {{source('velodrome_optimism','PairFactory_evt_PairCreated')}} cr on m.contract_address = cr.pair 
+ {% if is_incremental() %}
+ WHERE date_trunc('day', m.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+ {% else %}
+ WHERE date_trunc('day', m.evt_block_time) >= '{{ project_start_date }}'
+ {% endif %} 
+ and m.contract_address in (select address from pools)
+ group by 1,2,3,4
+ )
+ 
+ , burn_events as (
+ select DATE_TRUNC('day', b.evt_block_time) AS time,
+      b.contract_address AS pool,
+      cr.token0,
+      cr.token1,
+      (-1)*SUM(TRY_CAST(amount0 AS DOUBLE)) AS amount0,
+      (-1)*SUM(TRY_CAST(amount1 AS DOUBLE)) AS amount1
+ from {{source('velodrome_optimism','Pair_evt_Burn')}} b
+ left join {{source('velodrome_optimism','PairFactory_evt_PairCreated')}} cr on b.contract_address = cr.pair 
+ {% if is_incremental() %}
+ WHERE date_trunc('day', b.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+ {% else %}
+ WHERE date_trunc('day', b.evt_block_time) >= '{{ project_start_date }}'
+ {% endif %} 
+ and b.contract_address in (select address from pools)
+ group by 1,2,3,4
+ 
+ )
+
+, swap_events as (
+ select DATE_TRUNC('day', s.evt_block_time) AS time,
+      s.contract_address AS pool,
+      cr.token0,
+      cr.token1,
+      SUM(TRY_CAST(amount0In AS DOUBLE) - TRY_CAST(amount0Out AS DOUBLE)) AS amount0,
+      SUM(TRY_CAST(amount1In AS DOUBLE) - TRY_CAST(amount1Out AS DOUBLE)) AS amount1
+ from {{source('velodrome_optimism','Pair_evt_Swap')}} s
+ left join {{source('velodrome_optimism','PairFactory_evt_PairCreated')}} cr on s.contract_address = cr.pair 
+ {% if is_incremental() %}
+ WHERE date_trunc('day', s.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+ {% else %}
+ WHERE date_trunc('day', s.evt_block_time) >= '{{ project_start_date }}'
+ {% endif %} 
+ and s.contract_address in (select address from pools)
+ group by 1,2,3,4
+ 
+)
+
+, fee_events as (
+select
+    DATE_TRUNC('day', s.evt_block_time) AS time,
+      s.contract_address AS pool,
+      cr.token0,
+      cr.token1,
+      (-1)*SUM(TRY_CAST(amount0 AS DOUBLE) ) AS amount0,
+      (-1)*SUM(TRY_CAST(amount1 AS DOUBLE) ) AS amount1 
+ from {{source('velodrome_optimism','Pair_evt_Fees')}} s
+ left join {{source('velodrome_optimism','PairFactory_evt_PairCreated')}} cr on s.contract_address = cr.pair 
+ {% if is_incremental() %}
+ WHERE date_trunc('day', s.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+ {% else %}
+ WHERE date_trunc('day', s.evt_block_time) >= '{{ project_start_date }}'
+ {% endif %} 
+ and s.contract_address in (select address from pools)
+ group by 1,2,3,4
+ )
+ 
+, daily_delta_balance AS (
+
+select time, pool, token0, token1, sum(amount0) as amount0, sum(amount1) as amount1
+from (
+select time, pool,token0, token1, amount0, amount1
+from  mint_events
+
+union all
+
+select time, pool,token0, token1, amount0, amount1
+from  swap_events
+
+union all
+
+select time, pool,token0, token1, amount0, amount1
+from  burn_events
+
+union all
+
+select time, pool,token0, token1, amount0, amount1
+from  fee_events
+) group by 1,2,3,4
+)
+
+, pool_liquidity as (
+SELECT time,
+      LEAD(time, 1, CURRENT_DATE + INTERVAL '1' day) OVER (ORDER BY time) AS next_time,
+      pool,
+      token0,
+      token1,
+      SUM(amount0) OVER (PARTITION BY  pool   ORDER BY time) AS amount0,
+      SUM(amount1) OVER (PARTITION BY  pool   ORDER BY time) AS amount1
+    FROM
+      daily_delta_balance
+)
+
+, swap_events_hourly as (
+ select DATE_TRUNC('hour', s.evt_block_time) AS time,
+      s.contract_address AS pool,
+      sum(case when cr.token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') then TRY_CAST(amount0In AS DOUBLE) + TRY_CAST(amount0Out AS DOUBLE)
+      else TRY_CAST(amount1In AS DOUBLE) + TRY_CAST(amount1Out AS DOUBLE) end) as wsteth_amount
+ from {{source('velodrome_optimism','Pair_evt_Swap')}} s
+ left join {{source('velodrome_optimism','PairFactory_evt_PairCreated')}} cr on s.contract_address = cr.pair 
+ {% if is_incremental() %}
+ WHERE date_trunc('day', s.evt_block_time) >= date_trunc("day", now() - interval '1 week') 
+ {% else %}
+ WHERE date_trunc('day', s.evt_block_time) >= '{{ project_start_date }}'
+ {% endif %}  
+ and s.contract_address in (select address from pools)
+group by 1,2
+)
+
+, trading_volume_hourly AS (
+    SELECT
+      s.time,
+      pool,
+      wsteth_amount,
+      p.price,
+      COALESCE((p.price * wsteth_amount) / CAST(POWER(10, 18) AS DOUBLE), 0) AS volume
+    FROM
+      swap_events_hourly AS s
+      LEFT JOIN wsteth_prices_hourly_with_lead AS p ON s.time >= p.time
+      AND s.time < p.next_time
+  )
+  
+, trading_volume AS (
+    SELECT DISTINCT
+      DATE_TRUNC('day', time) AS time,
+      pool,
+      SUM(volume) AS volume
+    FROM trading_volume_hourly
+    GROUP BY 1, 2
+    )
+  
+, all_metrics AS (
+    SELECT
+      l.pool,
+      pools.blockchain,
+      pools.project,
+      pools.fee,
+      pools.pool_type,
+      l.time,
+      CASE WHEN token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') THEN token0 ELSE token1 END AS main_token,
+      CASE WHEN token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') THEN t0.symbol ELSE t1.symbol END AS main_token_symbol,
+      CASE WHEN token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') THEN token1 ELSE token0 END AS paired_token,
+      CASE WHEN token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') THEN t1.symbol ELSE t0.symbol END AS paired_token_symbol,
+      CASE WHEN token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') THEN (CASE WHEN amount0 > 0 THEN amount0 / CAST(POWER(10, t0.decimals) AS DOUBLE) ELSE 0 END)
+        ELSE (CASE WHEN amount1 > 0 THEN amount1 / CAST(POWER(10, t1.decimals) AS DOUBLE) ELSE 0 END) END AS main_token_reserve,
+      CASE WHEN token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') THEN (CASE WHEN amount1 > 0 THEN amount1 / CAST(POWER(10, t1.decimals) AS DOUBLE) ELSE 0 END)  
+        ELSE (CASE WHEN amount0 > 0 THEN amount0 / CAST(POWER(10, t0.decimals) AS DOUBLE) ELSE 0 END) END AS paired_token_reserve,
+      CASE WHEN token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') THEN (CASE WHEN amount0 > 0 THEN (p0.price * amount0) / CAST(POWER(10, t0.decimals) AS DOUBLE)
+            ELSE 0 END)
+        ELSE (CASE WHEN amount1 > 0 THEN (p1.price * amount1) / CAST(POWER(10, t1.decimals) AS DOUBLE)  ELSE 0 END) END AS main_token_usd_reserve,
+      CASE WHEN token0 = lower('0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb') THEN (
+          CASE WHEN amount1 > 0 THEN (p1.price * amount1) / CAST(POWER(10, t1.decimals) AS DOUBLE)
+            ELSE 0 END)
+        ELSE (CASE WHEN amount0 > 0 THEN (p0.price * amount0) / CAST(POWER(10, t0.decimals) AS DOUBLE) ELSE 0 END) END AS paired_token_usd_reserve,
+      coalesce(volume,0) AS trading_volume
+    FROM
+      pool_liquidity AS l
+      LEFT JOIN pools ON l.pool = pools.address
+      LEFT JOIN tokens AS t0 ON l.token0 = t0.token
+      LEFT JOIN tokens AS t1 ON l.token1 = t1.token
+      LEFT JOIN tokens_prices_daily AS p0 ON l.time = p0.time
+      AND l.token0 = p0.token
+      LEFT JOIN tokens_prices_daily AS p1 ON l.time = p1.time
+      AND l.token1 = p1.token
+      LEFT JOIN trading_volume AS tv ON l.time = tv.time
+      AND l.pool = tv.pool
+ )
+ 
+select  CONCAT(CONCAT(CONCAT(CONCAT(CONCAT(blockchain,CONCAT(' ', project)) ,' '), coalesce(paired_token_symbol,'unknown')),':') , main_token_symbol, ' ', pool_type) as pool_name,
+        pool,
+        blockchain,
+        project,
+        fee,
+        time,
+        main_token,
+        main_token_symbol,
+        paired_token,
+        paired_token_symbol,
+        main_token_reserve,
+        paired_token_reserve,
+        main_token_usd_reserve,
+        paired_token_usd_reserve,
+        trading_volume
+from all_metrics


### PR DESCRIPTION
Brief comments on the purpose of your changes:
adding of Velodrome Optimism pools to Lido liquidity model
target'query https://dune.com/queries/2650692?d=1

I've checked that:

### General checks:
* [x] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [x] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [x] if adding a new model, I added a test
* [x] the filename is unique and ends with .sql
* [x] each sql file is a select statement and has only one view, table or function defined  
* [x] column names are `lowercase_snake_cased`
* [x] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [x] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [x] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [x] where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [x] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
