### PR TITLE
Fix nft transfers on dunesql

### DIFF
--- a/models/nft/nft_transfers.sql
+++ b/models/nft/nft_transfers.sql
@@ -46,7 +46,7 @@ FROM (
         , unique_transfer_id
     FROM {{ nft_model }}
     {% if is_incremental() %}
-    WHERE block_time >= date_trunc("day", now() - interval '7' day)
+    WHERE block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
     {% if not loop.last %}
     UNION ALL

--- a/models/nft/nft_transfers.sql
+++ b/models/nft/nft_transfers.sql
@@ -46,7 +46,7 @@ FROM (
         , unique_transfer_id
     FROM {{ nft_model }}
     {% if is_incremental() %}
-    WHERE block_time >= date_trunc("day", now() - interval '7' days)
+    WHERE block_time >= date_trunc("day", now() - interval '7' day)
     {% endif %}
     {% if not loop.last %}
     UNION ALL


### PR DESCRIPTION
`nft.transfers` is failing on trino due to incorrect syntax on incremental filter

the initial PR didn't fully get through gh action CI tests due to memory issues on initial `dbt test` step. if we are running these locally instead of PI CI tests, we need to ensure we run the full process to mimic prod

run full refresh --> run test --> run incremental without full refresh flag --> run test again