### PR TITLE
Use partition_by in DuneSQL create table statements

### DIFF
--- a/macros/models/_sector/nft/nft_transfers.sql
+++ b/macros/models/_sector/nft/nft_transfers.sql
@@ -7,7 +7,7 @@ SELECT
 FROM(
      SELECT '{{blockchain}}' as blockchain
     , t.evt_block_time AS block_time
-    , date_trunc('day', t.evt_block_time) AS block_date
+    , cast(date_trunc('day', t.evt_block_time) as date) AS block_date
     , t.evt_block_number AS block_number
     , '{{token_standard_721}}' AS token_standard
     , 'single' AS transfer_type
@@ -39,7 +39,7 @@ FROM(
 
     SELECT '{{blockchain}}' as blockchain
     , t.evt_block_time AS block_time
-    , date_trunc('day', t.evt_block_time) AS block_date
+    , cast(date_trunc('day', t.evt_block_time) as date) AS block_date
     , t.evt_block_number AS block_number
     , '{{token_standard_1155}}' AS token_standard
     , 'single' AS transfer_type
@@ -71,7 +71,7 @@ FROM(
 
     SELECT '{{blockchain}}' as blockchain
     , t.evt_block_time AS block_time
-    , date_trunc('day', t.evt_block_time) AS block_date
+    , cast(date_trunc('day', t.evt_block_time) as date) AS block_date
     , t.evt_block_number AS block_number
     , '{{token_standard_1155}}'  AS token_standard
     , 'batch' AS transfer_type

--- a/models/nft/arbitrum/nft_arbitrum_approvals.sql
+++ b/models/nft/arbitrum/nft_arbitrum_approvals.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='approvals',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         incremental_strategy='merge',
         file_format = 'delta',

--- a/models/nft/arbitrum/nft_arbitrum_transfers_legacy.sql
+++ b/models/nft/arbitrum/nft_arbitrum_transfers_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias = alias('transfers', legacy_model=True),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/arbitrum/nft_arbitrum_wash_trades.sql
+++ b/models/nft/arbitrum/nft_arbitrum_wash_trades.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='wash_trades',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["arbitrum"]\',

--- a/models/nft/avalanche_c/nft_avalanche_c_approvals.sql
+++ b/models/nft/avalanche_c/nft_avalanche_c_approvals.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='approvals',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         incremental_strategy='merge',
         file_format = 'delta',

--- a/models/nft/avalanche_c/nft_avalanche_c_transfers_legacy.sql
+++ b/models/nft/avalanche_c/nft_avalanche_c_transfers_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias = alias('transfers', legacy_model=True),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/avalanche_c/nft_avalanche_c_wash_trades.sql
+++ b/models/nft/avalanche_c/nft_avalanche_c_wash_trades.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='wash_trades',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["avalanche_c"]\',

--- a/models/nft/bnb/nft_bnb_approvals.sql
+++ b/models/nft/bnb/nft_bnb_approvals.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='approvals',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         incremental_strategy='merge',
         file_format = 'delta',

--- a/models/nft/bnb/nft_bnb_transfers_legacy.sql
+++ b/models/nft/bnb/nft_bnb_transfers_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias = alias('transfers', legacy_model=True),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/bnb/nft_bnb_wash_trades.sql
+++ b/models/nft/bnb/nft_bnb_wash_trades.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='wash_trades',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["bnb"]\',

--- a/models/nft/chains/nft_arbitrum_transfers.sql
+++ b/models/nft/chains/nft_arbitrum_transfers.sql
@@ -2,7 +2,7 @@
         tags = ['dunesql'],
         schema = 'nft_arbitrum',
         alias=alias('transfers'),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/chains/nft_avalanche_c_transfers.sql
+++ b/models/nft/chains/nft_avalanche_c_transfers.sql
@@ -2,7 +2,7 @@
         tags = ['dunesql'],
         schema = 'nft_avalanche_c',
         alias =alias('transfers'),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/chains/nft_bnb_transfers.sql
+++ b/models/nft/chains/nft_bnb_transfers.sql
@@ -2,7 +2,7 @@
         tags = ['dunesql'],
         schema = 'nft_bnb',
         alias =alias('transfers'),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/chains/nft_ethereum_transfers.sql
+++ b/models/nft/chains/nft_ethereum_transfers.sql
@@ -2,7 +2,7 @@
         tags = ['dunesql'],
         schema = 'nft_ethereum',
         alias =alias('transfers'),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/chains/nft_fantom_transfers.sql
+++ b/models/nft/chains/nft_fantom_transfers.sql
@@ -2,7 +2,7 @@
         tags = ['dunesql'],
         schema = 'nft_fantom',
         alias =alias('transfers'),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/chains/nft_gnosis_transfers.sql
+++ b/models/nft/chains/nft_gnosis_transfers.sql
@@ -2,7 +2,7 @@
         tags = ['dunesql'],
         schema = 'nft_gnosis',
         alias =alias('transfers'),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/chains/nft_goerli_transfers.sql
+++ b/models/nft/chains/nft_goerli_transfers.sql
@@ -2,7 +2,7 @@
         tags = ['dunesql'],
         schema = 'nft_goerli',
         alias =alias('transfers'),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/chains/nft_optimism_transfers.sql
+++ b/models/nft/chains/nft_optimism_transfers.sql
@@ -2,7 +2,7 @@
         tags = ['dunesql'],
         schema = 'nft_optimism',
         alias =alias('transfers'),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/chains/nft_polygon_transfers.sql
+++ b/models/nft/chains/nft_polygon_transfers.sql
@@ -2,7 +2,7 @@
         tags = ['dunesql'],
         schema = 'nft_polygon',
         alias =alias('transfers'),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/ethereum/nft_ethereum_approvals.sql
+++ b/models/nft/ethereum/nft_ethereum_approvals.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='approvals',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         incremental_strategy='merge',
         file_format = 'delta',

--- a/models/nft/ethereum/nft_ethereum_transfers_legacy.sql
+++ b/models/nft/ethereum/nft_ethereum_transfers_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias = alias('transfers', legacy_model=True),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/ethereum/nft_ethereum_wash_trades.sql
+++ b/models/nft/ethereum/nft_ethereum_wash_trades.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='wash_trades',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/nft/fantom/nft_fantom_approvals.sql
+++ b/models/nft/fantom/nft_fantom_approvals.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='approvals',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         incremental_strategy='merge',
         file_format = 'delta',

--- a/models/nft/fantom/nft_fantom_transfers_legacy.sql
+++ b/models/nft/fantom/nft_fantom_transfers_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias = alias('transfers', legacy_model=True),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/gnosis/nft_gnosis_approvals.sql
+++ b/models/nft/gnosis/nft_gnosis_approvals.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='approvals',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         incremental_strategy='merge',
         file_format = 'delta',

--- a/models/nft/gnosis/nft_gnosis_transfers_legacy.sql
+++ b/models/nft/gnosis/nft_gnosis_transfers_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias = alias('transfers', legacy_model=True),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/gnosis/nft_gnosis_wash_trades.sql
+++ b/models/nft/gnosis/nft_gnosis_wash_trades.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='wash_trades',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["gnosis"]\',

--- a/models/nft/goerli/nft_goerli_approvals.sql
+++ b/models/nft/goerli/nft_goerli_approvals.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='approvals',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         incremental_strategy='merge',
         file_format = 'delta',

--- a/models/nft/goerli/nft_goerli_transfers_legacy.sql
+++ b/models/nft/goerli/nft_goerli_transfers_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias = alias('transfers', legacy_model=True),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/optimism/nft_optimism_approvals.sql
+++ b/models/nft/optimism/nft_optimism_approvals.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='approvals',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         incremental_strategy='merge',
         file_format = 'delta',

--- a/models/nft/optimism/nft_optimism_transfers_legacy.sql
+++ b/models/nft/optimism/nft_optimism_transfers_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias = alias('transfers', legacy_model=True),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/optimism/nft_optimism_wash_trades.sql
+++ b/models/nft/optimism/nft_optimism_wash_trades.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='wash_trades',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["optimism"]\',

--- a/models/nft/polygon/nft_polygon_approvals.sql
+++ b/models/nft/polygon/nft_polygon_approvals.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='approvals',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         incremental_strategy='merge',
         file_format = 'delta',

--- a/models/nft/polygon/nft_polygon_transfers_legacy.sql
+++ b/models/nft/polygon/nft_polygon_transfers_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias = alias('transfers', legacy_model=True),
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/nft/polygon/nft_polygon_wash_trades.sql
+++ b/models/nft/polygon/nft_polygon_wash_trades.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias ='wash_trades',
-        partition_by='block_date',
+        partition_by=['block_date'],
         materialized='incremental',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["polygon"]\',

--- a/models/tornado_cash/arbitrum/tornado_cash_arbitrum_deposits.sql
+++ b/models/tornado_cash/arbitrum/tornado_cash_arbitrum_deposits.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_arbitrum',
         alias ='deposits',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/arbitrum/tornado_cash_arbitrum_withdrawals.sql
+++ b/models/tornado_cash/arbitrum/tornado_cash_arbitrum_withdrawals.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_arbitrum',
         alias ='withdrawals',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/avalanche_c/tornado_cash_avalanche_c_deposits.sql
+++ b/models/tornado_cash/avalanche_c/tornado_cash_avalanche_c_deposits.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_avalanche_c',
         alias ='deposits',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/avalanche_c/tornado_cash_avalanche_c_withdrawals.sql
+++ b/models/tornado_cash/avalanche_c/tornado_cash_avalanche_c_withdrawals.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_avalanche_c',
         alias ='withdrawals',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/bnb/tornado_cash_bnb_deposits.sql
+++ b/models/tornado_cash/bnb/tornado_cash_bnb_deposits.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_bnb',
         alias ='deposits',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/bnb/tornado_cash_bnb_withdrawals.sql
+++ b/models/tornado_cash/bnb/tornado_cash_bnb_withdrawals.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_bnb',
         alias ='withdrawals',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/ethereum/tornado_cash_ethereum_deposits.sql
+++ b/models/tornado_cash/ethereum/tornado_cash_ethereum_deposits.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_ethereum',
         alias ='deposits',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/ethereum/tornado_cash_ethereum_withdrawals.sql
+++ b/models/tornado_cash/ethereum/tornado_cash_ethereum_withdrawals.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_ethereum',
         alias ='withdrawals',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/gnosis/tornado_cash_gnosis_deposits.sql
+++ b/models/tornado_cash/gnosis/tornado_cash_gnosis_deposits.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_gnosis',
         alias ='deposits',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/gnosis/tornado_cash_gnosis_withdrawals.sql
+++ b/models/tornado_cash/gnosis/tornado_cash_gnosis_withdrawals.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_gnosis',
         alias ='withdrawals',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/optimism/tornado_cash_optimism_deposits.sql
+++ b/models/tornado_cash/optimism/tornado_cash_optimism_deposits.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_optimism',
         alias ='deposits',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/optimism/tornado_cash_optimism_withdrawals.sql
+++ b/models/tornado_cash/optimism/tornado_cash_optimism_withdrawals.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_optimism',
         alias ='withdrawals',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/polygon/tornado_cash_polygon_deposits.sql
+++ b/models/tornado_cash/polygon/tornado_cash_polygon_deposits.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_polygon',
         alias ='deposits',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/polygon/tornado_cash_polygon_withdrawals.sql
+++ b/models/tornado_cash/polygon/tornado_cash_polygon_withdrawals.sql
@@ -2,7 +2,7 @@
         schema = 'tornado_cash_polygon',
         alias ='withdrawals',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/tornado_cash_deposits.sql
+++ b/models/tornado_cash/tornado_cash_deposits.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='deposits',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['blockchain', 'block_date', 'tx_hash', 'evt_index'],

--- a/models/tornado_cash/tornado_cash_withdrawals.sql
+++ b/models/tornado_cash/tornado_cash_withdrawals.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias ='withdrawals',
         materialized='incremental',
-        partition_by='block_date',
+        partition_by=['block_date'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['blockchain', 'block_date', 'tx_hash', 'evt_index'],


### PR DESCRIPTION
So far we have been running without partition_by when creating tables using DuneSQL. This impacts the data layout and could influence data skipping, although most table are likely overpartitioned, and we should partition on block_month instead. Note that we need to cast block_date explicitly to date when the column is used for partitioning.