### PR TITLE
exclude `dex.sandwiches` due to duplicate failures

### DIFF
--- a/models/dex/dex_sandwiches.sql
+++ b/models/dex/dex_sandwiches.sql
@@ -1,4 +1,5 @@
 {{ config(
+        tags=['prod_exclude'],
         alias ='sandwiches',
         partition_by = ['block_date'],
         materialized = 'incremental',


### PR DESCRIPTION
fyi @hildobby -- this model started to fail on dupes. feel free to investigate and submit a bug fix.