### PR TITLE
tokens_arbitrum_erc20: add mUMAMI and cmUMAMI

### DIFF
--- a/models/tokens/arbitrum/tokens_arbitrum_erc20.sql
+++ b/models/tokens/arbitrum/tokens_arbitrum_erc20.sql
@@ -54,6 +54,8 @@ FROM (VALUES
         ,('0x031d35296154279dc1984dcd93e392b1f946737b', 'CAP', 18)
         ,('0x82af49447d8a07e3bd95bd0d56f35241523fbab1', 'WETH', 18)
         ,('0x1622bf67e6e5747b81866fe0b85178a93c7f86e3','UMAMI', 9)
+        ,('0x2adabd6e8ce3e82f52d9998a7f64a90d294a92a4','mUMAMI', 9)
+        ,('0x1922c36f3bc762ca300b4a46bb2102f84b1684ab','cmUMAMI', 9)
         ,('0x5575552988a3a80504bbaeb1311674fcfd40ad4b', 'SPA', 18)
         ,('0xd74f5255d557944cf7dd0e45ff521520002d5748', 'USDs', 18)
         ,('0x539bde0d7dbd336b79148aa742883198bbf60342', 'MAGIC', 18)


### PR DESCRIPTION
# SPELLBOOK FREEZE

From June 22 to June 29, we will be freezing some Spellbook contributions for the migration to DuneSQL. We will not accept contributions to the lineage of the following models:

* dex.trades
* nft.trades
* labels
* token.erc20
* tokens.nft

Run the following command to see the list of affected files:

```
dbt ls --resource-type model --output path --select +dex_trades +labels +nft_trades +tokens_nft +tokens_erc20
```

Don't hesitate to reach out on Discord if you have any questions.

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
