### PR TITLE
Only check first degree children and parents for DuneSQL and Spark overlap

### DIFF
--- a/scripts/dunesql_spark_empty_intersection.sh
+++ b/scripts/dunesql_spark_empty_intersection.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-res=$(comm -12 <( dbt ls --exclude tag:dunesql | sort | grep -v "^source" ) <( dbt ls --select +tag:dunesql+ | sort | grep -v "^source" ))
+res=$(comm -12 <( dbt ls --exclude tag:dunesql | sort | grep -v "^source" ) <( dbt ls --select 1+tag:dunesql+1 | sort | grep -v "^source" ))
 if [ -z "$res" ]; then
   exit 0
 else

--- a/scripts/dunesql_spark_empty_intersection.sh
+++ b/scripts/dunesql_spark_empty_intersection.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-res=$(comm -12 <( dbt ls --exclude tag:dunesql | sort | grep -v "^source" ) <( dbt ls --select 1+tag:dunesql+1 | sort | grep -v "^source" ))
+res=$(comm -12 <( dbt ls --select resource_type:model --exclude tag:dunesql | sort ) <( dbt ls --exclude resource_type:source --select 1+tag:dunesql+1,resource_type:model | sort ))
 if [ -z "$res" ]; then
   exit 0
 else


### PR DESCRIPTION
It's sufficient to check that the first layer of parents or children are non-overlapping. This makes the error messages smaller and easier to inspect.