### PR TITLE
Run Spark CI before Trino

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [ self-hosted, linux, spellbook-trino ]
     strategy:
       matrix:
-        engine: [ 'dunesql', 'spark' ]
+        engine: [ 'spark', 'dunesql' ]
       max-parallel: 1
     timeout-minutes: 90
 

--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -35,6 +35,7 @@ jobs:
             echo "TAG=,tag:dunesql" >> $GITHUB_ENV
             echo "COMPILE_TAG=--select tag:dunesql" >> $GITHUB_ENV
             echo "S3_LOCATION=manifest-spellbook-dunesql" >> $GITHUB_ENV
+            echo "export DBT_ENV_CUSTOM_ENV_S3_BUCKET=prod-spellbook-trino-118330671040" >> $GITHUB_ENV
           elif [[ "${{ matrix.engine }}" == "spark" ]]; then
             printf "Using spark engine\n"
             echo "PROFILE=--profile spark" >> $GITHUB_ENV

--- a/macros/dune/adapters.sql
+++ b/macros/dune/adapters.sql
@@ -8,11 +8,11 @@
 {% endmacro %}
 
 {% macro create_table_properties(properties, relation) %}
-  {% set s3_bucket = var('DBT_ENV_CUSTOM_ENV_S3_BUCKET', 'local') %}
+  {% set s3_bucket = 'prod-spellbook-trino-118330671040' %}
   {% set modified_identifier = relation.identifier | replace("__dbt_tmp", "") %}
   {%- set unique_location = modified_identifier ~ '_' ~ time_salted_md5_prefix() -%}
       WITH (
-          location = 's3a://{{s3_bucket}}/hive/{{relation.schema}}/{{unique_location}}'
+          location = 's3a://{{s3_bucket}}/{{relation.schema}}/{{unique_location}}'
       )
 {%- endmacro -%}
 

--- a/macros/dune/adapters.sql
+++ b/macros/dune/adapters.sql
@@ -8,7 +8,7 @@
 {% endmacro %}
 
 {% macro create_table_properties(properties, relation) %}
-  {% set s3_bucket = 'prod-spellbook-trino-118330671040' %}
+  {% set s3_bucket = var('DBT_ENV_CUSTOM_ENV_S3_BUCKET', 'local') %}
   {% set modified_identifier = relation.identifier | replace("__dbt_tmp", "") %}
   {%- set unique_location = modified_identifier ~ '_' ~ time_salted_md5_prefix() -%}
       WITH (

--- a/macros/dune/schema.sql
+++ b/macros/dune/schema.sql
@@ -5,6 +5,6 @@
 {% macro default__create_schema(relation) -%}
   {% set s3_bucket = 'prod-spellbook-trino-118330671040' %}
   {%- call statement('create_schema') -%}
-   CREATE SCHEMA {{ relation }} WITH (location = 's3a://{{s3_bucket}}/hive/')
+   CREATE SCHEMA {{ relation }} WITH (location = 's3a://{{s3_bucket}}/')
   {% endcall %}
 {% endmacro %}

--- a/macros/dune/schema.sql
+++ b/macros/dune/schema.sql
@@ -3,7 +3,7 @@
 {% endmacro %}
 
 {% macro default__create_schema(relation) -%}
-  {% set s3_bucket = 'prod-spellbook-trino-118330671040' %}
+  {% set s3_bucket = var('DBT_ENV_CUSTOM_ENV_S3_BUCKET', 'local') %}
   {%- call statement('create_schema') -%}
    CREATE SCHEMA {{ relation }} WITH (location = 's3a://{{s3_bucket}}/')
   {% endcall %}


### PR DESCRIPTION
Changing the order of `dbt_slim_ci` matrix, letting the Spark job run before the DuneSQL job. Since most contributions will be to spark spells for the near term, those contributions won't need to wait for dune job for execution. When I have more time, i'll update the ci to only run on job corresponding to the query engine those files target.