### PR TITLE
fix missing alias macro on nft parent model

### DIFF
--- a/models/nft/ethereum/nft_ethereum_aggregators_manual.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators_manual.sql
@@ -1,6 +1,6 @@
 {{config(
     tags = ['dunesql'],
-    alias='aggregators_manual'
+    alias=alias('aggregators_manual')
 )}}
 SELECT
   contract_address,


### PR DESCRIPTION
fyi @0xRobin 

post-merge, commit manifest workflow failed: https://github.com/duneanalytics/spellbook/actions/runs/5487611575/jobs/9999293874

hopefully this is the only one missing and the logs didn't only show the first instance 🙏 

i tested a `dbt compile` locally before and after the change, and both worked, but that's with my trino profile set. the failure is on spark. this may be tricky to catch up front.