### PR TITLE
add small CI checks

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -65,6 +65,21 @@ jobs:
       - name: dbt compile to create manifest to compare to
         run: "dbt compile $PROFILE $COMPILE_TAG"
 
+      - name: check schemas
+        run: |
+          test=$(dbt --quiet --no-print ls --resource-type model --select config.schema:no_schema --output path)
+          [[ -z "$test" ]] && { echo "Success: All models have a custom schema"; exit 0; } || { echo "Found models without custom schema:"; echo "$test"; exit 1; }
+
+      - name: check duplicate tags
+        run: |
+          test=$(dbt --quiet --no-print ls --resource-type model --select tag:legacy,tag:dunesql --output path)
+          [[ -z "$test" ]] && { echo "Success: No models with both tags"; exit 0; } || { echo "Found models with both dunesql and legacy tags:"; echo "$test"; exit 1; }
+
+      - name: check tags
+        run: |
+          test=$(dbt --quiet --no-print ls --resource-type model --exclude tag:legacy tag:dunesql --output path)
+          [[ -z "$test" ]] && { echo "Success: No models without a tag"; exit 0; } || { echo "Found models with no dunesql or legacy tag:"; echo "$test"; exit 1; }
+
       - name: dbt seed
         run: "dbt seed $PROFILE --select state:modified$TAG --exclude tag:prod_exclude --state ."
 


### PR DESCRIPTION
this PR adds checks in the CI to catch:
1. models with no custom schema
2. models with no `dunesql` or `legacy` tag
3. models with both `dunesql` or `legacy` tag