### PR TITLE
Test

### DIFF
--- a/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
@@ -53,6 +53,9 @@ WITH
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash 
                 AND f.index = m.max_fee_evt_index
+        {% if is_incremental() %}
+        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
     ),
     swap_fees AS (
         SELECT

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
@@ -38,6 +38,7 @@ WITH
         {% if is_incremental() %}
         WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
+        GROUP BY 1, 2, 3
     ),
     edge_case_fees AS (
         SELECT 

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
@@ -16,69 +16,26 @@
 {% set project_start_date = '2021-08-27' %}
 
 WITH 
-    fees_base AS (
-        SELECT *, 
-            MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
+    fees_changes AS (
+        SELECT *, block_number + 0.0001 * index AS block_number_index_1
         FROM {{ ref('balancer_v2_arbitrum_pools_fees') }} 
-    ),
-    most_case_fees AS (
-        SELECT * FROM fees_base 
-        WHERE index = max_index_same_tx
-    ),
-    max_fee_change_evt_edge_case AS (
-        SELECT 
-            s.evt_block_number,
-            s.evt_tx_hash,
-            s.evt_index,
-            s.poolId,
-            MAX(f.index) AS max_fee_evt_index
-        FROM {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} s
-        INNER JOIN fees_base f 
-            ON f.tx_hash = s.evt_tx_hash
-            AND f.index < s.evt_index
-            AND f.contract_address = SUBSTRING(CAST(s.poolId AS varchar(66)), 1, 42)
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
-        GROUP BY 1, 2, 3, 4
-    ),
-    edge_case_fees AS (
-        SELECT 
-            s.evt_block_number,
-            s.evt_tx_hash,
-            s.evt_index,
-            s.poolId,
-            f.swap_fee_percentage 
-        FROM {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} s
-            INNER JOIN max_fee_change_evt_edge_case m
-                ON s.evt_block_number = m.evt_block_number
-                AND s.evt_tx_hash = m.evt_tx_hash 
-                AND s.evt_index = m.evt_index
-                AND s.poolId = m.poolId
-            INNER JOIN fees_base f 
-                ON s.evt_tx_hash = f.tx_hash 
-                AND f.index = m.max_fee_evt_index
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     swap_fees AS (
         SELECT
-            swap.evt_block_number,
-            swap.evt_tx_hash,
-            swap.evt_index,
-            SUBSTRING(swap.poolId, 0, 42) AS contract_address,
-            swap.evt_block_time,
-            MAX(fees.block_time) AS max_fee_evt_block_time
-        FROM
-            {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
-            LEFT JOIN {{ ref('balancer_v2_arbitrum_pools_fees') }} fees
-                ON fees.contract_address = SUBSTRING(swap.poolId, 0, 42)
-                AND fees.block_time <= swap.evt_block_time
+            swaps.poolId,
+            swaps.evt_block_number,
+            swaps.evt_tx_hash,
+            swaps.evt_index,
+            SUBSTRING(CAST(swaps.poolId AS varchar(66)), 1, 42) AS contract_address,
+            fees.swap_fee_percentage,
+            ROW_NUMBER() OVER (PARTITION BY poolId, evt_tx_hash, evt_index ORDER BY block_number_index_1 DESC) AS rn
+        FROM {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swaps
+        LEFT JOIN fees_changes fees
+            ON CAST(fees.contract_address AS varchar(66)) = substring(CAST(swaps.poolId AS varchar(66)), 1, 42)
+            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0001 * evt_index
         {% if is_incremental() %}
-        WHERE swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        WHERE swaps.evt_block_time >= date_trunc('day', NOW() - interval '1 week')
         {% endif %}
-        GROUP BY 1, 2, 3, 4, 5
     ),
     dexs AS (
         SELECT
@@ -93,28 +50,20 @@ WITH
             swap.tokenIn AS token_sold_address,
             swap_fees.contract_address AS project_contract_address,
             swap.poolId AS poolId,
-            COALESCE(most.swap_fee_percentage, edge.swap_fee_percentage) / POWER(10, 18) AS swap_fee,
+            swap_fees.swap_fee_percentage / POWER(10, 18) AS swap_fee,
             swap.evt_tx_hash AS tx_hash,
             '' AS trace_address,
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
+            INNER JOIN `balancer_v2_arbitrum`.`Vault_evt_Swap` swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index
-            LEFT JOIN most_case_fees most
-                ON most.contract_address = swap_fees.contract_address
-                AND most.block_time = swap_fees.max_fee_evt_block_time
-                AND most.tx_hash <> swap_fees.evt_tx_hash
-            LEFT JOIN edge_case_fees edge
-                ON edge.evt_block_number = swap_fees.evt_block_number
-                AND edge.evt_tx_hash = swap_fees.evt_tx_hash
-                AND edge.evt_index = swap_fees.evt_index
-                AND edge.poolId = swap.poolId
         WHERE
             swap.tokenIn <> swap_fees.contract_address
             AND swap.tokenOut <> swap_fees.contract_address
+            AND swap_fees.rn = 1
     ),
     bpa AS (
         SELECT

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
@@ -17,7 +17,7 @@
 
 WITH 
     fees_changes AS (
-        SELECT *, block_number + 0.0001 * index AS block_number_index_1
+        SELECT *, block_number + 0.0000001 * index AS block_number_index_1
         FROM {{ ref('balancer_v2_arbitrum_pools_fees') }} 
     ),
     swap_fees AS (
@@ -32,7 +32,7 @@ WITH
         FROM {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swaps
         LEFT JOIN fees_changes fees
             ON CAST(fees.contract_address AS varchar(66)) = substring(CAST(swaps.poolId AS varchar(66)), 1, 42)
-            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0001 * evt_index
+            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0000001 * evt_index
         {% if is_incremental() %}
         WHERE swaps.evt_block_time >= date_trunc('day', NOW() - interval '1 week')
         {% endif %}

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
@@ -15,7 +15,7 @@
 
 {% set project_start_date = '2021-08-27' %}
 
-WITH
+WITH 
     fees_base AS (
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
@@ -30,27 +30,31 @@ WITH
             s.evt_block_number,
             s.evt_tx_hash,
             s.evt_index,
+            s.poolId,
             MAX(f.index) AS max_fee_evt_index
         FROM {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} s
         INNER JOIN fees_base f 
-            ON s.evt_tx_hash = f.tx_hash 
+            ON f.tx_hash = s.evt_tx_hash
             AND f.index < s.evt_index
+            AND f.contract_address = SUBSTRING(CAST(s.poolId AS varchar(66)), 1, 42)
         {% if is_incremental() %}
         WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
-        GROUP BY 1, 2, 3
+        GROUP BY 1, 2, 3, 4
     ),
     edge_case_fees AS (
         SELECT 
             s.evt_block_number,
             s.evt_tx_hash,
             s.evt_index,
+            s.poolId,
             f.swap_fee_percentage 
         FROM {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} s
             INNER JOIN max_fee_change_evt_edge_case m
                 ON s.evt_block_number = m.evt_block_number
                 AND s.evt_tx_hash = m.evt_tx_hash 
                 AND s.evt_index = m.evt_index
+                AND s.poolId = m.poolId
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash 
                 AND f.index = m.max_fee_evt_index
@@ -107,6 +111,7 @@ WITH
                 ON edge.evt_block_number = swap_fees.evt_block_number
                 AND edge.evt_tx_hash = swap_fees.evt_tx_hash
                 AND edge.evt_index = swap_fees.evt_index
+                AND edge.poolId = swap.poolId
         WHERE
             swap.tokenIn <> swap_fees.contract_address
             AND swap.tokenOut <> swap_fees.contract_address

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
@@ -56,7 +56,7 @@ WITH
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN `balancer_v2_arbitrum`.`Vault_evt_Swap` swap
+            INNER JOIN {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_trades.sql
@@ -15,7 +15,7 @@
 
 {% set project_start_date = '2021-08-27' %}
 
-WITH 
+WITH
     fees_base AS (
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -15,7 +15,7 @@
 
 {% set project_start_date = '2021-04-20' %}
 
-WITH    
+WITH
     fees_base AS (
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -38,6 +38,7 @@ WITH
         {% if is_incremental() %}
         WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
+        GROUP BY 1, 2, 3
     ),
     edge_case_fees AS (
         SELECT 

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -26,6 +26,20 @@ WITH
         SELECT * FROM fees_base 
         WHERE index = max_index_same_tx
     ),
+    max_fee_change_evt_edge_case AS (
+        SELECT 
+            s.evt_block_number,
+            s.evt_tx_hash,
+            s.evt_index,
+            MAX(f.index) AS max_fee_evt_index
+        FROM {{ source ('balancer_v2_ethereum', 'Vault_evt_Swap') }} s
+        INNER JOIN fees_base f 
+            ON s.evt_tx_hash = f.tx_hash 
+            AND f.index < s.evt_index
+        {% if is_incremental() %}
+        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
+    ),
     edge_case_fees AS (
         SELECT 
             s.evt_block_number,
@@ -33,8 +47,13 @@ WITH
             s.evt_index,
             f.swap_fee_percentage 
         FROM {{ source ('balancer_v2_ethereum', 'Vault_evt_Swap') }} s
+            INNER JOIN max_fee_change_evt_edge_case m
+                ON s.evt_block_number = m.evt_block_number
+                AND s.evt_tx_hash = m.evt_tx_hash 
+                AND s.evt_index = m.evt_index
             INNER JOIN fees_base f 
-                ON s.evt_tx_hash = f.tx_hash AND f.index < s.evt_index
+                ON s.evt_tx_hash = f.tx_hash 
+                AND f.index = m.max_fee_evt_index
     ),
     swap_fees AS (
         SELECT

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -1,5 +1,4 @@
 {{ config(
-    tags=['prod_exclude'],
     schema = 'balancer_v2_ethereum',
     alias = 'trades',
     partition_by = ['block_date'],

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -56,7 +56,7 @@ WITH
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN `balancer_v2_ethereum`.`Vault_evt_Swap` swap
+            INNER JOIN {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -32,7 +32,7 @@ WITH
         FROM {{ source ('balancer_v2_ethereum', 'Vault_evt_Swap') }} swaps
         LEFT JOIN fees_changes fees
             ON CAST(fees.contract_address AS varchar(66)) = substring(CAST(swaps.poolId AS varchar(66)), 1, 42)
-            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0001 * evt_index
+            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0000001 * evt_index
         {% if is_incremental() %}
         WHERE swaps.evt_block_time >= date_trunc('day', NOW() - interval '1 week')
         {% endif %}

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -16,7 +16,7 @@
 
 {% set project_start_date = '2021-04-20' %}
 
-WITH
+WITH 
     fees_base AS (
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -54,6 +54,9 @@ WITH
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash 
                 AND f.index = m.max_fee_evt_index
+        {% if is_incremental() %}
+        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
     ),
     swap_fees AS (
         SELECT

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -56,7 +56,7 @@ WITH
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
+            INNER JOIN {{ source ('balancer_v2_ethereum', 'Vault_evt_Swap') }} swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index

--- a/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_trades.sql
@@ -17,7 +17,7 @@
 
 WITH 
     fees_changes AS (
-        SELECT *, block_number + 0.0001 * index AS block_number_index_1
+        SELECT *, block_number + 0.0000001 * index AS block_number_index_1
         FROM {{ ref('balancer_v2_ethereum_pools_fees') }} 
     ),
     swap_fees AS (

--- a/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
@@ -56,7 +56,7 @@ WITH
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN `balancer_v2_gnosis`.`Vault_evt_Swap` swap
+            INNER JOIN {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index

--- a/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
@@ -17,7 +17,7 @@
 
 WITH 
     fees_changes AS (
-        SELECT *, block_number + 0.0001 * index AS block_number_index_1
+        SELECT *, block_number + 0.0000001 * index AS block_number_index_1
         FROM {{ ref('balancer_v2_gnosis_pools_fees') }} 
     ),
     swap_fees AS (
@@ -32,7 +32,7 @@ WITH
         FROM {{ source ('balancer_v2_gnosis', 'Vault_evt_Swap') }} swaps
         LEFT JOIN fees_changes fees
             ON CAST(fees.contract_address AS varchar(66)) = substring(CAST(swaps.poolId AS varchar(66)), 1, 42)
-            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0001 * evt_index
+            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0000001 * evt_index
         {% if is_incremental() %}
         WHERE swaps.evt_block_time >= date_trunc('day', NOW() - interval '1 week')
         {% endif %}

--- a/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
@@ -53,6 +53,9 @@ WITH
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash 
                 AND f.index = m.max_fee_evt_index
+        {% if is_incremental() %}
+        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
     ),
     swap_fees AS (
         SELECT

--- a/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
@@ -38,6 +38,7 @@ WITH
         {% if is_incremental() %}
         WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
+        GROUP BY 1, 2, 3
     ),
     edge_case_fees AS (
         SELECT 

--- a/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
@@ -15,7 +15,7 @@
 
 {% set project_start_date = '2023-01-14' %}
 
-WITH    
+WITH 
     fees_base AS (
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
@@ -25,6 +25,20 @@ WITH
         SELECT * FROM fees_base 
         WHERE index = max_index_same_tx
     ),
+    max_fee_change_evt_edge_case AS (
+        SELECT 
+            s.evt_block_number,
+            s.evt_tx_hash,
+            s.evt_index,
+            MAX(f.index) AS max_fee_evt_index
+        FROM {{ source ('balancer_v2_gnosis', 'Vault_evt_Swap') }} s
+        INNER JOIN fees_base f 
+            ON s.evt_tx_hash = f.tx_hash 
+            AND f.index < s.evt_index
+        {% if is_incremental() %}
+        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
+    ),
     edge_case_fees AS (
         SELECT 
             s.evt_block_number,
@@ -32,8 +46,13 @@ WITH
             s.evt_index,
             f.swap_fee_percentage 
         FROM {{ source ('balancer_v2_gnosis', 'Vault_evt_Swap') }} s
+            INNER JOIN max_fee_change_evt_edge_case m
+                ON s.evt_block_number = m.evt_block_number
+                AND s.evt_tx_hash = m.evt_tx_hash 
+                AND s.evt_index = m.evt_index
             INNER JOIN fees_base f 
-                ON s.evt_tx_hash = f.tx_hash AND f.index < s.evt_index
+                ON s.evt_tx_hash = f.tx_hash 
+                AND f.index = m.max_fee_evt_index
     ),
     swap_fees AS (
         SELECT

--- a/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
@@ -16,69 +16,26 @@
 {% set project_start_date = '2023-01-14' %}
 
 WITH 
-    fees_base AS (
-        SELECT *, 
-            MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
+    fees_changes AS (
+        SELECT *, block_number + 0.0001 * index AS block_number_index_1
         FROM {{ ref('balancer_v2_gnosis_pools_fees') }} 
-    ),
-    most_case_fees AS (
-        SELECT * FROM fees_base 
-        WHERE index = max_index_same_tx
-    ),
-    max_fee_change_evt_edge_case AS (
-        SELECT 
-            s.evt_block_number,
-            s.evt_tx_hash,
-            s.evt_index,
-            s.poolId,
-            MAX(f.index) AS max_fee_evt_index
-        FROM {{ source ('balancer_v2_gnosis', 'Vault_evt_Swap') }} s
-        INNER JOIN fees_base f 
-            ON f.tx_hash = s.evt_tx_hash
-            AND f.index < s.evt_index
-            AND f.contract_address = SUBSTRING(CAST(s.poolId AS varchar(66)), 1, 42)
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
-        GROUP BY 1, 2, 3, 4
-    ),
-    edge_case_fees AS (
-        SELECT 
-            s.evt_block_number,
-            s.evt_tx_hash,
-            s.evt_index,
-            s.poolId,
-            f.swap_fee_percentage 
-        FROM {{ source ('balancer_v2_gnosis', 'Vault_evt_Swap') }} s
-            INNER JOIN max_fee_change_evt_edge_case m
-                ON s.evt_block_number = m.evt_block_number
-                AND s.evt_tx_hash = m.evt_tx_hash 
-                AND s.evt_index = m.evt_index
-                AND s.poolId = m.poolId
-            INNER JOIN fees_base f 
-                ON s.evt_tx_hash = f.tx_hash 
-                AND f.index = m.max_fee_evt_index
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     swap_fees AS (
         SELECT
-            swap.evt_block_number,
-            swap.evt_tx_hash,
-            swap.evt_index,
-            SUBSTRING(swap.poolId, 0, 42) AS contract_address,
-            swap.evt_block_time,
-            MAX(fees.block_time) AS max_fee_evt_block_time
-        FROM
-            {{ source ('balancer_v2_gnosis', 'Vault_evt_Swap') }} swap
-            LEFT JOIN {{ ref('balancer_v2_gnosis_pools_fees') }} fees
-                ON fees.contract_address = SUBSTRING(swap.poolId, 0, 42)
-                AND fees.block_time <= swap.evt_block_time
+            swaps.poolId,
+            swaps.evt_block_number,
+            swaps.evt_tx_hash,
+            swaps.evt_index,
+            SUBSTRING(CAST(swaps.poolId AS varchar(66)), 1, 42) AS contract_address,
+            fees.swap_fee_percentage,
+            ROW_NUMBER() OVER (PARTITION BY poolId, evt_tx_hash, evt_index ORDER BY block_number_index_1 DESC) AS rn
+        FROM {{ source ('balancer_v2_gnosis', 'Vault_evt_Swap') }} swaps
+        LEFT JOIN fees_changes fees
+            ON CAST(fees.contract_address AS varchar(66)) = substring(CAST(swaps.poolId AS varchar(66)), 1, 42)
+            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0001 * evt_index
         {% if is_incremental() %}
-        WHERE swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        WHERE swaps.evt_block_time >= date_trunc('day', NOW() - interval '1 week')
         {% endif %}
-        GROUP BY 1, 2, 3, 4, 5
     ),
     dexs AS (
         SELECT
@@ -93,28 +50,20 @@ WITH
             swap.tokenIn AS token_sold_address,
             swap_fees.contract_address AS project_contract_address,
             swap.poolId AS poolId,
-            COALESCE(most.swap_fee_percentage, edge.swap_fee_percentage) / POWER(10, 18) AS swap_fee,
+            swap_fees.swap_fee_percentage / POWER(10, 18) AS swap_fee,
             swap.evt_tx_hash AS tx_hash,
             '' AS trace_address,
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN {{ source ('balancer_v2_gnosis', 'Vault_evt_Swap') }} swap
+            INNER JOIN `balancer_v2_gnosis`.`Vault_evt_Swap` swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index
-            LEFT JOIN most_case_fees most
-                ON most.contract_address = swap_fees.contract_address
-                AND most.block_time = swap_fees.max_fee_evt_block_time
-                AND most.tx_hash <> swap_fees.evt_tx_hash
-            LEFT JOIN edge_case_fees edge
-                ON edge.evt_block_number = swap_fees.evt_block_number
-                AND edge.evt_tx_hash = swap_fees.evt_tx_hash
-                AND edge.evt_index = swap_fees.evt_index
-                AND edge.poolId = swap.poolId
         WHERE
             swap.tokenIn <> swap_fees.contract_address
             AND swap.tokenOut <> swap_fees.contract_address
+            AND swap_fees.rn = 1
     ),
     bpa AS (
         SELECT

--- a/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
@@ -30,27 +30,31 @@ WITH
             s.evt_block_number,
             s.evt_tx_hash,
             s.evt_index,
+            s.poolId,
             MAX(f.index) AS max_fee_evt_index
         FROM {{ source ('balancer_v2_gnosis', 'Vault_evt_Swap') }} s
         INNER JOIN fees_base f 
-            ON s.evt_tx_hash = f.tx_hash 
+            ON f.tx_hash = s.evt_tx_hash
             AND f.index < s.evt_index
+            AND f.contract_address = SUBSTRING(CAST(s.poolId AS varchar(66)), 1, 42)
         {% if is_incremental() %}
         WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
-        GROUP BY 1, 2, 3
+        GROUP BY 1, 2, 3, 4
     ),
     edge_case_fees AS (
         SELECT 
             s.evt_block_number,
             s.evt_tx_hash,
             s.evt_index,
+            s.poolId,
             f.swap_fee_percentage 
         FROM {{ source ('balancer_v2_gnosis', 'Vault_evt_Swap') }} s
             INNER JOIN max_fee_change_evt_edge_case m
                 ON s.evt_block_number = m.evt_block_number
                 AND s.evt_tx_hash = m.evt_tx_hash 
                 AND s.evt_index = m.evt_index
+                AND s.poolId = m.poolId
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash 
                 AND f.index = m.max_fee_evt_index
@@ -107,6 +111,7 @@ WITH
                 ON edge.evt_block_number = swap_fees.evt_block_number
                 AND edge.evt_tx_hash = swap_fees.evt_tx_hash
                 AND edge.evt_index = swap_fees.evt_index
+                AND edge.poolId = swap.poolId
         WHERE
             swap.tokenIn <> swap_fees.contract_address
             AND swap.tokenOut <> swap_fees.contract_address

--- a/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_trades.sql
@@ -56,7 +56,7 @@ WITH
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
+            INNER JOIN {{ source ('balancer_v2_gnosis', 'Vault_evt_Swap') }} swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -56,7 +56,7 @@ WITH
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
+            INNER JOIN {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -53,6 +53,9 @@ WITH
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash 
                 AND f.index = m.max_fee_evt_index
+        {% if is_incremental() %}
+        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
     ),
     swap_fees AS (
         SELECT

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -56,7 +56,7 @@ WITH
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN `balancer_v2_optimism`.`Vault_evt_Swap` swap
+            INNER JOIN {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -38,6 +38,7 @@ WITH
         {% if is_incremental() %}
         WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
+        GROUP BY 1, 2, 3
     ),
     edge_case_fees AS (
         SELECT 

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -17,7 +17,7 @@
 
 WITH 
     fees_changes AS (
-        SELECT *, block_number + 0.0001 * index AS block_number_index_1
+        SELECT *, block_number + 0.0000001 * index AS block_number_index_1
         FROM {{ ref('balancer_v2_optimism_pools_fees') }} 
     ),
     swap_fees AS (
@@ -32,7 +32,7 @@ WITH
         FROM {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} swaps
         LEFT JOIN fees_changes fees
             ON CAST(fees.contract_address AS varchar(66)) = substring(CAST(swaps.poolId AS varchar(66)), 1, 42)
-            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0001 * evt_index
+            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0000001 * evt_index
         {% if is_incremental() %}
         WHERE swaps.evt_block_time >= date_trunc('day', NOW() - interval '1 week')
         {% endif %}

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -16,69 +16,26 @@
 {% set project_start_date = '2022-05-23' %}
 
 WITH 
-    fees_base AS (
-        SELECT *, 
-            MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
+    fees_changes AS (
+        SELECT *, block_number + 0.0001 * index AS block_number_index_1
         FROM {{ ref('balancer_v2_optimism_pools_fees') }} 
-    ),
-    most_case_fees AS (
-        SELECT * FROM fees_base 
-        WHERE index = max_index_same_tx
-    ),
-    max_fee_change_evt_edge_case AS (
-        SELECT 
-            s.evt_block_number,
-            s.evt_tx_hash,
-            s.evt_index,
-            s.poolId,
-            MAX(f.index) AS max_fee_evt_index
-        FROM {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} s
-        INNER JOIN fees_base f 
-            ON f.tx_hash = s.evt_tx_hash
-            AND f.index < s.evt_index
-            AND f.contract_address = SUBSTRING(CAST(s.poolId AS varchar(66)), 1, 42)
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
-        GROUP BY 1, 2, 3, 4
-    ),
-    edge_case_fees AS (
-        SELECT 
-            s.evt_block_number,
-            s.evt_tx_hash,
-            s.evt_index,
-            s.poolId,
-            f.swap_fee_percentage 
-        FROM {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} s
-            INNER JOIN max_fee_change_evt_edge_case m
-                ON s.evt_block_number = m.evt_block_number
-                AND s.evt_tx_hash = m.evt_tx_hash 
-                AND s.evt_index = m.evt_index
-                AND s.poolId = m.poolId
-            INNER JOIN fees_base f 
-                ON s.evt_tx_hash = f.tx_hash 
-                AND f.index = m.max_fee_evt_index
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     swap_fees AS (
         SELECT
-            swap.evt_block_number,
-            swap.evt_tx_hash,
-            swap.evt_index,
-            SUBSTRING(swap.poolId, 0, 42) AS contract_address,
-            swap.evt_block_time,
-            MAX(fees.block_time) AS max_fee_evt_block_time
-        FROM
-            {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} swap
-            LEFT JOIN {{ ref('balancer_v2_optimism_pools_fees') }} fees
-                ON fees.contract_address = SUBSTRING(swap.poolId, 0, 42)
-                AND fees.block_time <= swap.evt_block_time
+            swaps.poolId,
+            swaps.evt_block_number,
+            swaps.evt_tx_hash,
+            swaps.evt_index,
+            SUBSTRING(CAST(swaps.poolId AS varchar(66)), 1, 42) AS contract_address,
+            fees.swap_fee_percentage,
+            ROW_NUMBER() OVER (PARTITION BY poolId, evt_tx_hash, evt_index ORDER BY block_number_index_1 DESC) AS rn
+        FROM {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} swaps
+        LEFT JOIN fees_changes fees
+            ON CAST(fees.contract_address AS varchar(66)) = substring(CAST(swaps.poolId AS varchar(66)), 1, 42)
+            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0001 * evt_index
         {% if is_incremental() %}
-        WHERE swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        WHERE swaps.evt_block_time >= date_trunc('day', NOW() - interval '1 week')
         {% endif %}
-        GROUP BY 1, 2, 3, 4, 5
     ),
     dexs AS (
         SELECT
@@ -93,28 +50,20 @@ WITH
             swap.tokenIn AS token_sold_address,
             swap_fees.contract_address AS project_contract_address,
             swap.poolId AS poolId,
-            COALESCE(most.swap_fee_percentage, edge.swap_fee_percentage) / POWER(10, 18) AS swap_fee,
+            swap_fees.swap_fee_percentage / POWER(10, 18) AS swap_fee,
             swap.evt_tx_hash AS tx_hash,
             '' AS trace_address,
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} swap
+            INNER JOIN `balancer_v2_optimism`.`Vault_evt_Swap` swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index
-            LEFT JOIN most_case_fees most
-                ON most.contract_address = swap_fees.contract_address
-                AND most.block_time = swap_fees.max_fee_evt_block_time
-                AND most.tx_hash <> swap_fees.evt_tx_hash
-            LEFT JOIN edge_case_fees edge
-                ON edge.evt_block_number = swap_fees.evt_block_number
-                AND edge.evt_tx_hash = swap_fees.evt_tx_hash
-                AND edge.evt_index = swap_fees.evt_index
-                AND edge.poolId = swap.poolId
         WHERE
             swap.tokenIn <> swap_fees.contract_address
             AND swap.tokenOut <> swap_fees.contract_address
+            AND swap_fees.rn = 1
     ),
     bpa AS (
         SELECT

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -15,7 +15,7 @@
 
 {% set project_start_date = '2022-05-23' %}
 
-WITH    
+WITH 
     fees_base AS (
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
@@ -25,6 +25,20 @@ WITH
         SELECT * FROM fees_base 
         WHERE index = max_index_same_tx
     ),
+    max_fee_change_evt_edge_case AS (
+        SELECT 
+            s.evt_block_number,
+            s.evt_tx_hash,
+            s.evt_index,
+            MAX(f.index) AS max_fee_evt_index
+        FROM {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} s
+        INNER JOIN fees_base f 
+            ON s.evt_tx_hash = f.tx_hash 
+            AND f.index < s.evt_index
+        {% if is_incremental() %}
+        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
+    ),
     edge_case_fees AS (
         SELECT 
             s.evt_block_number,
@@ -32,8 +46,13 @@ WITH
             s.evt_index,
             f.swap_fee_percentage 
         FROM {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} s
+            INNER JOIN max_fee_change_evt_edge_case m
+                ON s.evt_block_number = m.evt_block_number
+                AND s.evt_tx_hash = m.evt_tx_hash 
+                AND s.evt_index = m.evt_index
             INNER JOIN fees_base f 
-                ON s.evt_tx_hash = f.tx_hash AND f.index < s.evt_index
+                ON s.evt_tx_hash = f.tx_hash 
+                AND f.index = m.max_fee_evt_index
     ),
     swap_fees AS (
         SELECT

--- a/models/balancer/optimism/balancer_v2_optimism_trades.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_trades.sql
@@ -30,27 +30,31 @@ WITH
             s.evt_block_number,
             s.evt_tx_hash,
             s.evt_index,
+            s.poolId,
             MAX(f.index) AS max_fee_evt_index
         FROM {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} s
         INNER JOIN fees_base f 
-            ON s.evt_tx_hash = f.tx_hash 
+            ON f.tx_hash = s.evt_tx_hash
             AND f.index < s.evt_index
+            AND f.contract_address = SUBSTRING(CAST(s.poolId AS varchar(66)), 1, 42)
         {% if is_incremental() %}
         WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
-        GROUP BY 1, 2, 3
+        GROUP BY 1, 2, 3, 4
     ),
     edge_case_fees AS (
         SELECT 
             s.evt_block_number,
             s.evt_tx_hash,
             s.evt_index,
+            s.poolId,
             f.swap_fee_percentage 
         FROM {{ source ('balancer_v2_optimism', 'Vault_evt_Swap') }} s
             INNER JOIN max_fee_change_evt_edge_case m
                 ON s.evt_block_number = m.evt_block_number
                 AND s.evt_tx_hash = m.evt_tx_hash 
                 AND s.evt_index = m.evt_index
+                AND s.poolId = m.poolId
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash 
                 AND f.index = m.max_fee_evt_index
@@ -107,6 +111,7 @@ WITH
                 ON edge.evt_block_number = swap_fees.evt_block_number
                 AND edge.evt_tx_hash = swap_fees.evt_tx_hash
                 AND edge.evt_index = swap_fees.evt_index
+                AND edge.poolId = swap.poolId
         WHERE
             swap.tokenIn <> swap_fees.contract_address
             AND swap.tokenOut <> swap_fees.contract_address

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -17,7 +17,7 @@
 
 WITH 
     fees_changes AS (
-        SELECT *, block_number + 0.0001 * index AS block_number_index_1
+        SELECT *, block_number + 0.0000001 * index AS block_number_index_1
         FROM {{ ref('balancer_v2_polygon_pools_fees') }} 
     ),
     swap_fees AS (
@@ -32,7 +32,7 @@ WITH
         FROM {{ source ('balancer_v2_polygon', 'Vault_evt_Swap') }} swaps
         LEFT JOIN fees_changes fees
             ON CAST(fees.contract_address AS varchar(66)) = substring(CAST(swaps.poolId AS varchar(66)), 1, 42)
-            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0001 * evt_index
+            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0000001 * evt_index
         {% if is_incremental() %}
         WHERE swaps.evt_block_time >= date_trunc('day', NOW() - interval '1 week')
         {% endif %}

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -38,6 +38,7 @@ WITH
         {% if is_incremental() %}
         WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
         {% endif %}
+        GROUP BY 1, 2, 3
     ),
     edge_case_fees AS (
         SELECT 

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -56,7 +56,7 @@ WITH
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN `balancer_v2_polygon`.`Vault_evt_Swap` swap
+            INNER JOIN {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -1,5 +1,4 @@
 {{ config(
-    tags=['prod_exclude'],
     schema = 'balancer_v2_polygon',
     alias = 'trades',
     partition_by = ['block_date'],

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -16,7 +16,7 @@
 
 {% set project_start_date = '2021-06-24' %}
 
-WITH    
+WITH
     fees_base AS (
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -16,69 +16,26 @@
 {% set project_start_date = '2021-06-24' %}
 
 WITH 
-    fees_base AS (
-        SELECT *, 
-            MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
+    fees_changes AS (
+        SELECT *, block_number + 0.0001 * index AS block_number_index_1
         FROM {{ ref('balancer_v2_polygon_pools_fees') }} 
-    ),
-    most_case_fees AS (
-        SELECT * FROM fees_base 
-        WHERE index = max_index_same_tx
-    ),
-    max_fee_change_evt_edge_case AS (
-        SELECT 
-            s.evt_block_number,
-            s.evt_tx_hash,
-            s.evt_index,
-            s.poolId,
-            MAX(f.index) AS max_fee_evt_index
-        FROM {{ source ('balancer_v2_polygon', 'Vault_evt_Swap') }} s
-        INNER JOIN fees_base f 
-            ON f.tx_hash = s.evt_tx_hash
-            AND f.index < s.evt_index
-            AND f.contract_address = SUBSTRING(CAST(s.poolId AS varchar(66)), 1, 42)
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
-        GROUP BY 1, 2, 3, 4
-    ),
-    edge_case_fees AS (
-        SELECT 
-            s.evt_block_number,
-            s.evt_tx_hash,
-            s.evt_index,
-            s.poolId,
-            f.swap_fee_percentage 
-        FROM {{ source ('balancer_v2_polygon', 'Vault_evt_Swap') }} s
-            INNER JOIN max_fee_change_evt_edge_case m
-                ON s.evt_block_number = m.evt_block_number
-                AND s.evt_tx_hash = m.evt_tx_hash 
-                AND s.evt_index = m.evt_index
-                AND s.poolId = m.poolId
-            INNER JOIN fees_base f 
-                ON s.evt_tx_hash = f.tx_hash 
-                AND f.index = m.max_fee_evt_index
-        {% if is_incremental() %}
-        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
-        {% endif %}
     ),
     swap_fees AS (
         SELECT
-            swap.evt_block_number,
-            swap.evt_tx_hash,
-            swap.evt_index,
-            SUBSTRING(swap.poolId, 0, 42) AS contract_address,
-            swap.evt_block_time,
-            MAX(fees.block_time) AS max_fee_evt_block_time
-        FROM
-            {{ source ('balancer_v2_polygon', 'Vault_evt_Swap') }} swap
-            LEFT JOIN {{ ref('balancer_v2_polygon_pools_fees') }} fees
-                ON fees.contract_address = SUBSTRING(swap.poolId, 0, 42)
-                AND fees.block_time <= swap.evt_block_time
+            swaps.poolId,
+            swaps.evt_block_number,
+            swaps.evt_tx_hash,
+            swaps.evt_index,
+            SUBSTRING(CAST(swaps.poolId AS varchar(66)), 1, 42) AS contract_address,
+            fees.swap_fee_percentage,
+            ROW_NUMBER() OVER (PARTITION BY poolId, evt_tx_hash, evt_index ORDER BY block_number_index_1 DESC) AS rn
+        FROM {{ source ('balancer_v2_polygon', 'Vault_evt_Swap') }} swaps
+        LEFT JOIN fees_changes fees
+            ON CAST(fees.contract_address AS varchar(66)) = substring(CAST(swaps.poolId AS varchar(66)), 1, 42)
+            AND fees.block_number_index_1 < swaps.evt_block_number + 0.0001 * evt_index
         {% if is_incremental() %}
-        WHERE swap.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        WHERE swaps.evt_block_time >= date_trunc('day', NOW() - interval '1 week')
         {% endif %}
-        GROUP BY 1, 2, 3, 4, 5
     ),
     dexs AS (
         SELECT
@@ -93,28 +50,20 @@ WITH
             swap.tokenIn AS token_sold_address,
             swap_fees.contract_address AS project_contract_address,
             swap.poolId AS poolId,
-            COALESCE(most.swap_fee_percentage, edge.swap_fee_percentage) / POWER(10, 18) AS swap_fee,
+            swap_fees.swap_fee_percentage / POWER(10, 18) AS swap_fee,
             swap.evt_tx_hash AS tx_hash,
             '' AS trace_address,
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN {{ source ('balancer_v2_polygon', 'Vault_evt_Swap') }} swap
+            INNER JOIN `balancer_v2_polygon`.`Vault_evt_Swap` swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index
-            LEFT JOIN most_case_fees most
-                ON most.contract_address = swap_fees.contract_address
-                AND most.block_time = swap_fees.max_fee_evt_block_time
-                AND most.tx_hash <> swap_fees.evt_tx_hash
-            LEFT JOIN edge_case_fees edge
-                ON edge.evt_block_number = swap_fees.evt_block_number
-                AND edge.evt_tx_hash = swap_fees.evt_tx_hash
-                AND edge.evt_index = swap_fees.evt_index
-                AND edge.poolId = swap.poolId
         WHERE
             swap.tokenIn <> swap_fees.contract_address
             AND swap.tokenOut <> swap_fees.contract_address
+            AND swap_fees.rn = 1
     ),
     bpa AS (
         SELECT

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -54,6 +54,9 @@ WITH
             INNER JOIN fees_base f 
                 ON s.evt_tx_hash = f.tx_hash 
                 AND f.index = m.max_fee_evt_index
+        {% if is_incremental() %}
+        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
     ),
     swap_fees AS (
         SELECT

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -16,7 +16,7 @@
 
 {% set project_start_date = '2021-06-24' %}
 
-WITH
+WITH 
     fees_base AS (
         SELECT *, 
             MAX(index) OVER(PARTITION BY tx_hash, contract_address) AS max_index_same_tx 
@@ -26,6 +26,20 @@ WITH
         SELECT * FROM fees_base 
         WHERE index = max_index_same_tx
     ),
+    max_fee_change_evt_edge_case AS (
+        SELECT 
+            s.evt_block_number,
+            s.evt_tx_hash,
+            s.evt_index,
+            MAX(f.index) AS max_fee_evt_index
+        FROM {{ source ('balancer_v2_polygon', 'Vault_evt_Swap') }} s
+        INNER JOIN fees_base f 
+            ON s.evt_tx_hash = f.tx_hash 
+            AND f.index < s.evt_index
+        {% if is_incremental() %}
+        WHERE s.evt_block_time >= DATE_TRUNC("day", NOW() - interval '1 week')
+        {% endif %}
+    ),
     edge_case_fees AS (
         SELECT 
             s.evt_block_number,
@@ -33,8 +47,13 @@ WITH
             s.evt_index,
             f.swap_fee_percentage 
         FROM {{ source ('balancer_v2_polygon', 'Vault_evt_Swap') }} s
+            INNER JOIN max_fee_change_evt_edge_case m
+                ON s.evt_block_number = m.evt_block_number
+                AND s.evt_tx_hash = m.evt_tx_hash 
+                AND s.evt_index = m.evt_index
             INNER JOIN fees_base f 
-                ON s.evt_tx_hash = f.tx_hash AND f.index < s.evt_index
+                ON s.evt_tx_hash = f.tx_hash 
+                AND f.index = m.max_fee_evt_index
     ),
     swap_fees AS (
         SELECT

--- a/models/balancer/polygon/balancer_v2_polygon_trades.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_trades.sql
@@ -56,7 +56,7 @@ WITH
             swap.evt_index
         FROM
             swap_fees
-            INNER JOIN {{ source ('balancer_v2_arbitrum', 'Vault_evt_Swap') }} swap
+            INNER JOIN {{ source ('balancer_v2_polygon', 'Vault_evt_Swap') }} swap
                 ON swap.evt_block_number = swap_fees.evt_block_number
                 AND swap.evt_tx_hash = swap_fees.evt_tx_hash
                 AND swap.evt_index = swap_fees.evt_index


### PR DESCRIPTION
Test

# SPELLBOOK FREEZE

From June 22 to June 29, we will be freezing some Spellbook contributions for the migration to DuneSQL. We will not accept contributions to the lineage of the following models:

* dex.trades
* nft.trades
* labels
* token.erc20
* tokens.nft

Run the following command to see the list of affected files:

```
dbt ls --resource-type model --output path --select +dex_trades +labels +nft_trades +tokens_nft +tokens_erc20
```

Don't hesitate to reach out on Discord if you have any questions.

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
