### PR TITLE
Disable dunesql and use spellbook runner for commit manifest

### DIFF
--- a/.github/workflows/commit_manifest.yml
+++ b/.github/workflows/commit_manifest.yml
@@ -12,10 +12,10 @@ concurrency:
       
 jobs:
   commit_manifest:
-    runs-on: [ self-hosted, linux, spellbook-trino ]
+    runs-on: [ self-hosted, linux, spellbook ]
     strategy:
       matrix:
-        engine: [ 'spark', 'dunesql' ]
+        engine: [ 'spark' ]
       max-parallel: 1
 
     steps:


### PR DESCRIPTION
`spellbook-trino` runner doesn't seem to have the permissions to write to s3. Reverting to using `spellbook` runner and disabling `dunesql` in the matrix since we don't need it for now.