### PR TITLE
Partition by date or timestamp

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: "dbt seed $PROFILE --select state:modified$TAG --exclude tag:prod_exclude --state ."
 
       - name: dbt run initial model(s)
-        run: "dbt -x run $PROFILE --select state:modified$TAG --exclude tag:prod_exclude --defer --state ."
+        run: "dbt run $PROFILE --select state:modified$TAG --exclude tag:prod_exclude --defer --state ."
 
       - name: dbt test initial model(s)
         run: "dbt test $PROFILE --select state:new$TAG state:modified$TAG --exclude tag:prod_exclude --defer --state ."

--- a/models/some_model_partitioned_by_date.sql
+++ b/models/some_model_partitioned_by_date.sql
@@ -2,7 +2,8 @@
         schema = 'test_dont_merge',
         alias = alias('partitioned_by_date'),
         tags = ['dunesql'],
-        partition_by = ['partition_column']
+        partition_by = ['partition_column'],
+        materialized = 'table'
         )
 }}
 

--- a/models/some_model_partitioned_by_date.sql
+++ b/models/some_model_partitioned_by_date.sql
@@ -1,4 +1,5 @@
 {{ config(
+        schema = 'test_dont_merge',
         alias = alias('partitioned_by_time'),
         tags = ['dunesql'],
         partition_by = ['partition_column']

--- a/models/some_model_partitioned_by_date.sql
+++ b/models/some_model_partitioned_by_date.sql
@@ -1,0 +1,11 @@
+{{ config(
+        alias = alias('partitioned_by_time'),
+        tags = ['dunesql'],
+        partition_by = ['partition_column']
+        )
+}}
+
+select
+    cast(date_trunc('day', block_time) as date) as partition_column
+from {source('ethereum','transactions')}
+limit 20

--- a/models/some_model_partitioned_by_date.sql
+++ b/models/some_model_partitioned_by_date.sql
@@ -1,6 +1,6 @@
 {{ config(
         schema = 'test_dont_merge',
-        alias = alias('partitioned_by_time'),
+        alias = alias('partitioned_by_date'),
         tags = ['dunesql'],
         partition_by = ['partition_column']
         )

--- a/models/some_model_partitioned_by_date.sql
+++ b/models/some_model_partitioned_by_date.sql
@@ -8,5 +8,5 @@
 
 select
     cast(date_trunc('day', block_time) as date) as partition_column
-from {source('ethereum','transactions')}
+from {{ source('ethereum','transactions') }}
 limit 20

--- a/models/some_model_partitioned_by_timestamp.sql
+++ b/models/some_model_partitioned_by_timestamp.sql
@@ -1,0 +1,11 @@
+{{ config(
+        alias = alias('partitioned_by_time'),
+        tags = ['dunesql'],
+        partition_by = ['partition_column']
+        )
+}}
+
+select
+    date_trunc('day', block_time) as partition_column
+from {source('ethereum','transactions')}
+limit 20

--- a/models/some_model_partitioned_by_timestamp.sql
+++ b/models/some_model_partitioned_by_timestamp.sql
@@ -2,7 +2,8 @@
         schema = 'test_dont_merge',
         alias = alias('partitioned_by_time'),
         tags = ['dunesql'],
-        partition_by = ['partition_column']
+        partition_by = ['partition_column'],
+        materialized = 'table'
         )
 }}
 

--- a/models/some_model_partitioned_by_timestamp.sql
+++ b/models/some_model_partitioned_by_timestamp.sql
@@ -1,4 +1,5 @@
 {{ config(
+        schema = 'test_dont_merge',
         alias = alias('partitioned_by_time'),
         tags = ['dunesql'],
         partition_by = ['partition_column']

--- a/models/some_model_partitioned_by_timestamp.sql
+++ b/models/some_model_partitioned_by_timestamp.sql
@@ -8,5 +8,5 @@
 
 select
     date_trunc('day', block_time) as partition_column
-from {source('ethereum','transactions')}
+from {{ source('ethereum','transactions') }}
 limit 20


### PR DESCRIPTION
An example model showing the error when partitioning by `timestamp`.
And another example showing the resolution by casting to `date`.