### PR TITLE
Add Goerli to EVMs tables & Add Cols to Chain Info

### DIFF
--- a/models/chain_info/chain_info_dune_chains.sql
+++ b/models/chain_info/chain_info_dune_chains.sql
@@ -8,15 +8,21 @@
 
 
 SELECT dune_name
+     , chain_name
      , chain_id
+     , chain_type
 FROM (
   VALUES
-    ('ethereum', 1),
-    ('optimism', 10),
-    ('bnb', 56),
-    ('gnosis', 100),
-    ('polygon', 137),
-    ('fantom', 250),
-    ('arbitrum', 42161),
-    ('avalanche_c', 43114)
-) AS dune_chain_name_to_chain_id (dune_name, chain_id)
+    ('ethereum',	'Ethereum Mainnet',	1,	'Mainnet'),
+    ('optimism',	'OP Mainnet',	10,		'Mainnet'),
+    ('bnb',		'BNB Chain',	56,		'Mainnet'),
+    ('gnosis',		'Gnosis Chain',	100,		'Mainnet'),
+    ('polygon',		'Polygon Mainnet',	137,		'Mainnet'),
+    ('fantom',		'Fantom Mainnet',	250,	'Mainnet'),
+    ('arbitrum',	'Arbitrum One',	42161,		'Mainnet'),
+    ('avalanche_c',	'Avalanche C-Chain',	43114,	'Mainnet'),
+    ('celo',		'Celo Mainnet',	42220,	'Mainnet'),
+
+    ('goerli',		'Ethereum Goerli',	5,	'Testnet')
+
+) AS dune_chain_name_to_chain_id (dune_name, chain_name, chain_id, chain_type)

--- a/models/chain_info/chain_info_schema.yml
+++ b/models/chain_info/chain_info_schema.yml
@@ -46,7 +46,7 @@ models:
     config:
       tags: ['chains','cross-chain']
     description: >
-        Table mapping chain IDs to names. Compatible/joinable with `prices` project.
+        Table mapping chain IDs to names. Compatible/joinable with `prices` tables, and used for filtering chain types.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -55,4 +55,8 @@ models:
       - &dune_name
         name: dune_name
         description: "Name of the blockchain used on Dune (prices table)"
+      - &chain_name
+        name: chain_name
       - *chain_id
+      - &chain_type
+        name: chain_type 

--- a/models/chain_info/chain_info_schema.yml
+++ b/models/chain_info/chain_info_schema.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: chain_info_chain_ids
     meta:
-      blockchain: ethereum, optimism, bnb, gnosis, polygon, fantom, arbitrum, avalanche_c, solana
+      blockchain: ethereum, optimism, bnb, gnosis, polygon, fantom, arbitrum, avalanche_c, solana, gnosis
       project: chain_info
       contributors: msilb7
     config:
@@ -40,7 +40,7 @@ models:
 
   - name: chain_info_dune_chains
     meta:
-      blockchain: ethereum, optimism, bnb, gnosis, polygon, fantom, arbitrum, avalanche_c, solana
+      blockchain: ethereum, optimism, bnb, gnosis, polygon, fantom, arbitrum, avalanche_c, solana, gnosis
       project: chain_info
       contributors: cc7768, msilb7
     config:

--- a/models/chain_info/chain_info_schema.yml
+++ b/models/chain_info/chain_info_schema.yml
@@ -55,8 +55,7 @@ models:
       - &dune_name
         name: dune_name
         description: "Name of the blockchain used on Dune (prices table)"
-      - &chain_name
-        name: chain_name
+      - *chain_name
       - *chain_id
       - &chain_type
         name: chain_type 

--- a/models/evms/evms_blocks.sql
+++ b/models/evms/evms_blocks.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='blocks',
         unique_key=['blockchain', 'number'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('fantom', 'blocks'))
      , ('optimism', source('optimism', 'blocks'))
      , ('arbitrum', source('arbitrum', 'blocks'))
+     , ('goerli', source('goerli', 'blocks'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_contracts.sql
+++ b/models/evms/evms_contracts.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='contracts',
         unique_key=['blockchain', 'address', 'created_at'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,8 @@
      , ('fantom', source('fantom', 'contracts'))
      , ('optimism', source('optimism', 'contracts'))
      , ('arbitrum', source('arbitrum', 'contracts'))
+     , ('goerli', source('goerli', 'contracts'))
+     
 ] %}
 
 SELECT *

--- a/models/evms/evms_creation_traces.sql
+++ b/models/evms/evms_creation_traces.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='creation_traces',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,8 @@
      , ('fantom', source('fantom', 'creation_traces'))
      , ('optimism', source('optimism', 'creation_traces'))
      , ('arbitrum', source('arbitrum', 'creation_traces'))
+     , ('goerli', source('goerli', 'creation_traces'))
+     
 ] %}
 
 SELECT *

--- a/models/evms/evms_erc1155_approvalsforall.sql
+++ b/models/evms/evms_erc1155_approvalsforall.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='erc1155_approvalsforall',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('erc1155_fantom', 'evt_ApprovalForAll'))
      , ('optimism', source('erc1155_optimism', 'evt_ApprovalForAll'))
      , ('arbitrum', source('erc1155_arbitrum', 'evt_ApprovalForAll'))
+     , ('goerli', source('erc1155_goerli', 'evt_ApprovalForAll'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_erc1155_transfersbatch.sql
+++ b/models/evms/evms_erc1155_transfersbatch.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='erc1155_transfersbatch',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('erc1155_fantom', 'evt_transferbatch'))
      , ('optimism', source('erc1155_optimism', 'evt_transferbatch'))
      , ('arbitrum', source('erc1155_arbitrum', 'evt_transferbatch'))
+     , ('goerli', source('erc1155_goerli', 'evt_transferbatch'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_erc1155_transferssingle.sql
+++ b/models/evms/evms_erc1155_transferssingle.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='erc1155_transferssingle',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('erc1155_fantom', 'evt_transfersingle'))
      , ('optimism', source('erc1155_optimism', 'evt_transfersingle'))
      , ('arbitrum', source('erc1155_arbitrum', 'evt_transfersingle'))
+     , ('goerli', source('erc1155_goerli', 'evt_transfersingle'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_erc20_approvals.sql
+++ b/models/evms/evms_erc20_approvals.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='erc20_approvals',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('erc20_fantom', 'evt_approval'))
      , ('optimism', source('erc20_optimism', 'evt_Approval'))
      , ('arbitrum', source('erc20_arbitrum', 'evt_approval'))
+     , ('goerli', source('erc20_goerli', 'evt_approval'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_erc20_transfers.sql
+++ b/models/evms/evms_erc20_transfers.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='erc20_transfers',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('erc20_fantom', 'evt_transfer'))
      , ('optimism', source('erc20_optimism', 'evt_transfer'))
      , ('arbitrum', source('erc20_arbitrum', 'evt_transfer'))
+     , ('goerli', source('erc20_goerli', 'evt_transfer'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_erc721_approvals.sql
+++ b/models/evms/evms_erc721_approvals.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='erc721_approvals',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('erc721_fantom', 'evt_Approval'))
      , ('optimism', source('erc721_optimism', 'evt_Approval'))
      , ('arbitrum', source('erc721_arbitrum', 'evt_Approval'))
+     , ('goerli', source('erc721_goerli', 'evt_Approval'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_erc721_approvalsforall.sql
+++ b/models/evms/evms_erc721_approvalsforall.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='erc721_approvalsforall',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('erc721_fantom', 'evt_ApprovalForAll'))
      , ('optimism', source('erc721_optimism', 'evt_ApprovalForAll'))
      , ('arbitrum', source('erc721_arbitrum', 'evt_ApprovalForAll'))
+     , ('goerli', source('erc721_goerli', 'evt_ApprovalForAll'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_erc721_transfers.sql
+++ b/models/evms/evms_erc721_transfers.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='erc721_transfers',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('erc721_fantom', 'evt_transfer'))
      , ('optimism', source('erc721_optimism', 'evt_transfer'))
      , ('arbitrum', source('erc721_arbitrum', 'evt_transfer'))
+     , ('goerli', source('erc721_goerli', 'evt_transfer'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_logs.sql
+++ b/models/evms/evms_logs.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='logs',
         unique_key=['blockchain', 'tx_hash'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('fantom', 'logs'))
      , ('optimism', source('optimism', 'logs'))
      , ('arbitrum', source('arbitrum', 'logs'))
+     , ('goerli', source('goerli', 'logs'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_logs_decoded.sql
+++ b/models/evms/evms_logs_decoded.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='logs_decoded',
         unique_key=['blockchain', 'tx_hash'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('fantom', 'logs_decoded'))
      , ('optimism', source('optimism', 'logs_decoded'))
      , ('arbitrum', source('arbitrum', 'logs_decoded'))
+     , ('goerli', source('goerli', 'logs_decoded'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_schema.yml
+++ b/models/evms/evms_schema.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: evms_transactions
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -79,7 +79,7 @@ models:
 
   - name: evms_traces
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -133,7 +133,7 @@ models:
 
   - name: evms_traces_decoded
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -160,7 +160,7 @@ models:
 
   - name: evms_logs
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -191,7 +191,7 @@ models:
 
   - name: evms_logs_decoded
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -218,7 +218,7 @@ models:
 
   - name: evms_blocks
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -241,7 +241,7 @@ models:
 
   - name: evms_contracts
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -277,7 +277,7 @@ models:
       
   - name: evms_creation_traces
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -297,7 +297,7 @@ models:
 
   - name: evms_erc20_transfers
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -326,7 +326,7 @@ models:
 
   - name: evms_erc20_approvals
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -351,7 +351,7 @@ models:
 
   - name: evms_erc1155_transferssingle
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -376,7 +376,7 @@ models:
 
   - name: evms_erc1155_transfersbatch
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -401,7 +401,7 @@ models:
 
   - name: evms_erc1155_approvalsforall
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -429,7 +429,7 @@ models:
 
   - name: evms_erc721_transfers
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -450,7 +450,7 @@ models:
 
   - name: evms_erc721_approvals
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:
@@ -471,7 +471,7 @@ models:
 
   - name: evms_erc721_approvalsforall
     meta:
-      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, goerli
       sector: evms
       contributors: hildobby
     config:

--- a/models/evms/evms_traces.sql
+++ b/models/evms/evms_traces.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='traces',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('fantom', 'traces'))
      , ('optimism', source('optimism', 'traces'))
      , ('arbitrum', source('arbitrum', 'traces'))
+     , ('goerli', source('goerli', 'traces'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_traces_decoded.sql
+++ b/models/evms/evms_traces_decoded.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='traces_decoded',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@
      , ('fantom', source('fantom', 'traces_decoded'))
      , ('optimism', source('optimism', 'traces_decoded'))
      , ('arbitrum', source('arbitrum', 'traces_decoded'))
+     , ('goerli', source('goerli', 'traces_decoded'))
 ] %}
 
 SELECT *

--- a/models/evms/evms_transactions.sql
+++ b/models/evms/evms_transactions.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='transactions',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
-        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "goerli"]\',
                                     "sector",
                                     "evms",
                                     \'["hildobby"]\') }}'
@@ -16,6 +16,7 @@
      , ('gnosis', source('gnosis', 'transactions'))
      , ('fantom', source('fantom', 'transactions'))
      , ('arbitrum', source('arbitrum', 'transactions'))
+     , ('goerli', source('goerli', 'transactions'))
 ] %}
 
 SELECT *


### PR DESCRIPTION
Add Goerli to EVMs tables, and add columns to chain info for relevant filters (i.e. Mainnet vs Testnet)

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
