### PR TITLE
Set Trino view security to invoker

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -51,6 +51,7 @@ models:
         transaction: true
     +materialized: view
     +schema: no_schema    # this should be overriden in model specific configs
+    +view_security: invoker
 
     aave:
       +schema: aave


### PR DESCRIPTION
The default is definer, which means that the user querying the query get's the credentials of the definer, in this case spellbook. Unfortunately the spellbook user is not defined in our query clusters. See also https://docs.getdbt.com/reference/resource-configs/trino-configs#view