### PR TITLE
[CoW] migrate and add new field to cow.order_rewards

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_order_rewards.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_order_rewards.sql
@@ -1,4 +1,5 @@
 {{ config(alias='order_rewards',
+        tags = ['dunesql'],
         post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",
                                     "cow_protocol",
@@ -6,11 +7,12 @@
 )}}
 
 -- PoC Query here - https://dune.com/queries/1752782
-select
-    distinct order_uid,
-    block_number,
-    tx_hash,
-    solver,
-    data.amount as cow_reward,
-    cast(data.surplus_fee as double) as surplus_fee
-from {{ source('cowswap', 'raw_order_rewards') }}
+SELECT
+  DISTINCT from_hex(order_uid) as order_uid,
+  block_number,
+  from_hex(tx_hash) as tx_hash,
+  from_hex(solver) as solver,
+  from_hex(data.quote_solver) as quote_solver,
+  cast(data.amount as uint256)  AS cow_reward,
+  cast(data.surplus_fee as uint256) AS surplus_fee
+FROM {{ source('cowswap', 'raw_order_rewards') }}

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_order_rewards.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_order_rewards.sql
@@ -1,4 +1,4 @@
-{{ config(alias='order_rewards',
+{{ config(alias=alias('order_rewards'),
         tags = ['dunesql'],
         post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_order_rewards_legacy.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_order_rewards_legacy.sql
@@ -1,0 +1,17 @@
+{{ config(alias=alias('order_rewards', legacy_model=True),
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "project",
+                                    "cow_protocol",
+                                    \'["bh2smith"]\') }}'
+)}}
+
+-- PoC Query here - https://dune.com/queries/1752782
+select
+    distinct order_uid,
+    block_number,
+    tx_hash,
+    solver,
+    data.quote_solver as quote_solver,
+    data.amount as cow_reward,
+    cast(data.surplus_fee as double) as surplus_fee
+from {{ source('cowswap', 'raw_order_rewards') }}

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -228,7 +228,9 @@ models:
         to the solver competition on the granularity level of orders.
     columns:
       - *tx_hash
-      - *solver_address
+      - &solver
+        name: solver
+        description: "Address of the solver who settled the order (i.e. the from address of the corresponding transaction)"
       - *block_number
       - &cow_reward
         name: cow_reward

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -224,10 +224,8 @@ models:
     config:
       tags: ['ethereum','cow_protocol','app_data', "metadata"]
     description: >
-        Order Rewards contains the data necessary to compute Weekly Solver Payouts.
-        In particular, how much COW token solvers are entitled for each settled order.
-        Furthermore, since the introduction of limit orders into the protocol, 
-        this table also contains the surplus fee.
+        Order Rewards (or more appropriately named Order Meta) contains off-chain meta data relevant 
+        to the solver competition on the granularity level of orders.
     columns:
       - *tx_hash
       - *solver_address
@@ -239,6 +237,9 @@ models:
         name: surplus_fee
         description: "Fee taken from limit orders"
       - *order_uid
+      - &quote_solver
+        name: quote_solver
+        description: "Address of the solver who provided the winning quote for this order"
 
   - name: cow_protocol_ethereum_eth_flow_orders
     meta:


### PR DESCRIPTION
This PR migrates a basic spell to DuneSQL - while simultaneously adding a new field. This is already demonstrated to work as expected in the following PoC query.

Those with non-null new field: https://dune.com/queries/2714240

Regular PoC Query: https://dune.com/queries/1752782

cc @fhenneke, @harisang from the solver team and @gentrexha 