### PR TITLE
Fix typo in rubicon models to fix partial parsing

### DIFF
--- a/models/rubicon/optimism/rubicon_optimism_schema.yml
+++ b/models/rubicon/optimism/rubicon_optimism_schema.yml
@@ -197,7 +197,7 @@ models:
       - &bought_amount_raw
         name: bought_amount_raw
         description: "the raw amount of the token that the offer has bought"
-      - &sell_amount_usd: 
+      - &sell_amount_usd
         name: sell_amount_usd
         description: "the amount of the token that the maker is selling in USD (at the time of the offer creation)"
       - &buy_amount_usd

--- a/models/rubicon/rubicon_schema.yml
+++ b/models/rubicon/rubicon_schema.yml
@@ -142,7 +142,7 @@ models:
       - &bought_amount_raw
         name: bought_amount_raw
         description: "the raw amount of the token that the offer has bought"
-      - &sell_amount_usd: 
+      - &sell_amount_usd
         name: sell_amount_usd
         description: "the amount of the token that the maker is selling in USD (at the time of the offer creation)"
       - &buy_amount_usd


### PR DESCRIPTION
Some typos in the rubicon model YAML caused partial_parse.msgpack files to be written with None as a map key. By default, msgpack does not allow None as map keys when deserializing, triggering an exception, meaning that the partial_parse.msgpack file would be considered invalid. This mean that we would reparse the entire project on every dbt command.

The root cause is probably a bug in DBT. Either is should be impossible to create partial_parse.msgpack keys with None as a map key, or they should use the strict_map_key=False option to accept such files.

Before:
```
dbt clean
dbt parse
time dbt parse

real	0m35.185s
user	0m34.702s
sys	0m1.715s
```

After:
```
dbt clean
dbt parse
time dbt parse

real	0m3.263s
user	0m2.833s
sys	0m1.504s
```

The typo was introduced in https://github.com/duneanalytics/spellbook/commit/6993d5eb956eb0ad93f2d5f41382d6de32ec8f0c

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
