### PR TITLE
Migrate NFT Events

### DIFF
--- a/models/_sector/nft/trades/nft_events.sql
+++ b/models/_sector/nft/trades/nft_events.sql
@@ -1,6 +1,7 @@
 {{ config(
     schema = 'nft',
     alias = alias('events'),
+    tags= ['dunesql'],
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',


### PR DESCRIPTION
Migrate NFT Events table to remove blockers on transfers and downstream tables.