### PR TITLE
Add token price for EDU and ID on BNB chain

### DIFF
--- a/models/nft/ethereum/nft_ethereum_wash_trades.sql
+++ b/models/nft/ethereum/nft_ethereum_wash_trades.sql
@@ -55,6 +55,7 @@ WITH filter_1 AS (
         AND filter_bought_3x.token_id=nftt.token_id
         AND filter_bought_3x.buyer=nftt.buyer
         AND filter_bought_3x.token_standard IN ('erc721', 'erc20')
+        AND '0x29469395eaf6f95920e59f858042f0e28d98a20b' NOT IN (nftt.buyer, nftt.seller)
         {% if is_incremental() %}
         AND filter_bought_3x.block_time >= date_trunc("day", NOW() - interval '1 week')
         {% endif %}
@@ -78,6 +79,7 @@ WITH filter_1 AS (
         AND filter_sold_3x.token_id=nftt.token_id
         AND filter_sold_3x.seller=nftt.seller
         AND filter_sold_3x.token_standard IN ('erc721', 'erc20')
+        AND '0x29469395eaf6f95920e59f858042f0e28d98a20b' NOT IN (nftt.buyer, nftt.seller)
         {% if is_incremental() %}
         AND filter_sold_3x.block_time >= date_trunc("day", NOW() - interval '1 week')
         {% endif %}

--- a/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -1330,7 +1330,7 @@ FROM
     ('geth-goerli-eth', 'ethereum', 'GETH', '0xdD69DB25F6D620A7baD3023c5d32761D353D3De9', 18),
     ('bytes-bytes', 'ethereum', 'BYTES', '0x7d647b1A0dcD5525e9C6B3D14BE58f27674f8c95', 18),
     ('dc-dogechain-token', 'ethereum', 'DC', '0x7B4328c127B85369D9f82ca0503B000D09CF9180', 18),
-    ('luna-wrapped-luna-token', 'ethereum', 'LUNA', '0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9', 18),
+    ('luna-terra', 'ethereum', 'LUNC', '0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9', 18),
     ('sov-shiboriginalvision', 'ethereum', 'SOV', '0x2C5BC2Ba3614fD27FCc7022eA71d9172E2632c16', 18),
     ('texan-texan', 'ethereum', 'TEXAN', '0xcFCFfE432A48dB53F59c301422d2EdD77B2A88d7', 18),
     ('eggs-eggs', 'ethereum', 'EGGS', '0x2e516BA5Bf3b7eE47fb99B09eaDb60BDE80a82e0', 18),


### PR DESCRIPTION
# SPELLBOOK FREEZE

From June 22 to June 29, we will be freezing some Spellbook contributions for the migration to DuneSQL. We will not accept contributions to the lineage of the following models:

* dex.trades
* nft.trades
* labels
* token.erc20
* tokens.nft

Run the following command to see the list of affected files:

```
dbt ls --resource-type model --output path --select +dex_trades +labels +nft_trades +tokens_nft +tokens_erc20
```

Don't hesitate to reach out on Discord if you have any questions.

Brief comments on the purpose of your changes:

**Add token price for EDU and ID**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [x] `coin_id` represents the ID of the coin on coinpaprika.com
* [x] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
