### PR TITLE
Tweak trino OPTIMIZE configuration

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -45,6 +45,10 @@ seeds:
 models:
   spellbook:
     +post-hook:
+      - sql: "{{ set_trino_session_property(is_materialized(model), 'writer_min_size', model.config.get('writer_min_size', '500MB')) }}"
+        transaction: true
+      - sql: "{{ set_trino_session_property(is_materialized(model), 'task_scale_writers_enabled', false) }}"
+        transaction: true
       - sql: "{{ optimize_spell(this, model.config.materialized) }}"
         transaction: true
       - sql: "{{ mark_as_spell(this, model.config.materialized) }}"

--- a/macros/set_trino_session_property.sql
+++ b/macros/set_trino_session_property.sql
@@ -1,0 +1,10 @@
+{% macro set_trino_session_property(enabled, property, value) %}
+{%- if enabled and target.type == 'trino'-%}
+  SET SESSION {{property}}={{value if value is boolean else "'%s'" % value}}
+{%- endif -%}
+{%- endmacro -%}
+
+
+{%- macro is_materialized(model) -%}
+  {% do return(model.config.materialized in ('table', 'incremental')) %}
+{%- endmacro -%}


### PR DESCRIPTION
This sets the configuration options
* writer_min_size to 500MB, default is 32MB.
* task_scale_writers_enabled to false, default is true. when we run OPTIMIZE on Trino in the post-hook.

This reduces the fragmentation we see when running OPTIMIZE with Trino.

We may need to tweak the value of writer_min_size globally, and per model, especially considering that the way we have been running optimize has created a lot of file fragmentation. The strategy is then to start out with a fairly low value of `writer_min_size`, and then gradually increase it. It's possible to tweak writer_min_size per model, by setting `writer_min_size` in the model configuration.

If we have trouble running this in DBT cloud, we can run this manually on Trino by:
1. Connecting via the CLI.
2. Executing the following commands
```
SET SESSION writer_min_size='500MB'; -- or a lower value as appropriate
SET SESSION task_scale_writers_enabled=false;
ALTER TABLE hive.<schema-name>.<table-name> EXECUTE OPTIMIZE;
ALTER TABLE hive.<schema-name>.<table-name> EXECUTE OPTIMIZE WHERE block_date > date '2023-01-01'; -- If the above command runs into trouble
```
The amount of compaction taking place can be verified by looking at the delta log:
```
aws s3 cp s3://<table-location>/_delta_log/00000000000000000014.json - | jq -r '.add.path + " " + ((.add.size/1024.0/1024.0)|tostring)' | sort | uniq
```
The location can be obtained by running `SHOW CREATE TABLE <table-name>` through the CLI. The number of files should decrease on repeated runs of OPTIMIZE. If the number of files does not decrease `writer_min_size` can be increased.

Please note that `writer_min_size` is being deprecated and replaced by writer-scaling-min-data-processed in more recent Trino versions. We should address this after the Trino next upgrade. Please see https://trino.io/docs/current/admin/properties-writer-scaling.html#writer-scaling-min-data-processed