### PR TITLE
[CoW] Migrate and add utm to cow.app_data

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
@@ -1,4 +1,4 @@
-{{ config(alias='app_data',
+{{ config(alias=alias('app_data'),
         tags=['dunesql'],
         post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
@@ -8,39 +8,37 @@
 
 -- Find the PoC Query here: https://dune.com/queries/1751965
 with
-  partially_unpacked_app_content AS (
-    SELECT
-      app_hash,
-      content.appCode AS app_code,
-      content.environment,
-      content.metadata.orderClass.orderClass AS order_class,
-      content.metadata.quote,
-      content.metadata.referrer,
-      content.metadata.utm
-    FROM {{ source('cowswap', 'raw_app_data') }}
+  partially_unpacked_app_content as (
+    select
+        distinct app_hash,
+        content.appCode AS app_code,
+        content.environment,
+        content.metadata.orderClass.orderClass as order_class,
+        content.metadata.quote,
+        content.metadata.referrer,
+        content.metadata.utm
+    from {{ source('cowswap', 'raw_app_data') }}
   ),
-  unpacked_referrer_app_data AS (
-    SELECT
-      app_hash,
-      app_code,
-      environment,
-      order_class,
-      quote,
-      LOWER(COALESCE(referrer.address, referrer.referrer)) AS referrer,
-      utm
-    FROM
-      partially_unpacked_app_content
+  unpacked_referrer_app_data as (
+    select
+        app_hash,
+        app_code,
+        environment,
+        order_class,
+        quote,
+        coalesce(referrer.address, referrer.referrer)) as referrer,
+        utm
+    from partially_unpacked_app_content
   ),
-  results AS (
-    SELECT
-      app_hash,
-      app_code,
-      environment,
-      order_class,
-      referrer,
-      TRY_CAST(quote.slippageBips AS INTEGER) AS slippage_bips,
-      utm
-    FROM
-      unpacked_referrer_app_data
-  )
-SELECT * FROM results
+  results as (
+    select
+        app_hash,
+        app_code,
+        environment,
+        order_class,
+        from_hex(referrer) as referrer,
+        cast(quote.slippageBips as integer) as slippage_bips,
+        utm
+    from unpacked_referrer_app_data
+)
+select * from results

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
@@ -10,7 +10,7 @@
 with
   partially_unpacked_app_content as (
     select
-        distinct app_hash,
+        distinct from_hex(app_hash) as app_hash,
         content.appCode as app_code,
         content.environment,
         content.metadata.orderClass.orderClass as order_class,
@@ -26,7 +26,8 @@ with
         environment,
         order_class,
         quote,
-        coalesce(referrer.address, referrer.referrer) as referrer,
+        -- different app data versions put referrer in two possible places.
+        from_hex(coalesce(referrer.address, referrer.referrer)) as referrer,
         utm
     from partially_unpacked_app_content
   ),

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
@@ -11,7 +11,7 @@ with
   partially_unpacked_app_content as (
     select
         distinct app_hash,
-        content.appCode AS app_code,
+        content.appCode as app_code,
         content.environment,
         content.metadata.orderClass.orderClass as order_class,
         content.metadata.quote,
@@ -26,7 +26,7 @@ with
         environment,
         order_class,
         quote,
-        coalesce(referrer.address, referrer.referrer)) as referrer,
+        coalesce(referrer.address, referrer.referrer) as referrer,
         utm
     from partially_unpacked_app_content
   ),

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data.sql
@@ -1,4 +1,5 @@
 {{ config(alias='app_data',
+        tags=['dunesql'],
         post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",
                                     "cow_protocol",
@@ -7,41 +8,39 @@
 
 -- Find the PoC Query here: https://dune.com/queries/1751965
 with
-partially_unpacked_app_content as (
-    select
-        distinct app_hash,
-        content.appCode as app_code,
-        content.environment,
-        content.metadata.orderClass.orderClass as order_class,
-        content.metadata.quote,
-        content.metadata.referrer
-    from {{ source('cowswap', 'raw_app_data') }}
-),
-
-unpacked_referrer_app_data as (
-    select
-        app_hash,
-        app_code,
-        environment,
-        order_class,
-        quote,
-        -- different app data versions put referrer in two possible places.
-        lower(coalesce(referrer.address, referrer.referrer)) as referrer
-    from partially_unpacked_app_content
-),
-
-results as (
-    select
-        app_hash,
-        app_code,
-        environment,
-        order_class,
-        referrer,
-        cast(quote.slippageBips as integer) slippage_bips
-        -- There is only one App Data using buyAmount/sellAmount fields.
-        -- cast(quote.sellAmount as double) sell_amount,
-        -- cast(quote.buyAmount as double) buy_amount
-    from unpacked_referrer_app_data
-)
-
-select * from results
+  partially_unpacked_app_content AS (
+    SELECT
+      app_hash,
+      content.appCode AS app_code,
+      content.environment,
+      content.metadata.orderClass.orderClass AS order_class,
+      content.metadata.quote,
+      content.metadata.referrer,
+      content.metadata.utm
+    FROM {{ source('cowswap', 'raw_app_data') }}
+  ),
+  unpacked_referrer_app_data AS (
+    SELECT
+      app_hash,
+      app_code,
+      environment,
+      order_class,
+      quote,
+      LOWER(COALESCE(referrer.address, referrer.referrer)) AS referrer,
+      utm
+    FROM
+      partially_unpacked_app_content
+  ),
+  results AS (
+    SELECT
+      app_hash,
+      app_code,
+      environment,
+      order_class,
+      referrer,
+      TRY_CAST(quote.slippageBips AS INTEGER) AS slippage_bips,
+      utm
+    FROM
+      unpacked_referrer_app_data
+  )
+SELECT * FROM results

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data_legacy.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_app_data_legacy.sql
@@ -1,0 +1,50 @@
+{{ config(alias=alias('app_data', legacy_model=True),
+        post_hook='{{ expose_spells(\'["ethereum"]\',
+                                    "project",
+                                    "cow_protocol",
+                                    \'["bh2smith"]\') }}'
+)}}
+
+-- Find the PoC Query here: https://dune.com/queries/1751965
+with
+partially_unpacked_app_content as (
+    select
+        distinct app_hash,
+        content.appCode as app_code,
+        content.environment,
+        content.metadata.orderClass.orderClass as order_class,
+        content.metadata.quote,
+        content.metadata.referrer,
+        content.metadata.utm
+    from {{ source('cowswap', 'raw_app_data') }}
+),
+
+unpacked_referrer_app_data as (
+    select
+        app_hash,
+        app_code,
+        environment,
+        order_class,
+        quote,
+        -- different app data versions put referrer in two possible places.
+        lower(coalesce(referrer.address, referrer.referrer)) as referrer,
+        utm
+    from partially_unpacked_app_content
+),
+
+results as (
+    select
+        app_hash,
+        app_code,
+        environment,
+        order_class,
+        referrer,
+        cast(quote.slippageBips as integer) slippage_bips,
+        utm
+        -- There is only one App Data using buyAmount/sellAmount fields.
+        -- cast(quote.sellAmount as double) sell_amount,
+        -- cast(quote.buyAmount as double) buy_amount
+    from unpacked_referrer_app_data
+)
+
+select * from results

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_referrals.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_referrals.sql
@@ -1,4 +1,5 @@
-{{ config(alias='referrals',
+{{ config(
+        alias='referrals',
         post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",
                                     "cow_protocol",
@@ -11,7 +12,7 @@ referral_map as (
     select
         distinct app_hash,
         referrer
-    from {{ ref('cow_protocol_ethereum_app_data') }}
+    from {{ ref('cow_protocol_ethereum_app_data_legacy') }}
     where referrer is not null
 )
 

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_schema.yml
@@ -215,6 +215,9 @@ models:
       - &slippage_bips
         name: slippage_bips
         description: User's slippage tolerance configured through the interface. Used to compute trade execution price improvement (can be Null)
+      - &utm
+        name: utm
+        description: utm object associated with the app data (consisting of fields utmSource, utmContent and utmMedium)
 
   - name: cow_protocol_ethereum_order_rewards
     meta:

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_trade_slippage.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_trade_slippage.sql
@@ -28,7 +28,7 @@ select
     atoms_sold,
     usd_value as trade_usd_value,
     slippage_bips as tolerance_bips
-from {{ref('cow_protocol_ethereum_app_data')}} as ad
+from {{ref('cow_protocol_ethereum_app_data_legacy')}} as ad
 inner join {{ ref('cow_protocol_ethereum_trades') }} as t on t.app_data = ad.app_hash
 where slippage_bips is not null
 ),


### PR DESCRIPTION
This spell migrates the query to dunesql and adds a couple recent columns to the table: 

Check out the PoC Query here: https://dune.com/queries/1751965


Note that this cow.referrals depends on this, so we had to migrate it first. Funny thing is that it did not require any changes to migrate so we only added the tag here. However we will have to migrate `trade_slippage` as well/separately.


cc @gentrexha 