### PR TITLE
Seed and generic test support for DuneSQL

### DIFF
--- a/macros/dune/create_bindings.sql
+++ b/macros/dune/create_bindings.sql
@@ -1,0 +1,27 @@
+{#
+  This macro is used in https://github.com/starburstdata/dbt-trino/blob/master/dbt/include/trino/macros/materializations/seeds/helpers.sql
+  We need to override the type bindings to support varbinary hex addresses and hashes in seeds.
+#}
+
+
+{% macro create_bindings(row, types) %}
+  {% set values = [] %}
+  {% set re = modules.re %}
+
+  {%- for item in row -%}
+      {%- set type = types[loop.index0] -%}
+      {%- set match_type = re.match("(\w+)(\(.*\))?", type) -%}
+      {%- if item is not none and 'varbinary' in type.lower() -%}
+        {%- do values.append((none, item )) -%}
+      {%- elif item is not none and item is string and 'interval' in match_type.group(1) -%}
+        {%- do values.append((none, match_type.group(1).upper() ~ " " ~ item)) -%}
+      {%- elif item is not none and item is string and 'varchar' not in type.lower() -%}
+        {%- do values.append((none, match_type.group(1).upper() ~ " '" ~ item ~ "'")) -%}
+      {%- elif item is not none and 'varchar' in type.lower() -%}
+        {%- do values.append((get_binding_char(), item|string())) -%}
+      {%- else -%}
+        {%- do values.append((get_binding_char(), item)) -%}
+      {% endif -%}
+  {%- endfor -%}
+  {{ return(values) }}
+{% endmacro %}

--- a/macros/test-helpers/check_seed_macro.sql
+++ b/macros/test-helpers/check_seed_macro.sql
@@ -54,8 +54,9 @@
     matching_count_test as (
         select
             'matched records count' as test_description,
-            count(model_{{seed_matching_columns[0]}}) as `result_model`,
-            1 as `expected_seed`,
+            cast(count(model_{{seed_matching_columns[0]}}) as varchar) as result_model,
+            cast(1 as varchar) as expected_seed,
+            (count(model_{{seed_matching_columns[0]}}) = 1) as equality_check,
             {%- for column_name in seed_matching_columns %}
             seed_{{column_name}} as {{column_name}}{% if not loop.last %},{% endif %}
             {% endfor -%}
@@ -70,17 +71,14 @@
     (
         {%- for checked_column in seed_check_columns %}
         select
-            'equality test: {{checked_column}}' as test_description
-            ,test.*
-        from (
-            select
-                model_{{checked_column}} as `result_model`,
-                seed_{{checked_column}} as `expected_seed`,
-                {%- for column_name in seed_matching_columns %}
-                seed_{{column_name}} {% if not loop.last %},{% endif %}
-                {% endfor -%}
-            from matched_records
-        ) test
+            'equality test: {{checked_column}}' as test_description,
+            cast(model_{{checked_column}} as varchar) as result_model,
+            cast(seed_{{checked_column}} as varchar) as expected_seed,
+            (model_{{checked_column}} = seed_{{checked_column}}) as equality_check,
+            {%- for column_name in seed_matching_columns %}
+            seed_{{column_name}} as {{column_name}}{% if not loop.last %},{% endif %}
+            {% endfor -%}
+        from matched_records
         {%- if not loop.last %}
         UNION ALL
         {% endif -%}
@@ -95,5 +93,5 @@
         select *
         from equality_tests
     ) all
-    where `result_model` != `expected_seed`
+    where equality_check != true
 {% endmacro %}

--- a/macros/test-helpers/check_seed_macro.sql
+++ b/macros/test-helpers/check_seed_macro.sql
@@ -54,6 +54,7 @@
     matching_count_test as (
         select
             'matched records count' as test_description,
+            -- these are cast to varchar to unify column types, note this is only for displaying them in the test results
             cast(count(model_{{seed_matching_columns[0]}}) as varchar) as result_model,
             cast(1 as varchar) as expected_seed,
             (count(model_{{seed_matching_columns[0]}}) = 1) as equality_check,
@@ -71,7 +72,8 @@
     (
         {%- for checked_column in seed_check_columns %}
         select
-            'equality test: {{checked_column}}' as test_description,
+            'equality test: {{checked_column}}' as test_description
+            -- these are cast to varchar to unify column types, note this is only for displaying them in the test results
             cast(model_{{checked_column}} as varchar) as result_model,
             cast(seed_{{checked_column}} as varchar) as expected_seed,
             (model_{{checked_column}} = seed_{{checked_column}}) as equality_check,

--- a/macros/test-helpers/check_seed_macro_legacy.sql
+++ b/macros/test-helpers/check_seed_macro_legacy.sql
@@ -1,0 +1,99 @@
+-- this macro is used in generic tests that check a model for every row in a seed file.
+-- you need to specify the matching columns and the columns to check for equality.
+-- filter: dictionary filter of column:value that is applied to the seed file
+
+{% macro check_seed_macro_legacy(model, seed_file, seed_matching_columns=[], seed_check_columns=[], filter=None) %}
+
+    with matched_records as (
+        select
+            {%- for column_name in seed_matching_columns %}
+            seed.{{column_name}} as seed_{{column_name}},
+            model_sample.{{column_name}} as model_{{column_name}},
+            {% endfor -%}
+            {%- for column_name in seed_check_columns %}
+            seed.{{column_name}} as seed_{{column_name}},
+            model_sample.{{column_name}} as model_{{column_name}} {% if not loop.last %},{% endif %}
+            {% endfor -%}
+        from {{seed_file}} seed
+        left join (
+            select
+                {%- for column_name in seed_matching_columns %}
+                model.{{column_name}},
+                {% endfor -%}
+                {%- for column_name in seed_check_columns %}
+                model.{{column_name}} {% if not loop.last %},{% endif %}
+                {% endfor -%}
+            from  {{seed_file}} seed
+            inner join {{model}} model
+                ON 1=1
+                    {%- for column_name in seed_matching_columns %}
+                    {% if column_name == 'trace_address' %}
+                    AND COALESCE(CAST(split(seed.{{column_name}}, ',') as array<bigint>), ARRAY()) = model.{{column_name}}
+                    {% else %}
+                    AND seed.{{column_name}} = model.{{column_name}}
+                    {% endif %}
+                    {% endfor -%}
+            ) model_sample
+        ON 1=1
+            {%- for column_name in seed_matching_columns %}
+            {% if column_name == 'trace_address' %}
+            AND COALESCE(CAST(split(seed.{{column_name}}, ',') as array<bigint>), ARRAY()) = model_sample.{{column_name}}
+            {% else %}
+            AND seed.{{column_name}} = model_sample.{{column_name}}
+            {% endif %}
+            {% endfor -%}
+        WHERE 1=1
+              {%- if filter is not none %}
+                  {%- for col, val in filter.items() %}
+                      {% if val is not none %} AND seed.{{col}} = '{{val}}' {% endif %}
+                  {% endfor -%}
+              {% endif -%}
+    ),
+
+    -- check if the matching columns return singular results
+    matching_count_test as (
+        select
+            'matched records count' as test_description,
+            count(model_{{seed_matching_columns[0]}}) as `result_model`,
+            1 as `expected_seed`,
+            {%- for column_name in seed_matching_columns %}
+            seed_{{column_name}} as {{column_name}}{% if not loop.last %},{% endif %}
+            {% endfor -%}
+        from matched_records
+        GROUP BY
+            {%- for column_name in seed_matching_columns %}
+            seed_{{column_name}} {% if not loop.last %},{% endif %}
+            {% endfor -%}
+    ) ,
+
+    equality_tests as
+    (
+        {%- for checked_column in seed_check_columns %}
+        select
+            'equality test: {{checked_column}}' as test_description
+            ,test.*
+        from (
+            select
+                model_{{checked_column}} as `result_model`,
+                seed_{{checked_column}} as `expected_seed`,
+                {%- for column_name in seed_matching_columns %}
+                seed_{{column_name}} {% if not loop.last %},{% endif %}
+                {% endfor -%}
+            from matched_records
+        ) test
+        {%- if not loop.last %}
+        UNION ALL
+        {% endif -%}
+        {% endfor -%}
+    )
+
+
+    select * from (
+        select *
+        from matching_count_test
+        union all
+        select *
+        from equality_tests
+    ) all
+    where `result_model` != `expected_seed`
+{% endmacro %}

--- a/macros/test-helpers/test_helpers_schema.yml
+++ b/macros/test-helpers/test_helpers_schema.yml
@@ -1,5 +1,7 @@
 version: 2
 
 macros:
+  - name: check_seed_macro_legacy
+    description: "Macro to be used in generic seed check tests. It checks if every row in a seed file is present in the model"
   - name: check_seed_macro
     description: "Macro to be used in generic seed check tests. It checks if every row in a seed file is present in the model"

--- a/models/_sector/nft/trades/ethereum/platforms/_schema.yml
+++ b/models/_sector/nft/trades/ethereum/platforms/_schema.yml
@@ -16,7 +16,7 @@ models:
      - equal_rowcount_with_sources:
          evt_sources:
            - source('archipelago_ethereum','ArchipelagoMarket_evt_Trade')
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('archipelago_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -44,7 +44,7 @@ models:
    tests:
      - dbt_utils.unique_combination_of_columns:
          combination_of_columns: [ 'block_number','tx_hash','sub_tx_trade_id' ]
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('superrare_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -78,7 +78,7 @@ models:
            - source('foundation_ethereum','market_evt_BuyPriceAccepted')
            - source('foundation_ethereum','market_evt_OfferAccepted')
            - source('foundation_ethereum','market_evt_PrivateSaleFinalized')
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('foundation_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -109,7 +109,7 @@ models:
          error_if: ">1"
          evt_sources:
            - source('cryptopunks_ethereum','CryptoPunksMarket_evt_PunkBought')
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('cryptopunks_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -136,7 +136,7 @@ models:
    tests:
      - dbt_utils.unique_combination_of_columns:
          combination_of_columns: [ 'block_number','tx_hash','sub_tx_trade_id' ]
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('blur_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -169,7 +169,7 @@ models:
            - source('element_ex_ethereum','OrdersFeature_evt_ERC721BuyOrderFilled')
            - source('element_ex_ethereum','OrdersFeature_evt_ERC1155SellOrderFilled')
            - source('element_ex_ethereum','OrdersFeature_evt_ERC1155BuyOrderFilled')
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('element_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -199,7 +199,7 @@ models:
      - equal_rowcount_with_sources:
          evt_sources:
            - source('x2y2_ethereum','X2Y2_r1_evt_EvInventory')
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('x2y2_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -230,7 +230,7 @@ models:
          evt_sources:
            - source('looksrare_ethereum','LooksRareExchange_evt_TakerAsk')
            - source('looksrare_ethereum','LooksRareExchange_evt_TakerBid')
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('looksrare_v1_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -261,7 +261,7 @@ models:
          evt_sources:
            - source('looksrare_v2_ethereum','LooksRareProtocol_evt_TakerAsk')
            - source('looksrare_v2_ethereum','LooksRareProtocol_evt_TakerBid')
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('looksrare_v2_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -287,7 +287,7 @@ models:
    tests:
      - dbt_utils.unique_combination_of_columns:
          combination_of_columns: [ 'block_number','tx_hash','sub_tx_trade_id' ]
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('zora_v1_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -317,7 +317,7 @@ models:
      - equal_rowcount_with_sources:
          evt_sources:
            - source('zora_ethereum','AuctionHouse_evt_AuctionEnded')
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('zora_v2_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -357,7 +357,7 @@ models:
            - source('zora_v3_ethereum','ReserveAuctionListingErc20_evt_AuctionEnded')
            - source('zora_v3_ethereum','AsksPrivateEth_evt_AskFilled')
            - source('zora_v3_ethereum','AsksCoreEth_evt_AskFilled')
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('zora_v3_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -384,7 +384,7 @@ models:
    tests:
      - dbt_utils.unique_combination_of_columns:
          combination_of_columns: [ 'block_number','tx_hash','sub_tx_trade_id' ]
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('sudoswap_ethereum_base_trades_seed')
          match_columns:
            - block_number
@@ -411,7 +411,7 @@ models:
    tests:
      - dbt_utils.unique_combination_of_columns:
          combination_of_columns: [ 'block_number','tx_hash','sub_tx_trade_id' ]
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('collectionswap_ethereum_base_trades_seed')
          match_columns:
            - block_number

--- a/models/_sector/nft/trades/old/platforms/_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/_schema.yml
@@ -183,7 +183,7 @@ models:
             - token_id
             - sub_type
             - sub_idx
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('nftearth_events_seed')
           filter:
             blockchain: optimism
@@ -223,7 +223,7 @@ models:
           combination_of_columns:
             - block_date
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('pancakeswap_nft_trades_samples')
           match_columns:
             - block_time

--- a/models/_sector/nft/trades/old/platforms/decentraland_polygon_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/decentraland_polygon_schema.yml
@@ -15,7 +15,7 @@ models:
           combination_of_columns:
             - block_time
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('decentraland_polygon_sample_trades')
           match_columns:
             - block_number

--- a/models/_sector/nft/trades/old/platforms/fractal_polygon_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/fractal_polygon_schema.yml
@@ -15,7 +15,7 @@ models:
           combination_of_columns:
             - block_time
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('fractal_polygon_sample_trades')
           match_columns:
             - block_number

--- a/models/_sector/nft/trades/old/platforms/liquidifty_bnb_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/liquidifty_bnb_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['liquidifty', 'nft', 'trades']
     description: "NFT trades on liquidifty on BNB blockchain"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('liquidifty_bnb_nft_trades_samples')
           match_columns:
             - block_number

--- a/models/_sector/nft/trades/old/platforms/liquidifty_ethereum_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/liquidifty_ethereum_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['liquidifty', 'nft', 'trades']
     description: "NFT trades on liquidifty on ethereum blockchain"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('liquidifty_ethereum_nft_trades_samples')
           match_columns:
             - block_number

--- a/models/_sector/nft/trades/old/platforms/magiceden_polygon_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/magiceden_polygon_schema.yml
@@ -11,7 +11,7 @@ models:
     description: >
         Magic Eden events on Polygon
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('magiceden_polygon_sample_trades')
           match_columns:
             - block_number

--- a/models/_sector/nft/trades/old/platforms/nftb_bnb_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/nftb_bnb_schema.yml
@@ -16,7 +16,7 @@ models:
              - block_date
              - tx_hash
              - evt_index
-       - check_seed:
+       - check_seed_legacy:
            seed_file: ref('nftb_nft_trades_samples')
            match_columns:
              - block_number

--- a/models/_sector/nft/trades/old/platforms/nftrade_bnb_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/nftrade_bnb_schema.yml
@@ -16,7 +16,7 @@ models:
              - block_date
              - tx_hash
              - evt_index
-       - check_seed:
+       - check_seed_legacy:
            seed_file: ref('nftrade_nft_trades_samples')
            match_columns:
              - block_number

--- a/models/_sector/nft/trades/old/platforms/tofu_arbitrum_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/tofu_arbitrum_schema.yml
@@ -20,7 +20,7 @@ models:
             - tx_hash
             - evt_index
             - bundle_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('tofu_arbitrum_nft_trades_samples')
           match_columns:
             - block_number

--- a/models/_sector/nft/trades/old/platforms/tofu_bnb_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/tofu_bnb_schema.yml
@@ -15,7 +15,7 @@ models:
           combination_of_columns:
             - block_date
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('tofu_bnb_trades_samples')
           match_columns:
             - block_number

--- a/models/_sector/nft/trades/old/platforms/tofu_optimism_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/tofu_optimism_schema.yml
@@ -15,7 +15,7 @@ models:
           combination_of_columns:
             - block_date
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('tofu_optimism_trades_samples')
           match_columns:
             - block_date

--- a/models/_sector/nft/trades/old/platforms/tofu_polygon_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/tofu_polygon_schema.yml
@@ -20,7 +20,7 @@ models:
             - tx_hash
             - evt_index
             - bundle_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('tofu_polygon_nft_trades_samples')
           match_columns:
             - block_number

--- a/models/_sector/nft/trades/old/platforms/trove_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/trove_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['trove', 'treasure', 'nft', 'trades']
     description: "NFT trades on trove on ethereum"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('trove_ethereum_nft_trades_samples')
           match_columns:
             - block_number
@@ -96,7 +96,7 @@ models:
       tags: ['trove', 'treasure', 'nft', 'trades']
     description: "NFT trades on trove v2 on arbitrum blockchain"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('trove_v2_arbitrum_nft_samples')
           match_columns:
             - block_number
@@ -145,7 +145,7 @@ models:
       tags: ['trove', 'treasure', 'nft', 'trades']
     description: "NFT trades on trove v1 on arbitrum blockchain"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('trove_v1_arbitrum_nft_samples')
           match_columns:
             - block_number

--- a/models/_sector/nft/trades/old/platforms/zonic_optimism_schema.yml
+++ b/models/_sector/nft/trades/old/platforms/zonic_optimism_schema.yml
@@ -16,7 +16,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zonic_events_seed')
           match_columns:
             - block_number

--- a/models/account_abstraction/erc4337/arbitrum/account_abstraction_erc4337_arbitrum_schema.yml
+++ b/models/account_abstraction/erc4337/arbitrum/account_abstraction_erc4337_arbitrum_schema.yml
@@ -92,7 +92,7 @@ models:
           combination_of_columns:
             - userop_hash
             - tx_hash
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('account_abstraction_erc4337_userops_seed')
           filter:
             blockchain: arbitrum
@@ -102,7 +102,7 @@ models:
           check_columns:
             - tx_hash
             - bundler
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('account_abstraction_erc4337_userops_seed')
           filter:
             blockchain: arbitrum

--- a/models/account_abstraction/erc4337/avalanche_c/account_abstraction_erc4337_avalanche_c_schema.yml
+++ b/models/account_abstraction/erc4337/avalanche_c/account_abstraction_erc4337_avalanche_c_schema.yml
@@ -90,7 +90,7 @@ models:
           combination_of_columns:
             - userop_hash
             - tx_hash
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('account_abstraction_erc4337_userops_seed')
           filter:
             blockchain: avalanche_c
@@ -100,7 +100,7 @@ models:
           check_columns:
             - tx_hash
             - bundler
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('account_abstraction_erc4337_userops_seed')
           filter:
             blockchain: avalanche_c

--- a/models/account_abstraction/erc4337/ethereum/account_abstraction_erc4337_ethereum_schema.yml
+++ b/models/account_abstraction/erc4337/ethereum/account_abstraction_erc4337_ethereum_schema.yml
@@ -92,7 +92,7 @@ models:
           combination_of_columns:
             - userop_hash
             - tx_hash
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('account_abstraction_erc4337_userops_seed')
           filter:
             blockchain: ethereum
@@ -102,7 +102,7 @@ models:
           check_columns:
             - tx_hash
             - bundler
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('account_abstraction_erc4337_userops_seed')
           filter:
             blockchain: ethereum

--- a/models/account_abstraction/erc4337/gnosis/account_abstraction_erc4337_gnosis_schema.yml
+++ b/models/account_abstraction/erc4337/gnosis/account_abstraction_erc4337_gnosis_schema.yml
@@ -92,7 +92,7 @@ models:
           combination_of_columns:
             - userop_hash
             - tx_hash
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('account_abstraction_erc4337_userops_seed')
           filter:
             blockchain: gnosis
@@ -102,7 +102,7 @@ models:
           check_columns:
             - tx_hash
             - bundler
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('account_abstraction_erc4337_userops_seed')
           filter:
             blockchain: gnosis

--- a/models/account_abstraction/erc4337/optimism/account_abstraction_erc4337_optimism_schema.yml
+++ b/models/account_abstraction/erc4337/optimism/account_abstraction_erc4337_optimism_schema.yml
@@ -92,7 +92,7 @@ models:
           combination_of_columns:
             - userop_hash
             - tx_hash
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('account_abstraction_erc4337_userops_seed')
           filter:
             blockchain: optimism
@@ -102,7 +102,7 @@ models:
           check_columns:
             - tx_hash
             - bundler
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('account_abstraction_erc4337_userops_seed')
           filter:
             blockchain: optimism

--- a/models/account_abstraction/erc4337/polygon/account_abstraction_erc4337_polygon_schema.yml
+++ b/models/account_abstraction/erc4337/polygon/account_abstraction_erc4337_polygon_schema.yml
@@ -92,7 +92,7 @@ models:
           combination_of_columns:
             - userop_hash
             - tx_hash
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('account_abstraction_erc4337_userops_seed')
           filter:
             blockchain: polygon
@@ -102,7 +102,7 @@ models:
           check_columns:
             - tx_hash
             - bundler
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('account_abstraction_erc4337_userops_seed')
           filter:
             blockchain: polygon

--- a/models/addresses_events/arbitrum/addresses_events_arbitrum_schema.yml
+++ b/models/addresses_events/arbitrum/addresses_events_arbitrum_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['table', 'funded', 'addresses_events', 'arbitrum']
     description: "Table showing who first funded each Arbitrum address in ETH"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('first_funded_by_seed')
           filter:
             blockchain: arbitrum

--- a/models/addresses_events/avalanche_c/addresses_events_avalanche_c_schema.yml
+++ b/models/addresses_events/avalanche_c/addresses_events_avalanche_c_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['table', 'funded', 'addresses_events', 'avalanche_c']
     description: "Table showing who first funded each Avalanche address in AVAX"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('first_funded_by_seed')
           filter:
             blockchain: avalanche_c

--- a/models/addresses_events/bnb/addresses_events_bnb_schema.yml
+++ b/models/addresses_events/bnb/addresses_events_bnb_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['table', 'funded', 'addresses_events', 'bnb']
     description: "Table showing who first funded each BNB address in BNB"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('first_funded_by_seed')
           filter:
             blockchain: bnb

--- a/models/addresses_events/ethereum/addresses_events_ethereum_schema.yml
+++ b/models/addresses_events/ethereum/addresses_events_ethereum_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['table', 'funded', 'addresses_events', 'ethereum']
     description: "Table showing who first funded each Ethereum address in ETH"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('first_funded_by_seed')
           filter:
             blockchain: ethereum

--- a/models/addresses_events/fantom/addresses_events_fantom_schema.yml
+++ b/models/addresses_events/fantom/addresses_events_fantom_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['table', 'funded', 'addresses_events', 'fantom']
     description: "Table showing who first funded each Fantom address in FTM"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('first_funded_by_seed')
           filter:
             blockchain: fantom

--- a/models/addresses_events/gnosis/addresses_events_gnosis_schema.yml
+++ b/models/addresses_events/gnosis/addresses_events_gnosis_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['table', 'funded', 'addresses_events', 'gnosis']
     description: "Table showing who first funded each Gnosis address in xDAI"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('first_funded_by_seed')
           filter:
             blockchain: gnosis

--- a/models/addresses_events/optimism/addresses_events_optimism_schema.yml
+++ b/models/addresses_events/optimism/addresses_events_optimism_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['table', 'funded', 'addresses_events', 'optimism']
     description: "Table showing who first funded each Optimism address in ETH"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('first_funded_by_seed')
           filter:
             blockchain: optimism

--- a/models/addresses_events/polygon/addresses_events_polygon_schema.yml
+++ b/models/addresses_events/polygon/addresses_events_polygon_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['table', 'funded', 'addresses_events', 'polygon']
     description: "Table showing who first funded each Polygon address in MATIC"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('first_funded_by_seed')
           filter:
             blockchain: polygon

--- a/models/addresses_events_testnets/goerli/addresses_events_testnets_goerli_schema.yml
+++ b/models/addresses_events_testnets/goerli/addresses_events_testnets_goerli_schema.yml
@@ -11,7 +11,7 @@ models:
       tags: ['table', 'funded', 'addresses_events', 'goerli']
     description: "Table showing who first funded each Goerli address in ETH"
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('first_funded_by_seed')
           filter:
             blockchain: goerli

--- a/models/airswap/ethereum/airswap_ethereum_schema.yml
+++ b/models/airswap/ethereum/airswap_ethereum_schema.yml
@@ -21,23 +21,23 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: airswap
           version: light
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: airswap
           version: light_v0
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: airswap
           version: swap
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: airswap
           version: swap_v3
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: airswap
           version: swap_erc20_v4

--- a/models/apeswap/bnb/apeswap_bnb_schema.yml
+++ b/models/apeswap/bnb/apeswap_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: apeswap
           version: 1

--- a/models/apeswap/ethereum/apeswap_ethereum_schema.yml
+++ b/models/apeswap/ethereum/apeswap_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: apeswap
           version: 1

--- a/models/apeswap/polygon/apeswap_polygon_schema.yml
+++ b/models/apeswap/polygon/apeswap_polygon_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: poylgon
           project: apeswap
           version: 1

--- a/models/arbswap/arbswap_trades_schema.yml
+++ b/models/arbswap/arbswap_trades_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: arbswap
           version: 1

--- a/models/babyswap/bnb/babyswap_bnb_schema.yml
+++ b/models/babyswap/bnb/babyswap_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: babyswap
           version: 1

--- a/models/balancer/arbitrum/balancer_arbitrum_schema.yml
+++ b/models/balancer/arbitrum/balancer_arbitrum_schema.yml
@@ -68,7 +68,7 @@ models:
             - evt_tx_hash
             - evt_index
             - block_date
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('balancer_transfers_bpt_seed')
           filter:
             blockchain: arbitrum
@@ -180,7 +180,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: balancer
           version: 2
@@ -356,7 +356,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: balancer
           version: 2

--- a/models/balancer/ethereum/balancer_ethereum_schema.yml
+++ b/models/balancer/ethereum/balancer_ethereum_schema.yml
@@ -99,7 +99,7 @@ models:
             - evt_tx_hash
             - evt_index
             - block_date
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('balancer_transfers_bpt_seed')
           filter:
             blockchain: ethereum
@@ -361,7 +361,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: balancer
           version: 1
@@ -409,7 +409,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: balancer
           version: 2

--- a/models/balancer/gnosis/balancer_gnosis_schema.yml
+++ b/models/balancer/gnosis/balancer_gnosis_schema.yml
@@ -20,7 +20,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: gnosis
           project: balancer
           version: 2
@@ -200,7 +200,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: gnosis
           project: balancer
           version: 2

--- a/models/balancer/optimism/balancer_optimism_schema.yml
+++ b/models/balancer/optimism/balancer_optimism_schema.yml
@@ -68,7 +68,7 @@ models:
             - evt_tx_hash
             - evt_index
             - block_date
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('balancer_transfers_bpt_seed')
           filter:
             blockchain: optimism
@@ -180,7 +180,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: balancer
           version: 2
@@ -388,7 +388,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: balancer
           version: 2

--- a/models/balancer/polygon/balancer_polygon_schema.yml
+++ b/models/balancer/polygon/balancer_polygon_schema.yml
@@ -68,7 +68,7 @@ models:
             - evt_tx_hash
             - evt_index
             - block_date
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('balancer_transfers_bpt_seed')
           filter:
             blockchain: polygon
@@ -180,7 +180,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: balancer
           version: 2
@@ -378,7 +378,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: balancer
           version: 2

--- a/models/bancor/ethereum/bancor_ethereum_schema.yml
+++ b/models/bancor/ethereum/bancor_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: Bancor Network
           version: 1

--- a/models/bebop/arbitrum/bebop_arbitrum_schema.yml
+++ b/models/bebop/arbitrum/bebop_arbitrum_schema.yml
@@ -20,7 +20,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: arbitrum
           project: bebop
           version: 1

--- a/models/bebop/ethereum/bebop_ethereum_schema.yml
+++ b/models/bebop/ethereum/bebop_ethereum_schema.yml
@@ -20,7 +20,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: bebop
           version: 1

--- a/models/bebop/polygon/bebop_polygon_schema.yml
+++ b/models/bebop/polygon/bebop_polygon_schema.yml
@@ -20,7 +20,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: polygon
           project: bebop
           version: 1

--- a/models/beethoven_x/fantom/beethoven_x_fantom_schema.yml
+++ b/models/beethoven_x/fantom/beethoven_x_fantom_schema.yml
@@ -20,7 +20,7 @@ models:
               - tx_hash
               - evt_index
               - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: fantom
           project: beethoven_x
           version: 1

--- a/models/beethoven_x/optimism/beethoven_x_optimism_schema.yml
+++ b/models/beethoven_x/optimism/beethoven_x_optimism_schema.yml
@@ -20,7 +20,7 @@ models:
               - tx_hash
               - evt_index
               - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: beethoven_x
           version: 2

--- a/models/bend_dao/ethereum/bend_dao_ethereum_schema.yml
+++ b/models/bend_dao/ethereum/bend_dao_ethereum_schema.yml
@@ -20,7 +20,7 @@ models:
               - evt_type
               - tx_hash
               - evt_index
-        - check_seed:
+        - check_seed_legacy:
             seed_file: ref('bend_dao_nft_lending')
             match_columns:
               - block_number

--- a/models/biswap/bnb/biswap_bnb_schema.yml
+++ b/models/biswap/bnb/biswap_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: biswap
           version: 1

--- a/models/camelot/arbitrum/camelot_arbitrum_schema.yml
+++ b/models/camelot/arbitrum/camelot_arbitrum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: camelot
           version: 1

--- a/models/chainlink/bnb/chainlink_bnb_schema.yml
+++ b/models/chainlink/bnb/chainlink_bnb_schema.yml
@@ -17,7 +17,7 @@ models:
               - block_number
               - proxy_address
               - underlying_token_address
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('chainlink_get_price_seed')
           filter:
             blockchain: bnb

--- a/models/chainlink/optimism/chainlink_optimism_schema.yml
+++ b/models/chainlink/optimism/chainlink_optimism_schema.yml
@@ -17,7 +17,7 @@ models:
               - block_number
               - proxy_address
               - underlying_token_address
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('chainlink_get_price_seed')
           filter:
             blockchain: optimism

--- a/models/chainlink/polygon/chainlink_polygon_schema.yml
+++ b/models/chainlink/polygon/chainlink_polygon_schema.yml
@@ -17,7 +17,7 @@ models:
               - block_number
               - proxy_address
               - underlying_token_address
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('chainlink_get_price_seed')
           filter:
             blockchain: polygon

--- a/models/clipper/arbitrum/clipper_arbitrum_schema.yml
+++ b/models/clipper/arbitrum/clipper_arbitrum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: clipper
           version: 1
@@ -151,7 +151,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: clipper
           version: coves1

--- a/models/clipper/ethereum/clipper_ethereum_schema.yml
+++ b/models/clipper/ethereum/clipper_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: clipper
           version: 1
@@ -116,7 +116,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: clipper
           version: 2
@@ -166,7 +166,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: clipper
           version: 3
@@ -215,7 +215,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: clipper
           version: 4

--- a/models/clipper/optimism/clipper_optimism_schema.yml
+++ b/models/clipper/optimism/clipper_optimism_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: clipper
           version: 1
@@ -116,7 +116,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: clipper
           version: 2
@@ -165,7 +165,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: clipper
           version: coves1

--- a/models/clipper/polygon/clipper_polygon_schema.yml
+++ b/models/clipper/polygon/clipper_polygon_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: clipper
           version: 1
@@ -116,7 +116,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: clipper
           version: 2
@@ -165,7 +165,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: clipper
           version: coves1

--- a/models/curvefi/avalanche_c/curvefi_avalanche_c_schema.yml
+++ b/models/curvefi/avalanche_c/curvefi_avalanche_c_schema.yml
@@ -20,7 +20,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: avalanche_c
           project: curve
           version: 2

--- a/models/curvefi/ethereum/curvefi_ethereum_schema.yml
+++ b/models/curvefi/ethereum/curvefi_ethereum_schema.yml
@@ -127,19 +127,19 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: Curve
           version: Regular
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: Curve
           version: Factory V1 Meta
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: Curve
           version: Factory V1 Plain
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: Curve
           version: Factory V2

--- a/models/curvefi/fantom/curvefi_fantom_schema.yml
+++ b/models/curvefi/fantom/curvefi_fantom_schema.yml
@@ -17,7 +17,7 @@ models:
             - pool
             - token_id
             - token_type
-      - check_dex_pools_seed:
+      - check_dex_pools_seed_legacy:
           blockchain: fantom
           project: curve
           version: 2
@@ -67,7 +67,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: fantom
           project: curve
           version: 2

--- a/models/curvefi/optimism/curvefi_optimism_schema.yml
+++ b/models/curvefi/optimism/curvefi_optimism_schema.yml
@@ -59,7 +59,7 @@ models:
               - tx_hash
               - evt_index
               - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: curve
           version: 1

--- a/models/defiswap/ethereum/defiswap_ethereum_schema.yml
+++ b/models/defiswap/ethereum/defiswap_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: defiswap
           version: 1

--- a/models/dfx/ethereum/dfx_ethereum_schema.yml
+++ b/models/dfx/ethereum/dfx_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: dfx
           version: 0.5

--- a/models/dodo/arbitrum/dodo_arbitrum_schema.yml
+++ b/models/dodo/arbitrum/dodo_arbitrum_schema.yml
@@ -112,15 +112,15 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: DODO
           version: 1
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: DODO
           version: 2_dvm
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: DODO
           version: 2_dsp
@@ -169,7 +169,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: arbitrum
           project: DODO
           version: 0

--- a/models/dodo/bnb/dodo_bnb_schema.yml
+++ b/models/dodo/bnb/dodo_bnb_schema.yml
@@ -112,19 +112,19 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: DODO
           version: 1
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: DODO
           version: 2_dvm
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: DODO
           version: 2_dsp
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: DODO
           version: 2_dpp
@@ -173,7 +173,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: bnb
           project: DODO
           version: 0

--- a/models/dodo/ethereum/dodo_ethereum_schema.yml
+++ b/models/dodo/ethereum/dodo_ethereum_schema.yml
@@ -112,15 +112,15 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: DODO
           version: 1
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: DODO
           version: 2_dvm
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: DODO
           version: 2_dsp
@@ -169,7 +169,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: DODO
           version: 0

--- a/models/dodo/optimism/dodo_optimism_schema.yml
+++ b/models/dodo/optimism/dodo_optimism_schema.yml
@@ -112,15 +112,15 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: DODO
           version: 1
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: DODO
           version: 2_dvm
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: DODO
           version: 2_dpp
@@ -169,7 +169,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: optimism
           project: DODO
           version: 0

--- a/models/dodo/polygon/dodo_polygon_schema.yml
+++ b/models/dodo/polygon/dodo_polygon_schema.yml
@@ -112,15 +112,15 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: DODO
           version: 1
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: DODO
           version: 2_dvm
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: DODO
           version: 2_dpp
@@ -169,7 +169,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: polygon
           project: DODO
           version: 0

--- a/models/ellipsis_finance/bnb/ellipsis_finance_bnb_schema.yml
+++ b/models/ellipsis_finance/bnb/ellipsis_finance_bnb_schema.yml
@@ -17,7 +17,7 @@ models:
             - pool
             - token_id
             - token_type
-      - check_dex_pools_seed:
+      - check_dex_pools_seed_legacy:
           blockchain: bnb
           project: ellipsis_finance
           version: 1
@@ -67,7 +67,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: ellipsis_finance
           version: 1

--- a/models/emdx/avalanche_c/emdx_avalanche_c_schema.yml
+++ b/models/emdx/avalanche_c/emdx_avalanche_c_schema.yml
@@ -20,7 +20,7 @@ models:
             - version
             - tx_hash
             - evt_index
-      - check_perpetuals_seed:
+      - check_perpetuals_seed_legacy:
           blockchain: avalanche_c
           project: emdx
           version: 1

--- a/models/equalizer_exchange/fantom/equalizer_exchange_fantom_schema.yml
+++ b/models/equalizer_exchange/fantom/equalizer_exchange_fantom_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: fantom
           project: equalizer_exchange
           version: 1

--- a/models/fraxswap/avalanche_c/fraxswap_avalanche_c_schema.yml
+++ b/models/fraxswap/avalanche_c/fraxswap_avalanche_c_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: avalanche_c
           project: fraxswap
           version: 1

--- a/models/fraxswap/bnb/fraxswap_bnb_schema.yml
+++ b/models/fraxswap/bnb/fraxswap_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: fraxswap
           version: 1

--- a/models/fraxswap/ethereum/fraxswap_ethereum_schema.yml
+++ b/models/fraxswap/ethereum/fraxswap_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: fraxswap
           version: 1

--- a/models/fraxswap/polygon/fraxswap_polygon_schema.yml
+++ b/models/fraxswap/polygon/fraxswap_polygon_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: fraxswap
           version: 1

--- a/models/glacier/avalanche_c/glacier_avalanche_c_schema.yml
+++ b/models/glacier/avalanche_c/glacier_avalanche_c_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: avalanche_c 
           project: glacier
           version: 1

--- a/models/gmx/arbitrum/gmx_arbitrum_schema.yml
+++ b/models/gmx/arbitrum/gmx_arbitrum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: gmx
           version: 1
@@ -115,7 +115,7 @@ models:
             - version
             - tx_hash
             - evt_index
-      - check_perpetuals_seed:
+      - check_perpetuals_seed_legacy:
           blockchain: arbitrum
           project: gmx
           version: 1

--- a/models/gmx/avalanche_c/gmx_avalanche_c_schema.yml
+++ b/models/gmx/avalanche_c/gmx_avalanche_c_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: avalanche_c
           project: gmx
           version: 1
@@ -115,7 +115,7 @@ models:
             - version
             - tx_hash
             - evt_index
-      - check_perpetuals_seed:
+      - check_perpetuals_seed_legacy:
           blockchain: avalanche_c
           project: gmx
           version: 1

--- a/models/hashflow/avalanche_c/hashflow_avalanche_c_schema.yml
+++ b/models/hashflow/avalanche_c/hashflow_avalanche_c_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: avalanche_c
           project: hashflow
           version: 1

--- a/models/hashflow/bnb/hashflow_bnb_schema.yml
+++ b/models/hashflow/bnb/hashflow_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: hashflow
           version: 1

--- a/models/hashflow/ethereum/hashflow_ethereum_schema.yml
+++ b/models/hashflow/ethereum/hashflow_ethereum_schema.yml
@@ -87,7 +87,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: hashflow
           version: 1

--- a/models/hubble_exchange/avalanche_c/hubble_exchange_avalanche_c_schema.yml
+++ b/models/hubble_exchange/avalanche_c/hubble_exchange_avalanche_c_schema.yml
@@ -20,7 +20,7 @@ models:
             - version
             - tx_hash
             - evt_index
-      - check_perpetuals_seed:
+      - check_perpetuals_seed_legacy:
           blockchain: avalanche_c
           project: hubble_exchange
           version: 1

--- a/models/integral/arbitrum/integral_arbitrum_schema.yml
+++ b/models/integral/arbitrum/integral_arbitrum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: integral
           version: size

--- a/models/integral/ethereum/integral_ethereum_schema.yml
+++ b/models/integral/ethereum/integral_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: integral
           version: size

--- a/models/iziswap/bnb/iziswap_bnb_schema.yml
+++ b/models/iziswap/bnb/iziswap_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: iziswap
           version: 1

--- a/models/kyberswap/arbitrum/kyberswap_arbitrum_schema.yml
+++ b/models/kyberswap/arbitrum/kyberswap_arbitrum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: kyberswap
           version: elastic

--- a/models/kyberswap/avalanche_c/kyberswap_avalanche_c_schema.yml
+++ b/models/kyberswap/avalanche_c/kyberswap_avalanche_c_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: avalanche_c
           project: kyberswap
           version: dmm

--- a/models/kyberswap/ethereum/kyberswap_ethereum_schema.yml
+++ b/models/kyberswap/ethereum/kyberswap_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: kyberswap
           version: elastic

--- a/models/kyberswap/optimism/kyberswap_optimism_schema.yml
+++ b/models/kyberswap/optimism/kyberswap_optimism_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: kyberswap
           version: dmm

--- a/models/layerzero/arbitrum/layerzero_arbitrum_schema.yml
+++ b/models/layerzero/arbitrum/layerzero_arbitrum_schema.yml
@@ -10,7 +10,7 @@ models:
      tags: ['arbitrum', 'layerzero', 'send']
    description: "LayerZero message send call on arbitrum"
    tests:
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('layerzero_arbitrum_send_samples')
          check_columns:
            - destination_chain_id

--- a/models/layerzero/avalanche_c/layerzero_avalanche_c_schema.yml
+++ b/models/layerzero/avalanche_c/layerzero_avalanche_c_schema.yml
@@ -10,7 +10,7 @@ models:
      tags: ['avalanche_c', 'layerzero', 'send']
    description: "LayerZero message send call on avalanche c"
    tests:
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('layerzero_avalanche_c_send_samples')
          check_columns:
            - destination_chain_id

--- a/models/layerzero/bnb/layerzero_bnb_schema.yml
+++ b/models/layerzero/bnb/layerzero_bnb_schema.yml
@@ -10,7 +10,7 @@ models:
      tags: ['bnb', 'layerzero', 'send']
    description: "LayerZero message send call on bnb"
    tests:
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('layerzero_bnb_send_samples')
          check_columns:
            - destination_chain_id

--- a/models/layerzero/ethereum/layerzero_ethereum_schema.yml
+++ b/models/layerzero/ethereum/layerzero_ethereum_schema.yml
@@ -10,7 +10,7 @@ models:
      tags: ['ethereum', 'layerzero', 'send']
    description: "LayerZero message send call on ethereum"
    tests:
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('layerzero_ethereum_send_samples')
          check_columns:
            - destination_chain_id

--- a/models/layerzero/fantom/layerzero_fantom_schema.yml
+++ b/models/layerzero/fantom/layerzero_fantom_schema.yml
@@ -10,7 +10,7 @@ models:
      tags: ['fantom', 'layerzero', 'send']
    description: "LayerZero message send call on fantom"
    tests:
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('layerzero_fantom_send_samples')
          check_columns:
            - destination_chain_id

--- a/models/layerzero/gnosis/layerzero_gnosis_schema.yml
+++ b/models/layerzero/gnosis/layerzero_gnosis_schema.yml
@@ -10,7 +10,7 @@ models:
      tags: ['gnosis', 'layerzero', 'send']
    description: "LayerZero message send call on gnosis"
    tests:
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('layerzero_gnosis_send_samples')
          check_columns:
            - destination_chain_id

--- a/models/layerzero/optimism/layerzero_optimism_schema.yml
+++ b/models/layerzero/optimism/layerzero_optimism_schema.yml
@@ -10,7 +10,7 @@ models:
      tags: ['optimism', 'layerzero', 'send']
    description: "LayerZero message send call on optimism"
    tests:
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('layerzero_optimism_send_samples')
          check_columns:
            - destination_chain_id

--- a/models/layerzero/polygon/layerzero_polygon_schema.yml
+++ b/models/layerzero/polygon/layerzero_polygon_schema.yml
@@ -10,7 +10,7 @@ models:
      tags: ['polygon', 'layerzero', 'send']
    description: "LayerZero message send call on polygon"
    tests:
-     - check_seed:
+     - check_seed_legacy:
          seed_file: ref('layerzero_polygon_send_samples')
          check_columns:
            - destination_chain_id

--- a/models/lifi/fantom/lifi_fantom_schema.yml
+++ b/models/lifi/fantom/lifi_fantom_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: fantom
           project: lifi
           version: 2

--- a/models/maverick/ethereum/maverick_ethereum_schema.yml
+++ b/models/maverick/ethereum/maverick_ethereum_schema.yml
@@ -20,7 +20,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: maverick
           version: 1

--- a/models/mdex/bnb/mdex_bnb_schema.yml
+++ b/models/mdex/bnb/mdex_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: mdex
           version: 1

--- a/models/mstable/ethereum/mstable_ethereum_schema.yml
+++ b/models/mstable/ethereum/mstable_ethereum_schema.yml
@@ -21,11 +21,11 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: mstable
           version: feederpool
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: mstable
           version: masset

--- a/models/nexusmutual/ethereum/nexusmutual_ethereum_schema.yml
+++ b/models/nexusmutual/ethereum/nexusmutual_ethereum_schema.yml
@@ -9,7 +9,7 @@ models:
     description: >
         nexusmutual product information for v1
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('nexusmutual_ethereum_product_information_seed')
           match_columns:
             - product_contract_address
@@ -130,7 +130,7 @@ models:
     description: >
         Daily summary for ethereum entering and leaving the nexus mutual capital pool contracts
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('nexusmutual_ethereum_capital_pool_eth_daily_transaction_summary_seed')
           match_columns:
             - day

--- a/models/nft/arbitrum/nft_arbitrum_schema.yml
+++ b/models/nft/arbitrum/nft_arbitrum_schema.yml
@@ -111,7 +111,7 @@ models:
         description:  "Address that received the transaction"
       - name: unique_trade_id
         tests:
-          - is_unique_filtered
+          - is_unique_filtered_legacy
       - &buyer_first_funded_by
         name: buyer_first_funded_by
         description: "Which wallet first funded the buyer's wallet in ETH"

--- a/models/nft/avalanche_c/nft_avalanche_c_schema.yml
+++ b/models/nft/avalanche_c/nft_avalanche_c_schema.yml
@@ -132,7 +132,7 @@ models:
         description:  "Address that received the transaction"
       - name: unique_trade_id
         tests:
-          - is_unique_filtered
+          - is_unique_filtered_legacy
       - &buyer_first_funded_by
         name: buyer_first_funded_by
         description: "Which wallet first funded the buyer's wallet in ETH"

--- a/models/nft/bnb/nft_bnb_schema.yml
+++ b/models/nft/bnb/nft_bnb_schema.yml
@@ -128,7 +128,7 @@ models:
         description:  "Address that received the transaction"
       - name: unique_trade_id
         tests:
-          - is_unique_filtered
+          - is_unique_filtered_legacy
       - &buyer_first_funded_by
         name: buyer_first_funded_by
         description: "Which wallet first funded the buyer's wallet in ETH"

--- a/models/nft/ethereum/nft_ethereum_schema.yml
+++ b/models/nft/ethereum/nft_ethereum_schema.yml
@@ -458,7 +458,7 @@ models:
         description:  "Address that received the transaction"
       - name: unique_trade_id
         tests:
-          - is_unique_filtered
+          - is_unique_filtered_legacy
       - &buyer_first_funded_by
         name: buyer_first_funded_by
         description: "Which wallet first funded the buyer's wallet in ETH"

--- a/models/nft/gnosis/nft_gnosis_schema.yml
+++ b/models/nft/gnosis/nft_gnosis_schema.yml
@@ -111,7 +111,7 @@ models:
         description:  "Address that received the transaction"
       - name: unique_trade_id
         tests:
-          - is_unique_filtered
+          - is_unique_filtered_legacy
       - &buyer_first_funded_by
         name: buyer_first_funded_by
         description: "Which wallet first funded the buyer's wallet in ETH"

--- a/models/nft/nft_schema.yml
+++ b/models/nft/nft_schema.yml
@@ -175,7 +175,7 @@ models:
       - *tx_to
       - name: unique_trade_id
         tests:
-          - is_unique_filtered
+          - is_unique_filtered_legacy
       - &buyer_first_funded_by
         name: buyer_first_funded_by
         description: "Which wallet first funded the buyer's wallet in ETH"

--- a/models/nft/optimism/nft_optimism_schema.yml
+++ b/models/nft/optimism/nft_optimism_schema.yml
@@ -175,7 +175,7 @@ models:
         description:  "Address that received the transaction"
       - name: unique_trade_id
         tests:
-          - is_unique_filtered
+          - is_unique_filtered_legacy
       - &buyer_first_funded_by
         name: buyer_first_funded_by
         description: "Which wallet first funded the buyer's wallet in ETH"

--- a/models/nft/polygon/nft_polygon_schema.yml
+++ b/models/nft/polygon/nft_polygon_schema.yml
@@ -128,7 +128,7 @@ models:
         description:  "Address that received the transaction"
       - name: unique_trade_id
         tests:
-          - is_unique_filtered
+          - is_unique_filtered_legacy
       - &buyer_first_funded_by
         name: buyer_first_funded_by
         description: "Which wallet first funded the buyer's wallet in ETH"

--- a/models/nomiswap/bnb/nomiswap_bnb_schema.yml
+++ b/models/nomiswap/bnb/nomiswap_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: nomiswap
           version: 1

--- a/models/odos/avalanche_c/odos_avalanche_c_schema.yml
+++ b/models/odos/avalanche_c/odos_avalanche_c_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: avalanche_c
           project: odos
           version: 1

--- a/models/oneinch/ethereum/oneinch_ethereum_schema.yml
+++ b/models/oneinch/ethereum/oneinch_ethereum_schema.yml
@@ -20,7 +20,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch
           version: 1
@@ -114,7 +114,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch
           version: 2
@@ -162,7 +162,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch
           version: 3
@@ -210,7 +210,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch
           version: 4
@@ -258,7 +258,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch
           version: 5
@@ -306,7 +306,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch
           version: 1split
@@ -354,7 +354,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch
           version: 1proto
@@ -402,7 +402,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch
           version: ZRX
@@ -494,7 +494,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch
           version: 'UNI v2'
@@ -586,7 +586,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch
           version: 'UNI v3'
@@ -634,7 +634,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch
           version: 'Clipper v1'
@@ -682,7 +682,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch Limit Order Protocol
           version: '1'
@@ -730,7 +730,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch Limit Order Protocol
           version: '2'
@@ -778,7 +778,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch Limit Order Protocol
           version: '3'
@@ -826,7 +826,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch Limit Order Protocol
           version: 'eRFQ v1'
@@ -874,7 +874,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch Limit Order Protocol
           version: 'RFQ v1'
@@ -922,7 +922,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch Limit Order Protocol
           version: 'RFQ v2'
@@ -970,7 +970,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: 1inch Limit Order Protocol
           version: 'RFQ v3'

--- a/models/onepunchswap/bnb/onepunchswap_bnb_schema.yml
+++ b/models/onepunchswap/bnb/onepunchswap_bnb_schema.yml
@@ -21,11 +21,11 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: onepunchswap
           version: quick
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: onepunchswap
           version: normal

--- a/models/openocean/avalanche_c/openocean_avalanche_c_schema.yml
+++ b/models/openocean/avalanche_c/openocean_avalanche_c_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: avalanche_c
           project: openocean
           version: 2

--- a/models/openocean/fantom/openocean_fantom_schema.yml
+++ b/models/openocean/fantom/openocean_fantom_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: fantom
           project: openocean
           version: 2

--- a/models/opensea/arbitrum/opensea_arbitrum_schema.yml
+++ b/models/opensea/arbitrum/opensea_arbitrum_schema.yml
@@ -207,7 +207,7 @@ models:
           combination_of_columns:
             - block_date
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('opensea_arbitrum_seaport_trades_samples')
           filter:
             blockchain: arbitrum
@@ -298,7 +298,7 @@ models:
           combination_of_columns:
             - block_date
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('opensea_arbitrum_seaport_trades_samples')
           filter:
             blockchain: arbitrum

--- a/models/opensea/ethereum/opensea_ethereum_schema.yml
+++ b/models/opensea/ethereum/opensea_ethereum_schema.yml
@@ -208,7 +208,7 @@ models:
           combination_of_columns:
             - block_date
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('opensea_wyvern_trades_samples')
           match_columns:
             - block_time
@@ -274,7 +274,7 @@ models:
           combination_of_columns:
             - block_date
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('opensea_ethereum_seaport_trades_samples')
           filter:
             blockchain: ethereum
@@ -367,7 +367,7 @@ models:
           combination_of_columns:
             - block_date
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('opensea_ethereum_seaport_trades_samples')
           filter:
             blockchain: ethereum

--- a/models/opensea/optimism/opensea_optimism_schema.yml
+++ b/models/opensea/optimism/opensea_optimism_schema.yml
@@ -203,7 +203,7 @@ models:
     description: >
         Opensea events on optimism, from Seaport v1.1
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('opensea_optimism_seaport_trades_samples')
           filter:
             blockchain: optimism
@@ -294,7 +294,7 @@ models:
           combination_of_columns:
             - block_date
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('opensea_optimism_seaport_trades_samples')
           filter:
             blockchain: optimism

--- a/models/opensea/polygon/opensea_polygon_schema.yml
+++ b/models/opensea/polygon/opensea_polygon_schema.yml
@@ -203,7 +203,7 @@ models:
     description: >
         Opensea Wyvern trades on Polygon
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('opensea_polygon_zeroex_trades_samples')
           filter:
             blockchain: polygon
@@ -279,7 +279,7 @@ models:
           combination_of_columns:
             - block_date
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('opensea_polygon_seaport_trades_samples')
           filter:
             blockchain: polygon
@@ -370,7 +370,7 @@ models:
           combination_of_columns:
             - block_date
             - unique_trade_id
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('opensea_polygon_seaport_trades_samples')
           filter:
             blockchain: polygon

--- a/models/pancakeswap/bnb/pancakeswap_bnb_schema.yml
+++ b/models/pancakeswap/bnb/pancakeswap_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: pancakeswap
           version: 2
@@ -93,7 +93,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: pancakeswap
           version: mmpool
@@ -165,7 +165,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: pancakeswap
           version: stableswap
@@ -238,7 +238,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: pancakeswap
           version: 3

--- a/models/pancakeswap/ethereum/pancakeswap_ethereum_schema.yml
+++ b/models/pancakeswap/ethereum/pancakeswap_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: pancakeswap
           version: 2
@@ -93,7 +93,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: pancakeswap
           version: 3
@@ -165,7 +165,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: pancakeswap
           version: mmpool

--- a/models/paraswap/arbitrum/paraswap_arbitrum_schema.yml
+++ b/models/paraswap/arbitrum/paraswap_arbitrum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: arbitrum
           project: paraswap
           version: 5

--- a/models/paraswap/avalanche_c/paraswap_avalanche_c_schema.yml
+++ b/models/paraswap/avalanche_c/paraswap_avalanche_c_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: avalanche_c
           project: paraswap
           version: 5

--- a/models/paraswap/bnb/paraswap_bnb_schema.yml
+++ b/models/paraswap/bnb/paraswap_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: bnb
           project: paraswap
           version: 4
@@ -116,7 +116,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: bnb
           project: paraswap
           version: 5

--- a/models/paraswap/ethereum/paraswap_ethereum_schema.yml
+++ b/models/paraswap/ethereum/paraswap_ethereum_schema.yml
@@ -80,7 +80,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: paraswap
           version: 4
@@ -163,7 +163,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: ethereum
           project: paraswap
           version: 5

--- a/models/paraswap/fantom/paraswap_fantom_schema.yml
+++ b/models/paraswap/fantom/paraswap_fantom_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: fantom
           project: paraswap
           version: 5

--- a/models/paraswap/optimism/paraswap_optimism_schema.yml
+++ b/models/paraswap/optimism/paraswap_optimism_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: optimism
           project: paraswap
           version: 5

--- a/models/paraswap/polygon/paraswap_polygon_schema.yml
+++ b/models/paraswap/polygon/paraswap_polygon_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: polygon
           project: paraswap
           version: 4
@@ -116,7 +116,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: polygon
           project: paraswap
           version: 5

--- a/models/platypus_finance/avalanche_c/platypus_finance_avalanche_c_schema.yml
+++ b/models/platypus_finance/avalanche_c/platypus_finance_avalanche_c_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: avalanche_c
           project: platypus_finance
           version: 1

--- a/models/quickswap/polygon/quickswap_polygon_schema.yml
+++ b/models/quickswap/polygon/quickswap_polygon_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: quickswap
           version: 3
@@ -116,7 +116,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: quickswap
           version: 2

--- a/models/quix/optimism/quix_optimism_schema.yml
+++ b/models/quix/optimism/quix_optimism_schema.yml
@@ -18,7 +18,7 @@ models:
             - token_id
             - seller
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('quix_events_seed')
           filter:
             blockchain: optimism
@@ -267,7 +267,7 @@ models:
             - token_id
             - seller
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('quix_events_seed')
           filter:
             blockchain: optimism
@@ -337,7 +337,7 @@ models:
             - token_id
             - seller
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('quix_events_seed')
           filter:
             blockchain: optimism
@@ -407,7 +407,7 @@ models:
             - token_id
             - seller
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('quix_events_seed')
           filter:
             blockchain: optimism
@@ -477,7 +477,7 @@ models:
             - token_id
             - seller
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('quix_events_seed')
           filter:
             blockchain: optimism
@@ -551,7 +551,7 @@ models:
             - token_id
             - sub_type
             - sub_idx
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('quix_events_seed')
           filter:
             blockchain: optimism

--- a/models/rubicon/optimism/rubicon_optimism_schema.yml
+++ b/models/rubicon/optimism/rubicon_optimism_schema.yml
@@ -20,7 +20,7 @@ models:
               - tx_hash
               - evt_index
               - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: rubicon
           version: 1
@@ -105,7 +105,7 @@ models:
     description: >
         A table containing all offers of rubicon on optimism
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('dex_offers_seed')
           match_columns:
             - block_date

--- a/models/seaport/arbitrum/seaport_arbitrum_schema.yml
+++ b/models/seaport/arbitrum/seaport_arbitrum_schema.yml
@@ -132,7 +132,7 @@ models:
             - token_id
             - sub_type
             - sub_idx
-      - check_seaport_seed:
+      - check_seaport_seed_legacy:
           blockchain: arbitrum
           project: seaport
           version: v1

--- a/models/seaport/avalanche_c/seaport_avalanche_c_schema.yml
+++ b/models/seaport/avalanche_c/seaport_avalanche_c_schema.yml
@@ -132,7 +132,7 @@ models:
             - token_id
             - sub_type
             - sub_idx
-      - check_seaport_seed:
+      - check_seaport_seed_legacy:
           blockchain: avalanche_c
           project: seaport
           version: v1

--- a/models/seaport/bnb/seaport_bnb_schema.yml
+++ b/models/seaport/bnb/seaport_bnb_schema.yml
@@ -132,7 +132,7 @@ models:
             - token_id
             - sub_type
             - sub_idx
-      - check_seaport_seed:
+      - check_seaport_seed_legacy:
           blockchain: bnb
           project: seaport
           version: v1

--- a/models/seaport/ethereum/seaport_ethereum_schema.yml
+++ b/models/seaport/ethereum/seaport_ethereum_schema.yml
@@ -109,7 +109,7 @@ models:
             - token_id
             - sub_type
             - sub_idx
-      - check_seaport_seed:
+      - check_seaport_seed_legacy:
           blockchain: ethereum
           project: seaport
           version: v1        
@@ -266,7 +266,7 @@ models:
             - token_id
             - sub_type
             - sub_idx
-      - check_seaport_seed:
+      - check_seaport_seed_legacy:
           blockchain: ethereum
           project: seaport
           version: v1        

--- a/models/seaport/optimism/seaport_optimism_schema.yml
+++ b/models/seaport/optimism/seaport_optimism_schema.yml
@@ -135,7 +135,7 @@ models:
             - token_id
             - sub_type
             - sub_idx
-      - check_seaport_seed:
+      - check_seaport_seed_legacy:
           blockchain: optimism
           project: seaport
           version: v1

--- a/models/seaport/polygon/seaport_polygon_schema.yml
+++ b/models/seaport/polygon/seaport_polygon_schema.yml
@@ -135,7 +135,7 @@ models:
             - token_id
             - sub_type
             - sub_idx
-      - check_seaport_seed:
+      - check_seaport_seed_legacy:
           blockchain: polygon
           project: seaport
           version: v1

--- a/models/shibaswap/ethereum/shibaswap_ethereum_schema.yml
+++ b/models/shibaswap/ethereum/shibaswap_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: shibaswap
           version: 1

--- a/models/spartacus_exchange/fantom/spartacus_exchange_fantom_schema.yml
+++ b/models/spartacus_exchange/fantom/spartacus_exchange_fantom_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: fantom
           project: spartacus_exchange
           version: 1

--- a/models/spiritswap/fantom/spiritswap_fantom_schema.yml
+++ b/models/spiritswap/fantom/spiritswap_fantom_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: fantom
           project: spiritswap
           version: 1

--- a/models/spookyswap/fantom/spookyswap_fantom_schema.yml
+++ b/models/spookyswap/fantom/spookyswap_fantom_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: fantom
           project: spookyswap
           version: 1

--- a/models/sushiswap/arbitrum/sushiswap_arbitrum_schema.yml
+++ b/models/sushiswap/arbitrum/sushiswap_arbitrum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: sushiswap
           version: 1

--- a/models/sushiswap/avalanche_c/sushiswap_avalanche_c_schema.yml
+++ b/models/sushiswap/avalanche_c/sushiswap_avalanche_c_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: avalanche_c
           project: sushiswap
           version: 1

--- a/models/sushiswap/bnb/sushiswap_bnb_schema.yml
+++ b/models/sushiswap/bnb/sushiswap_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: sushiswap
           version: 1

--- a/models/sushiswap/ethereum/sushiswap_ethereum_schema.yml
+++ b/models/sushiswap/ethereum/sushiswap_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: sushiswap
           version: 1

--- a/models/sushiswap/fantom/sushiswap_fantom_schema.yml
+++ b/models/sushiswap/fantom/sushiswap_fantom_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: fantom
           project: sushiswap
           version: 1

--- a/models/sushiswap/gnosis/sushiswap_gnosis_schema.yml
+++ b/models/sushiswap/gnosis/sushiswap_gnosis_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: gnosis
           project: sushiswap
           version: 1

--- a/models/sushiswap/optimism/sushiswap_optimism_schema.yml
+++ b/models/sushiswap/optimism/sushiswap_optimism_schema.yml
@@ -21,11 +21,11 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: sushiswap
           version: trident-cpp
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: sushiswap
           version: trident-sp

--- a/models/sushiswap/polygon/sushiswap_polygon_schema.yml
+++ b/models/sushiswap/polygon/sushiswap_polygon_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: sushiswap
           version: 1

--- a/models/swapr/ethereum/swapr_ethereum_schema.yml
+++ b/models/swapr/ethereum/swapr_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: swapr
           version: 1

--- a/models/synthetix/optimism/synthetix_optimism_schema.yml
+++ b/models/synthetix/optimism/synthetix_optimism_schema.yml
@@ -20,7 +20,7 @@ models:
             - version
             - tx_hash
             - evt_index
-      - check_perpetuals_seed:
+      - check_perpetuals_seed_legacy:
           blockchain: optimism
           project: Synthetix
           version: 1
@@ -108,7 +108,7 @@ models:
             - version
             - tx_hash
             - evt_index
-      - check_perpetuals_seed:
+      - check_perpetuals_seed_legacy:
           blockchain: optimism
           project: Synthetix
           version: 2
@@ -183,7 +183,7 @@ models:
               - tx_hash
               - evt_index
               - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: synthetix
           version: 1

--- a/models/tessera/ethereum/tessera_ethereum_schema.yml
+++ b/models/tessera/ethereum/tessera_ethereum_schema.yml
@@ -9,7 +9,7 @@ models:
     config:
       tags: ["ethereum", "tessera", "vault"]
     tests:
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('tessera_ethereum_vault_deploy_test_data')
           match_columns:
             - tx_hash

--- a/models/thena/bnb/thena_bnb_schema.yml
+++ b/models/thena/bnb/thena_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: thena
           version: 1
@@ -94,7 +94,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: thena
           version: fusion

--- a/models/trader_joe/avalanche_c/trader_joe_avalanche_c_schema.yml
+++ b/models/trader_joe/avalanche_c/trader_joe_avalanche_c_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: avalanche_c
           project: trader_joe
           version: 1
@@ -116,7 +116,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: avalanche_c
           project: trader_joe
           version: 2

--- a/models/trader_joe/bnb/trader_joe_bnb_schema.yml
+++ b/models/trader_joe/bnb/trader_joe_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: trader_joe
           version: 2

--- a/models/uniswap/arbitrum/uniswap_arbitrum_schema.yml
+++ b/models/uniswap/arbitrum/uniswap_arbitrum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: uniswap
           version: 3

--- a/models/uniswap/bnb/uniswap_bnb_schema.yml
+++ b/models/uniswap/bnb/uniswap_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: uniswap
           version: 3

--- a/models/uniswap/ethereum/uniswap_ethereum_schema.yml
+++ b/models/uniswap/ethereum/uniswap_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: uniswap
           version: 1
@@ -116,7 +116,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: uniswap
           version: 2
@@ -165,7 +165,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: uniswap
           version: 3

--- a/models/uniswap/optimism/uniswap_optimism_schema.yml
+++ b/models/uniswap/optimism/uniswap_optimism_schema.yml
@@ -70,7 +70,7 @@ models:
               - tx_hash
               - evt_index
               - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: uniswap
           version: 3

--- a/models/uniswap/polygon/uniswap_polygon_schema.yml
+++ b/models/uniswap/polygon/uniswap_polygon_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: uniswap
           version: 3

--- a/models/velodrome/optimism/velodrome_optimism_schema.yml
+++ b/models/velodrome/optimism/velodrome_optimism_schema.yml
@@ -20,7 +20,7 @@ models:
               - tx_hash
               - evt_index
               - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: velodrome
           version: 1

--- a/models/verse_dex/ethereum/verse_dex_ethereum_schema.yml
+++ b/models/verse_dex/ethereum/verse_dex_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: verse_dex
           version: 1

--- a/models/wigoswap/fantom/wigoswap_fantom_schema.yml
+++ b/models/wigoswap/fantom/wigoswap_fantom_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: fantom
           project: wigoswap
           version: 1

--- a/models/wombat/bnb/wombat_bnb_schema.yml
+++ b/models/wombat/bnb/wombat_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: wombat
           version: 1

--- a/models/woofi/avalanche_c/woofi_avalanche_c_schema.yml
+++ b/models/woofi/avalanche_c/woofi_avalanche_c_schema.yml
@@ -20,7 +20,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: avalanche_c
           project: woofi
           version: 1

--- a/models/woofi/bnb/woofi_bnb_schema.yml
+++ b/models/woofi/bnb/woofi_bnb_schema.yml
@@ -20,11 +20,11 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: woofi
           version: 1
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: woofi
           version: 2

--- a/models/xchange/arbitrum/xchange_arbitrum_schema.yml
+++ b/models/xchange/arbitrum/xchange_arbitrum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address 
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: xchange
           version: 1      

--- a/models/xchange/bnb/xchange_bnb_schema.yml
+++ b/models/xchange/bnb/xchange_bnb_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address         
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: bnb
           project: xchange
           version: 1  

--- a/models/xchange/ethereum/xchange_ethereum_schema.yml
+++ b/models/xchange/ethereum/xchange_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('xchange_ethereum_trades_seed')
           filter:
             blockchain: ethereum
@@ -38,7 +38,7 @@ models:
             - token_sold_address
             - token_bought_amount
             - token_sold_amount      
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: ethereum
           project: xchange
           version: 1       

--- a/models/xchange/polygon/xchange_polygon_schema.yml
+++ b/models/xchange/polygon/xchange_polygon_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address         
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: polygon
           project: xchange
           version: 1  

--- a/models/yield_yak/avalanche_c/yield_yak_avalanche_c_schema.yml
+++ b/models/yield_yak/avalanche_c/yield_yak_avalanche_c_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_aggregator_seed:
+      - check_dex_aggregator_seed_legacy:
           blockchain: avalanche_c
           project: yield_yak
           version: 1

--- a/models/zeroex/arbitrum/zeroex_arbitrum_schema.yml
+++ b/models/zeroex/arbitrum/zeroex_arbitrum_schema.yml
@@ -16,7 +16,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_arbitrum_api_fills_sample')
           match_columns:
             - tx_hash
@@ -104,7 +104,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_arbitrum_api_fills_deduped_sample')
           match_columns:
             - tx_hash
@@ -161,7 +161,7 @@ models:
             - block_time
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_arbitrum_native_fills_sample')
           match_columns:
             - tx_hash

--- a/models/zeroex/avalanche_c/zeroex_avalanche_c_schema.yml
+++ b/models/zeroex/avalanche_c/zeroex_avalanche_c_schema.yml
@@ -16,7 +16,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_avalanche_c_api_fills_sample')
           match_columns:
             - tx_hash
@@ -104,7 +104,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_avalanche_c_api_fills_deduped_sample')
           match_columns:
             - tx_hash

--- a/models/zeroex/bnb/zeroex_bnb_schema.yml
+++ b/models/zeroex/bnb/zeroex_bnb_schema.yml
@@ -17,7 +17,7 @@ models:
             - tx_hash
             - evt_index
             - type
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_bnb_api_fills_sample')
           match_columns:
             - tx_hash
@@ -155,7 +155,7 @@ models:
             - block_time
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_bnb_native_fills_sample')
           match_columns:
             - tx_hash

--- a/models/zeroex/ethereum/zeroex_ethereum_schema.yml
+++ b/models/zeroex/ethereum/zeroex_ethereum_schema.yml
@@ -16,7 +16,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_ethereum_api_fills_sample')
           match_columns:
             - tx_hash
@@ -163,7 +163,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_ethereum_nft_fills_sample')
           match_columns:
             - block_date
@@ -234,7 +234,7 @@ models:
             - tx_hash
             - evt_index
             - volume_usd
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_ethereum_native_fills_sample')
           match_columns:
             - tx_hash

--- a/models/zeroex/fantom/zeroex_fantom_schema.yml
+++ b/models/zeroex/fantom/zeroex_fantom_schema.yml
@@ -16,7 +16,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_fantom_api_fills_sample')
           match_columns:
             - tx_hash
@@ -104,7 +104,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_fantom_api_fills_deduped_sample')
           match_columns:
             - tx_hash

--- a/models/zeroex/optimism/zeroex_optimism_schema.yml
+++ b/models/zeroex/optimism/zeroex_optimism_schema.yml
@@ -16,7 +16,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_optimism_api_fills_sample')
           match_columns:
             - tx_hash
@@ -104,7 +104,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_optimism_api_fills_deduped_sample')
           match_columns:
             - tx_hash

--- a/models/zeroex/polygon/zeroex_polygon_schema.yml
+++ b/models/zeroex/polygon/zeroex_polygon_schema.yml
@@ -16,7 +16,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_polygon_api_fills_sample')
           match_columns:
             - tx_hash
@@ -94,7 +94,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_polygon_nft_fills_sample')
           match_columns:
             - block_date
@@ -164,7 +164,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_polygon_api_fills_deduped_sample')
           match_columns:
             - tx_hash
@@ -220,7 +220,7 @@ models:
             - block_time
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_polygon_native_fills_sample')
           match_columns:
             - tx_hash

--- a/models/zeroex/zeroex_schema.yml
+++ b/models/zeroex/zeroex_schema.yml
@@ -16,7 +16,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_api_fills_sample')
           match_columns:
             - tx_hash
@@ -119,7 +119,7 @@ models:
             - block_date
             - tx_hash
             - evt_index
-      - check_seed:
+      - check_seed_legacy:
           seed_file: ref('zeroex_api_fills_deduped_sample')
           match_columns:
             - tx_hash

--- a/models/zigzag/arbitrum/zigzag_arbitrum_schema.yml
+++ b/models/zigzag/arbitrum/zigzag_arbitrum_schema.yml
@@ -21,7 +21,7 @@ models:
             - tx_hash
             - evt_index
             - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: arbitrum
           project: zigzag
           version: 1

--- a/models/zipswap/optimism/zipswap_optimism_schema.yml
+++ b/models/zipswap/optimism/zipswap_optimism_schema.yml
@@ -21,7 +21,7 @@ models:
               - tx_hash
               - evt_index
               - trace_address
-      - check_dex_seed:
+      - check_dex_seed_legacy:
           blockchain: optimism
           project: zipswap
           version: 1

--- a/tests/generic/check_dex_aggregator_seed_legacy.sql
+++ b/tests/generic/check_dex_aggregator_seed_legacy.sql
@@ -1,0 +1,12 @@
+-- this tests checks a dex  aggregator trades model for every row in a seed file.
+-- actual implementation in macros/test-helpers/check_seed.sql
+{% test check_dex_aggregator_seed_legacy(model, blockchain=None, project=None, version=None) %}
+
+    {%- set seed_file = ref('dex_aggregator_seed') -%}
+    {%- set seed_check_columns = ['token_bought_address','token_sold_address'] -%}
+    {%- set seed_matching_columns = ['block_date','blockchain','project','version','tx_hash','evt_index','trace_address'] -%}
+    {%- set filter = {'blockchain':blockchain, 'project':project, 'version':version} -%}
+
+    {{ check_seed_macro_legacy(model,seed_file,seed_matching_columns,seed_check_columns,filter) }}
+
+{% endtest %}

--- a/tests/generic/check_dex_pools_seed_legacy.sql
+++ b/tests/generic/check_dex_pools_seed_legacy.sql
@@ -1,0 +1,13 @@
+-- this tests checks that the tokenid and token address is accurate for hardcoded pool data
+-- e.g curvefi pools & ellipsis pools
+-- actual implementation in macros/test-helpers/check_seed.sql
+{% test check_dex_pools_seed_legacy(model, blockchain=None, project=None, version=None) %}
+
+    {%- set seed_file = ref('dex_pools_seed') -%}
+    {%- set seed_check_columns = ['token_address'] -%}
+    {%- set seed_matching_columns = ['pool','blockchain','project','version','token_type','token_id'] -%}
+    {%- set filter = {'blockchain':blockchain, 'project':project, 'version':version} -%}
+
+    {{ check_seed_macro_legacy(model,seed_file,seed_matching_columns,seed_check_columns,filter) }}
+
+{% endtest %}

--- a/tests/generic/check_dex_seed_legacy.sql
+++ b/tests/generic/check_dex_seed_legacy.sql
@@ -1,0 +1,12 @@
+-- this tests checks a dex trades model for every row in a seed file.
+-- actual implementation in macros/test-helpers/check_seed.sql
+{% test check_dex_seed_legacy(model, blockchain=None, project=None, version=None) %}
+
+    {%- set seed_file = ref('dex_trades_seed') -%}
+    {%- set seed_check_columns = ['token_bought_address','token_sold_address'] -%}
+    {%- set seed_matching_columns = ['block_date','blockchain','project','version','tx_hash','evt_index'] -%}
+    {%- set filter = {'blockchain':blockchain, 'project':project, 'version':version} -%}
+
+    {{ check_seed_macro_legacy(model,seed_file,seed_matching_columns,seed_check_columns,filter) }}
+
+{% endtest %}

--- a/tests/generic/check_perpetuals_seed_legacy.sql
+++ b/tests/generic/check_perpetuals_seed_legacy.sql
@@ -1,0 +1,12 @@
+-- this tests checks a perpetual trades model for every row in a seed file.
+-- actual implementation in macros/test-helpers/check_seed.sql
+{% test check_perpetuals_seed_legacy(model, blockchain=None, project=None, version=None) %}
+
+    {%- set seed_file = ref('perpetual_trades_seed') -%}
+    {%- set seed_check_columns = ['market_address','trade'] -%}
+    {%- set seed_matching_columns = ['block_date','blockchain','project','version','tx_hash'] -%}
+    {%- set filter = {'blockchain':blockchain, 'project':project, 'version':version} -%}
+
+    {{ check_seed_macro_legacy(model,seed_file,seed_matching_columns,seed_check_columns,filter) }}
+
+{% endtest %}

--- a/tests/generic/check_seaport_seed_legacy.sql
+++ b/tests/generic/check_seaport_seed_legacy.sql
@@ -1,0 +1,12 @@
+-- this tests checks a nft trades model for every row in a seed file.
+-- actual implementation in macros/test-helpers/check_seed.sql
+{% test check_seaport_seed_legacy(model, blockchain=None, project=None, version=None) %}
+
+    {%- set seed_file = ref('seaport_trades_seed') -%}
+    {%- set seed_check_columns = ['buyer','seller'] -%}
+    {%- set seed_matching_columns = ['block_date','blockchain','project','version','tx_hash','evt_index','nft_contract_address','token_id','sub_type','sub_idx'] -%}
+    {%- set filter = {'blockchain':blockchain, 'project':project, 'version':version} -%}
+
+    {{ check_seed_macro_legacy(model,seed_file,seed_matching_columns,seed_check_columns,filter) }}
+
+{% endtest %}

--- a/tests/generic/check_seed_legacy.sql
+++ b/tests/generic/check_seed_legacy.sql
@@ -1,0 +1,20 @@
+-- this tests checks a model for every row in a seed file.
+-- you need to specify the matching columns and the columns to check for equality.
+-- filter: dictionary filter of column:value that is applied to the seed file
+-- actual implementation in macros/test-helpers/check_seed.sql
+{% test check_seed_legacy(model, seed_file, match_columns=[], check_columns=[], filter=None) %}
+    {#
+        --jinja comment
+        --    potential dynamic approach, but requires db access -- ci setup to allow in future?
+        --    {%- set unique_columns = config.get('unique_key') -%}
+        --    {%- set seed_check_columns = dbt_utils.get_filtered_columns_in_relation(from=seed_file, except=unique_columns) -%}
+        --    {%- set seed_matching_columns = dbt_utils.get_filtered_columns_in_relation(from=seed_file, except=seed_check_columns) -%}
+        --jinja comment
+    #}
+    {{ config(severity = 'error') }}
+    {%- set seed_check_columns = check_columns -%}
+    {%- set seed_matching_columns = match_columns -%}
+    {%- set seed = seed_file -%}
+    {{ check_seed_macro_legacy(model,seed,seed_matching_columns,seed_check_columns,filter) }}
+
+{% endtest %}

--- a/tests/generic/is_unique_filtered.sql
+++ b/tests/generic/is_unique_filtered.sql
@@ -6,7 +6,7 @@ select
 
 from {{ model }}
 where {{ column_name }} is not null
-    and block_date >= NOW() - interval '2 days'
+    and block_date >= NOW() - interval '2' days
 group by {{ column_name }}
 having count(*) > 1
 

--- a/tests/generic/is_unique_filtered_legacy.sql
+++ b/tests/generic/is_unique_filtered_legacy.sql
@@ -1,0 +1,13 @@
+{% test is_unique_filtered(model, column_name) %}
+
+select
+    {{ column_name }} as unique_field,
+    count(*) as n_records
+
+from {{ model }}
+where {{ column_name }} is not null
+    and block_date >= NOW() - interval '2 days'
+group by {{ column_name }}
+having count(*) > 1
+
+{% endtest %}

--- a/tests/generic/is_unique_filtered_legacy.sql
+++ b/tests/generic/is_unique_filtered_legacy.sql
@@ -1,4 +1,4 @@
-{% test is_unique_filtered(model, column_name) %}
+{% test is_unique_filtered_legacy(model, column_name) %}
 
 select
     {{ column_name }} as unique_field,


### PR DESCRIPTION
1. Copied generic spark tests to a `_legacy` version
2. Changed all current test refs to use the `_legacy` version
3. Included DuneSQL versions of the `check_seed` generic macro and tests
4. added support for `varbinary` in seed columns for DuneSQL seeds