### PR TITLE
Create spell for the latest usd price of every token in dex.trades

### DIFF
--- a/models/dex/dex_prices_latest.sql
+++ b/models/dex/dex_prices_latest.sql
@@ -35,7 +35,7 @@ FROM (
             token_bought_amount AS token_amount,
             token_bought_amount_raw AS token_amount_raw,
             amount_usd
-        FROM dex.trades
+        FROM {{ ref('dex_trades') }}
         {% if is_incremental() %}
         WHERE block_time >= now() - interval '7' day
         {% endif %}
@@ -46,7 +46,7 @@ FROM (
             token_sold_amount AS token_amount,
             token_sold_amount_raw AS token_amount_raw,
             amount_usd
-        FROM dex.trades
+        FROM {{ ref('dex_trades') }}
         {% if is_incremental() %}
         WHERE block_time >= now() - interval '7' day
         {% endif %}

--- a/models/dex/dex_prices_latest.sql
+++ b/models/dex/dex_prices_latest.sql
@@ -1,5 +1,6 @@
 {{ config(
         alias = alias('prices_latest'),
+        tags = ['dunesql'],
         partition_by = ['block_date'],
         materialized = 'incremental',
         file_format = 'delta',

--- a/models/dex/dex_prices_latest.sql
+++ b/models/dex/dex_prices_latest.sql
@@ -1,0 +1,55 @@
+{{ config(
+        alias = alias('prices_latest'),
+        partition_by = ['block_date'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['block_date', 'token_address'],
+        post_hook='{{ expose_spells(\'["ethereum", "bnb", "avalanche_c", "gnosis", "optimism", "arbitrum", "fantom", "polygon"]\',
+                                "sector",
+                                "dex",
+                                \'["bernat"]\') }}'
+        )
+}}
+
+SELECT
+    block_time,
+    token_address,
+    token_price_usd,
+    token_price_usd_raw
+FROM (
+    SELECT
+        block_time,
+        token_address,
+        amount_usd / token_amount AS token_price_usd,
+        amount_usd / cast(token_amount_raw as uint256) AS token_price_usd_raw,
+        amount_usd,
+        token_amount,
+        token_amount_raw,
+        ROW_NUMBER() OVER (PARTITION BY token_address ORDER BY block_time DESC) AS rn
+    FROM (
+        SELECT
+            block_time,
+            token_bought_address AS token_address,
+            token_bought_amount AS token_amount,
+            token_bought_amount_raw AS token_amount_raw,
+            amount_usd
+        FROM dex.trades
+        {% if is_incremental() %}
+        WHERE block_time >= now() - interval '7' day
+        {% endif %}
+        UNION ALL
+        SELECT
+            block_time,
+            token_sold_address AS token_address,
+            token_sold_amount AS token_amount,
+            token_sold_amount_raw AS token_amount_raw,
+            amount_usd
+        FROM dex.trades
+        {% if is_incremental() %}
+        WHERE block_time >= now() - interval '7' day
+        {% endif %}
+    ) subquery
+) most_recent
+WHERE rn = 1 
+AND amount_usd > 0

--- a/models/dex/dex_schema.yml
+++ b/models/dex/dex_schema.yml
@@ -448,7 +448,7 @@ models:
         description: "Backrun transaction fee"
 
 
-  - name: prices_latest
+  - name: dex_prices_latest
     meta:
       blockchain: ethereum, bnb, avalanche_c, gnosis, optimism, arbitrum, fantom
       sector: dex

--- a/models/dex/dex_schema.yml
+++ b/models/dex/dex_schema.yml
@@ -446,3 +446,26 @@ models:
       - &backrun_tx_fee
         name: backrun_tx_fee
         description: "Backrun transaction fee"
+
+
+  - name: prices_latest
+    meta:
+      blockchain: ethereum, bnb, avalanche_c, gnosis, optimism, arbitrum, fantom
+      sector: dex
+      contributors: bernat
+    config:
+      tags: ['erc20', 'prices', 'ethereum', 'polygon', 'arbitrum', 'optimism', 'gnosis', 'fantom', 'avalanche_c', 'bnb']
+    description: >
+      Latest token prices from dex.trades
+    columns:
+      - *block_time
+      - &token_address
+        name: token_address
+        description: "Token's contract address"
+      - &token_price_usd
+        name: token_price_usd
+        description: "USD price of the token"
+      - &token_price_usd_raw
+        name: token_price_usd_raw
+        description: "USD price of the token's raw amount"
+      

--- a/models/dex/dex_schema.yml
+++ b/models/dex/dex_schema.yml
@@ -468,4 +468,3 @@ models:
       - &token_price_usd_raw
         name: token_price_usd_raw
         description: "USD price of the token's raw amount"
-      


### PR DESCRIPTION
This spell aims to offer a solution to obtaining USD prices from tokens which don't get traded often enough to reliably show up in the Coinpaprika price feed.

Examples of tokens which sometimes don't have a price in Coinpaprika:
- vBNT: https://coinpaprika.com/coin/vbnt-bancor-governance-token/
- CRETH2: https://coinpaprika.com/coin/creth2-cream-eth-token/

For vBNT (`0x48fb253446873234f2febbf9bdeaa72d9d387f94`), we can find it through the query in this PR on Dune:
<img width="1037" alt="image" src="https://github.com/duneanalytics/spellbook/assets/565238/7f55cf8e-5dd9-4621-a9ce-b3168249fc68">

This spell includes the USD value calculation of raw token units for cases where we don't know the number of decimals of the token.