### PR TITLE
Add legacy tag to *_legacy.sql files

### DIFF
--- a/models/_sector/nft/trades/ethereum/platforms/foundation_ethereum_base_trades_legacy.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/foundation_ethereum_base_trades_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
     schema = 'foundation_ethereum',
     alias = alias('base_trades', legacy_model=True),
     partition_by = ['block_date'],

--- a/models/aave/aave_v3_tokens_legacy.sql
+++ b/models/aave/aave_v3_tokens_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         schema = 'aave_v3'
         , alias = alias('tokens', legacy_model=True)
         , materialized = 'incremental'

--- a/models/evms/evms_blocks_legacy.sql
+++ b/models/evms/evms_blocks_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('blocks', legacy_model=True),
         unique_key=['blockchain', 'number'],
         post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum"]\',

--- a/models/nft/arbitrum/nft_arbitrum_aggregators_legacy.sql
+++ b/models/nft/arbitrum/nft_arbitrum_aggregators_legacy.sql
@@ -1,4 +1,5 @@
 {{config(
+	tags=['legacy'],
     alias=alias('aggregators', legacy_model=True)
 )}}
 

--- a/models/nft/arbitrum/nft_arbitrum_transfers_legacy.sql
+++ b/models/nft/arbitrum/nft_arbitrum_transfers_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('transfers', legacy_model=True),
         partition_by=['block_date'],
         materialized='incremental',

--- a/models/nft/avalanche_c/nft_avalanche_c_aggregators_legacy.sql
+++ b/models/nft/avalanche_c/nft_avalanche_c_aggregators_legacy.sql
@@ -1,4 +1,5 @@
 {{config(
+	tags=['legacy'],
     alias = alias('aggregators', legacy_model=True)
     )
 }}

--- a/models/nft/avalanche_c/nft_avalanche_c_transfers_legacy.sql
+++ b/models/nft/avalanche_c/nft_avalanche_c_transfers_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('transfers', legacy_model=True),
         partition_by=['block_date'],
         materialized='incremental',

--- a/models/nft/bnb/nft_bnb_aggregators_legacy.sql
+++ b/models/nft/bnb/nft_bnb_aggregators_legacy.sql
@@ -1,4 +1,5 @@
- {{ config( alias = alias('aggregators', legacy_model=True)) }}
+ {{ config(
+	tags=['legacy'], alias = alias('aggregators', legacy_model=True)) }}
 
 SELECT
   contract_address,

--- a/models/nft/bnb/nft_bnb_transfers_legacy.sql
+++ b/models/nft/bnb/nft_bnb_transfers_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('transfers', legacy_model=True),
         partition_by=['block_date'],
         materialized='incremental',

--- a/models/nft/ethereum/nft_ethereum_aggregators_gem_legacy.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators_gem_legacy.sql
@@ -1,4 +1,5 @@
-{{config(alias = alias('aggregators_gem', legacy_model=True))}}
+{{config(
+	tags=['legacy'],alias = alias('aggregators_gem', legacy_model=True))}}
 WITH vasa_contracts as (
     SELECT distinct
     address AS contract_address

--- a/models/nft/ethereum/nft_ethereum_aggregators_legacy.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators_legacy.sql
@@ -1,4 +1,5 @@
-{{config(alias = alias('aggregators', legacy_model=True), materialized='table', file_format = 'delta')}}
+{{config(
+	tags=['legacy'],alias = alias('aggregators', legacy_model=True), materialized='table', file_format = 'delta')}}
 
 SELECT contract_address, name
 FROM {{ ref('nft_ethereum_aggregators_manual_legacy')}}

--- a/models/nft/ethereum/nft_ethereum_aggregators_manual_legacy.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators_manual_legacy.sql
@@ -1,4 +1,5 @@
-{{config(alias = alias('aggregators_manual', legacy_model=True))}}
+{{config(
+	tags=['legacy'],alias = alias('aggregators_manual', legacy_model=True))}}
 SELECT
   LOWER(contract_address) AS contract_address,
   name

--- a/models/nft/ethereum/nft_ethereum_aggregators_markers_legacy.sql
+++ b/models/nft/ethereum/nft_ethereum_aggregators_markers_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('aggregators_markers', legacy_model=True),
 		materialized = 'table',
         unique_key='hash_marker',

--- a/models/nft/ethereum/nft_ethereum_transfers_legacy.sql
+++ b/models/nft/ethereum/nft_ethereum_transfers_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('transfers', legacy_model=True),
         partition_by=['block_date'],
         materialized='incremental',

--- a/models/nft/fantom/nft_fantom_transfers_legacy.sql
+++ b/models/nft/fantom/nft_fantom_transfers_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('transfers', legacy_model=True),
         partition_by=['block_date'],
         materialized='incremental',

--- a/models/nft/gnosis/nft_gnosis_transfers_legacy.sql
+++ b/models/nft/gnosis/nft_gnosis_transfers_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('transfers', legacy_model=True),
         partition_by=['block_date'],
         materialized='incremental',

--- a/models/nft/goerli/nft_goerli_transfers_legacy.sql
+++ b/models/nft/goerli/nft_goerli_transfers_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('transfers', legacy_model=True),
         partition_by=['block_date'],
         materialized='incremental',

--- a/models/nft/nft_aggregators_legacy.sql
+++ b/models/nft/nft_aggregators_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('aggregators', legacy_model=True),
         post_hook='{{ expose_spells(\'["avalanche_c","bnb","ethereum","polygon", "optimism"]\',
                                     "sector",

--- a/models/nft/nft_transfers_legacy.sql
+++ b/models/nft/nft_transfers_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('transfers', legacy_model=True),
         partition_by = ['block_date'],
         materialized = 'incremental',

--- a/models/nft/optimism/nft_optimism_aggregators_legacy.sql
+++ b/models/nft/optimism/nft_optimism_aggregators_legacy.sql
@@ -1,4 +1,5 @@
-{{ config( alias = alias('aggregators', legacy_model=True)) }}
+{{ config(
+	tags=['legacy'], alias = alias('aggregators', legacy_model=True)) }}
 
 SELECT
   lower(contract_address) as contract_address,

--- a/models/nft/optimism/nft_optimism_transfers_legacy.sql
+++ b/models/nft/optimism/nft_optimism_transfers_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('transfers', legacy_model=True),
         partition_by=['block_date'],
         materialized='incremental',

--- a/models/nft/polygon/nft_polygon_aggregators_legacy.sql
+++ b/models/nft/polygon/nft_polygon_aggregators_legacy.sql
@@ -1,4 +1,5 @@
- {{ config( alias = alias('aggregators', legacy_model=True)) }}
+ {{ config(
+	tags=['legacy'], alias = alias('aggregators', legacy_model=True)) }}
 
 SELECT
   contract_address,

--- a/models/nft/polygon/nft_polygon_transfers_legacy.sql
+++ b/models/nft/polygon/nft_polygon_transfers_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('transfers', legacy_model=True),
         partition_by=['block_date'],
         materialized='incremental',

--- a/models/ovm/optimism/ovm_optimism_l2_token_factory_legacy.sql
+++ b/models/ovm/optimism/ovm_optimism_l2_token_factory_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         schema = 'ovm_optimism'
         , alias = alias('l2_token_factory', legacy_model=True)
         , materialized = 'incremental'

--- a/models/prices/prices_usd_forward_fill_legacy.sql
+++ b/models/prices/prices_usd_forward_fill_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         schema='prices',
         alias = alias('usd_forward_fill', legacy_model=True),
         post_hook='{{ expose_spells_hide_trino(\'["ethereum", "solana", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c", "polygon"]\',

--- a/models/the_granary/optimism/the_granary_optimism_tokens_legacy.sql
+++ b/models/the_granary/optimism/the_granary_optimism_tokens_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
     alias = alias('tokens', legacy_model=True)
     , materialized = 'incremental'
     , file_format = 'delta'

--- a/models/tokens/arbitrum/tokens_arbitrum_erc20_legacy.sql
+++ b/models/tokens/arbitrum/tokens_arbitrum_erc20_legacy.sql
@@ -1,4 +1,4 @@
-{{ config( alias = alias('erc20', legacy_model=True), tags=['static'])}}
+{{ config( alias = alias('erc20', legacy_model=True), tags=['static', 'legacy'])}}
 
 SELECT LOWER(contract_address) as contract_address, symbol, decimals
 FROM (VALUES

--- a/models/tokens/arbitrum/tokens_arbitrum_nft_curated_legacy.sql
+++ b/models/tokens/arbitrum/tokens_arbitrum_nft_curated_legacy.sql
@@ -1,4 +1,4 @@
-{{ config( alias = alias('nft_curated', legacy_model=True), tags=['static']) }}
+{{ config( alias = alias('nft_curated', legacy_model=True), tags=['static', 'legacy']) }}
 
 SELECT LOWER(contract_address) AS contract_address, name, symbol
 FROM (VALUES

--- a/models/tokens/arbitrum/tokens_arbitrum_nft_legacy.sql
+++ b/models/tokens/arbitrum/tokens_arbitrum_nft_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft', legacy_model=True)
         , materialized = 'table'
         , post_hook='{{ expose_spells(\'["arbitrum"]\',

--- a/models/tokens/arbitrum/tokens_arbitrum_nft_standards_legacy.sql
+++ b/models/tokens/arbitrum/tokens_arbitrum_nft_standards_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft_standards', legacy_model=True),
         materialized='incremental',
 	    incremental_strategy = 'merge',

--- a/models/tokens/avalanche_c/tokens_avalanche_c_erc20_legacy.sql
+++ b/models/tokens/avalanche_c/tokens_avalanche_c_erc20_legacy.sql
@@ -1,4 +1,4 @@
-{{ config( alias = alias('erc20', legacy_model=True), tags=['static'])}}
+{{ config( alias = alias('erc20', legacy_model=True), tags=['static', 'legacy'])}}
 
 SELECT LOWER(contract_address) AS contract_address, symbol, decimals
 FROM (VALUES

--- a/models/tokens/avalanche_c/tokens_avalanche_c_nft_curated_legacy.sql
+++ b/models/tokens/avalanche_c/tokens_avalanche_c_nft_curated_legacy.sql
@@ -1,4 +1,4 @@
-{{ config( alias = alias('nft_curated', legacy_model=True), tags=['static']) }}
+{{ config( alias = alias('nft_curated', legacy_model=True), tags=['static', 'legacy']) }}
 
 SELECT LOWER(contract_address) AS contract_address, name, symbol
 FROM (VALUES

--- a/models/tokens/avalanche_c/tokens_avalanche_c_nft_legacy.sql
+++ b/models/tokens/avalanche_c/tokens_avalanche_c_nft_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft', legacy_model=True)
         , materialized = 'table'
         , post_hook='{{ expose_spells(\'["avalanche_c"]\',

--- a/models/tokens/avalanche_c/tokens_avalanche_c_nft_standards_legacy.sql
+++ b/models/tokens/avalanche_c/tokens_avalanche_c_nft_standards_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft_standards', legacy_model=True),
         materialized='incremental',
         incremental_strategy = 'merge',

--- a/models/tokens/bnb/tokens_bnb_bep20_legacy.sql
+++ b/models/tokens/bnb/tokens_bnb_bep20_legacy.sql
@@ -1,4 +1,4 @@
-{{ config( alias = alias('bep20', legacy_model=True), tags=['static'])}}
+{{ config( alias = alias('bep20', legacy_model=True), tags=['static', 'legacy'])}}
 
 SELECT LOWER(contract_address) AS contract_address, symbol, decimals
   FROM (VALUES 

--- a/models/tokens/bnb/tokens_bnb_nft_curated_legacy.sql
+++ b/models/tokens/bnb/tokens_bnb_nft_curated_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias = alias('nft_curated', legacy_model=True),
-        tags=['static']
+        tags=['static', 'legacy']
         )
 }}
 

--- a/models/tokens/bnb/tokens_bnb_nft_legacy.sql
+++ b/models/tokens/bnb/tokens_bnb_nft_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft', legacy_model=True)
         , materialized = 'table'
         , post_hook='{{ expose_spells(\'["bnb"]\',

--- a/models/tokens/bnb/tokens_bnb_nft_standards_legacy.sql
+++ b/models/tokens/bnb/tokens_bnb_nft_standards_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft_standards', legacy_model=True),
         materialized='incremental',
         incremental_strategy = 'merge',

--- a/models/tokens/ethereum/tokens_ethereum_erc20_legacy.sql
+++ b/models/tokens/ethereum/tokens_ethereum_erc20_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(
         alias = alias('erc20', legacy_model=True)
-        , tags=['static']
+        , tags=['static', 'legacy']
         )
 }}
 SELECT

--- a/models/tokens/ethereum/tokens_ethereum_nft_legacy.sql
+++ b/models/tokens/ethereum/tokens_ethereum_nft_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft', legacy_model=True)
         , materialized = 'table'
         , post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/tokens/ethereum/tokens_ethereum_nft_standards_legacy.sql
+++ b/models/tokens/ethereum/tokens_ethereum_nft_standards_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft_standards', legacy_model=True),
         materialized='incremental',
         incremental_strategy = 'merge',

--- a/models/tokens/fantom/tokens_fantom_erc20_legacy.sql
+++ b/models/tokens/fantom/tokens_fantom_erc20_legacy.sql
@@ -1,4 +1,4 @@
-{{ config( alias = alias('erc20', legacy_model=True), tags=['static'])}}
+{{ config( alias = alias('erc20', legacy_model=True), tags=['static', 'legacy'])}}
 
 SELECT LOWER(contract_address) as contract_address, symbol, decimals 
 FROM (VALUES

--- a/models/tokens/fantom/tokens_fantom_nft_curated_legacy.sql
+++ b/models/tokens/fantom/tokens_fantom_nft_curated_legacy.sql
@@ -1,4 +1,4 @@
-{{ config( alias = alias('nft_curated', legacy_model=True), tags=['static']) }}
+{{ config( alias = alias('nft_curated', legacy_model=True), tags=['static', 'legacy']) }}
 
 SELECT LOWER(contract_address) AS contract_address, name, symbol
 FROM (VALUES

--- a/models/tokens/fantom/tokens_fantom_nft_legacy.sql
+++ b/models/tokens/fantom/tokens_fantom_nft_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft', legacy_model=True)
         , materialized = 'table'
         , post_hook='{{ expose_spells(\'["fantom"]\',

--- a/models/tokens/fantom/tokens_fantom_nft_standards_legacy.sql
+++ b/models/tokens/fantom/tokens_fantom_nft_standards_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft_standards', legacy_model=True),
         materialized='incremental',
         incremental_strategy = 'merge',

--- a/models/tokens/gnosis/tokens_gnosis_erc20_legacy.sql
+++ b/models/tokens/gnosis/tokens_gnosis_erc20_legacy.sql
@@ -1,4 +1,4 @@
-{{ config( alias = alias('erc20', legacy_model=True), tags=['static'])}}
+{{ config( alias = alias('erc20', legacy_model=True), tags=['static', 'legacy'])}}
 
 SELECT LOWER(contract_address) as contract_address, symbol, decimals
 FROM (VALUES ('0x3f9463bdb502ec2079bf39da6c924d4022ff9f4c', 'biubiu.tools', 18),

--- a/models/tokens/gnosis/tokens_gnosis_nft_curated_legacy.sql
+++ b/models/tokens/gnosis/tokens_gnosis_nft_curated_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(schema = 'tokens_gnosis',
         alias = alias('nft_curated', legacy_model=True),
-        tags=['static']
+        tags=['static', 'legacy']
         )
 }}
 

--- a/models/tokens/gnosis/tokens_gnosis_nft_legacy.sql
+++ b/models/tokens/gnosis/tokens_gnosis_nft_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft', legacy_model=True)
         , materialized = 'table'
         , post_hook='{{ expose_spells(\'["gnosis"]\',

--- a/models/tokens/gnosis/tokens_gnosis_nft_standards_legacy.sql
+++ b/models/tokens/gnosis/tokens_gnosis_nft_standards_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft_standards', legacy_model=True),
         materialized='incremental',
         incremental_strategy = 'merge',

--- a/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping_legacy.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping_legacy.sql
@@ -1,5 +1,6 @@
  {{
   config(
+	tags=['legacy'],
     alias = alias('erc20_bridged_mapping', legacy_model=True)
     , materialized = 'incremental'
     , file_format = 'delta'

--- a/models/tokens/optimism/tokens_optimism_erc20_curated_legacy.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20_curated_legacy.sql
@@ -1,4 +1,4 @@
-{{ config( alias = alias('erc20_curated', legacy_model=True), tags=['static'],
+{{ config( alias = alias('erc20_curated', legacy_model=True), tags=['static', 'legacy'],
     post_hook='{{ expose_spells(\'["optimism"]\',
                                     "sector",
                                     "tokens",

--- a/models/tokens/optimism/tokens_optimism_erc20_generated_legacy.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20_generated_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
     alias = alias('erc20_generated', legacy_model=True),
     post_hook='{{ expose_spells(\'["optimism"]\',
                                     "sector",

--- a/models/tokens/optimism/tokens_optimism_erc20_legacy.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20_legacy.sql
@@ -1,4 +1,5 @@
-{{ config( alias = alias('erc20', legacy_model=True), materialized = 'table',
+{{ config(
+	tags=['legacy'], alias = alias('erc20', legacy_model=True), materialized = 'table',
     post_hook='{{ expose_spells(\'["optimism"]\',
                                     "sector",
                                     "tokens",

--- a/models/tokens/optimism/tokens_optimism_erc20_transfer_source_legacy.sql
+++ b/models/tokens/optimism/tokens_optimism_erc20_transfer_source_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('erc20_transfer_source', legacy_model=True),
         materialized='incremental',
         incremental_strategy = 'merge',

--- a/models/tokens/optimism/tokens_optimism_nft_bridged_mapping_legacy.sql
+++ b/models/tokens/optimism/tokens_optimism_nft_bridged_mapping_legacy.sql
@@ -1,5 +1,6 @@
  {{
   config(
+	tags=['legacy'],
     alias = alias('nft_bridged_mapping', legacy_model=True),
         post_hook='{{ expose_spells(\'["optimism"]\',
                                     "sector",

--- a/models/tokens/optimism/tokens_optimism_nft_curated_legacy.sql
+++ b/models/tokens/optimism/tokens_optimism_nft_curated_legacy.sql
@@ -1,4 +1,4 @@
-{{ config(alias = alias('nft_curated', legacy_model=True), tags=['static']) }}
+{{ config(alias = alias('nft_curated', legacy_model=True), tags=['static', 'legacy']) }}
 
 SELECT
   LOWER(contract_address) AS contract_address, name, '' as symbol

--- a/models/tokens/optimism/tokens_optimism_nft_legacy.sql
+++ b/models/tokens/optimism/tokens_optimism_nft_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft', legacy_model=True)
         , materialized = 'table'
         , post_hook='{{ expose_spells(\'["optimism"]\',

--- a/models/tokens/optimism/tokens_optimism_nft_standards_legacy.sql
+++ b/models/tokens/optimism/tokens_optimism_nft_standards_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft_standards', legacy_model=True),
         materialized='incremental',
         incremental_strategy = 'merge',

--- a/models/tokens/polygon/tokens_polygon_erc20_legacy.sql
+++ b/models/tokens/polygon/tokens_polygon_erc20_legacy.sql
@@ -1,4 +1,4 @@
-{{ config( alias = alias('erc20', legacy_model=True), tags=['static'])}}
+{{ config( alias = alias('erc20', legacy_model=True), tags=['static', 'legacy'])}}
 
 SELECT LOWER(contract_address) AS contract_address, symbol, decimals
   FROM (VALUES

--- a/models/tokens/polygon/tokens_polygon_nft_curated_legacy.sql
+++ b/models/tokens/polygon/tokens_polygon_nft_curated_legacy.sql
@@ -1,4 +1,4 @@
-{{ config(alias = alias('nft_curated', legacy_model=True), tags=['static']) }}
+{{ config(alias = alias('nft_curated', legacy_model=True), tags=['static', 'legacy']) }}
 
 SELECT
   LOWER(contract_address) AS contract_address, name, '' as symbol

--- a/models/tokens/polygon/tokens_polygon_nft_legacy.sql
+++ b/models/tokens/polygon/tokens_polygon_nft_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft', legacy_model=True)
         , materialized = 'table'
         , post_hook='{{ expose_spells(\'["polygon"]\',

--- a/models/tokens/polygon/tokens_polygon_nft_standards_legacy.sql
+++ b/models/tokens/polygon/tokens_polygon_nft_standards_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         alias = alias('nft_standards', legacy_model=True),
         materialized='incremental',
         incremental_strategy = 'merge',

--- a/models/tokens/tokens_erc20_legacy.sql
+++ b/models/tokens/tokens_erc20_legacy.sql
@@ -1,5 +1,5 @@
 {{ config( alias = alias('erc20', legacy_model=True),
-        tags=['static'],
+        tags=['static', 'legacy'],
         post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","bnb","ethereum","optimism", "gnosis", "fantom", "polygon"]\',
                                     "sector",
                                     "tokens",

--- a/models/tokens/tokens_nft_legacy.sql
+++ b/models/tokens/tokens_nft_legacy.sql
@@ -1,4 +1,5 @@
-{{ config( alias = alias('nft', legacy_model=True),
+{{ config(
+	tags=['legacy'], alias = alias('nft', legacy_model=True),
         post_hook='{{ expose_spells(\'["avalanche_c","bnb","ethereum","optimism", "gnosis", "fantom","arbitrum","polygon"]\',
                                     "sector",
                                     "tokens",

--- a/models/yearn/optimism/yearn_optimism_vaults_legacy.sql
+++ b/models/yearn/optimism/yearn_optimism_vaults_legacy.sql
@@ -1,4 +1,5 @@
 {{ config(
+	tags=['legacy'],
         schema = 'yearn'
         , alias = alias('vaults', legacy_model=True)
         , materialized = 'incremental'

--- a/scripts/add_legacy_tag.py
+++ b/scripts/add_legacy_tag.py
@@ -1,0 +1,27 @@
+"""
+reads all files with names ending with _legacy.sql in the models directory and adds tag "legacy" to the config
+"""
+
+import os
+import sys
+import yaml
+
+from pathlib import Path
+
+# walk models directory and open every file ending with _legacy.sql
+for root, dirs, files in os.walk("models"):
+    for file in files:
+        if file.endswith("_legacy.sql"):
+            path = os.path.join(root, file)
+            # open file and read the first line
+            with open(path, "r") as f:
+                content = f.read()
+            if "tags=['static']" in content:
+                content = content.replace("tags=['static']", "tags=['static', 'legacy']")
+            else:
+                content = content.replace("config(", "config(\n\ttags=['legacy'],\n\t")
+            # write the first line back to the file
+            with open(path, "w") as f:
+                f.write(content)
+
+                


### PR DESCRIPTION
Adds "legacy" tag to all `_legacy.sql` models to help differentiate with `dunesql` tagged models in internal orchestration.