### PR TITLE
Fix `evms.transactions` arbitrum duplicates

### DIFF
--- a/models/evms/evms_transactions.sql
+++ b/models/evms/evms_transactions.sql
@@ -87,36 +87,4 @@ FROM (
         , l1_timestamp
         , CAST(NULL AS DECIMAL(38,0)) AS effective_gas_price
         FROM {{ source('optimism', 'transactions') }}
-
-        UNION ALL
-
-        SELECT 'arbitrum' AS blockchain
-        , access_list
-        , block_hash
-        , data
-        , `from`
-        , hash
-        , to
-        , block_number
-        , block_time
-        , gas_limit
-        , CAST(gas_price AS double) AS gas_price
-        , gas_used
-        , index
-        , max_fee_per_gas
-        , max_priority_fee_per_gas
-        , nonce
-        , priority_fee_per_gas
-        , success
-        , `type`
-        , CAST(value AS double) AS value
-        , NULL AS l1_tx_origin
-        , CAST(NULL AS double) AS l1_fee_scalar
-        , CAST(NULL AS DECIMAL(38,0)) AS l1_fee_scalar
-        , CAST(NULL AS DECIMAL(38,0)) AS l1_fee
-        , CAST(NULL AS DECIMAL(38,0)) AS l1_gas_price
-        , gas_used_for_l1 AS l1_gas_used
-        , NULL AS l1_timestamp
-        , effective_gas_price
-        FROM {{ source('arbitrum', 'transactions') }}
         );


### PR DESCRIPTION
With arbitrum both in the Jinja loop and added separately, it lead to duplicates, so I removed that last instance.

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
