### PR TITLE
Critical Fix for Balancer Trades

### DIFF
--- a/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
@@ -108,10 +108,10 @@ WITH
             LEFT JOIN {{ ref('balancer_v2_arbitrum_bpt_prices') }} bpt_prices
                 ON bpt_prices.contract_address = dexs.token_bought_address
                 AND bpt_prices.hour <= dexs.block_time
-                {% if not is_incremental () %}
+                {% if not is_incremental() %}
                 AND bpt_prices.hour >= '{{ project_start_date }}'
                 {% endif %}
-                {% if is_incremental () %}
+                {% if is_incremental() %}
                 AND bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
                 {% endif %}
         GROUP BY 1, 2, 3, 4, 5
@@ -129,10 +129,10 @@ WITH
             LEFT JOIN {{ ref('balancer_v2_arbitrum_bpt_prices') }} bpt_prices
                 ON bpt_prices.contract_address = dexs.token_sold_address
                 AND bpt_prices.hour <= dexs.block_time
-                {% if not is_incremental () %}
+                {% if not is_incremental() %}
                 AND bpt_prices.hour >= '{{ project_start_date }}'
                 {% endif %}
-                {% if is_incremental () %}
+                {% if is_incremental() %}
                 AND bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
                 {% endif %}
         GROUP BY 1, 2, 3, 4, 5
@@ -180,10 +180,10 @@ FROM
     dexs
     INNER JOIN {{ source ('arbitrum', 'transactions') }} tx
         ON tx.hash = dexs.tx_hash
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND tx.block_time >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     LEFT JOIN {{ ref ('tokens_erc20') }} erc20a
@@ -196,20 +196,20 @@ FROM
         ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
         AND p_bought.contract_address = dexs.token_bought_address
         AND p_bought.blockchain = 'arbitrum'
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND p_bought.minute >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     LEFT JOIN {{ source ('prices', 'usd') }} p_sold
         ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
         AND p_sold.contract_address = dexs.token_sold_address
         AND p_sold.blockchain = 'arbitrum'
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND p_sold.minute >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     INNER JOIN bpa
@@ -219,10 +219,10 @@ FROM
     LEFT JOIN {{ ref('balancer_v2_arbitrum_bpt_prices') }} bpa_bpt_prices
         ON bpa_bpt_prices.contract_address = bpa.contract_address
         AND bpa_bpt_prices.hour = bpa.bpa_max_block_time
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND bpa_bpt_prices.hour >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND bpa_bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     INNER JOIN bpb
@@ -232,9 +232,9 @@ FROM
     LEFT JOIN {{ ref('balancer_v2_arbitrum_bpt_prices') }} bpb_bpt_prices
         ON bpb_bpt_prices.contract_address = bpb.contract_address
         AND bpb_bpt_prices.hour = bpb.bpb_max_block_time
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND bpa_bpt_prices.hour >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND bpa_bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
@@ -20,9 +20,6 @@ WITH
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
         FROM {{ ref('balancer_v2_arbitrum_pools_fees') }} 
-        {% if is_incremental() %}
-        WHERE block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     most_case_fees AS (
         SELECT * FROM fees_base 
@@ -37,9 +34,6 @@ WITH
         FROM {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} s
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash AND f.index < s.evt_index
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     swap_fees AS (
         SELECT
@@ -56,7 +50,6 @@ WITH
                 AND fees.block_time <= swap.evt_block_time
         {% if is_incremental() %}
         WHERE swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-            AND fees.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
         GROUP BY 1, 2, 3, 4, 5
     ),

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -108,10 +108,10 @@ WITH
             LEFT JOIN {{ ref('balancer_v2_ethereum_bpt_prices') }} bpt_prices
                 ON bpt_prices.contract_address = dexs.token_bought_address
                 AND bpt_prices.hour <= dexs.block_time
-                {% if not is_incremental () %}
+                {% if not is_incremental() %}
                 AND bpt_prices.hour >= '{{ project_start_date }}'
                 {% endif %}
-                {% if is_incremental () %}
+                {% if is_incremental() %}
                 AND bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
                 {% endif %}
         GROUP BY 1, 2, 3, 4, 5
@@ -129,10 +129,10 @@ WITH
             LEFT JOIN {{ ref('balancer_v2_ethereum_bpt_prices') }} bpt_prices
                 ON bpt_prices.contract_address = dexs.token_sold_address
                 AND bpt_prices.hour <= dexs.block_time
-                {% if not is_incremental () %}
+                {% if not is_incremental() %}
                 AND bpt_prices.hour >= '{{ project_start_date }}'
                 {% endif %}
-                {% if is_incremental () %}
+                {% if is_incremental() %}
                 AND bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
                 {% endif %}
         GROUP BY 1, 2, 3, 4, 5
@@ -180,10 +180,10 @@ FROM
     dexs
     INNER JOIN {{ source ('ethereum', 'transactions') }} tx
         ON tx.hash = dexs.tx_hash
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND tx.block_time >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     LEFT JOIN {{ ref ('tokens_erc20') }} erc20a
@@ -196,20 +196,20 @@ FROM
         ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
         AND p_bought.contract_address = dexs.token_bought_address
         AND p_bought.blockchain = 'ethereum'
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND p_bought.minute >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     LEFT JOIN {{ source ('prices', 'usd') }} p_sold
         ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
         AND p_sold.contract_address = dexs.token_sold_address
         AND p_sold.blockchain = 'ethereum'
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND p_sold.minute >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     INNER JOIN bpa
@@ -219,10 +219,10 @@ FROM
     LEFT JOIN {{ ref('balancer_v2_ethereum_bpt_prices') }} bpa_bpt_prices
         ON bpa_bpt_prices.contract_address = bpa.contract_address
         AND bpa_bpt_prices.hour = bpa.bpa_max_block_time
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND bpa_bpt_prices.hour >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND bpa_bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     INNER JOIN bpb
@@ -232,9 +232,9 @@ FROM
     LEFT JOIN {{ ref('balancer_v2_ethereum_bpt_prices') }} bpb_bpt_prices
         ON bpb_bpt_prices.contract_address = bpb.contract_address
         AND bpb_bpt_prices.hour = bpb.bpb_max_block_time
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND bpa_bpt_prices.hour >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND bpa_bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -20,9 +20,6 @@ WITH
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
         FROM {{ ref('balancer_v2_ethereum_pools_fees') }} 
-        {% if is_incremental() %}
-        WHERE block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     most_case_fees AS (
         SELECT * FROM fees_base 
@@ -37,9 +34,6 @@ WITH
         FROM {{ source ('balancer_v2_ethereum', 'Vault_evt_Swap') }} s
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash AND f.index < s.evt_index
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     swap_fees AS (
         SELECT
@@ -56,7 +50,6 @@ WITH
                 AND fees.block_time <= swap.evt_block_time
         {% if is_incremental() %}
         WHERE swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-            AND fees.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
         GROUP BY 1, 2, 3, 4, 5
     ),

--- a/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
@@ -108,10 +108,10 @@ WITH
             LEFT JOIN {{ ref('balancer_v2_gnosis_bpt_prices') }} bpt_prices
                 ON bpt_prices.contract_address = dexs.token_bought_address
                 AND bpt_prices.hour <= dexs.block_time
-                {% if not is_incremental () %}
+                {% if not is_incremental() %}
                 AND bpt_prices.hour >= '{{ project_start_date }}'
                 {% endif %}
-                {% if is_incremental () %}
+                {% if is_incremental() %}
                 AND bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
                 {% endif %}
         GROUP BY 1, 2, 3, 4, 5
@@ -129,10 +129,10 @@ WITH
             LEFT JOIN {{ ref('balancer_v2_gnosis_bpt_prices') }} bpt_prices
                 ON bpt_prices.contract_address = dexs.token_sold_address
                 AND bpt_prices.hour <= dexs.block_time
-                {% if not is_incremental () %}
+                {% if not is_incremental() %}
                 AND bpt_prices.hour >= '{{ project_start_date }}'
                 {% endif %}
-                {% if is_incremental () %}
+                {% if is_incremental() %}
                 AND bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
                 {% endif %}
         GROUP BY 1, 2, 3, 4, 5
@@ -180,10 +180,10 @@ FROM
     dexs
     INNER JOIN {{ source ('gnosis', 'transactions') }} tx
         ON tx.hash = dexs.tx_hash
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND tx.block_time >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     LEFT JOIN {{ ref ('tokens_erc20') }} erc20a
@@ -196,20 +196,20 @@ FROM
         ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
         AND p_bought.contract_address = dexs.token_bought_address
         AND p_bought.blockchain = 'gnosis'
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND p_bought.minute >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     LEFT JOIN {{ source ('prices', 'usd') }} p_sold
         ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
         AND p_sold.contract_address = dexs.token_sold_address
         AND p_sold.blockchain = 'gnosis'
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND p_sold.minute >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     INNER JOIN bpa
@@ -219,10 +219,10 @@ FROM
     LEFT JOIN {{ ref('balancer_v2_gnosis_bpt_prices') }} bpa_bpt_prices
         ON bpa_bpt_prices.contract_address = bpa.contract_address
         AND bpa_bpt_prices.hour = bpa.bpa_max_block_time
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND bpa_bpt_prices.hour >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND bpa_bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     INNER JOIN bpb
@@ -232,9 +232,9 @@ FROM
     LEFT JOIN {{ ref('balancer_v2_gnosis_bpt_prices') }} bpb_bpt_prices
         ON bpb_bpt_prices.contract_address = bpb.contract_address
         AND bpb_bpt_prices.hour = bpb.bpb_max_block_time
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND bpa_bpt_prices.hour >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND bpa_bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}

--- a/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
@@ -20,9 +20,6 @@ WITH
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
         FROM {{ ref('balancer_v2_gnosis_pools_fees') }} 
-        {% if is_incremental() %}
-        WHERE block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     most_case_fees AS (
         SELECT * FROM fees_base 
@@ -37,9 +34,6 @@ WITH
         FROM {{ source ('balancer_v2_gnosis', 'Vault_evt_Swap') }} s
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash AND f.index < s.evt_index
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     swap_fees AS (
         SELECT
@@ -56,7 +50,6 @@ WITH
                 AND fees.block_time <= swap.evt_block_time
         {% if is_incremental() %}
         WHERE swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-            AND fees.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
         GROUP BY 1, 2, 3, 4, 5
     ),

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -20,9 +20,6 @@ WITH
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
         FROM {{ ref('balancer_v2_optimism_pools_fees') }} 
-        {% if is_incremental() %}
-        WHERE block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     most_case_fees AS (
         SELECT * FROM fees_base 
@@ -37,9 +34,6 @@ WITH
         FROM {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} s
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash AND f.index < s.evt_index
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     swap_fees AS (
         SELECT
@@ -56,7 +50,6 @@ WITH
                 AND fees.block_time <= swap.evt_block_time
         {% if is_incremental() %}
         WHERE swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-            AND fees.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
         GROUP BY 1, 2, 3, 4, 5
     ),

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -108,10 +108,10 @@ WITH
             LEFT JOIN {{ ref('balancer_v2_optimism_bpt_prices') }} bpt_prices
                 ON bpt_prices.contract_address = dexs.token_bought_address
                 AND bpt_prices.hour <= dexs.block_time
-                {% if not is_incremental () %}
+                {% if not is_incremental() %}
                 AND bpt_prices.hour >= '{{ project_start_date }}'
                 {% endif %}
-                {% if is_incremental () %}
+                {% if is_incremental() %}
                 AND bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
                 {% endif %}
         GROUP BY 1, 2, 3, 4, 5
@@ -129,10 +129,10 @@ WITH
             LEFT JOIN {{ ref('balancer_v2_optimism_bpt_prices') }} bpt_prices
                 ON bpt_prices.contract_address = dexs.token_sold_address
                 AND bpt_prices.hour <= dexs.block_time
-                {% if not is_incremental () %}
+                {% if not is_incremental() %}
                 AND bpt_prices.hour >= '{{ project_start_date }}'
                 {% endif %}
-                {% if is_incremental () %}
+                {% if is_incremental() %}
                 AND bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
                 {% endif %}
         GROUP BY 1, 2, 3, 4, 5
@@ -180,10 +180,10 @@ FROM
     dexs
     INNER JOIN {{ source ('optimism', 'transactions') }} tx
         ON tx.hash = dexs.tx_hash
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND tx.block_time >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     LEFT JOIN {{ ref ('tokens_erc20') }} erc20a
@@ -196,20 +196,20 @@ FROM
         ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
         AND p_bought.contract_address = dexs.token_bought_address
         AND p_bought.blockchain = 'optimism'
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND p_bought.minute >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     LEFT JOIN {{ source ('prices', 'usd') }} p_sold
         ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
         AND p_sold.contract_address = dexs.token_sold_address
         AND p_sold.blockchain = 'optimism'
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND p_sold.minute >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     INNER JOIN bpa
@@ -219,10 +219,10 @@ FROM
     LEFT JOIN {{ ref('balancer_v2_optimism_bpt_prices') }} bpa_bpt_prices
         ON bpa_bpt_prices.contract_address = bpa.contract_address
         AND bpa_bpt_prices.hour = bpa.bpa_max_block_time
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND bpa_bpt_prices.hour >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND bpa_bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     INNER JOIN bpb
@@ -232,9 +232,9 @@ FROM
     LEFT JOIN {{ ref('balancer_v2_optimism_bpt_prices') }} bpb_bpt_prices
         ON bpb_bpt_prices.contract_address = bpb.contract_address
         AND bpb_bpt_prices.hour = bpb.bpb_max_block_time
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND bpa_bpt_prices.hour >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND bpa_bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -20,9 +20,6 @@ WITH
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
         FROM {{ ref('balancer_v2_polygon_pools_fees') }} 
-        {% if is_incremental() %}
-        WHERE block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     most_case_fees AS (
         SELECT * FROM fees_base 
@@ -37,9 +34,6 @@ WITH
         FROM {{ source ('balancer_v2_polygon', 'Vault_evt_Swap') }} s
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash AND f.index < s.evt_index
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     swap_fees AS (
         SELECT
@@ -56,7 +50,6 @@ WITH
                 AND fees.block_time <= swap.evt_block_time
         {% if is_incremental() %}
         WHERE swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-            AND fees.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
         GROUP BY 1, 2, 3, 4, 5
     ),

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -108,10 +108,10 @@ WITH
             LEFT JOIN {{ ref('balancer_v2_polygon_bpt_prices') }} bpt_prices
                 ON bpt_prices.contract_address = dexs.token_bought_address
                 AND bpt_prices.hour <= dexs.block_time
-                {% if not is_incremental () %}
+                {% if not is_incremental() %}
                 AND bpt_prices.hour >= '{{ project_start_date }}'
                 {% endif %}
-                {% if is_incremental () %}
+                {% if is_incremental() %}
                 AND bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
                 {% endif %}
         GROUP BY 1, 2, 3, 4, 5
@@ -129,10 +129,10 @@ WITH
             LEFT JOIN {{ ref('balancer_v2_polygon_bpt_prices') }} bpt_prices
                 ON bpt_prices.contract_address = dexs.token_sold_address
                 AND bpt_prices.hour <= dexs.block_time
-                {% if not is_incremental () %}
+                {% if not is_incremental() %}
                 AND bpt_prices.hour >= '{{ project_start_date }}'
                 {% endif %}
-                {% if is_incremental () %}
+                {% if is_incremental() %}
                 AND bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
                 {% endif %}
         GROUP BY 1, 2, 3, 4, 5
@@ -180,10 +180,10 @@ FROM
     dexs
     INNER JOIN {{ source ('polygon', 'transactions') }} tx
         ON tx.hash = dexs.tx_hash
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND tx.block_time >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND tx.block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     LEFT JOIN {{ ref ('tokens_erc20') }} erc20a
@@ -196,20 +196,20 @@ FROM
         ON p_bought.minute = DATE_TRUNC('minute', dexs.block_time)
         AND p_bought.contract_address = dexs.token_bought_address
         AND p_bought.blockchain = 'polygon'
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND p_bought.minute >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND p_bought.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     LEFT JOIN {{ source ('prices', 'usd') }} p_sold
         ON p_sold.minute = DATE_TRUNC('minute', dexs.block_time)
         AND p_sold.contract_address = dexs.token_sold_address
         AND p_sold.blockchain = 'polygon'
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND p_sold.minute >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND p_sold.minute >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     INNER JOIN bpa
@@ -219,10 +219,10 @@ FROM
     LEFT JOIN {{ ref('balancer_v2_polygon_bpt_prices') }} bpa_bpt_prices
         ON bpa_bpt_prices.contract_address = bpa.contract_address
         AND bpa_bpt_prices.hour = bpa.bpa_max_block_time
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND bpa_bpt_prices.hour >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND bpa_bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
     INNER JOIN bpb
@@ -232,9 +232,9 @@ FROM
     LEFT JOIN {{ ref('balancer_v2_polygon_bpt_prices') }} bpb_bpt_prices
         ON bpb_bpt_prices.contract_address = bpb.contract_address
         AND bpb_bpt_prices.hour = bpb.bpb_max_block_time
-        {% if not is_incremental () %}
+        {% if not is_incremental() %}
         AND bpa_bpt_prices.hour >= '{{ project_start_date }}'
         {% endif %}
-        {% if is_incremental () %}
+        {% if is_incremental() %}
         AND bpa_bpt_prices.hour >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}


### PR DESCRIPTION
# SPELLBOOK FREEZE

From June 22 to June 29, we will be freezing some Spellbook contributions for the migration to DuneSQL. We will not accept contributions to the lineage of the following models:

* dex.trades
* nft.trades
* labels
* token.erc20
* tokens.nft

Run the following command to see the list of affected files:

```
dbt ls --resource-type model --output path --select +dex_trades +labels +nft_trades +tokens_nft +tokens_erc20
```

Don't hesitate to reach out on Discord if you have any questions.

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
