### PR TITLE
Change the order of commit manifest runs to run spark first

### DIFF
--- a/.github/workflows/commit_manifest.yml
+++ b/.github/workflows/commit_manifest.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [ self-hosted, linux, spellbook-trino ]
     strategy:
       matrix:
-        engine: [ 'dunesql', 'spark' ]
+        engine: [ 'spark', 'dunesql' ]
       max-parallel: 1
 
     steps:


### PR DESCRIPTION
Changing the order of Commit Manifest workflow to run spark first since dunesql is failing.