### PR TITLE
Wash trading blend fix

### DIFF
--- a/models/nft/ethereum/nft_ethereum_wash_trades.sql
+++ b/models/nft/ethereum/nft_ethereum_wash_trades.sql
@@ -55,6 +55,7 @@ WITH filter_1 AS (
         AND filter_bought_3x.token_id=nftt.token_id
         AND filter_bought_3x.buyer=nftt.buyer
         AND filter_bought_3x.token_standard IN ('erc721', 'erc20')
+        AND '0x29469395eaf6f95920e59f858042f0e28d98a20b' NOT IN (nftt.buyer, nftt.seller)
         {% if is_incremental() %}
         AND filter_bought_3x.block_time >= date_trunc("day", NOW() - interval '1 week')
         {% endif %}
@@ -78,6 +79,7 @@ WITH filter_1 AS (
         AND filter_sold_3x.token_id=nftt.token_id
         AND filter_sold_3x.seller=nftt.seller
         AND filter_sold_3x.token_standard IN ('erc721', 'erc20')
+        AND '0x29469395eaf6f95920e59f858042f0e28d98a20b' NOT IN (nftt.buyer, nftt.seller)
         {% if is_incremental() %}
         AND filter_sold_3x.block_time >= date_trunc("day", NOW() - interval '1 week')
         {% endif %}


### PR DESCRIPTION
Most NFT trades that involve Blur's blend wallet are getting flagged by the "Wash Filter 3 - Bought NFTs 3X" filter (since the blend wallet holds all the lent NFTs, it always appears as `seller` or `buyer` when used).

Post DuneSQL migration, I'll make a `blend.loans` abstraction. Using that, I'll modify the `blur.trades` model to show the proper `buyer`/`seller` (of NFT trades involving Blend) and remove these temporary 2 lines.

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
