### PR TITLE
Remove concurrency job from commit_manifest.yml

### DIFF
--- a/.github/workflows/commit_manifest.yml
+++ b/.github/workflows/commit_manifest.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches:
       - "main"
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
       
 jobs:
   commit_manifest:


### PR DESCRIPTION
I don't think commit manifest should be subject to this concurrency group. This job shouldn't get canceled by incoming CI runs.
