### PR TITLE
[CoW Protocol] Add Enso solver

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_solvers.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_solvers.sql
@@ -79,6 +79,8 @@ known_solver_metadata (address, environment, name) as (
                  ('0xD8b9c8e1a94baEAaf4D1CA2C45723eb88236130E', 'prod', 'Raven'),
                  ('0x0C60276BeaDc5BA35007661A89E0d5E7476523f8', 'prod', 'Barter'),
                  ('0x452d604f08affFc4E87E74e3279BdBdeCeD07232', 'prod', 'PropellerHeads'),
+                 ('0xAd897CF33E5AF59F33C1fD19490C5b94a8a2759b', 'prod', 'Enso'),
+                 ('0x40ADd124002E47119E9DeACdF650dE150F637b6f', 'barn', 'Enso'),
                  ('0x69f9365405762405cc17f7979aa8e94fd95c1e80', 'barn', 'Barter'),
                  ('0xFFC5E9d86c0e069f8B037c841ACc72cF94eeBaD8', 'barn', 'Barter'),
                  ('0x1857afb4da9bd4cc1c6e5287ad41cb5be469f14e', 'barn', 'Raven'),


### PR DESCRIPTION
# SPELLBOOK FREEZE

From June 22 to June 29, we will be freezing some Spellbook contributions for the migration to DuneSQL. We will not accept contributions to the lineage of the following models:

* dex.trades
* nft.trades
* labels
* token.erc20
* tokens.nft

Run the following command to see the list of affected files:

```
dbt ls --resource-type model --output path --select +dex_trades +labels +nft_trades +tokens_nft +tokens_erc20
```

Don't hesitate to reach out on Discord if you have any questions.

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
