### PR TITLE
Standardise Uniswap V3 Factory names accross chains

### DIFF
--- a/models/uniswap/arbitrum/uniswap_arbitrum_pools.sql
+++ b/models/uniswap/arbitrum/uniswap_arbitrum_pools.sql
@@ -22,7 +22,7 @@ SELECT 'arbitrum' AS blockchain
 , evt_block_time AS creation_block_time
 , evt_block_number AS creation_block_number
 , contract_address
-FROM {{ source('uniswap_v3_arbitrum', 'UniswapV3Factory_evt_PoolCreated') }}
+FROM {{ source('uniswap_v3_arbitrum', 'Factory_evt_PoolCreated') }}
 {% if is_incremental() %}
 WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')
 {% endif %}

--- a/models/uniswap/arbitrum/uniswap_arbitrum_sources.yml
+++ b/models/uniswap/arbitrum/uniswap_arbitrum_sources.yml
@@ -1,6 +1,6 @@
 version: 2
 
-sources: 
+sources:
   - name: uniswap_v3_arbitrum
     description: "Arbitrum decoded tables related to Uniswap v3 contract"
     freshness:
@@ -47,8 +47,8 @@ sources:
           - &tick
             name: tick
             description: the log base 1.0001 of price of the pool after the swap"
-            
-      - name: UniswapV3Factory_evt_PoolCreated
+
+      - name: Factory_evt_PoolCreated
         loaded_at_field: evt_block_time
         description: "" # to-do
         columns:

--- a/models/uniswap/arbitrum/uniswap_v3_arbitrum_flashloans.sql
+++ b/models/uniswap/arbitrum/uniswap_v3_arbitrum_flashloans.sql
@@ -24,7 +24,7 @@ WITH flashloans AS (
     , CASE WHEN f.amount0 = 0 THEN erc20b.decimals ELSE erc20a.decimals END AS currency_decimals
     , f.contract_address
     FROM {{ source('uniswap_v3_arbitrum','Pair_evt_Flash') }} f
-        INNER JOIN {{ source('uniswap_v3_arbitrum','UniswapV3Factory_evt_PoolCreated') }} p ON f.contract_address = p.pool
+        INNER JOIN {{ source('uniswap_v3_arbitrum','Factory_evt_PoolCreated') }} p ON f.contract_address = p.pool
     LEFT JOIN {{ ref('tokens_arbitrum_erc20_legacy') }} erc20a ON p.token0 = erc20a.contract_address
     LEFT JOIN {{ ref('tokens_arbitrum_erc20_legacy') }} erc20b ON p.token1 = erc20b.contract_address
     WHERE f.evt_block_time > NOW() - interval '1' month

--- a/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades.sql
+++ b/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades.sql
@@ -34,7 +34,7 @@ WITH dexs AS
     FROM
         {{ source('uniswap_v3_arbitrum', 'Pair_evt_Swap') }} t
     INNER JOIN 
-        {{ source('uniswap_v3_arbitrum', 'UniswapV3Factory_evt_PoolCreated') }} f
+        {{ source('uniswap_v3_arbitrum', 'Factory_evt_PoolCreated') }} f
         ON f.pool = t.contract_address
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')

--- a/models/uniswap/bnb/uniswap_bnb_sources.yml
+++ b/models/uniswap/bnb/uniswap_bnb_sources.yml
@@ -1,6 +1,6 @@
 version: 2
 
-sources: 
+sources:
   - name: uniswap_v3_bnb
     description: "BNB chain decoded tables related to Uniswap v3 contract"
     freshness:
@@ -48,7 +48,7 @@ sources:
             name: tick
             description: the log base 1.0001 of price of the pool after the swap"
 
-      - name: UniswapV3Factory_evt_PoolCreated
+      - name: Factory_evt_PoolCreated
         loaded_at_field: evt_block_time
         description: "Uniswap v3 Factory PoolCreated events table"
         columns:
@@ -74,6 +74,6 @@ sources:
           - &token1
             name: token1
             description: "The second of the two tokens in the pool"
-            
+
       - name: Pair_evt_Flash
         loaded_at_field: evt_block_time

--- a/models/uniswap/bnb/uniswap_v3_bnb_flashloans.sql
+++ b/models/uniswap/bnb/uniswap_v3_bnb_flashloans.sql
@@ -24,7 +24,7 @@ WITH flashloans AS (
     , CASE WHEN f.amount0 = 0 THEN bep20b.decimals ELSE bep20a.decimals END AS currency_decimals
     , f.contract_address
     FROM {{ source('uniswap_v3_bnb','Pair_evt_Flash') }} f
-        INNER JOIN {{ source('uniswap_v3_bnb','UniswapV3Factory_evt_PoolCreated') }} p ON f.contract_address = p.pool
+        INNER JOIN {{ source('uniswap_v3_bnb','Factory_evt_PoolCreated') }} p ON f.contract_address = p.pool
     LEFT JOIN {{ ref('tokens_bnb_bep20_legacy') }} bep20a ON p.token0 = bep20a.contract_address
     LEFT JOIN {{ ref('tokens_bnb_bep20_legacy') }} bep20b ON p.token1 = bep20b.contract_address
     WHERE f.evt_block_time > NOW() - interval '1' month

--- a/models/uniswap/bnb/uniswap_v3_bnb_trades.sql
+++ b/models/uniswap/bnb/uniswap_v3_bnb_trades.sql
@@ -34,7 +34,7 @@ WITH dexs AS
     FROM
         {{ source('uniswap_v3_bnb', 'Pair_evt_Swap') }} t
     INNER JOIN 
-        {{ source('uniswap_v3_bnb', 'UniswapV3Factory_evt_PoolCreated') }} f
+        {{ source('uniswap_v3_bnb', 'Factory_evt_PoolCreated') }} f
         ON f.pool = t.contract_address
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')

--- a/models/uniswap/polygon/uniswap_polygon_pools.sql
+++ b/models/uniswap/polygon/uniswap_polygon_pools.sql
@@ -22,7 +22,7 @@ SELECT 'polygon' AS blockchain
 , evt_block_time AS creation_block_time
 , evt_block_number AS creation_block_number
 , contract_address
-FROM {{ source('uniswap_v3_polygon', 'factory_polygon_evt_PoolCreated') }}
+FROM {{ source('uniswap_v3_polygon', 'Factory_evt_PoolCreated') }}
 {% if is_incremental() %}
 WHERE evt_block_time >= date_trunc("day", now() - interval '1 week')
 {% endif %}

--- a/models/uniswap/polygon/uniswap_polygon_sources.yml
+++ b/models/uniswap/polygon/uniswap_polygon_sources.yml
@@ -1,6 +1,6 @@
 version: 2
 
-sources: 
+sources:
   - name: uniswap_v3_polygon
     description: "Polygon decoded tables related to Uniswap v3 contract"
     freshness:
@@ -48,7 +48,7 @@ sources:
             name: tick
             description: the log base 1.0001 of price of the pool after the swap"
 
-      - name: factory_polygon_evt_PoolCreated
+      - name: Factory_evt_PoolCreated
         loaded_at_field: evt_block_time
         description: "" # to-do
         columns:

--- a/models/uniswap/polygon/uniswap_v3_polygon_flashloans.sql
+++ b/models/uniswap/polygon/uniswap_v3_polygon_flashloans.sql
@@ -24,7 +24,7 @@ WITH flashloans AS (
     , CASE WHEN f.amount0 = 0 THEN erc20b.decimals ELSE erc20a.decimals END AS currency_decimals
     , f.contract_address
     FROM {{ source('uniswap_v3_polygon','UniswapV3Pool_evt_Flash') }} f
-        INNER JOIN {{ source('uniswap_v3_polygon','factory_polygon_evt_PoolCreated') }} p ON f.contract_address = p.pool
+        INNER JOIN {{ source('uniswap_v3_polygon','Factory_evt_PoolCreated') }} p ON f.contract_address = p.pool
     LEFT JOIN {{ ref('tokens_polygon_erc20_legacy') }} erc20a ON p.token0 = erc20a.contract_address
     LEFT JOIN {{ ref('tokens_polygon_erc20_legacy') }} erc20b ON p.token1 = erc20b.contract_address
     WHERE f.evt_block_time > NOW() - interval '1' month

--- a/models/uniswap/polygon/uniswap_v3_polygon_trades.sql
+++ b/models/uniswap/polygon/uniswap_v3_polygon_trades.sql
@@ -34,7 +34,7 @@ WITH dexs AS
     FROM
         {{ source('uniswap_v3_polygon', 'UniswapV3Pool_evt_Swap') }} t
     INNER JOIN 
-        {{ source('uniswap_v3_polygon', 'factory_polygon_evt_PoolCreated') }} f
+        {{ source('uniswap_v3_polygon', 'Factory_evt_PoolCreated') }} f
         ON f.pool = t.contract_address
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc("day", now() - interval '1 week')

--- a/models/zeroex/polygon/zeroex_polygon_api_fills.sql
+++ b/models/zeroex/polygon/zeroex_polygon_api_fills.sql
@@ -295,7 +295,7 @@ direct_uniswapv3 AS (
             TRUE                                                                                    AS swap_flag,
             FALSE                                                                                   AS matcha_limit_order_flag
     FROM {{ source('uniswap_v3_polygon', 'UniswapV3Pool_evt_Swap') }} swap
-   LEFT JOIN {{ source('uniswap_v3_polygon', 'factory_polygon_evt_PoolCreated') }} pair ON pair.pool = swap.contract_address
+   LEFT JOIN {{ source('uniswap_v3_polygon', 'Factory_evt_PoolCreated') }} pair ON pair.pool = swap.contract_address
    INNER JOIN zeroex_tx ON zeroex_tx.tx_hash = swap.evt_tx_hash
    WHERE sender = '0xdef1c0ded9bec7f1a1670819833240f027b25eff'
 


### PR DESCRIPTION
Similar a previous PR we had to revert. Cleaning up and uniformising uniswap_v3_{blockchain}.Factory naming accross Arbitrum, BNB and Polygon.