### PR TITLE
Add CI step to verify that DuneSQL and Spark models are distinct

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -58,6 +58,10 @@ jobs:
       - name: dbt dependencies
         run: "dbt deps"
 
+      - name: Check no common models between DuneSQL and Spark
+        if: matrix.engine == 'dunesql'
+        run: "./scripts/dunesql_spark_empty_intersection.sh"
+
       - name: dbt compile to create manifest to compare to
         run: "dbt compile $PROFILE $COMPILE_TAG"
 

--- a/scripts/dunesql_spark_empty_intersection.sh
+++ b/scripts/dunesql_spark_empty_intersection.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+res=$(comm -12 <( dbt ls --exclude tag:dunesql | sort | grep -v "^source" ) <( dbt ls --select +tag:dunesql+ | sort | grep -v "^source" ))
+if [ -z "$res" ]; then
+  exit 0
+else
+  echo "Common models between DuneSQL and Spark:"
+  echo "$res"
+  exit 1
+fi


### PR DESCRIPTION
Verifies that the DuneSQL models and Spark models are distinct and do not share any parents (except for common sources) or children.
