### PR TITLE
Revert "Removes trace address from legacy files aswell" on uniswap lineage

### DIFF
--- a/models/uniswap/arbitrum/uniswap_arbitrum_trades_legacy.sql
+++ b/models/uniswap/arbitrum/uniswap_arbitrum_trades_legacy.sql
@@ -35,6 +35,7 @@ FROM (
         tx_hash,
         tx_from,
         tx_to,
+        trace_address,
         evt_index
     FROM {{ ref(dex_model) }}
     {% if not loop.last %}

--- a/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades_legacy.sql
+++ b/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades_legacy.sql
@@ -7,7 +7,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index'],
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
     post_hook='{{ expose_spells(\'["arbitrum"]\',
                                 "project",
                                 "uniswap_v3",
@@ -31,6 +31,7 @@ WITH dexs AS
         ,CASE WHEN amount0 < '0' THEN f.token1 ELSE f.token0 END AS token_sold_address
         ,CAST(t.contract_address as string) as project_contract_address
         ,t.evt_tx_hash AS tx_hash
+        ,'' AS trace_address
         ,t.evt_index
     FROM
         {{ source('uniswap_v3_arbitrum', 'Pair_evt_Swap') }} t
@@ -70,6 +71,7 @@ SELECT DISTINCT
     ,dexs.tx_hash
     ,tx.from AS tx_from
     ,tx.to AS tx_to
+    ,dexs.trace_address
     ,dexs.evt_index
 FROM dexs
 INNER JOIN 

--- a/models/uniswap/bnb/uniswap_bnb_trades_legacy.sql
+++ b/models/uniswap/bnb/uniswap_bnb_trades_legacy.sql
@@ -35,6 +35,7 @@ FROM (
         tx_hash,
         tx_from,
         tx_to,
+        trace_address,
         evt_index
     FROM {{ dex_model }}
     {% if not loop.last %}

--- a/models/uniswap/bnb/uniswap_v3_bnb_trades_legacy.sql
+++ b/models/uniswap/bnb/uniswap_v3_bnb_trades_legacy.sql
@@ -7,7 +7,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index'],
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
     post_hook='{{ expose_spells(\'["bnb"]\',
                                 "project",
                                 "uniswap_v3",
@@ -31,6 +31,7 @@ WITH dexs AS
         ,CASE WHEN amount0 < '0' THEN f.token1 ELSE f.token0 END AS token_sold_address
         ,CAST(t.contract_address as string) as project_contract_address
         ,t.evt_tx_hash AS tx_hash
+        ,'' AS trace_address
         ,t.evt_index
     FROM
         {{ source('uniswap_v3_bnb', 'Pair_evt_Swap') }} t
@@ -70,6 +71,7 @@ SELECT
     ,dexs.tx_hash
     ,tx.from AS tx_from
     ,tx.to AS tx_to
+    ,dexs.trace_address
     ,dexs.evt_index
 FROM dexs
 INNER JOIN 

--- a/models/uniswap/ethereum/uniswap_ethereum_trades_legacy.sql
+++ b/models/uniswap/ethereum/uniswap_ethereum_trades_legacy.sql
@@ -37,6 +37,7 @@ FROM (
         tx_hash,
         tx_from,
         tx_to,
+        trace_address,
         evt_index
     FROM {{ ref(dex_model) }}
     {% if not loop.last %}

--- a/models/uniswap/ethereum/uniswap_v1_ethereum_trades_legacy.sql
+++ b/models/uniswap/ethereum/uniswap_v1_ethereum_trades_legacy.sql
@@ -7,7 +7,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index'],
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
     post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "project",
                                 "uniswap_v1",
@@ -32,6 +32,7 @@ WITH dexs AS
         ,'{{weth_address}}' AS token_sold_address --Using WETH for easier joining with USD price table
         ,t.contract_address AS project_contract_address
         ,t.evt_tx_hash AS tx_hash
+        ,'' AS trace_address
         ,t.evt_index
     FROM
         {{ source('uniswap_ethereum', 'Exchange_evt_TokenPurchase') }} t
@@ -55,6 +56,7 @@ WITH dexs AS
         ,f.token AS token_sold_address
         ,t.contract_address AS project_contract_address
         ,t.evt_tx_hash AS tx_hash
+        ,'' AS trace_address
         ,t.evt_index
     FROM
         {{ source('uniswap_ethereum', 'Exchange_evt_EthPurchase') }} t
@@ -93,6 +95,7 @@ SELECT
     ,dexs.tx_hash
     ,tx.from AS tx_from
     ,tx.to AS tx_to
+    ,dexs.trace_address
     ,dexs.evt_index
 FROM dexs
 INNER JOIN {{ source('ethereum', 'transactions') }} tx

--- a/models/uniswap/ethereum/uniswap_v2_ethereum_trades_legacy.sql
+++ b/models/uniswap/ethereum/uniswap_v2_ethereum_trades_legacy.sql
@@ -7,7 +7,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index'],
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
     post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "project",
                                 "uniswap_v2",
@@ -34,6 +34,7 @@ WITH dexs AS
         ,CASE WHEN amount0In = 0 OR amount1Out = 0 THEN f.token1 ELSE f.token0 END AS token_sold_address
         ,t.contract_address AS project_contract_address
         ,t.evt_tx_hash AS tx_hash
+        ,'' AS trace_address
         ,t.evt_index
     FROM
         {{ source('uniswap_v2_ethereum', 'Pair_evt_Swap') }} t
@@ -76,6 +77,7 @@ SELECT
     ,dexs.tx_hash
     ,tx.from AS tx_from
     ,tx.to AS tx_to
+    ,dexs.trace_address
     ,dexs.evt_index
 FROM dexs
 INNER JOIN {{ source('ethereum', 'transactions') }} tx

--- a/models/uniswap/ethereum/uniswap_v3_ethereum_trades_legacy.sql
+++ b/models/uniswap/ethereum/uniswap_v3_ethereum_trades_legacy.sql
@@ -7,7 +7,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index'],
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
     post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "project",
                                 "uniswap_v3",
@@ -32,6 +32,7 @@ WITH dexs AS
         ,CAST(t.contract_address as string) as project_contract_address
         ,f.fee -- field is unique to this model and will not affect downstream spells
         ,t.evt_tx_hash AS tx_hash
+        ,'' AS trace_address
         ,t.evt_index
     FROM
         {{ source('uniswap_v3_ethereum', 'Pair_evt_Swap') }} t
@@ -71,6 +72,7 @@ SELECT
     ,dexs.tx_hash
     ,tx.from AS tx_from
     ,tx.to AS tx_to
+    ,dexs.trace_address
     ,dexs.evt_index
 FROM dexs
 INNER JOIN {{ source('ethereum', 'transactions') }} tx

--- a/models/uniswap/optimism/uniswap_optimism_trades_legacy.sql
+++ b/models/uniswap/optimism/uniswap_optimism_trades_legacy.sql
@@ -35,6 +35,7 @@ FROM (
         tx_hash,
         tx_from,
         tx_to,
+        trace_address,
         evt_index
     FROM {{ ref(dex_model) }}
     {% if not loop.last %}

--- a/models/uniswap/optimism/uniswap_v3_optimism_trades_legacy.sql
+++ b/models/uniswap/optimism/uniswap_v3_optimism_trades_legacy.sql
@@ -7,7 +7,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index'],
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
     post_hook='{{ expose_spells(\'["optimism"]\',
                                 "project",
                                 "uniswap_v3",
@@ -32,6 +32,7 @@ WITH dexs AS
         ,LOWER(CASE WHEN amount0 < '0' THEN f.token1 ELSE f.token0 END) AS token_sold_address
         ,CAST(t.contract_address as string) as project_contract_address
         ,t.evt_tx_hash AS tx_hash
+        ,'' AS trace_address
         ,t.evt_index
     FROM
         {{ source('uniswap_v3_optimism', 'Pair_evt_Swap') }} t
@@ -70,6 +71,7 @@ SELECT
     ,dexs.tx_hash
     ,tx.from AS tx_from
     ,tx.to AS tx_to
+    ,dexs.trace_address
     ,dexs.evt_index
 FROM dexs
 INNER JOIN {{ source('optimism', 'transactions') }} tx

--- a/models/uniswap/polygon/uniswap_polygon_trades_legacy.sql
+++ b/models/uniswap/polygon/uniswap_polygon_trades_legacy.sql
@@ -35,6 +35,7 @@ FROM (
         tx_hash,
         tx_from,
         tx_to,
+        trace_address,
         evt_index
     FROM {{ ref(dex_model) }}
     {% if not loop.last %}

--- a/models/uniswap/polygon/uniswap_v3_polygon_trades_legacy.sql
+++ b/models/uniswap/polygon/uniswap_v3_polygon_trades_legacy.sql
@@ -7,7 +7,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index'],
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
     post_hook='{{ expose_spells(\'["polygon"]\',
                                 "project",
                                 "uniswap_v3",
@@ -31,6 +31,7 @@ WITH dexs AS
         ,CASE WHEN amount0 < '0' THEN f.token1 ELSE f.token0 END AS token_sold_address
         ,CAST(t.contract_address as string) as project_contract_address
         ,t.evt_tx_hash AS tx_hash
+        ,'' AS trace_address
         ,t.evt_index
     FROM
         {{ source('uniswap_v3_polygon', 'UniswapV3Pool_evt_Swap') }} t
@@ -70,6 +71,7 @@ SELECT
     ,dexs.tx_hash
     ,tx.from AS tx_from
     ,tx.to AS tx_to
+    ,dexs.trace_address
     ,dexs.evt_index
 FROM dexs
 INNER JOIN 

--- a/models/uniswap/uniswap_trades_legacy.sql
+++ b/models/uniswap/uniswap_trades_legacy.sql
@@ -43,6 +43,7 @@ FROM (
         tx_hash,
         tx_from,
         tx_to,
+        trace_address,
         evt_index
     FROM {{ dex_model }}
     {% if not loop.last %}


### PR DESCRIPTION
fyi @couralex6 -- i need to add this back on legacy files, as all other dexes still use it and causes downstream failures. we will need to just let the column live on spark for now, shouldn't hurt anything.