### PR TITLE
[OP hotfix] Readd Token Symbol to Contracts

### DIFF
--- a/models/contracts/optimism/contracts_optimism_contract_mapping.sql
+++ b/models/contracts/optimism/contracts_optimism_contract_mapping.sql
@@ -470,6 +470,7 @@ SELECT
     , x -> concat(upper(substr(x,1,1)),substr(x,2,length(x))))),' ',''))
     AS contract_project
   --
+, token_symbol
 , contract_name, creator_address, created_time, contract_creator_if_factory
 , is_self_destruct, creation_tx_hash, created_block_number, created_tx_from
 , created_tx_to, created_tx_method_id, created_tx_index

--- a/models/contracts/optimism/contracts_optimism_contract_mapping_legacy.sql
+++ b/models/contracts/optimism/contracts_optimism_contract_mapping_legacy.sql
@@ -468,6 +468,7 @@ SELECT
 
   initcap(contract_project) AS contract_project
   --
+, token_symbol
 , contract_name, creator_address, created_time, contract_creator_if_factory
 , is_self_destruct, creation_tx_hash, created_block_number, created_tx_from
 , created_tx_to, created_tx_method_id, created_tx_index


### PR DESCRIPTION
Somehow accidentally deleted the token symbol column. Readding.