### PR TITLE
Migrate NFT parent models

### DIFF
--- a/models/_sector/nft/trades/nft_ethereum_trades_beta.sql
+++ b/models/_sector/nft/trades/nft_ethereum_trades_beta.sql
@@ -35,7 +35,7 @@ WITH cte_prices_patch as (
         ,minute
         ,price
         ,symbol
-    FROM {{ ref('prices_usd_forward_fill') }}
+    FROM {{ ref('prices_usd_forward_fill_legacy') }}
     WHERE blockchain = 'ethereum'
     {% if is_incremental() %}
     AND minute >= date_trunc("day", now() - interval '1 week')
@@ -48,7 +48,7 @@ WITH cte_prices_patch as (
         ,minute
         ,price
         ,'ETH' as symbol
-    FROM {{ ref('prices_usd_forward_fill') }}
+    FROM {{ ref('prices_usd_forward_fill_legacy') }}
     WHERE blockchain is null AND symbol = 'ETH'
     {% if is_incremental() %}
     AND minute >= date_trunc("day", now() - interval '1 week')
@@ -64,8 +64,8 @@ enriched_trades as (
         tokens_nft_model=ref('tokens_ethereum_nft_legacy'),
         tokens_erc20_model=ref('tokens_ethereum_erc20_legacy'),
         prices_model='cte_prices_patch',
-        aggregators=ref('nft_ethereum_aggregators'),
-        aggregator_markers=ref('nft_ethereum_aggregators_markers')
+        aggregators=ref('nft_ethereum_aggregators_legacy'),
+        aggregator_markers=ref('nft_ethereum_aggregators_markers_legacy')
     )
 }}
 )

--- a/models/_sector/nft/trades/old/platforms/aavegotchi_polygon_events.sql
+++ b/models/_sector/nft/trades/old/platforms/aavegotchi_polygon_events.sql
@@ -127,4 +127,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p
     AND p.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
     AND p.minute = date_trunc('minute', a.evt_block_time)
-LEFT JOIN {{ ref('nft_aggregators') }} agg ON agg.blockchain = 'polygon' AND agg.contract_address = t.`to`
+LEFT JOIN {{ ref('nft_aggregators_legacy') }} agg ON agg.blockchain = 'polygon' AND agg.contract_address = t.`to`

--- a/models/_sector/nft/trades/old/platforms/decentraland_polygon_events.sql
+++ b/models/_sector/nft/trades/old/platforms/decentraland_polygon_events.sql
@@ -95,6 +95,6 @@ LEFT JOIN
     AND p.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
 LEFT JOIN 
-{{ ref('nft_aggregators') }} agg 
+{{ ref('nft_aggregators_legacy') }} agg 
     ON agg.blockchain = 'polygon' 
     AND agg.contract_address = t.`to`

--- a/models/_sector/nft/trades/old/platforms/element_avalanche_c_events.sql
+++ b/models/_sector/nft/trades/old/platforms/element_avalanche_c_events.sql
@@ -156,7 +156,7 @@ SELECT alet.blockchain
 , CAST('0' AS VARCHAR(5)) AS royalty_fee_currency_symbol
 , alet.blockchain || alet.project || alet.version || alet.tx_hash || alet.seller  || alet.buyer || alet.nft_contract_address || alet.token_id AS unique_trade_id
 FROM element_txs alet
-LEFT JOIN {{ ref('nft_aggregators') }} agg ON alet.buyer=agg.contract_address AND agg.blockchain='avalanche_c'
+LEFT JOIN {{ ref('nft_aggregators_legacy') }} agg ON alet.buyer=agg.contract_address AND agg.blockchain='avalanche_c'
 LEFT JOIN {{ ref('tokens_erc20_legacy') }} ava_erc20_tokens ON ava_erc20_tokens.contract_address=alet.currency_contract AND ava_erc20_tokens.blockchain='avalanche_c'
 LEFT JOIN {{ ref('tokens_nft_legacy') }} ava_nft_tokens ON ava_nft_tokens.contract_address=alet.currency_contract AND ava_nft_tokens.blockchain='avalanche_c'
 LEFT JOIN {{ source('prices', 'usd') }} prices ON prices.minute=date_trunc('minute', alet.block_time)

--- a/models/_sector/nft/trades/old/platforms/element_bnb_events.sql
+++ b/models/_sector/nft/trades/old/platforms/element_bnb_events.sql
@@ -156,7 +156,7 @@ SELECT alet.blockchain
 , CAST('0' AS VARCHAR(5)) AS royalty_fee_currency_symbol
 , alet.blockchain || alet.project || alet.version || alet.tx_hash || alet.seller  || alet.buyer || alet.nft_contract_address || alet.token_id AS unique_trade_id
 FROM element_txs alet
-LEFT JOIN {{ ref('nft_aggregators') }} agg ON alet.buyer=agg.contract_address AND agg.blockchain='bnb'
+LEFT JOIN {{ ref('nft_aggregators_legacy') }} agg ON alet.buyer=agg.contract_address AND agg.blockchain='bnb'
 LEFT JOIN {{ ref('tokens_erc20_legacy') }} bnb_bep20_tokens ON bnb_bep20_tokens.contract_address=alet.currency_contract AND bnb_bep20_tokens.blockchain='bnb'
 LEFT JOIN {{ ref('tokens_nft_legacy') }} bnb_nft_tokens ON bnb_nft_tokens.contract_address=alet.currency_contract AND bnb_nft_tokens.blockchain='bnb'
 LEFT JOIN {{ source('prices', 'usd') }} prices ON prices.minute=date_trunc('minute', alet.block_time)

--- a/models/_sector/nft/trades/old/platforms/element_polygon_events.sql
+++ b/models/_sector/nft/trades/old/platforms/element_polygon_events.sql
@@ -160,7 +160,7 @@ SELECT alet.blockchain
 , CAST('0' AS VARCHAR(5)) AS royalty_fee_currency_symbol
 , alet.blockchain || alet.project || alet.version || alet.tx_hash || alet.seller  || alet.buyer || alet.nft_contract_address || alet.token_id || alet.evt_index AS unique_trade_id
 FROM element_txs alet
-LEFT JOIN {{ ref('nft_aggregators') }} agg ON alet.buyer=agg.contract_address AND agg.blockchain='polygon'
+LEFT JOIN {{ ref('nft_aggregators_legacy') }} agg ON alet.buyer=agg.contract_address AND agg.blockchain='polygon'
 LEFT JOIN {{ ref('tokens_erc20_legacy') }} polygon_bep20_tokens ON polygon_bep20_tokens.contract_address=alet.currency_contract AND polygon_bep20_tokens.blockchain='polygon'
 LEFT JOIN {{ ref('tokens_nft_legacy') }} polygon_nft_tokens ON polygon_nft_tokens.contract_address=alet.currency_contract AND polygon_nft_tokens.blockchain='polygon'
 LEFT JOIN {{ source('prices', 'usd') }} prices ON prices.minute=date_trunc('minute', alet.block_time)

--- a/models/_sector/nft/trades/old/platforms/fractal_polygon_events.sql
+++ b/models/_sector/nft/trades/old/platforms/fractal_polygon_events.sql
@@ -172,4 +172,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p ON p.blockchain = 'polygon'
     {% if is_incremental() %}
     AND p.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('nft_aggregators') }} agg ON agg.blockchain = 'polygon' AND agg.contract_address = t.`to`
+LEFT JOIN {{ ref('nft_aggregators_legacy') }} agg ON agg.blockchain = 'polygon' AND agg.contract_address = t.`to`

--- a/models/_sector/nft/trades/old/platforms/magiceden_polygon_events.sql
+++ b/models/_sector/nft/trades/old/platforms/magiceden_polygon_events.sql
@@ -275,4 +275,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p ON p.contract_address = a.currency_con
     {% if is_incremental() %}
     AND p.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('nft_aggregators') }} agg ON agg.blockchain = 'polygon' AND agg.contract_address = t.`to`
+LEFT JOIN {{ ref('nft_aggregators_legacy') }} agg ON agg.blockchain = 'polygon' AND agg.contract_address = t.`to`

--- a/models/_sector/nft/trades/old/platforms/nftb_bnb_events.sql
+++ b/models/_sector/nft/trades/old/platforms/nftb_bnb_events.sql
@@ -285,7 +285,7 @@ AND erc721.evt_block_time >= date_trunc("day", now() - interval '1 week')
 LEFT JOIN {{ ref('tokens_bnb_nft_legacy') }} nft_token
 ON nft_token.contract_address = ae.nft_contract_address
 
-LEFT JOIN {{ ref('nft_bnb_aggregators')}} agg
+LEFT JOIN {{ ref('nft_bnb_aggregators_legacy')}} agg
 ON agg.contract_address = btx.`to`
 
 

--- a/models/_sector/nft/trades/old/platforms/nftearth_optimism_events.sql
+++ b/models/_sector/nft/trades/old/platforms/nftearth_optimism_events.sql
@@ -45,7 +45,7 @@ with source_optimism_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-    from {{ ref('nft_aggregators') }}
+    from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'optimism'
 )
 ,source_prices_usd as (

--- a/models/_sector/nft/trades/old/platforms/nftrade_bnb_events.sql
+++ b/models/_sector/nft/trades/old/platforms/nftrade_bnb_events.sql
@@ -159,7 +159,7 @@ source_inventory_enriched as (
         AND p.minute >= date_trunc("day", now() - interval '1 week')
         {% endif %}
     LEFT JOIN
-    {{ ref('nft_bnb_aggregators') }} agg
+    {{ ref('nft_bnb_aggregators_legacy') }} agg
         ON agg.contract_address = src.sender_address
     LEFT JOIN
     {{ source('erc721_bnb','evt_transfer') }} erc721

--- a/models/_sector/nft/trades/old/platforms/oneplanet_polygon_events.sql
+++ b/models/_sector/nft/trades/old/platforms/oneplanet_polygon_events.sql
@@ -43,7 +43,7 @@ with source_polygon_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-    from {{ ref('nft_aggregators') }}
+    from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'polygon'
 )
 ,source_prices_usd as (

--- a/models/_sector/nft/trades/old/platforms/pancakeswap_bnb_nft_events.sql
+++ b/models/_sector/nft/trades/old/platforms/pancakeswap_bnb_nft_events.sql
@@ -78,7 +78,7 @@ WITH events AS (
         events.block_number || '-' || events.tx_hash || '-' || events.evt_index AS unique_trade_id
 
     FROM events
-    LEFT JOIN {{ ref('nft_aggregators') }} agg ON events.buyer=agg.contract_address AND agg.blockchain='bnb'
+    LEFT JOIN {{ ref('nft_aggregators_legacy') }} agg ON events.buyer=agg.contract_address AND agg.blockchain='bnb'
     LEFT JOIN {{ ref('tokens_erc20_legacy') }} bnb_bep20_tokens ON bnb_bep20_tokens.contract_address=events.currency_contract AND bnb_bep20_tokens.blockchain='bnb'
     LEFT JOIN {{ ref('tokens_nft_legacy') }} bnb_nft_tokens ON bnb_nft_tokens.contract_address=events.currency_contract AND bnb_nft_tokens.blockchain='bnb'
     LEFT JOIN {{ source('prices', 'usd') }} prices ON prices.minute=date_trunc('minute', events.block_time)

--- a/models/_sector/nft/trades/old/platforms/quix_seaport_optimism_events.sql
+++ b/models/_sector/nft/trades/old/platforms/quix_seaport_optimism_events.sql
@@ -45,7 +45,7 @@ with source_optimism_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-    from {{ ref('nft_aggregators') }}
+    from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'optimism'
 )
 ,source_prices_usd as (

--- a/models/_sector/nft/trades/old/platforms/quix_v1_optimism_events.sql
+++ b/models/_sector/nft/trades/old/platforms/quix_v1_optimism_events.sql
@@ -148,7 +148,7 @@ with events_raw as (
         {% if is_incremental() %}
         and tx.block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    left join {{ ref('nft_aggregators') }} as agg
+    left join {{ ref('nft_aggregators_legacy') }} as agg
         on agg.contract_address = tx.to
         and agg.blockchain = 'optimism'
     left join {{ ref('tokens_nft_legacy') }} n

--- a/models/_sector/nft/trades/old/platforms/quix_v2_optimism_events.sql
+++ b/models/_sector/nft/trades/old/platforms/quix_v2_optimism_events.sql
@@ -186,7 +186,7 @@ with events_raw as (
         {% if is_incremental() %}
         and tx.block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    left join {{ ref('nft_aggregators') }} as agg
+    left join {{ ref('nft_aggregators_legacy') }} as agg
         on agg.contract_address = tx.to
         and agg.blockchain = 'optimism'
     left join {{ ref('tokens_nft_legacy') }} n

--- a/models/_sector/nft/trades/old/platforms/quix_v3_optimism_events.sql
+++ b/models/_sector/nft/trades/old/platforms/quix_v3_optimism_events.sql
@@ -191,7 +191,7 @@ with events_raw as (
         {% if is_incremental() %}
         and tx.block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    left join {{ ref('nft_aggregators') }} as agg
+    left join {{ ref('nft_aggregators_legacy') }} as agg
         on agg.contract_address = tx.to
         and agg.blockchain = 'optimism'
     left join {{ ref('tokens_nft_legacy') }} n

--- a/models/_sector/nft/trades/old/platforms/quix_v4_optimism_events.sql
+++ b/models/_sector/nft/trades/old/platforms/quix_v4_optimism_events.sql
@@ -254,7 +254,7 @@ with events_raw as (
         {% if is_incremental() %}
         and tx.block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    left join {{ ref('nft_aggregators') }} as agg
+    left join {{ ref('nft_aggregators_legacy') }} as agg
         on agg.contract_address = tx.to
         and agg.blockchain = 'optimism'
     left join {{ ref('tokens_nft_legacy') }} n

--- a/models/_sector/nft/trades/old/platforms/quix_v5_optimism_events.sql
+++ b/models/_sector/nft/trades/old/platforms/quix_v5_optimism_events.sql
@@ -180,7 +180,7 @@ with events_raw as (
         {% if is_incremental() %}
         and tx.block_time >= date_trunc("day", now() - interval '1 week')
         {% endif %}
-    left join {{ ref('nft_aggregators') }} as agg
+    left join {{ ref('nft_aggregators_legacy') }} as agg
         on agg.contract_address = tx.to
         and agg.blockchain = 'optimism'
     left join {{ ref('tokens_nft_legacy') }} n

--- a/models/_sector/nft/trades/old/platforms/rarible_polygon_events.sql
+++ b/models/_sector/nft/trades/old/platforms/rarible_polygon_events.sql
@@ -257,4 +257,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p ON p.contract_address = a.currency_con
     {% if is_incremental() %}
     AND p.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('nft_aggregators') }} agg ON agg.blockchain = 'polygon' AND agg.contract_address = t.`to`
+LEFT JOIN {{ ref('nft_aggregators_legacy') }} agg ON agg.blockchain = 'polygon' AND agg.contract_address = t.`to`

--- a/models/_sector/nft/trades/old/platforms/stealcam_arbitrum_events.sql
+++ b/models/_sector/nft/trades/old/platforms/stealcam_arbitrum_events.sql
@@ -73,7 +73,7 @@ INNER JOIN {{ source('arbitrum', 'transactions') }} at ON at.block_number=sc.evt
     {% if not is_incremental() %}
     AND at.block_time >= '{{project_start_date}}'
     {% endif %}
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
     AND pu.minute=date_trunc('minute', sc.evt_block_time)
     {% if is_incremental() %}

--- a/models/_sector/nft/trades/old/platforms/tofu_arbitrum_events.sql
+++ b/models/_sector/nft/trades/old/platforms/tofu_arbitrum_events.sql
@@ -139,6 +139,6 @@ FROM tfe
                        {% if is_incremental() %}
                        AND pu.minute >= date_trunc("day", now() - interval '1 week')
                        {% endif %}
-         LEFT JOIN {{ ref('nft_aggregators')}} agg
+         LEFT JOIN {{ ref('nft_aggregators_legacy')}} agg
                    ON agg.contract_address = tx.`to`
                    AND agg.blockchain = 'arbitrum'

--- a/models/_sector/nft/trades/old/platforms/tofu_bnb_events.sql
+++ b/models/_sector/nft/trades/old/platforms/tofu_bnb_events.sql
@@ -129,5 +129,5 @@ FROM tfe
                        {% if is_incremental() %}
                        AND pu.minute >= date_trunc("day", now() - interval '1 week')
                        {% endif %}
-         LEFT JOIN {{ ref('nft_bnb_aggregators')}} agg
+         LEFT JOIN {{ ref('nft_bnb_aggregators_legacy')}} agg
                    ON agg.contract_address = tx.`to`

--- a/models/_sector/nft/trades/old/platforms/tofu_optimism_events.sql
+++ b/models/_sector/nft/trades/old/platforms/tofu_optimism_events.sql
@@ -139,6 +139,6 @@ left join {{ source('prices', 'usd') }} as pu
     {% else %}
     and pu.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-left join {{ ref('nft_aggregators') }} as agg
+left join {{ ref('nft_aggregators_legacy') }} as agg
     on agg.contract_address = tx.to
     and agg.blockchain = 'optimism'

--- a/models/_sector/nft/trades/old/platforms/tofu_polygon_events.sql
+++ b/models/_sector/nft/trades/old/platforms/tofu_polygon_events.sql
@@ -143,7 +143,7 @@ FROM tfe
                        {% if is_incremental() %}
                        AND pu.minute >= date_trunc("day", now() - interval '1 week')
                        {% endif %}
-         LEFT JOIN {{ ref('nft_aggregators')}} agg
+         LEFT JOIN {{ ref('nft_aggregators_legacy')}} agg
                    ON agg.contract_address = tx.`to`
                    AND agg.blockchain = 'polygon'
 

--- a/models/_sector/nft/trades/old/platforms/zonic_optimism_events.sql
+++ b/models/_sector/nft/trades/old/platforms/zonic_optimism_events.sql
@@ -37,7 +37,7 @@ with source_optimism_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-    from {{ ref('nft_aggregators') }}
+    from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'optimism'
 )
 ,source_prices_usd as (

--- a/models/ampleforth/ethereum/ampleforth_ethereum_airdrop_claims.sql
+++ b/models/ampleforth/ethereum/ampleforth_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'FORTH' AS token_symbol
 , t.evt_index
 FROM {{ source('erc20_ethereum', 'evt_transfer') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{forth_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2021-04-20' AND '2022-04-16'

--- a/models/apecoin/ethereum/apecoin_ethereum_airdrop_claims.sql
+++ b/models/apecoin/ethereum/apecoin_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'APE' AS token_symbol
 , t.evt_index
 FROM {{ source('apecoin_ethereum', 'AirdropGrapesToken_evt_AirDrop') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{ape_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2022-03-17' AND '2022-06-16'

--- a/models/arbitrum/arbitrum/arbitrum_arbitrum_airdrop_claims.sql
+++ b/models/arbitrum/arbitrum/arbitrum_arbitrum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'arbitrum' AS blockchain
 , 'ARB' AS token_symbol
 , t.evt_index
 FROM {{ source('arbitrum_arbitrum', 'TokenDistributor_evt_HasClaimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'arbitrum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'arbitrum'
     AND pu.contract_address='{{arb_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/bend_dao/ethereum/bend_dao_ethereum_airdrop_claims.sql
+++ b/models/bend_dao/ethereum/bend_dao_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'BEND' AS token_symbol
 , t.evt_index
 FROM {{ source('benddao_ethereum', 'MerkleDistributor_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{bend_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2022-03-21' AND '2022-06-19'

--- a/models/blur/ethereum/blur_ethereum_airdrop_1_claims.sql
+++ b/models/blur/ethereum/blur_ethereum_airdrop_1_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'BLUR' AS token_symbol
 , t.evt_index
 FROM {{ source('blur_ethereum', 'BlurAirdrop_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{blur_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/botto/ethereum/botto_ethereum_airdrop_claims.sql
+++ b/models/botto/ethereum/botto_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'BOTTO' AS token_symbol
 , t.evt_index
 FROM {{ source('botto_ethereum', 'BottoAirdrop_evt_AirdropTransfer') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{botto_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2021-10-07' AND '2022-01-09'

--- a/models/component/ethereum/component_ethereum_airdrop_claims.sql
+++ b/models/component/ethereum/component_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'CMP' AS token_symbol
 , t.evt_index
 FROM {{ source('component_ethereum', 'MerkleDistributor_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{cmp_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2021-04-27' AND '2021-07-29'

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_airdrop_claims.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'COW' AS token_symbol
 , t.evt_index
 FROM {{ source('cow_protocol_ethereum', 'CowProtocolVirtualToken_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{cow_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2022-02-11' AND '2022-03-26'

--- a/models/dappradar/ethereum/dappradar_ethereum_airdrop_claims.sql
+++ b/models/dappradar/ethereum/dappradar_ethereum_airdrop_claims.sql
@@ -41,7 +41,7 @@ SELECT 'ethereum' AS blockchain
 , 'RADAR' AS token_symbol
 , t.evt_index
 FROM {{ source('dappradar_ethereum', 'Airdrop_evt_TokenClaimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{radar_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2021-12-14' AND '2022-03-20'

--- a/models/dydx/ethereum/dydx_ethereum_airdrop_claims.sql
+++ b/models/dydx/ethereum/dydx_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'DYDX' AS token_symbol
 , t.evt_index
 FROM {{ source('erc20_ethereum', 'evt_transfer') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{dydx_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/ellipsis_finance/bnb/ellipsis_finance_bnb_airdrop_claims.sql
+++ b/models/ellipsis_finance/bnb/ellipsis_finance_bnb_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'bnb' AS blockchain
 , 'EPS' AS token_symbol
 , t.evt_index
 FROM {{ source('ellipsis_finance_bnb', 'AirdropClaim_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'bnb'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'bnb'
     AND pu.contract_address='{{eps_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2021-03-24' AND '2022-04-01'

--- a/models/ens/ethereum/ens_ethereum_airdrop_claims.sql
+++ b/models/ens/ethereum/ens_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'ENS' AS token_symbol
 , t.evt_index
 FROM {{ source('ethereumnameservice_ethereum', 'ENSToken_evt_Claim') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{ens_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/forefront/ethereum/forefront_ethereum_airdrop_claims.sql
+++ b/models/forefront/ethereum/forefront_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'FF' AS token_symbol
 , evt_index
 FROM {{ source('forefront_ethereum', 'ForefrontMerkle_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{ff_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2021-03-31' AND '2021-04-16'

--- a/models/forta_network/ethereum/forta_network_ethereum_airdrop_claims.sql
+++ b/models/forta_network/ethereum/forta_network_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'FORT' AS token_symbol
 , t.evt_index
 FROM {{ source('forta_network_ethereum', 'Airdrop_evt_TokensReleased') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{forta_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2022-06-14' AND '2022-09-16'

--- a/models/galxe/ethereum/galxe_ethereum_airdrop_claims.sql
+++ b/models/galxe/ethereum/galxe_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'GAL' AS token_symbol
 , t.evt_index
 FROM {{ source('galaxy_ethereum', 'MerkleDistributor_Airdrop_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{gal_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2022-05-05' AND '2022-06-05'

--- a/models/gas_dao/ethereum/gas_dao_ethereum_airdrop_claims.sql
+++ b/models/gas_dao/ethereum/gas_dao_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'GAS' AS token_symbol
 , t.evt_index
 FROM {{ source('gas_dao_ethereum', 'GASToken_evt_Claim') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{gas_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/genie/ethereum/genie_ethereum_airdrop_claims.sql
+++ b/models/genie/ethereum/genie_ethereum_airdrop_claims.sql
@@ -30,7 +30,7 @@ SELECT 'ethereum' AS blockchain
 , 'USDC' AS token_symbol
 , t.evt_index
 FROM {{ source('uniswap_ethereum', 'MerkleDistributorWithDeadline_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{usdc_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/gitcoin/ethereum/gitcoin_ethereum_airdrop_claims.sql
+++ b/models/gitcoin/ethereum/gitcoin_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'GTC' AS token_symbol
 , t.evt_index
 FROM {{ source('gitcoin_ethereum', 'TokenDistributor_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{gtc_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2021-05-24' AND '2021-06-24'

--- a/models/giveth/gnosis/giveth_gnosis_airdrop_claims.sql
+++ b/models/giveth/gnosis/giveth_gnosis_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'gnosis' AS blockchain
 , 'GIV' AS token_symbol
 , t.evt_index
 FROM {{ source('giveth_gnosis', 'MerkleDistro_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'gnosis'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'gnosis'
     AND pu.contract_address='{{giv_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2021-12-24' AND '2022-12-31'

--- a/models/hop_protocol/ethereum/hop_protocol_ethereum_airdrop_claims.sql
+++ b/models/hop_protocol/ethereum/hop_protocol_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'HOP' AS token_symbol
 , t.evt_index
 FROM {{ source('hop_protocol_ethereum', 'HOPToken_evt_Claim') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{hop_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/looksrare/ethereum/looksrare_ethereum_airdrop_claims.sql
+++ b/models/looksrare/ethereum/looksrare_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'LOOKS' AS token_symbol
 , t.evt_index
 FROM {{ source('looksrare_ethereum', 'LooksRareAirdrop_evt_AirdropRewardsClaim') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{looks_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2022-01-10' AND '2022-03-19'

--- a/models/nft/arbitrum/nft_arbitrum_aggregators.sql
+++ b/models/nft/arbitrum/nft_arbitrum_aggregators.sql
@@ -1,4 +1,7 @@
-{{ config( alias='aggregators') }}
+{{config(
+    tags= ['dunesql'],
+    alias=alias('aggregators')
+)}}
 
 SELECT
   lower(contract_address) as contract_address,

--- a/models/nft/arbitrum/nft_arbitrum_aggregators.sql
+++ b/models/nft/arbitrum/nft_arbitrum_aggregators.sql
@@ -4,7 +4,7 @@
 )}}
 
 SELECT
-  lower(contract_address) as contract_address,
+  contract_address as contract_address,
   name
 FROM
   (

--- a/models/nft/arbitrum/nft_arbitrum_aggregators.sql
+++ b/models/nft/arbitrum/nft_arbitrum_aggregators.sql
@@ -6,6 +6,6 @@ SELECT
 FROM
   (
     VALUES
-      ('0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad', 'Uniswap') -- Uniswap's Universal Router 3
-      , ('0xc2c862322e9c97d6244a3506655da95f05246fd8', 'Reservoir') -- Reservoir v6.0.1
+      (0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad, 'Uniswap') -- Uniswap's Universal Router 3
+      , (0xc2c862322e9c97d6244a3506655da95f05246fd8, 'Reservoir') -- Reservoir v6.0.1
   ) AS temp_table (contract_address, name)

--- a/models/nft/arbitrum/nft_arbitrum_aggregators_legacy.sql
+++ b/models/nft/arbitrum/nft_arbitrum_aggregators_legacy.sql
@@ -1,4 +1,6 @@
-{{ config( alias=alias('aggregators', legacy_model=True ) }}
+{{config(
+    alias=alias('aggregators', legacy_model=True)
+)}}
 
 SELECT
   lower(contract_address) as contract_address,

--- a/models/nft/arbitrum/nft_arbitrum_aggregators_legacy.sql
+++ b/models/nft/arbitrum/nft_arbitrum_aggregators_legacy.sql
@@ -1,0 +1,11 @@
+{{ config( alias=alias('aggregators', legacy_model=True ) }}
+
+SELECT
+  lower(contract_address) as contract_address,
+  name
+FROM
+  (
+    VALUES
+      ('0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad', 'Uniswap') -- Uniswap's Universal Router 3
+      , ('0xc2c862322e9c97d6244a3506655da95f05246fd8', 'Reservoir') -- Reservoir v6.0.1
+  ) AS temp_table (contract_address, name)

--- a/models/nft/avalanche_c/nft_avalanche_c_aggregators.sql
+++ b/models/nft/avalanche_c/nft_avalanche_c_aggregators.sql
@@ -1,10 +1,13 @@
- {{ config( alias='aggregators') }}
-
+{{config(
+      tags = ['dunesql'],
+      alias=alias('aggregators')
+  )
+}}
 SELECT
   contract_address,
   name
 FROM
   (
     VALUES
-      ('0x37ad2bd1e4f1c0109133e07955488491233c9372', 'Element') -- Element NFT Marketplace Aggregator
+      (0x37ad2bd1e4f1c0109133e07955488491233c9372, 'Element') -- Element NFT Marketplace Aggregator
   ) AS temp_table (contract_address, name)

--- a/models/nft/avalanche_c/nft_avalanche_c_aggregators_legacy.sql
+++ b/models/nft/avalanche_c/nft_avalanche_c_aggregators_legacy.sql
@@ -1,0 +1,13 @@
+{{config(
+    alias = alias('aggregators', legacy_model=True)
+    )
+}}
+
+SELECT
+  contract_address,
+  name
+FROM
+  (
+    VALUES
+      ('0x37ad2bd1e4f1c0109133e07955488491233c9372', 'Element') -- Element NFT Marketplace Aggregator
+  ) AS temp_table (contract_address, name)

--- a/models/nft/bnb/nft_bnb_aggregators.sql
+++ b/models/nft/bnb/nft_bnb_aggregators.sql
@@ -1,4 +1,7 @@
- {{ config( alias='aggregators') }}
+{{config(
+    tags = ['dunesql'],
+    alias = alias('aggregators')
+)}}
 
 SELECT
   contract_address,
@@ -6,8 +9,7 @@ SELECT
 FROM
   (
     VALUES
-      ('0x56085ea9c43dea3c994c304c53b9915bff132d20', 'Element') -- Element NFT Marketplace Aggregator
-      , ('0x48939e2b2549710df8b7d9085207279a8f0fe3e5', 'Oxalus') -- Oxalus NFT Aggregator
-      , ('0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad', 'Uniswap') -- Uniswap's Universal Router
-      , ('0xc2c862322e9c97d6244a3506655da95f05246fd8', 'Reservoir') -- Reservoir v6.0.1
+      (0x56085ea9c43dea3c994c304c53b9915bff132d20, 'Element') -- Element NFT Marketplace Aggregator
+      , (0x48939e2b2549710df8b7d9085207279a8f0fe3e5, 'Oxalus') -- Oxalus NFT Aggregator
+      , (0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad, 'Uniswap') -- Uniswap's Universal Router
   ) AS temp_table (contract_address, name)

--- a/models/nft/bnb/nft_bnb_aggregators.sql
+++ b/models/nft/bnb/nft_bnb_aggregators.sql
@@ -12,4 +12,5 @@ FROM
       (0x56085ea9c43dea3c994c304c53b9915bff132d20, 'Element') -- Element NFT Marketplace Aggregator
       , (0x48939e2b2549710df8b7d9085207279a8f0fe3e5, 'Oxalus') -- Oxalus NFT Aggregator
       , (0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad, 'Uniswap') -- Uniswap's Universal Router
+      , (0xc2c862322e9c97d6244a3506655da95f05246fd8, 'Reservoir') -- Reservoir v6.0.1
   ) AS temp_table (contract_address, name)

--- a/models/nft/bnb/nft_bnb_aggregators_legacy.sql
+++ b/models/nft/bnb/nft_bnb_aggregators_legacy.sql
@@ -1,0 +1,13 @@
+ {{ config( alias = alias('aggregators', legacy_model=True)) }}
+
+SELECT
+  contract_address,
+  name
+FROM
+  (
+    VALUES
+      ('0x56085ea9c43dea3c994c304c53b9915bff132d20', 'Element') -- Element NFT Marketplace Aggregator
+      , ('0x48939e2b2549710df8b7d9085207279a8f0fe3e5', 'Oxalus') -- Oxalus NFT Aggregator
+      , ('0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad', 'Uniswap') -- Uniswap's Universal Router
+      , ('0xc2c862322e9c97d6244a3506655da95f05246fd8', 'Reservoir') -- Reservoir v6.0.1
+  ) AS temp_table (contract_address, name)

--- a/models/nft/ethereum/nft_ethereum_aggregators.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators.sql
@@ -1,8 +1,17 @@
-{{config(alias='aggregators', materialized='table', file_format = 'delta')}}
+{{config(
+    tags = ['dunesql'],
+    alias=alias('aggregators'),
+     materialized='table',
+      file_format = 'delta'
+)}}
 
-SELECT contract_address, name
-FROM {{ ref('nft_ethereum_aggregators_manual_legacy')}}
-UNION -- no union all to resolve any duplicates
-SELECT contract_address, name
-FROM {{ ref('nft_ethereum_aggregators_gem_legacy')}}
+
+SELECT DISTINCT *
+FROM(
+--    SELECT contract_address, name
+--    FROM {{ ref('nft_ethereum_aggregators_manual')}}
+--    UNION ALL
+    SELECT contract_address, name
+    FROM {{ ref('nft_ethereum_aggregators_gem')}}
+)
 

--- a/models/nft/ethereum/nft_ethereum_aggregators.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators.sql
@@ -8,9 +8,9 @@
 
 SELECT DISTINCT *
 FROM(
---    SELECT contract_address, name
---    FROM {{ ref('nft_ethereum_aggregators_manual')}}
---    UNION ALL
+    SELECT contract_address, name
+    FROM {{ ref('nft_ethereum_aggregators_manual')}}
+    UNION ALL
     SELECT contract_address, name
     FROM {{ ref('nft_ethereum_aggregators_gem')}}
 )

--- a/models/nft/ethereum/nft_ethereum_aggregators.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators.sql
@@ -1,8 +1,8 @@
 {{config(alias='aggregators', materialized='table', file_format = 'delta')}}
 
 SELECT contract_address, name
-FROM {{ ref('nft_ethereum_aggregators_manual')}}
+FROM {{ ref('nft_ethereum_aggregators_manual_legacy')}}
 UNION -- no union all to resolve any duplicates
 SELECT contract_address, name
-FROM {{ ref('nft_ethereum_aggregators_gem')}}
+FROM {{ ref('nft_ethereum_aggregators_gem_legacy')}}
 

--- a/models/nft/ethereum/nft_ethereum_aggregators_gem_legacy.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators_gem_legacy.sql
@@ -1,13 +1,10 @@
-{{config(
-    tags = ['dunesql'],
-    alias = alias('aggregators_gem')
-)}}
+{{config(alias = alias('aggregators_gem', legacy_model=True))}}
 WITH vasa_contracts as (
     SELECT distinct
     address AS contract_address
     FROM {{ source('ethereum','creation_traces') }}
-    WHERE "from" = 0x073ab1c0cad3677cde9bdb0cdeedc2085c029579
-    and block_time >= TIMESTAMP '2021-10-12'
+    WHERE `from` = '0x073ab1c0cad3677cde9bdb0cdeedc2085c029579'
+    and block_time >= CAST('2021-10-12' AS TIMESTAMP)
 )
 
 
@@ -17,8 +14,8 @@ select
 from vasa_contracts c
 left join {{ source('ethereum','transactions') }} t
 on t.block_time >= CAST('2021-10-12' AS TIMESTAMP) and t.to = c.contract_address
-left join {{ ref('nft_ethereum_transfers') }} nt
+left join {{ ref('nft_ethereum_transfers_legacy') }} nt
 on t.block_number = nt.block_number and t.hash = nt.tx_hash
 group by 1,2
-having count(distinct t.hash) filter(where t."from" != 0x073ab1c0cad3677cde9bdb0cdeedc2085c029579) > 10
+having count(distinct t.hash) filter(where t.`from` != '0x073ab1c0cad3677cde9bdb0cdeedc2085c029579') > 10
     and count(distinct nt.contract_address) > 2

--- a/models/nft/ethereum/nft_ethereum_aggregators_legacy.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators_legacy.sql
@@ -1,0 +1,8 @@
+{{config(alias = alias('aggregators', legacy_model=True), materialized='table', file_format = 'delta')}}
+
+SELECT contract_address, name
+FROM {{ ref('nft_ethereum_aggregators_manual_legacy')}}
+UNION -- no union all to resolve any duplicates
+SELECT contract_address, name
+FROM {{ ref('nft_ethereum_aggregators_gem_legacy')}}
+

--- a/models/nft/ethereum/nft_ethereum_aggregators_manual.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators_manual.sql
@@ -1,59 +1,60 @@
-{{config(alias='aggregators_manual')}}
+{{config(
+    tags = ['dunesql'],
+    alias='aggregators_manual'
+)}}
 SELECT
-  LOWER(contract_address) AS contract_address,
+  contract_address,
   name
 FROM
   (
     VALUES
-      ('0x0a267cf51ef038fc00e71801f5a524aec06e4f07', 'Genie') -- Genie
-    , ('0x2af4b707e1dce8fc345f38cfeeaa2421e54976d5', 'Genie') -- Genie 2
-    , ('0xcdface5643b90ca4b3160dd2b5de80c1bf1cb088', 'Genie') -- Genie
-    , ('0x31837aaf36961274a04b915697fdfca1af31a0c7', 'Genie') -- Genie
-    , ('0xf97e9727d8e7db7aa8f006d1742d107cf9411412', 'Genie') -- Genie
-    , ('0xf24629fbb477e10f2cf331c2b7452d8596b5c7a5', 'Gem') -- Gem
-    , ('0x83c8f28c26bf6aaca652df1dbbe0e1b56f8baba2', 'Gem') -- Gem 2
-    , ('0x0000000031f7382a812c64b604da4fc520afef4b', 'Gem') -- Gem Single Contract Checkout 1
-    , ('0x0000000035634b55f3d99b071b5a354f48e10bef', 'Gem') -- Gem Single Contract Checkout 2
-    , ('0x00000000a50bb64b4bbeceb18715748dface08af', 'Gem') -- Gem Single Contract Checkout 3
-    , ('0xae9c73fd0fd237c1c6f66fe009d24ce969e98704', 'Gem') -- Gem Protection Enabled Address
-    , ('0x9e97195f937c9372fe5fda5e3b86e9b88cbefed7', 'Gem') -- Gem's X2Y2 Batch Buys (Old)
-    , ('0x539ea5d6ec0093ff6401dbcd14d049c37a77151b', 'Gem') -- Gem's X2Y2 Batch Buys
-    , ('0xf22007700b8c443bcb36a39580f7804bffdb1169', 'Gem') -- Gem's Blur Batch Buys
-    , ('0x4326275317acc0fae4aa5c68fce4c54c74dc08d3', 'Gem') -- Gem v2 X2Y2
-    , ('0x29ab6d8f7e3d815168d6b40ebb12625b4fe13998', 'Gem') -- Gem v2
-    , ('0x241b8e59e81455e66b9cd0e2ffb2506be1838144', 'Gem') -- Gem v2
-    , ('0x56dd5bbede9bfdb10a2845c4d70d4a2950163044', 'X2Y2') -- X2Y2's OpenSea Sniper
-    , ('0x69cf8871f61fb03f540bc519dd1f1d4682ea0bf6', 'Element') -- Element NFT Marketplace Aggregator
-    , ('0xb4e7b8946fa2b35912cc0581772cccd69a33000c', 'Element') -- Element NFT Marketplace Aggregator 2
-    , ('0x39da41747a83aee658334415666f3ef92dd0d541', 'Blur') -- Blur
-    , ('0x7f6cdf5869bd780ea351df4d841f68d73cbcc16b', 'NFTInit') -- NFTInit.com
-    , ('0x92701d42e1504ef9fce6d66a2054218b048dda43', 'OKX') -- OKX
-    , ('0xc52b521b284792498c1036d4c2ed4b73387b3859', 'Reservoir') -- Reservoir v1
-    , ('0x5aa9ca240174a54af6d9bfc69214b2ed948de86d', 'Reservoir') -- Reservoir v2
-    , ('0x7c9733b19e14f37aca367fbd78922c098c55c874', 'Reservoir') -- Reservoir v3
-    , ('0x8005488ff4f8982d2d8c1d602e6d747b1428dd41', 'Reservoir') -- Reservoir v4
-    , ('0x9ebfb53fa8526906738856848a27cb11b0285c3f', 'Reservoir') -- Reservoir v5
-    , ('0x178a86d36d89c7fdebea90b739605da7b131ff6a', 'Reservoir') -- Reservoir v6
-    , ('0xc2c862322e9c97d6244a3506655da95f05246fd8', 'Reservoir') -- Reservoir v6.0.1
-    , ('0x39b6862c4783db2651d64bc160349dc9a15f1fb7', 'Rarity Garden') -- Rarity Garden v2
-    , ('0x9d0a89bc35fb160a076de0341d9280830d3013ca', 'Rarity Garden') -- Rarity Garden v1.02
-    , ('0x603d022611bfe6a101dcdab207d96c527f1d4d8e', 'BitKeep') -- BitKeep
-    , ('0x2a7251d1e7d708c507b1b0d3ff328007beecce5d', 'Rarible') -- Rarible
-    , ('0x2c45af926d5f62c5935278106800a03eb565778e', 'Rarible') -- Rarible
-    , ('0x1ee3151cff01321059e3865214379b85c79ca984', 'Magic Eden') -- Magic Eden
-    , ('0x141efc30c4093bc0f8204accb8afa6643fddecf2', 'Alpha Sharks') -- Alpha Sharks
-    , ('0x552b16d19dbad7af2786fe5a40d96d2a5c09428c', 'Alpha Sharks') -- Alpha Sharks 2.0
-    , ('0x114e54a100a0415abf9727234c92c83dbcc59abf', 'Alpha Sharks') -- Alpha Sharks 2.1
-    , ('0x1ed3d33b41e392014e0c9d8125369aba4e09798f', 'Alpha Sharks') -- Magically (Alpha Sharks)
-    , ('0x04898894a0b6c094a920eafd180ef4ac30f00a43', 'Alpha Sharks') -- Magically (Alpha Sharks)
-    , ('0xef1c6e67703c7bd7107eed8303fbe6ec2554bf6b', 'Uniswap') -- Uniswap's Universal Router
-    , ('0x4c60051384bd2d3c01bfc845cf5f4b44bcbe9de5', 'Uniswap') -- Uniswap's Universal Router 2
-    , ('0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad', 'Uniswap') -- Uniswap's Universal Router 3
-    , ('0x00000000005228b791a99a61f36a130d50600106', 'LooksRare') -- LooksRare Aggregator
-    , ('0x36ab1c395b3711d3d5ed2af8ac8371cc991aa06c', 'Flip') -- Flip
-    , ('0x7db11e30ae8ad7495668701c3f2c1b6d60587eda', 'Flip') -- Flip's LooksRare Checkout
-    , ('0xb123504fa220ba482768dd1e798594c1af88d7dc', 'Tiny Astro') -- Tiny Astro
-    , ('0x4c9712cd94376c537464caa4d87bce198d59936c', 'GigaMart') -- GigaMart's GigaAggregator
-    , ('0xdc077a4e3f46138dedac5d684882d33fcc927cf7', 'GigaMart') -- GigaMart's GigaAggregator v 1.2
-    , ('0x4abab19c2ad968adbc52e2c8a5ccda5379629576', 'Skillet') -- Skillet
+      (0x0a267cf51ef038fc00e71801f5a524aec06e4f07, 'Genie') -- Genie
+    , (0x2af4b707e1dce8fc345f38cfeeaa2421e54976d5, 'Genie') -- Genie 2
+    , (0xcdface5643b90ca4b3160dd2b5de80c1bf1cb088, 'Genie') -- Genie
+    , (0x31837aaf36961274a04b915697fdfca1af31a0c7, 'Genie') -- Genie
+    , (0xf97e9727d8e7db7aa8f006d1742d107cf9411412, 'Genie') -- Genie
+    , (0xf24629fbb477e10f2cf331c2b7452d8596b5c7a5, 'Gem') -- Gem
+    , (0x83c8f28c26bf6aaca652df1dbbe0e1b56f8baba2, 'Gem') -- Gem 2
+    , (0x0000000031f7382a812c64b604da4fc520afef4b, 'Gem') -- Gem Single Contract Checkout 1
+    , (0x0000000035634b55f3d99b071b5a354f48e10bef, 'Gem') -- Gem Single Contract Checkout 2
+    , (0x00000000a50bb64b4bbeceb18715748dface08af, 'Gem') -- Gem Single Contract Checkout 3
+    , (0xae9c73fd0fd237c1c6f66fe009d24ce969e98704, 'Gem') -- Gem Protection Enabled Address
+    , (0x9e97195f937c9372fe5fda5e3b86e9b88cbefed7, 'Gem') -- Gem's X2Y2 Batch Buys (Old)
+    , (0x539ea5d6ec0093ff6401dbcd14d049c37a77151b, 'Gem') -- Gem's X2Y2 Batch Buys
+    , (0xf22007700b8c443bcb36a39580f7804bffdb1169, 'Gem') -- Gem's Blur Batch Buys
+    , (0x4326275317acc0fae4aa5c68fce4c54c74dc08d3, 'Gem') -- Gem v2 X2Y2
+    , (0x29ab6d8f7e3d815168d6b40ebb12625b4fe13998, 'Gem') -- Gem v2
+    , (0x241b8e59e81455e66b9cd0e2ffb2506be1838144, 'Gem') -- Gem v2
+    , (0x56dd5bbede9bfdb10a2845c4d70d4a2950163044, 'X2Y2') -- X2Y2's OpenSea Sniper
+    , (0x69cf8871f61fb03f540bc519dd1f1d4682ea0bf6, 'Element') -- Element NFT Marketplace Aggregator
+    , (0xb4e7b8946fa2b35912cc0581772cccd69a33000c, 'Element') -- Element NFT Marketplace Aggregator 2
+    , (0x39da41747a83aee658334415666f3ef92dd0d541, 'Blur') -- Blur
+    , (0x7f6cdf5869bd780ea351df4d841f68d73cbcc16b, 'NFTInit') -- NFTInit.com
+    , (0x92701d42e1504ef9fce6d66a2054218b048dda43, 'OKX') -- OKX
+    , (0xc52b521b284792498c1036d4c2ed4b73387b3859, 'Reservoir') -- Reservoir v1
+    , (0x5aa9ca240174a54af6d9bfc69214b2ed948de86d, 'Reservoir') -- Reservoir v2
+    , (0x7c9733b19e14f37aca367fbd78922c098c55c874, 'Reservoir') -- Reservoir v3
+    , (0x8005488ff4f8982d2d8c1d602e6d747b1428dd41, 'Reservoir') -- Reservoir v4
+    , (0x9ebfb53fa8526906738856848a27cb11b0285c3f, 'Reservoir') -- Reservoir v5
+    , (0x178a86d36d89c7fdebea90b739605da7b131ff6a, 'Reservoir') -- Reservoir v6
+    , (0x39b6862c4783db2651d64bc160349dc9a15f1fb7, 'Rarity Garden') -- Rarity Garden v2
+    , (0x9d0a89bc35fb160a076de0341d9280830d3013ca, 'Rarity Garden') -- Rarity Garden v1.02
+    , (0x603d022611bfe6a101dcdab207d96c527f1d4d8e, 'BitKeep') -- BitKeep
+    , (0x2a7251d1e7d708c507b1b0d3ff328007beecce5d, 'Rarible') -- Rarible
+    , (0x2c45af926d5f62c5935278106800a03eb565778e, 'Rarible') -- Rarible
+    , (0x1ee3151cff01321059e3865214379b85c79ca984, 'Magic Eden') -- Magic Eden
+    , (0x141efc30c4093bc0f8204accb8afa6643fddecf2, 'Alpha Sharks') -- Alpha Sharks
+    , (0x552b16d19dbad7af2786fe5a40d96d2a5c09428c, 'Alpha Sharks') -- Alpha Sharks 2.0
+    , (0x114e54a100a0415abf9727234c92c83dbcc59abf, 'Alpha Sharks') -- Alpha Sharks 2.1
+    , (0x1ed3d33b41e392014e0c9d8125369aba4e09798f, 'Alpha Sharks') -- Magically (Alpha Sharks)
+    , (0x04898894a0b6c094a920eafd180ef4ac30f00a43, 'Alpha Sharks') -- Magically (Alpha Sharks)
+    , (0xef1c6e67703c7bd7107eed8303fbe6ec2554bf6b, 'Uniswap') -- Uniswap's Universal Router
+    , (0x4c60051384bd2d3c01bfc845cf5f4b44bcbe9de5, 'Uniswap') -- Uniswap's Universal Router (New)
+    , (0x00000000005228b791a99a61f36a130d50600106, 'LooksRare') -- LooksRare Aggregator
+    , (0x36ab1c395b3711d3d5ed2af8ac8371cc991aa06c, 'Flip') -- Flip
+    , (0x7db11e30ae8ad7495668701c3f2c1b6d60587eda, 'Flip') -- Flip's LooksRare Checkout
+    , (0xb123504fa220ba482768dd1e798594c1af88d7dc, 'Tiny Astro') -- Tiny Astro
+    , (0x4c9712cd94376c537464caa4d87bce198d59936c, 'GigaMart') -- GigaMart's GigaAggregator
+    , (0xdc077a4e3f46138dedac5d684882d33fcc927cf7, 'GigaMart') -- GigaMart's GigaAggregator v 1.2
+    , (0x4abab19c2ad968adbc52e2c8a5ccda5379629576, 'Skillet') -- Skillet
   ) AS temp_table (contract_address, name)

--- a/models/nft/ethereum/nft_ethereum_aggregators_manual_legacy.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators_manual_legacy.sql
@@ -1,0 +1,59 @@
+{{config(alias = alias('aggregators_manual', legacy_model=True))}}
+SELECT
+  LOWER(contract_address) AS contract_address,
+  name
+FROM
+  (
+    VALUES
+      ('0x0a267cf51ef038fc00e71801f5a524aec06e4f07', 'Genie') -- Genie
+    , ('0x2af4b707e1dce8fc345f38cfeeaa2421e54976d5', 'Genie') -- Genie 2
+    , ('0xcdface5643b90ca4b3160dd2b5de80c1bf1cb088', 'Genie') -- Genie
+    , ('0x31837aaf36961274a04b915697fdfca1af31a0c7', 'Genie') -- Genie
+    , ('0xf97e9727d8e7db7aa8f006d1742d107cf9411412', 'Genie') -- Genie
+    , ('0xf24629fbb477e10f2cf331c2b7452d8596b5c7a5', 'Gem') -- Gem
+    , ('0x83c8f28c26bf6aaca652df1dbbe0e1b56f8baba2', 'Gem') -- Gem 2
+    , ('0x0000000031f7382a812c64b604da4fc520afef4b', 'Gem') -- Gem Single Contract Checkout 1
+    , ('0x0000000035634b55f3d99b071b5a354f48e10bef', 'Gem') -- Gem Single Contract Checkout 2
+    , ('0x00000000a50bb64b4bbeceb18715748dface08af', 'Gem') -- Gem Single Contract Checkout 3
+    , ('0xae9c73fd0fd237c1c6f66fe009d24ce969e98704', 'Gem') -- Gem Protection Enabled Address
+    , ('0x9e97195f937c9372fe5fda5e3b86e9b88cbefed7', 'Gem') -- Gem's X2Y2 Batch Buys (Old)
+    , ('0x539ea5d6ec0093ff6401dbcd14d049c37a77151b', 'Gem') -- Gem's X2Y2 Batch Buys
+    , ('0xf22007700b8c443bcb36a39580f7804bffdb1169', 'Gem') -- Gem's Blur Batch Buys
+    , ('0x4326275317acc0fae4aa5c68fce4c54c74dc08d3', 'Gem') -- Gem v2 X2Y2
+    , ('0x29ab6d8f7e3d815168d6b40ebb12625b4fe13998', 'Gem') -- Gem v2
+    , ('0x241b8e59e81455e66b9cd0e2ffb2506be1838144', 'Gem') -- Gem v2
+    , ('0x56dd5bbede9bfdb10a2845c4d70d4a2950163044', 'X2Y2') -- X2Y2's OpenSea Sniper
+    , ('0x69cf8871f61fb03f540bc519dd1f1d4682ea0bf6', 'Element') -- Element NFT Marketplace Aggregator
+    , ('0xb4e7b8946fa2b35912cc0581772cccd69a33000c', 'Element') -- Element NFT Marketplace Aggregator 2
+    , ('0x39da41747a83aee658334415666f3ef92dd0d541', 'Blur') -- Blur
+    , ('0x7f6cdf5869bd780ea351df4d841f68d73cbcc16b', 'NFTInit') -- NFTInit.com
+    , ('0x92701d42e1504ef9fce6d66a2054218b048dda43', 'OKX') -- OKX
+    , ('0xc52b521b284792498c1036d4c2ed4b73387b3859', 'Reservoir') -- Reservoir v1
+    , ('0x5aa9ca240174a54af6d9bfc69214b2ed948de86d', 'Reservoir') -- Reservoir v2
+    , ('0x7c9733b19e14f37aca367fbd78922c098c55c874', 'Reservoir') -- Reservoir v3
+    , ('0x8005488ff4f8982d2d8c1d602e6d747b1428dd41', 'Reservoir') -- Reservoir v4
+    , ('0x9ebfb53fa8526906738856848a27cb11b0285c3f', 'Reservoir') -- Reservoir v5
+    , ('0x178a86d36d89c7fdebea90b739605da7b131ff6a', 'Reservoir') -- Reservoir v6
+    , ('0xc2c862322e9c97d6244a3506655da95f05246fd8', 'Reservoir') -- Reservoir v6.0.1
+    , ('0x39b6862c4783db2651d64bc160349dc9a15f1fb7', 'Rarity Garden') -- Rarity Garden v2
+    , ('0x9d0a89bc35fb160a076de0341d9280830d3013ca', 'Rarity Garden') -- Rarity Garden v1.02
+    , ('0x603d022611bfe6a101dcdab207d96c527f1d4d8e', 'BitKeep') -- BitKeep
+    , ('0x2a7251d1e7d708c507b1b0d3ff328007beecce5d', 'Rarible') -- Rarible
+    , ('0x2c45af926d5f62c5935278106800a03eb565778e', 'Rarible') -- Rarible
+    , ('0x1ee3151cff01321059e3865214379b85c79ca984', 'Magic Eden') -- Magic Eden
+    , ('0x141efc30c4093bc0f8204accb8afa6643fddecf2', 'Alpha Sharks') -- Alpha Sharks
+    , ('0x552b16d19dbad7af2786fe5a40d96d2a5c09428c', 'Alpha Sharks') -- Alpha Sharks 2.0
+    , ('0x114e54a100a0415abf9727234c92c83dbcc59abf', 'Alpha Sharks') -- Alpha Sharks 2.1
+    , ('0x1ed3d33b41e392014e0c9d8125369aba4e09798f', 'Alpha Sharks') -- Magically (Alpha Sharks)
+    , ('0x04898894a0b6c094a920eafd180ef4ac30f00a43', 'Alpha Sharks') -- Magically (Alpha Sharks)
+    , ('0xef1c6e67703c7bd7107eed8303fbe6ec2554bf6b', 'Uniswap') -- Uniswap's Universal Router
+    , ('0x4c60051384bd2d3c01bfc845cf5f4b44bcbe9de5', 'Uniswap') -- Uniswap's Universal Router 2
+    , ('0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad', 'Uniswap') -- Uniswap's Universal Router 3
+    , ('0x00000000005228b791a99a61f36a130d50600106', 'LooksRare') -- LooksRare Aggregator
+    , ('0x36ab1c395b3711d3d5ed2af8ac8371cc991aa06c', 'Flip') -- Flip
+    , ('0x7db11e30ae8ad7495668701c3f2c1b6d60587eda', 'Flip') -- Flip's LooksRare Checkout
+    , ('0xb123504fa220ba482768dd1e798594c1af88d7dc', 'Tiny Astro') -- Tiny Astro
+    , ('0x4c9712cd94376c537464caa4d87bce198d59936c', 'GigaMart') -- GigaMart's GigaAggregator
+    , ('0xdc077a4e3f46138dedac5d684882d33fcc927cf7', 'GigaMart') -- GigaMart's GigaAggregator v 1.2
+    , ('0x4abab19c2ad968adbc52e2c8a5ccda5379629576', 'Skillet') -- Skillet
+  ) AS temp_table (contract_address, name)

--- a/models/nft/ethereum/nft_ethereum_aggregators_markers_legacy.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators_markers_legacy.sql
@@ -1,6 +1,5 @@
 {{ config(
-        tags = ['dunesql'],
-        alias = alias('aggregators_markers'),
+        alias = alias('aggregators_markers', legacy_model=True),
 		materialized = 'table',
         unique_key='hash_marker',
         post_hook='{{ expose_spells(\'["ethereum"]\',
@@ -10,30 +9,29 @@
 }}
 
  WITH reservoir AS (
-    SELECT distinct from_utf8(from_hex(substring(regexp_replace(cast(data as varchar), '^.*00', ''), 3, length(regexp_replace(cast(data as varchar), '^.*00', ''))-4))) AS router_website
-    , from_hex(regexp_replace(cast(data as varchar), '^.*00', '')) AS hash_marker
+    SELECT distinct substring(unhex(regexp_replace(data, '^.*00', '')), 2, length(unhex(regexp_replace(data, '^.*00', '')))-2) AS router_website
+    , regexp_replace(data, '^.*00', '') AS hash_marker
     FROM {{ source('ethereum','transactions') }}
     WHERE to IN (
-        0x00000000006c3852cbef3e08e8df289169ede581, --seaport
-        0x74312363e45dcaba76c59ec49a7aa8a65a67eed3, --x2y2
-        0x59728544b08ab483533076417fbbb2fd0b17ce3a, --looksrare
-        0x9ebfb53fa8526906738856848a27cb11b0285c3f  --reservoir
+        '0x00000000006c3852cbef3e08e8df289169ede581', --seaport
+        '0x74312363e45dcaba76c59ec49a7aa8a65a67eed3', --x2y2
+        '0x59728544b08ab483533076417fbbb2fd0b17ce3a', --looksrare
+        '0x9ebfb53fa8526906738856848a27cb11b0285c3f'  --reservoir
     )
-    AND substr(cast(data as varchar),length(cast(data as varchar))-1, 2) = '1f'
-    AND substr(regexp_replace(cast(data as varchar), '^.*00', ''),1, 2)='1f'
-    AND regexp_replace(cast(data as varchar), '^.*00', '') != '1f'
-    AND length(regexp_replace(cast(data as varchar), '^.*00', ''))%2 = 0
-    AND block_time > TIMESTAMP '2022-10-15'
+    AND `RIGHT`(data, 2) = '1f'
+    AND `LEFT`(regexp_replace(data, '^.*00', ''), 2)='1f'
+    AND regexp_replace(data, '^.*00', '') != '1f'
+    AND length(regexp_replace(data, '^.*00', ''))%2 = 0
+    AND block_time > '2022-10-15'
     )
 
   -- needed to eliminate duplicates
   , reservoir_fixed as (
     select r_a.*
     from reservoir r_a
-    LEFT join reservoir r_b
+    anti join reservoir r_b
         ON r_a.hash_marker != r_b.hash_marker
-        and bytearray_starts_with(bytearray_reverse(r_a.hash_marker),bytearray_reverse(r_b.hash_marker)) --equivalent to ends_with
-    WHERE r_b.hash_marker is null
+        and `right`(r_a.hash_marker, length(r_b.hash_marker)) = r_b.hash_marker
   )
 
   , all_markers as (
@@ -88,18 +86,18 @@
             WHEN router_website='nounish.market' THEN 'Nounish Market'
             WHEN router_website='dev.evaluate.xyz' THEN 'Evaluate Market'
             WHEN router_website='market.cosmoskidznft.com' THEN 'Cosmos Kidz'
-            ELSE router_website
+            ELSE router_website::string
             END AS router_name
     FROM reservoir_fixed
     UNION ALL
     SELECT
         hash_marker ,aggregator_name, router_name
     FROM ( VALUES
-      (0x72db8c0b, 'Gem', null)
-    , (0x332d1229, 'Blur', null)
-    , (0xa8a9c101, 'Alpha Sharks', null)
-    , (0x09616c6c64617461, 'Rarible', null)
-    , (0x61598d6d, 'Flip', null)
+      ('72db8c0b', 'Gem', null)
+    , ('332d1229', 'Blur', null)
+    , ('a8a9c101', 'Alpha Sharks', null)
+    , ('9616c6c64617461', 'Rarible', null)
+    , ('61598d6d', 'Flip', null)
     ) AS temp_table (hash_marker ,aggregator_name, router_name)
   )
 

--- a/models/nft/ethereum/nft_ethereum_native_mints.sql
+++ b/models/nft/ethereum/nft_ethereum_native_mints.sql
@@ -100,7 +100,7 @@ LEFT JOIN {{ source('ethereum','transactions') }} etxs ON etxs.block_time=nft_mi
     {% if is_incremental() %}
     AND  etxs.block_time >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('nft_ethereum_aggregators') }} agg ON etxs.to=agg.contract_address
+LEFT JOIN {{ ref('nft_ethereum_aggregators_legacy') }} agg ON etxs.to=agg.contract_address
 LEFT JOIN {{ ref('tokens_ethereum_nft_legacy') }} tok ON tok.contract_address=nft_mints.contract_address
 LEFT JOIN namespaces ec ON etxs.to=ec.address
 {% if is_incremental() %}

--- a/models/nft/nft_aggregators.sql
+++ b/models/nft/nft_aggregators.sql
@@ -1,17 +1,18 @@
 {{ config(
-        alias ='aggregators',
+        tags = ['dunesql'],
+        alias = alias('aggregators'),
         post_hook='{{ expose_spells(\'["avalanche_c","bnb","ethereum","polygon", "optimism"]\',
                                     "sector",
                                     "nft",
                                     \'["soispoke","hildobby", "chuxin"]\') }}')
 }}
 
-SELECT 'avalanche_c' as blockchain, * FROM  {{ ref('nft_avalanche_c_aggregators_legacy') }}
+SELECT 'avalanche_c' as blockchain, * FROM  {{ ref('nft_avalanche_c_aggregators') }}
 UNION ALL
-SELECT 'bnb' as blockchain, * FROM  {{ ref('nft_bnb_aggregators_legacy') }}
+SELECT 'bnb' as blockchain, * FROM  {{ ref('nft_bnb_aggregators') }}
 UNION ALL
-SELECT 'ethereum' as blockchain, * FROM  {{ ref('nft_ethereum_aggregators_legacy') }}
+SELECT 'ethereum' as blockchain, * FROM  {{ ref('nft_ethereum_aggregators') }}
 UNION ALL
-SELECT 'polygon' as blockchain, * FROM  {{ ref('nft_polygon_aggregators_legacy') }}
+SELECT 'polygon' as blockchain, * FROM  {{ ref('nft_polygon_aggregators') }}
 UNION ALL
-SELECT 'optimism' as blockchain, * FROM  {{ ref('nft_optimism_aggregators_legacy') }}
+SELECT 'optimism' as blockchain, * FROM  {{ ref('nft_optimism_aggregators') }}

--- a/models/nft/nft_aggregators.sql
+++ b/models/nft/nft_aggregators.sql
@@ -16,3 +16,6 @@ UNION ALL
 SELECT 'polygon' as blockchain, * FROM  {{ ref('nft_polygon_aggregators') }}
 UNION ALL
 SELECT 'optimism' as blockchain, * FROM  {{ ref('nft_optimism_aggregators') }}
+UNION ALL
+SELECT 'arbitrum' as blockchain, * FROM  {{ ref('nft_arbitrum_aggregators') }}
+

--- a/models/nft/nft_aggregators.sql
+++ b/models/nft/nft_aggregators.sql
@@ -6,12 +6,12 @@
                                     \'["soispoke","hildobby", "chuxin"]\') }}')
 }}
 
-SELECT 'avalanche_c' as blockchain, * FROM  {{ ref('nft_avalanche_c_aggregators') }}
+SELECT 'avalanche_c' as blockchain, * FROM  {{ ref('nft_avalanche_c_aggregators_legacy') }}
 UNION ALL
-SELECT 'bnb' as blockchain, * FROM  {{ ref('nft_bnb_aggregators') }}
+SELECT 'bnb' as blockchain, * FROM  {{ ref('nft_bnb_aggregators_legacy') }}
 UNION ALL
-SELECT 'ethereum' as blockchain, * FROM  {{ ref('nft_ethereum_aggregators') }}
+SELECT 'ethereum' as blockchain, * FROM  {{ ref('nft_ethereum_aggregators_legacy') }}
 UNION ALL
-SELECT 'polygon' as blockchain, * FROM  {{ ref('nft_polygon_aggregators') }}
+SELECT 'polygon' as blockchain, * FROM  {{ ref('nft_polygon_aggregators_legacy') }}
 UNION ALL
-SELECT 'optimism' as blockchain, * FROM  {{ ref('nft_optimism_aggregators') }}
+SELECT 'optimism' as blockchain, * FROM  {{ ref('nft_optimism_aggregators_legacy') }}

--- a/models/nft/nft_aggregators_legacy.sql
+++ b/models/nft/nft_aggregators_legacy.sql
@@ -1,0 +1,17 @@
+{{ config(
+        alias = alias('aggregators', legacy_model=True),
+        post_hook='{{ expose_spells(\'["avalanche_c","bnb","ethereum","polygon", "optimism"]\',
+                                    "sector",
+                                    "nft",
+                                    \'["soispoke","hildobby", "chuxin"]\') }}')
+}}
+
+SELECT 'avalanche_c' as blockchain, * FROM  {{ ref('nft_avalanche_c_aggregators_legacy') }}
+UNION ALL
+SELECT 'bnb' as blockchain, * FROM  {{ ref('nft_bnb_aggregators_legacy') }}
+UNION ALL
+SELECT 'ethereum' as blockchain, * FROM  {{ ref('nft_ethereum_aggregators_legacy') }}
+UNION ALL
+SELECT 'polygon' as blockchain, * FROM  {{ ref('nft_polygon_aggregators_legacy') }}
+UNION ALL
+SELECT 'optimism' as blockchain, * FROM  {{ ref('nft_optimism_aggregators_legacy') }}

--- a/models/nft/nft_aggregators_legacy.sql
+++ b/models/nft/nft_aggregators_legacy.sql
@@ -15,3 +15,5 @@ UNION ALL
 SELECT 'polygon' as blockchain, * FROM  {{ ref('nft_polygon_aggregators_legacy') }}
 UNION ALL
 SELECT 'optimism' as blockchain, * FROM  {{ ref('nft_optimism_aggregators_legacy') }}
+UNION ALL
+SELECT 'arbitrum' as blockchain, * FROM  {{ ref('nft_arbitrum_aggregators_legacy') }}

--- a/models/nft/optimism/nft_optimism_aggregators.sql
+++ b/models/nft/optimism/nft_optimism_aggregators.sql
@@ -1,13 +1,15 @@
-{{ config( alias='aggregators') }}
+{{config(
+    tags = ['dunesql'],
+    alias = alias('aggregators')
+)}}
 
 SELECT
-  lower(contract_address) as contract_address,
+  contract_address as contract_address,
   name
 FROM
   (
     VALUES
-      ('0xbbbbbbbe843515689f3182b748b5671665541e58', 'bluesweep') -- bluesweep
-      , ('0x92D932aBBC7885999c4347880Eb069F854982eDD', 'okx') --okx
-      , ('0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad', 'Uniswap') -- Uniswap's Universal Router 3
-      , ('0xc2c862322e9c97d6244a3506655da95f05246fd8', 'Reservoir') -- Reservoir v6.0.1
+      (0xbbbbbbbe843515689f3182b748b5671665541e58, 'bluesweep') -- bluesweep
+      , (0x92D932aBBC7885999c4347880Eb069F854982eDD, 'okx') --okx
+      , (0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad, 'Uniswap') -- Uniswap's Universal Router 3
   ) AS temp_table (contract_address, name)

--- a/models/nft/optimism/nft_optimism_aggregators.sql
+++ b/models/nft/optimism/nft_optimism_aggregators.sql
@@ -12,4 +12,5 @@ FROM
       (0xbbbbbbbe843515689f3182b748b5671665541e58, 'bluesweep') -- bluesweep
       , (0x92D932aBBC7885999c4347880Eb069F854982eDD, 'okx') --okx
       , (0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad, 'Uniswap') -- Uniswap's Universal Router 3
+      , (0xc2c862322e9c97d6244a3506655da95f05246fd8, 'Reservoir') -- Reservoir v6.0.1
   ) AS temp_table (contract_address, name)

--- a/models/nft/optimism/nft_optimism_aggregators_legacy.sql
+++ b/models/nft/optimism/nft_optimism_aggregators_legacy.sql
@@ -1,0 +1,13 @@
+{{ config( alias = alias('aggregators', legacy_model=True)) }}
+
+SELECT
+  lower(contract_address) as contract_address,
+  name
+FROM
+  (
+    VALUES
+      ('0xbbbbbbbe843515689f3182b748b5671665541e58', 'bluesweep') -- bluesweep
+      , ('0x92D932aBBC7885999c4347880Eb069F854982eDD', 'okx') --okx
+      , ('0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad', 'Uniswap') -- Uniswap's Universal Router 3
+      , ('0xc2c862322e9c97d6244a3506655da95f05246fd8', 'Reservoir') -- Reservoir v6.0.1
+  ) AS temp_table (contract_address, name)

--- a/models/nft/optimism/nft_optimism_native_mints.sql
+++ b/models/nft/optimism/nft_optimism_native_mints.sql
@@ -106,7 +106,7 @@ left join {{ source('prices','usd') }} as pu_erc20s
     {% endif %}
 left join namespaces as ec
     on etxs.to=ec.address
-left join {{ ref('nft_optimism_aggregators') }} as agg
+left join {{ ref('nft_optimism_aggregators_legacy') }} as agg
     on etxs.to=agg.contract_address
 left join nfts_per_tx as nft_count
     on nft_count.tx_hash=nft_mints.tx_hash

--- a/models/nft/polygon/nft_polygon_aggregators.sql
+++ b/models/nft/polygon/nft_polygon_aggregators.sql
@@ -15,4 +15,5 @@ FROM
       , (0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad, 'Uniswap') -- Uniswap's Universal Router 3
       , (0xfbf4c42bb3981e6d5b85ad340d7f0213db7b132c, 'BitKeep') -- BitKeep
       , (0x954dab8830ad2b9c312bb87ace96f6cce0f51e3a, 'OKX')  -- OKX
+      , (0xc2c862322e9c97d6244a3506655da95f05246fd8, 'Reservoir') -- Reservoir v6.0.1
   ) AS temp_table (contract_address, name)

--- a/models/nft/polygon/nft_polygon_aggregators.sql
+++ b/models/nft/polygon/nft_polygon_aggregators.sql
@@ -1,4 +1,7 @@
- {{ config( alias='aggregators') }}
+{{config(
+    tags = ['dunesql'],
+    alias = alias('aggregators')
+}}
 
 SELECT
   contract_address,
@@ -6,11 +9,10 @@ SELECT
 FROM
   (
     VALUES
-      ('0xb3e808e102ac4be070ee3daac70672ffc7c1adca', 'Element') -- Element NFT Marketplace Aggregator
-      , ('0x84efdf0052bf79f2cd3a2369a5d62322923512af', 'Element') -- Element Swap 2
-      , ('0x5e06c349a4a1b8dde8da31e0f167d1cb1d99967c', 'Dew') -- Dew
-      , ('0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad', 'Uniswap') -- Uniswap's Universal Router 3
-      , ('0xfbf4c42bb3981e6d5b85ad340d7f0213db7b132c', 'BitKeep') -- BitKeep
-      , ('0x954dab8830ad2b9c312bb87ace96f6cce0f51e3a', 'OKX')  -- OKX
-      , ('0xc2c862322e9c97d6244a3506655da95f05246fd8', 'Reservoir') -- Reservoir v6.0.1
+      (0xb3e808e102ac4be070ee3daac70672ffc7c1adca, 'Element') -- Element NFT Marketplace Aggregator
+      , (0x84efdf0052bf79f2cd3a2369a5d62322923512af, 'Element') -- Element Swap 2
+      , (0x5e06c349a4a1b8dde8da31e0f167d1cb1d99967c, 'Dew') -- Dew
+      , (0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad, 'Uniswap') -- Uniswap's Universal Router 3
+      , (0xfbf4c42bb3981e6d5b85ad340d7f0213db7b132c, 'BitKeep') -- BitKeep
+      , (0x954dab8830ad2b9c312bb87ace96f6cce0f51e3a, 'OKX')  -- OKX
   ) AS temp_table (contract_address, name)

--- a/models/nft/polygon/nft_polygon_aggregators.sql
+++ b/models/nft/polygon/nft_polygon_aggregators.sql
@@ -1,7 +1,7 @@
 {{config(
     tags = ['dunesql'],
     alias = alias('aggregators')
-}}
+)}}
 
 SELECT
   contract_address,

--- a/models/nft/polygon/nft_polygon_aggregators_legacy.sql
+++ b/models/nft/polygon/nft_polygon_aggregators_legacy.sql
@@ -1,0 +1,16 @@
+ {{ config( alias = alias('aggregators', legacy_model=True)) }}
+
+SELECT
+  contract_address,
+  name
+FROM
+  (
+    VALUES
+      ('0xb3e808e102ac4be070ee3daac70672ffc7c1adca', 'Element') -- Element NFT Marketplace Aggregator
+      , ('0x84efdf0052bf79f2cd3a2369a5d62322923512af', 'Element') -- Element Swap 2
+      , ('0x5e06c349a4a1b8dde8da31e0f167d1cb1d99967c', 'Dew') -- Dew
+      , ('0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad', 'Uniswap') -- Uniswap's Universal Router 3
+      , ('0xfbf4c42bb3981e6d5b85ad340d7f0213db7b132c', 'BitKeep') -- BitKeep
+      , ('0x954dab8830ad2b9c312bb87ace96f6cce0f51e3a', 'OKX')  -- OKX
+      , ('0xc2c862322e9c97d6244a3506655da95f05246fd8', 'Reservoir') -- Reservoir v6.0.1
+  ) AS temp_table (contract_address, name)

--- a/models/notional/ethereum/notional_ethereum_airdrop_claims.sql
+++ b/models/notional/ethereum/notional_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'NOTE' AS token_symbol
 , t.evt_index
 FROM {{ source('notional_ethereum', 'MerkleDistributor_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{note_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/oneinch/ethereum/oneinch_ethereum_airdrop_claims.sql
+++ b/models/oneinch/ethereum/oneinch_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , '1INCH' AS token_symbol
 , t.evt_index
 FROM {{ source('oneinch_ethereum', 'MerkleDistributor_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{oinch_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/op/optimism/op_optimism_airdrop_1_claims.sql
+++ b/models/op/optimism/op_optimism_airdrop_1_claims.sql
@@ -40,7 +40,7 @@ SELECT 'optimism' AS blockchain
 , 'OP' AS token_symbol
 , t.evt_index
 FROM {{ source('op_optimism', 'MerkleDistributor_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'optimism'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'optimism'
     AND pu.contract_address='{{op_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/opensea/arbitrum/opensea_v4_arbitrum_events.sql
+++ b/models/opensea/arbitrum/opensea_v4_arbitrum_events.sql
@@ -46,7 +46,7 @@ with source_arbitrum_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-      from {{ ref('nft_aggregators') }}
+      from {{ ref('nft_aggregators_legacy') }}
      where blockchain = 'arbitrum'
 )
 ,source_prices_usd as (

--- a/models/opensea/ethereum/opensea_v1_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v1_ethereum_events.sql
@@ -187,7 +187,7 @@ FROM enhanced_trades t
 INNER JOIN {{ source('ethereum','transactions') }} tx ON t.block_number = tx.block_number AND t.tx_hash = tx.hash
     AND tx.block_time >= '{{START_DATE}}' AND tx.block_time <= '{{END_DATE}}'
 LEFT JOIN {{ ref('tokens_nft_legacy') }} nft ON nft.contract_address = t.nft_contract_address and nft.blockchain = 'ethereum'
-LEFT JOIN {{ ref('nft_aggregators') }} agg ON agg.contract_address = tx.to AND agg.blockchain = 'ethereum'
+LEFT JOIN {{ ref('nft_aggregators_legacy') }} agg ON agg.contract_address = tx.to AND agg.blockchain = 'ethereum'
 LEFT JOIN {{ source('prices', 'usd') }} p ON p.minute = date_trunc('minute', t.block_time)
     AND p.contract_address = t.currency_contract
     AND p.blockchain ='ethereum'

--- a/models/opensea/ethereum/opensea_v3_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v3_ethereum_events.sql
@@ -44,12 +44,12 @@ with source_ethereum_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-      from {{ ref('nft_aggregators') }}
+      from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'ethereum'
 )
 ,ref_nft_aggregators_marks as (
     select *
-    from {{ ref('nft_ethereum_aggregators_markers') }}
+    from {{ ref('nft_ethereum_aggregators_markers_legacy') }}
 )
 ,source_prices_usd as (
     select *

--- a/models/opensea/ethereum/opensea_v4_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v4_ethereum_events.sql
@@ -40,12 +40,12 @@ with source_ethereum_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-    from {{ ref('nft_aggregators') }}
+    from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'ethereum'
 )
 ,ref_nft_aggregators_marks as (
     select *
-    from {{ ref('nft_ethereum_aggregators_markers') }}
+    from {{ ref('nft_ethereum_aggregators_markers_legacy') }}
 )
 ,source_prices_usd as (
     select *

--- a/models/opensea/optimism/opensea_v3_optimism_events.sql
+++ b/models/opensea/optimism/opensea_v3_optimism_events.sql
@@ -43,7 +43,7 @@ with source_optimism_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-      from {{ ref('nft_aggregators') }}
+      from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'optimism'
 )
 ,source_prices_usd as (

--- a/models/opensea/optimism/opensea_v4_optimism_events.sql
+++ b/models/opensea/optimism/opensea_v4_optimism_events.sql
@@ -45,7 +45,7 @@ with source_optimism_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-      from {{ ref('nft_aggregators') }}
+      from {{ ref('nft_aggregators_legacy') }}
      where blockchain = 'optimism'
 )
 ,source_prices_usd as (

--- a/models/opensea/polygon/opensea_v2_polygon_events.sql
+++ b/models/opensea/polygon/opensea_v2_polygon_events.sql
@@ -147,4 +147,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p ON p.minute = date_trunc('minute', a.b
     AND minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
 LEFT JOIN {{ ref('tokens_erc20_legacy') }} erc20 ON erc20.contract_address = a.currency_contract and erc20.blockchain = 'polygon'
-LEFT JOIN {{ ref('nft_aggregators') }} agg ON agg.blockchain = 'polygon' AND agg.contract_address = t.`to`
+LEFT JOIN {{ ref('nft_aggregators_legacy') }} agg ON agg.blockchain = 'polygon' AND agg.contract_address = t.`to`

--- a/models/opensea/polygon/opensea_v3_polygon_events.sql
+++ b/models/opensea/polygon/opensea_v3_polygon_events.sql
@@ -46,7 +46,7 @@ with source_polygon_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-      from {{ ref('nft_aggregators') }}
+      from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'polygon'
 )
 ,source_prices_usd as (

--- a/models/opensea/polygon/opensea_v4_polygon_events.sql
+++ b/models/opensea/polygon/opensea_v4_polygon_events.sql
@@ -47,7 +47,7 @@ with source_polygon_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-      from {{ ref('nft_aggregators') }}
+      from {{ ref('nft_aggregators_legacy') }}
      where blockchain = 'polygon'
 )
 ,source_prices_usd as (

--- a/models/paladin/ethereum/paladin_ethereum_airdrop_claims.sql
+++ b/models/paladin/ethereum/paladin_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'PAL' AS token_symbol
 , t.evt_index
 FROM {{ source('paladin_ethereum', 'MerkleDistributor_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{pal_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2021-11-03' AND '2022-02-02'

--- a/models/pangolin/avalanche_c/pangolin_avalanche_c_airdrop_claims.sql
+++ b/models/pangolin/avalanche_c/pangolin_avalanche_c_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'avalanche_c' AS blockchain
 , 'PNG' AS token_symbol
 , t.evt_index
 FROM {{ source('pangolin_exchange_avalanche_c', 'Airdrop_evt_PngClaimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'avalanche_c'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'avalanche_c'
     AND pu.contract_address='{{png_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2021-02-09' AND '2021-03-10'

--- a/models/pooltogether/ethereum/pooltogether_ethereum_airdrop_claims.sql
+++ b/models/pooltogether/ethereum/pooltogether_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'POOL' AS token_symbol
 , t.evt_index
 FROM {{ source('pooltogether_ethereum', 'MerkleDistributor_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{pool_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/prices/prices_schema.yml
+++ b/models/prices/prices_schema.yml
@@ -93,6 +93,7 @@ models:
             severity: error
             error_if: ">5"        #there are 5 duplicates in the source prices table (29/11/2022)
             warn_if: "!=0"
+            where: "minute > now() - interval '30' day"
     columns:
       - name: minute
         description: "UTC event block time truncated to the minute mark"

--- a/models/prices/prices_usd_forward_fill_legacy.sql
+++ b/models/prices/prices_usd_forward_fill_legacy.sql
@@ -1,8 +1,7 @@
 {{ config(
-        tags = ['dunesql'],
         schema='prices',
-        alias = alias('usd_forward_fill'),
-        post_hook='{{ expose_spells(\'["ethereum", "solana", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c", "polygon"]\',
+        alias = alias('usd_forward_fill', legacy_model=True),
+        post_hook='{{ expose_spells_hide_trino(\'["ethereum", "solana", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c", "polygon"]\',
                                     "sector",
                                     "prices",
                                     \'["0xRob"]\') }}'
@@ -11,7 +10,7 @@
 
 -- how much time we look back, anything before is considered finalized, anything after is forward filled.
 -- we could decrease this to optimize query performance but it's a tradeoff with resiliency to lateness.
-{%- set lookback_interval = "'2' day" %}
+{%- set lookback_interval = '2 day' %}
 
 
 WITH
@@ -29,10 +28,10 @@ WITH
 )
 
 , timeseries as (
-    select * from unnest(sequence(
-        cast(date_trunc('minute', now() - interval {{lookback_interval}}) as timestamp)
-        ,cast(date_trunc('minute', now()) as timestamp)
-        ,interval '1' minute)) as foo(minute)
+    select explode(sequence(
+        date_trunc('minute', now() - interval {{lookback_interval}})
+        ,date_trunc('minute', now())
+        ,interval 1 minute)) as minute
 )
 
 , forward_fill as (
@@ -65,4 +64,4 @@ SELECT
     ,symbol
     ,price
 FROM forward_fill
-
+;

--- a/models/ribbon/ethereum/ribbon_ethereum_airdrop_claims.sql
+++ b/models/ribbon/ethereum/ribbon_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'RBN' AS token_symbol
 , t.evt_index
 FROM {{ source('ribbon_ethereum', 'MerkleDistributor_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{rbn_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/seaport/arbitrum/seaport_arbitrum_trades.sql
+++ b/models/seaport/arbitrum/seaport_arbitrum_trades.sql
@@ -47,7 +47,7 @@ with source_arbitrum_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-    from {{ ref('nft_aggregators') }}
+    from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'arbitrum'
 )
 ,source_prices_usd as (

--- a/models/seaport/avalanche_c/seaport_avalanche_c_trades.sql
+++ b/models/seaport/avalanche_c/seaport_avalanche_c_trades.sql
@@ -47,7 +47,7 @@ with source_avalanche_c_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-    from {{ ref('nft_aggregators') }}
+    from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'avalanche_c'
 )
 ,source_prices_usd as (

--- a/models/seaport/bnb/seaport_bnb_trades.sql
+++ b/models/seaport/bnb/seaport_bnb_trades.sql
@@ -47,7 +47,7 @@ with source_bnb_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-    from {{ ref('nft_aggregators') }}
+    from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'bnb'
 )
 ,source_prices_usd as (

--- a/models/seaport/ethereum/seaport_v1_ethereum_trades.sql
+++ b/models/seaport/ethereum/seaport_v1_ethereum_trades.sql
@@ -49,12 +49,12 @@ with source_ethereum_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-    from {{ ref('nft_aggregators') }}
+    from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'ethereum'
 )
 ,ref_nft_aggregators_marks as (
     select *
-    from {{ ref('nft_ethereum_aggregators_markers') }}
+    from {{ ref('nft_ethereum_aggregators_markers_legacy') }}
 )
 ,source_prices_usd as (
     select *

--- a/models/seaport/ethereum/seaport_v2_ethereum_trades.sql
+++ b/models/seaport/ethereum/seaport_v2_ethereum_trades.sql
@@ -49,12 +49,12 @@ with source_ethereum_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-    from {{ ref('nft_aggregators') }}
+    from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'ethereum'
 )
 ,ref_nft_aggregators_marks as (
     select *
-    from {{ ref('nft_ethereum_aggregators_markers') }}
+    from {{ ref('nft_ethereum_aggregators_markers_legacy') }}
 )
 ,source_prices_usd as (
     select *

--- a/models/seaport/optimism/seaport_optimism_trades.sql
+++ b/models/seaport/optimism/seaport_optimism_trades.sql
@@ -47,7 +47,7 @@ with source_optimism_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-    from {{ ref('nft_aggregators') }}
+    from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'optimism'
 )
 ,source_prices_usd as (

--- a/models/seaport/polygon/seaport_polygon_trades.sql
+++ b/models/seaport/polygon/seaport_polygon_trades.sql
@@ -47,7 +47,7 @@ with source_polygon_transactions as (
 )
 ,ref_nft_aggregators as (
     select *
-    from {{ ref('nft_aggregators') }}
+    from {{ ref('nft_aggregators_legacy') }}
     where blockchain = 'polygon'
 )
 ,source_prices_usd as (

--- a/models/shapeshift/ethereum/shapeshift_ethereum_airdrop_claims.sql
+++ b/models/shapeshift/ethereum/shapeshift_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'FOX' AS token_symbol
 , t.evt_index
 FROM {{ source('shapeshift_ethereum', 'TokenDistributor_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{fox_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2021-07-08' AND '2021-10-22'

--- a/models/snowswap/ethereum/snowswap_ethereum_airdrop_claims.sql
+++ b/models/snowswap/ethereum/snowswap_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'SNOW' AS token_symbol
 , t.evt_index
 FROM {{ source('snowswap_ethereum', 'MerkleDistributor_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{snow_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2020-10-14' AND '2020-10-31'

--- a/models/sudoswap/ethereum/sudoswap_ethereum_airdrop_claims.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'SUDO' AS token_symbol
 , t.evt_index
 FROM {{ source('sudoswap_ethereum', 'Astrodrop_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{sudo_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/sudoswap/ethereum/sudoswap_ethereum_pool_trades_agg_day.sql
+++ b/models/sudoswap/ethereum/sudoswap_ethereum_pool_trades_agg_day.sql
@@ -40,7 +40,7 @@ SELECT
       END
     ) AS nft_change_trading
 FROM {{ ref('sudoswap_ethereum_base_trades') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} usd
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} usd
 ON usd.blockchain = null and usd.symbol = 'ETH'
     AND usd.minute = date_trunc('minute',t.block_time)
     {% if not is_incremental() %}

--- a/models/tokenfy/ethereum/tokenfy_ethereum_airdrop_claims.sql
+++ b/models/tokenfy/ethereum/tokenfy_ethereum_airdrop_claims.sql
@@ -42,7 +42,7 @@ SELECT 'ethereum' AS blockchain
 FROM {{ source('erc20_ethereum', 'evt_transfer') }} t
 INNER JOIN {{source( 'tokenfy_ethereum', 'Tokenfy_call_claim' ) }} c ON c.call_block_number=t.evt_block_number
     AND c.call_tx_hash=t.evt_tx_hash
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{tknfy_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2022-01-21' AND '2022-02-05'

--- a/models/tornado_cash/ethereum/tornado_cash_ethereum_airdrop_claims.sql
+++ b/models/tornado_cash/ethereum/tornado_cash_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'TORN' AS token_symbol
 , t.evt_index
 FROM {{ source('erc20_ethereum', 'evt_transfer') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{torn_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2020-12-18' AND '2021-12-13'

--- a/models/uniswap/ethereum/uniswap_ethereum_airdrop_claims.sql
+++ b/models/uniswap/ethereum/uniswap_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'UNI' AS token_symbol
 , t.evt_index
 FROM {{ source('uniswap_ethereum', 'MerkleDistributor_evt_Claimed') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{uni_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
     {% if is_incremental() %}

--- a/models/x2y2/ethereum/x2y2_ethereum_airdrop_claims.sql
+++ b/models/x2y2/ethereum/x2y2_ethereum_airdrop_claims.sql
@@ -40,7 +40,7 @@ SELECT 'ethereum' AS blockchain
 , 'X2Y2' AS token_symbol
 , t.evt_index
 FROM {{ source('erc20_ethereum', 'evt_transfer') }} t
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu ON pu.blockchain = 'ethereum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu ON pu.blockchain = 'ethereum'
     AND pu.contract_address='{{xtyt_token_address}}'
     AND pu.minute=date_trunc('minute', t.evt_block_time)
 WHERE t.evt_block_time BETWEEN '2022-02-15' AND '2022-03-31'

--- a/models/zerion/arbitrum/zerion_arbitrum_trades.sql
+++ b/models/zerion/arbitrum/zerion_arbitrum_trades.sql
@@ -89,7 +89,7 @@ SELECT 'arbitrum' AS blockchain
     ELSE CAST(trades.zerion_fee_amount_raw/POWER(10, COALESCE(trades.tok_sold_decimals, pu_sold.decimals)) AS double)
     END AS double) AS zerion_fee_amount_original
 FROM zerion_trades trades
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='arbitrum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_sold ON pu_sold.blockchain='arbitrum'
     AND pu_sold.contract_address=trades.token_sold_address
     AND pu_sold.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}
@@ -98,7 +98,7 @@ LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='ar
     {% if is_incremental() %}
     AND pu_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_bought ON pu_bought.blockchain='arbitrum'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_bought ON pu_bought.blockchain='arbitrum'
     AND pu_bought.contract_address=trades.token_bought_address
     AND pu_bought.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}

--- a/models/zerion/avalanche_c/zerion_avalanche_c_trades.sql
+++ b/models/zerion/avalanche_c/zerion_avalanche_c_trades.sql
@@ -89,7 +89,7 @@ SELECT 'avalanche_c' AS blockchain
     ELSE CAST(trades.zerion_fee_amount_raw/POWER(10, COALESCE(trades.tok_sold_decimals, pu_sold.decimals)) AS double)
     END AS double) AS zerion_fee_amount_original
 FROM zerion_trades trades
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='avalanche_c'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_sold ON pu_sold.blockchain='avalanche_c'
     AND pu_sold.contract_address=trades.token_sold_address
     AND pu_sold.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}
@@ -98,7 +98,7 @@ LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='av
     {% if is_incremental() %}
     AND pu_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_bought ON pu_bought.blockchain='avalanche_c'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_bought ON pu_bought.blockchain='avalanche_c'
     AND pu_bought.contract_address=trades.token_bought_address
     AND pu_bought.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}

--- a/models/zerion/bnb/zerion_bnb_trades.sql
+++ b/models/zerion/bnb/zerion_bnb_trades.sql
@@ -92,7 +92,7 @@ SELECT 'bnb' AS blockchain
     ELSE CAST(trades.zerion_fee_amount_raw/POWER(10, COALESCE(trades.tok_sold_decimals, pu_sold.decimals)) AS double)
     END AS double) AS zerion_fee_amount_original
 FROM zerion_trades trades
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='bnb'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_sold ON pu_sold.blockchain='bnb'
     AND pu_sold.contract_address=trades.token_sold_address
     AND pu_sold.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}
@@ -101,7 +101,7 @@ LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='bn
     {% if is_incremental() %}
     AND pu_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_bought ON pu_bought.blockchain='bnb'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_bought ON pu_bought.blockchain='bnb'
     AND pu_bought.contract_address=trades.token_bought_address
     AND pu_bought.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}

--- a/models/zerion/fantom/zerion_fantom_trades.sql
+++ b/models/zerion/fantom/zerion_fantom_trades.sql
@@ -89,7 +89,7 @@ SELECT 'fantom' AS blockchain
     ELSE CAST(trades.zerion_fee_amount_raw/POWER(10, COALESCE(trades.tok_sold_decimals, pu_sold.decimals)) AS double)
     END AS double) AS zerion_fee_amount_original
 FROM zerion_trades trades
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='fantom'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_sold ON pu_sold.blockchain='fantom'
     AND pu_sold.contract_address=trades.token_sold_address
     AND pu_sold.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}
@@ -98,7 +98,7 @@ LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='fa
     {% if is_incremental() %}
     AND pu_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_bought ON pu_bought.blockchain='fantom'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_bought ON pu_bought.blockchain='fantom'
     AND pu_bought.contract_address=trades.token_bought_address
     AND pu_bought.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}

--- a/models/zerion/gnosis/zerion_gnosis_trades.sql
+++ b/models/zerion/gnosis/zerion_gnosis_trades.sql
@@ -89,7 +89,7 @@ SELECT 'gnosis' AS blockchain
     ELSE CAST(trades.zerion_fee_amount_raw/POWER(10, COALESCE(trades.tok_sold_decimals, pu_sold.decimals)) AS double)
     END AS double) AS zerion_fee_amount_original
 FROM zerion_trades trades
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='gnosis'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_sold ON pu_sold.blockchain='gnosis'
     AND pu_sold.contract_address=trades.token_sold_address
     AND pu_sold.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}
@@ -98,7 +98,7 @@ LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='gn
     {% if is_incremental() %}
     AND pu_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_bought ON pu_bought.blockchain='gnosis'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_bought ON pu_bought.blockchain='gnosis'
     AND pu_bought.contract_address=trades.token_bought_address
     AND pu_bought.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}

--- a/models/zerion/optimism/zerion_optimism_trades.sql
+++ b/models/zerion/optimism/zerion_optimism_trades.sql
@@ -89,7 +89,7 @@ SELECT 'optimism' AS blockchain
     ELSE CAST(trades.zerion_fee_amount_raw/POWER(10, COALESCE(trades.tok_sold_decimals, pu_sold.decimals)) AS double)
     END AS double) AS zerion_fee_amount_original
 FROM zerion_trades trades
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='optimism'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_sold ON pu_sold.blockchain='optimism'
     AND pu_sold.contract_address=trades.token_sold_address
     AND pu_sold.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}
@@ -98,7 +98,7 @@ LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='op
     {% if is_incremental() %}
     AND pu_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_bought ON pu_bought.blockchain='optimism'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_bought ON pu_bought.blockchain='optimism'
     AND pu_bought.contract_address=trades.token_bought_address
     AND pu_bought.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}

--- a/models/zerion/polygon/zerion_polygon_trades.sql
+++ b/models/zerion/polygon/zerion_polygon_trades.sql
@@ -89,7 +89,7 @@ SELECT 'polygon' AS blockchain
     ELSE CAST(trades.zerion_fee_amount_raw/POWER(10, COALESCE(trades.tok_sold_decimals, pu_sold.decimals)) AS double)
     END AS double) AS zerion_fee_amount_original
 FROM zerion_trades trades
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='polygon'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_sold ON pu_sold.blockchain='polygon'
     AND pu_sold.contract_address=trades.token_sold_address
     AND pu_sold.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}
@@ -98,7 +98,7 @@ LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_sold ON pu_sold.blockchain='po
     {% if is_incremental() %}
     AND pu_sold.minute >= date_trunc("day", now() - interval '1 week')
     {% endif %}
-LEFT JOIN {{ ref('prices_usd_forward_fill') }} pu_bought ON pu_bought.blockchain='polygon'
+LEFT JOIN {{ ref('prices_usd_forward_fill_legacy') }} pu_bought ON pu_bought.blockchain='polygon'
     AND pu_bought.contract_address=trades.token_bought_address
     AND pu_bought.minute=date_trunc('minute', trades.block_time)
     {% if not is_incremental() %}

--- a/tests/nft/ethereum/nft_ethereum_aggregators_markers_no_collisions.sql
+++ b/tests/nft/ethereum/nft_ethereum_aggregators_markers_no_collisions.sql
@@ -3,7 +3,7 @@ WITH unit_test as (
     from {{ ref('nft_ethereum_aggregators_markers') }} a
     inner join {{ ref('nft_ethereum_aggregators_markers') }} b
     on a.router_name != b.router_name
-    and a.hash_marker LIKE '%'|| b.hash_marker
+    and bytearray_starts_with(bytearray_reverse(a.hash_marker),bytearray_reverse(b.hash_marker))
 )
 
 select * from unit_test


### PR DESCRIPTION
Migrating all NFT parent models (except marketplaces, those will follow in a separate PR) of `nft_ethereum_trades_beta`.
does not include `+nft_tokens` as that is already handled in this PR: [..]

steps taken:
1. `dbt ls --resource-type model --output path --select +prices_usd_forward_fill +nft_aggregators +nft_ethereum_aggregators_markers | python scripts/generate_legacy_models.py`
2. moved all affected migrated files to this repo.