### PR TITLE
Add macros to enable offline Trino compiles and speed up Trino compiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ dmypy.json
 target/
 dbt_packages/
 logs/
+.user.yml
 
 # exclusions
 !target/manifest.json

--- a/README.md
+++ b/README.md
@@ -130,36 +130,6 @@ pipenv shell
 
 You have now created a virtual environment for this project. You can read more about virtual environments [here](https://realpython.com/pipenv-guide/).
 
-To initiate the dbt project run:
-
-```console
-dbt init
-```
-
-Enter the values as shown below:
-
-```console
-Which database would you like to use?
-[1] databricks
-[2] spark
-
-(Don't see the one you want? https://docs.getdbt.com/docs/available-adapters)
-
-Enter a number: 1
-host (yourorg.databricks.com): .
-http_path (HTTP Path): .
-token (dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX):
-[1] use Unity Catalog
-[2] not use Unity Catalog
-Desired unity catalog option (enter a number): 2
-schema (default schema that dbt will build objects in): wizard
-threads (1 or more) [1]: 2
-```
-
-This will not connect to the database but you have access to some dbt actions.
-**When you are prompted to choose a schema, please enter `wizard` so we know you are an external contributor.**
-Should you make an error during this process (not entering `wizard` being the only one you can make), simply quit the CLI and start over.
-
 To pull the dbt project dependencies run:
 
 ```console
@@ -240,18 +210,6 @@ As a preview, you can do [things](https://docs.getdbt.com/reference/resource-pro
 - Link to other models in your descriptions.
 - Add images / project logos from the repo into descriptions.
 - Use HTML in your description.
-
-### Troubleshooting
-
-If you fail to run `dbt compile`, here are some common error messages:
-
-- `Could not find profile named 'spellbook'` <br> Check `~/.dbt/profiles.yml` and make sure there is a profile named `spellbook`. When you run `dbt init` to initiate a project, a profile gets created. Inside `spellbook` you cannot initiate a project called the same name, so you need to run `dbt init spellbook` outside the project so it creates the profile, or create one with a different name and then manually edit the `profiles.yml` file.
-- ```console
-  Credentials in profile "spellbook", target "dev" invalid: Runtime Error
-   http connection method requires additional dependencies.
-   Install the additional required dependencies with pip install dbt-spark[PyHive]
-  ```
-  You've probably selected the `spark` option instead of the `databricks` option when running `dbt init`. Rerun `dbt init`, overwrite the profile, and select the `databricks` option.
 
 ### DBT Resources:
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -5,7 +5,7 @@ version: "1.0.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
-profile: "spellbook"
+profile: "spellbook-local"
 
 vars:
   DBT_ENV_CUSTOM_ENV_S3_BUCKET: "{{ env_var('DBT_ENV_CUSTOM_ENV_S3_BUCKET', 'local') }}"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -5,7 +5,7 @@ version: "1.0.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
-profile: "spellbook-local"
+profile: "spellbook"
 
 vars:
   DBT_ENV_CUSTOM_ENV_S3_BUCKET: "{{ env_var('DBT_ENV_CUSTOM_ENV_S3_BUCKET', 'local') }}"

--- a/macros/dune/no-relation-listing.sql
+++ b/macros/dune/no-relation-listing.sql
@@ -1,11 +1,11 @@
 {# Macros for disabling listing of relations from the warehouse.
- Enabled by default for the spellbook-local profile.  Run dbt compile with the flag --vars 'no-relation-listing: "true"'
+ Enabled by default for the spellbook profile.  Run dbt compile with the flag --vars 'no-relation-listing: "true"'
  on the command line to explicitly enable or disable this.
  This speeds up DBT compile times. It must not be used in combination with dbt run.
  #}
 {% macro get_catalog(information_schema, schemas) -%}
   {% do log(target) %}
-  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook-local') -%}
+  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook') -%}
     {{ return([]) }}
   {%- else -%}
     {{ return(adapter.dispatch('get_catalog')(information_schema, schemas)) }}
@@ -14,7 +14,7 @@
 
 {% macro list_schemas(database) -%}
   {% do log(target) %}
-  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook-local') -%}
+  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook') -%}
     {{ return([]) }}
   {%- else -%}
     {{ return(adapter.dispatch('list_schemas')(database)) }}
@@ -22,7 +22,7 @@
 {%- endmacro %}
 
 {% macro list_relations_without_caching(schema_relation) %}
-  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook-local') -%}
+  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook') -%}
     {{ return([]) }}
   {%- else -%}
     {{ return(adapter.dispatch('list_relations_without_caching')(schema_relation)) }}

--- a/macros/dune/no-relation-listing.sql
+++ b/macros/dune/no-relation-listing.sql
@@ -1,27 +1,30 @@
 {# Macros for disabling listing of relations from the warehouse.
- Run dbt compile with the flag --vars 'no-relation-listing: "true"' on the command line to enable this.
+ Enabled by default for the spellbook-local profile.  Run dbt compile with the flag --vars 'no-relation-listing: "true"'
+ on the command line to explicitly enable or disable this.
  This speeds up DBT compile times. It must not be used in combination with dbt run.
  #}
 {% macro get_catalog(information_schema, schemas) -%}
-  {%- if var('no-relation-listing', 'false').lower() != 'true' -%}
-    {{ return(adapter.dispatch('get_catalog')(information_schema, schemas)) }}
-  {%- else -%}
+  {% do log(target) %}
+  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook-local') -%}
     {{ return([]) }}
+  {%- else -%}
+    {{ return(adapter.dispatch('get_catalog')(information_schema, schemas)) }}
   {%- endif -%}
 {%- endmacro %}
 
 {% macro list_schemas(database) -%}
-  {%- if var('no-relation-listing', 'false').lower() != 'true' -%}
-    {{ return(adapter.dispatch('list_schemas')(database)) }}
-  {%- else -%}
+  {% do log(target) %}
+  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook-local') -%}
     {{ return([]) }}
+  {%- else -%}
+    {{ return(adapter.dispatch('list_schemas')(database)) }}
   {%- endif -%}
 {%- endmacro %}
 
 {% macro list_relations_without_caching(schema_relation) %}
-  {%- if var('no-relation-listing', 'false').lower() != 'true' -%}
-    {{ return(adapter.dispatch('list_relations_without_caching')(schema_relation)) }}
-  {%- else -%}
+  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook-local') -%}
     {{ return([]) }}
+  {%- else -%}
+    {{ return(adapter.dispatch('list_relations_without_caching')(schema_relation)) }}
   {%- endif -%}
 {%- endmacro %}

--- a/macros/dune/no-relation-listing.sql
+++ b/macros/dune/no-relation-listing.sql
@@ -1,0 +1,27 @@
+{# Macros for disabling listing of relations from the warehouse.
+ Run dbt compile with the flag --vars 'no-relation-listing: "true"' on the command line to enable this.
+ This speeds up DBT compile times. It must not be used in combination with dbt run.
+ #}
+{% macro get_catalog(information_schema, schemas) -%}
+  {%- if var('no-relation-listing', 'false').lower() != 'true' -%}
+    {{ return(adapter.dispatch('get_catalog')(information_schema, schemas)) }}
+  {%- else -%}
+    {{ return([]) }}
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro list_schemas(database) -%}
+  {%- if var('no-relation-listing', 'false').lower() != 'true' -%}
+    {{ return(adapter.dispatch('list_schemas')(database)) }}
+  {%- else -%}
+    {{ return([]) }}
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro list_relations_without_caching(schema_relation) %}
+  {%- if var('no-relation-listing', 'false').lower() != 'true' -%}
+    {{ return(adapter.dispatch('list_relations_without_caching')(schema_relation)) }}
+  {%- else -%}
+    {{ return([]) }}
+  {%- endif -%}
+{%- endmacro %}

--- a/macros/dune/no-relation-listing.sql
+++ b/macros/dune/no-relation-listing.sql
@@ -5,7 +5,7 @@
  #}
 {% macro get_catalog(information_schema, schemas) -%}
   {% do log(target) %}
-  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook') -%}
+  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook-local') -%}
     {{ return([]) }}
   {%- else -%}
     {{ return(adapter.dispatch('get_catalog')(information_schema, schemas)) }}
@@ -14,7 +14,7 @@
 
 {% macro list_schemas(database) -%}
   {% do log(target) %}
-  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook') -%}
+  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook-local') -%}
     {{ return([]) }}
   {%- else -%}
     {{ return(adapter.dispatch('list_schemas')(database)) }}
@@ -22,7 +22,7 @@
 {%- endmacro %}
 
 {% macro list_relations_without_caching(schema_relation) %}
-  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook') -%}
+  {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook-local') -%}
     {{ return([]) }}
   {%- else -%}
     {{ return(adapter.dispatch('list_relations_without_caching')(schema_relation)) }}

--- a/profiles.yml
+++ b/profiles.yml
@@ -1,4 +1,4 @@
-spellbook-local:
+spellbook:
   target: dev
   outputs:
     dev:

--- a/profiles.yml
+++ b/profiles.yml
@@ -1,4 +1,4 @@
-spellbook:
+spellbook-local:
   target: dev
   outputs:
     dev:

--- a/profiles.yml
+++ b/profiles.yml
@@ -8,5 +8,5 @@ spellbook-local:
       host: trino
       port: 1234
       database: hive
-      schema: dbt
+      schema: wizard
       threads: 1

--- a/profiles.yml
+++ b/profiles.yml
@@ -1,0 +1,12 @@
+spellbook-local:
+  target: dev
+  outputs:
+    dev:
+      type: trino
+      user: trino
+      password: trino
+      host: trino
+      port: 1234
+      database: hive
+      schema: dbt
+      threads: 1


### PR DESCRIPTION
The macros are used to disable listing of relations from the warehouse. Run `dbt compile` with the flag `--vars 'no-relation-listing: "true"'` on the command line to enable this. This speeds up DBT compile times. It must not be used with `dbt run`.

This enables running `dbt compile` without access to a Trino cluster. It is also faster than running with a Trino cluster.

Potentially we could also use this to make the local setup of `dbt` simpler:
* We add a `profiles.yml` file to the root of spellbook:
```
spellbook:
  target: dev
  outputs:
    dev:
      type: trino
      user: trino
      password: trino
      host: trino
      port: 1234
      database: hive
      schema: dbt
      threads: 1
```
* User setup from a fresh repository is then:
  * `pipenv install`
  * `pipenv shell`
  * `dbt deps`
* Dev workflow: `dbt compile` (we use the profile name instead of a vars to enable or disable listings)