### PR TITLE
OP Traces Agg - Handle for negative gas used

### DIFF
--- a/models/gas/optimism/gas_optimism_fees_traces.sql
+++ b/models/gas/optimism/gas_optimism_fees_traces.sql
@@ -83,17 +83,17 @@ SELECT 'optimism' AS blockchain
 , traces.gas_used_original
 , traces.gas_used_trace
 , txs.gas_used AS tx_gas_used
-, traces.gas_used_original/txs.gas_used AS gas_used_original_percentage
-, traces.gas_used_trace/txs.gas_used AS gas_used_trace_percentage
+, cast( traces.gas_used_original as double)/cast( txs.gas_used as double) AS gas_used_original_percentage
+, cast( traces.gas_used_trace as double)/cast( txs.gas_used as double) AS gas_used_trace_percentage
 , txs.gas_price AS tx_gas_price
 , traces.trace_type
 , traces.trace_value
 , traces.trace_success
 , traces.tx_success
-, (traces.gas_used_original*txs.gas_price)/POWER(10, 18) AS gas_fee_spent_original
+, cast(traces.gas_used_original*txs.gas_price as double)/1e18 AS gas_fee_spent_original
 , (pu.price*traces.gas_used_original*txs.gas_price)/POWER(10, 18) AS gas_fee_spent_original_usd
-, (traces.gas_used_trace*txs.gas_price)/POWER(10, 18) AS gas_fee_spent_trace
-, (pu.price*traces.gas_used_trace*txs.gas_price)/POWER(10, 18) AS gas_fee_spent_trace_usd
+, cast(coalesce( traces.gas_used_trace,0) *txs.gas_price as double)/POWER(10, 18) AS gas_fee_spent_trace
+, cast(pu.price*tcoalesce(races.gas_used_trace,0)*txs.gas_price as double)/POWER(10, 18) AS gas_fee_spent_trace_usd
 FROM traces
 INNER JOIN {{ source('optimism','transactions') }} txs ON txs.block_time=traces.block_time
      AND txs.hash=traces.tx_hash


### PR DESCRIPTION
Found gases where the trace attribution logic results in negative gas used for OP transactions.

We need to deep-dive the root cause, but in the interim, making edits here so that negatives don't throw errors when the table is queried in dunesql (uint negative numbers).

This is just spark for now, but we could make it for both spark and dunesql

# SPELLBOOK FREEZE

From June 22 to June 29, we will be freezing some Spellbook contributions for the migration to DuneSQL. We will not accept contributions to the lineage of the following models:

* dex.trades
* nft.trades
* labels
* token.erc20
* tokens.nft

Run the following command to see the list of affected files:

```
dbt ls --resource-type model --output path --select +dex_trades +labels +nft_trades +tokens_nft +tokens_erc20
```

Don't hesitate to reach out on Discord if you have any questions.

Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
