### PR TITLE
docs: fix typos

### DIFF
--- a/.github/workflows/dbt_precommit_hooks.yml
+++ b/.github/workflows/dbt_precommit_hooks.yml
@@ -29,7 +29,7 @@ jobs:
           format: space-delimited
           token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
-      - name: Set modfied and added files as arg
+      - name: Set modified and added files as arg
         run: |
           echo "FILES=$(echo ${{ steps.abc.outputs.added_modified }})" >> $GITHUB_ENV
       - name: dbt dependencies

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ensure you are still in Spellbook root directory, then run the following command
 dbt compile
 ```
 
-A recent change in the new setup was to include a `profiles.yml` file, which helps tell dbt how to run commmands. The profile is located in the root directory [here](https://github.com/duneanalytics/spellbook/blob/main/profiles.yml). This should never need modified, unless done intentionally by the Dune team.  
+A recent change in the new setup was to include a `profiles.yml` file, which helps tell dbt how to run commands. The profile is located in the root directory [here](https://github.com/duneanalytics/spellbook/blob/main/profiles.yml). This should never need modified, unless done intentionally by the Dune team.  
 Due to the `profiles.yml` file being stored in the root directory, this is why users **must** be in the root directory on the command line to run `dbt compile`.
 
 ## High-level overview of Spellbook current state


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `.github/workflows/dbt_precommit_hooks.yml`
1 typo in `README.md`


Best!