### PR TITLE
T-32005 Set join_distribution_type on materialized and partitioned models

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -75,11 +75,11 @@ jobs:
           test=$(dbt --quiet --no-print ls $PROFILE --resource-type model --select  state:modified,config.schema:no_schema --output path --state .)
           [[ -z "$test" ]] && { echo "Success: All models have a custom schema"; exit 0; } || { echo "Found models without custom schema:"; echo "$test"; exit 1; }
 
-      # - name: check tags
-      #   if: matrix.engine == 'dunesql'
-      #   run: |
-      #     test=$(dbt --quiet --no-print ls $PROFILE --resource-type model --select state:modified --exclude tag:legacy tag:dunesql --output path --state .)
-      #     [[ -z "$test" ]] && { echo "Success: No models without a tag"; exit 0; } || { echo "Found models with no dunesql or legacy tag:"; echo "$test"; exit 1; }
+      - name: check tags
+        if: matrix.engine == 'dunesql'
+        run: |
+          test=$(dbt --quiet --no-print ls $PROFILE --resource-type model --select state:modified --exclude tag:legacy tag:dunesql --output path --state .)
+          [[ -z "$test" ]] && { echo "Success: No models without a tag"; exit 0; } || { echo "Found models with no dunesql or legacy tag:"; echo "$test"; exit 1; }
 
       - name: dbt seed
         run: "dbt seed $PROFILE --select state:modified$TAG --exclude tag:prod_exclude --state ."

--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -75,11 +75,11 @@ jobs:
           test=$(dbt --quiet --no-print ls $PROFILE --resource-type model --select  state:modified,config.schema:no_schema --output path --state .)
           [[ -z "$test" ]] && { echo "Success: All models have a custom schema"; exit 0; } || { echo "Found models without custom schema:"; echo "$test"; exit 1; }
 
-      - name: check tags
-        if: matrix.engine == 'dunesql'
-        run: |
-          test=$(dbt --quiet --no-print ls $PROFILE --resource-type model --select state:modified --exclude tag:legacy tag:dunesql --output path --state .)
-          [[ -z "$test" ]] && { echo "Success: No models without a tag"; exit 0; } || { echo "Found models with no dunesql or legacy tag:"; echo "$test"; exit 1; }
+      # - name: check tags
+      #   if: matrix.engine == 'dunesql'
+      #   run: |
+      #     test=$(dbt --quiet --no-print ls $PROFILE --resource-type model --select state:modified --exclude tag:legacy tag:dunesql --output path --state .)
+      #     [[ -z "$test" ]] && { echo "Success: No models without a tag"; exit 0; } || { echo "Found models with no dunesql or legacy tag:"; echo "$test"; exit 1; }
 
       - name: dbt seed
         run: "dbt seed $PROFILE --select state:modified$TAG --exclude tag:prod_exclude --state ."

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -49,6 +49,9 @@ seeds:
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
 models:
   spellbook:
+    +pre-hook:
+      - sql: "{{ set_trino_session_property(is_materialized(model) and is_partitioned(model), 'join_distribution_type', 'PARTITIONED') }}"
+        transaction: true
     +post-hook:
       - sql: "{{ set_trino_session_property(is_materialized(model), 'writer_min_size', model.config.get('writer_min_size', '500MB')) }}"
         transaction: true

--- a/models/nft/chains/nft_polygon_transfers.sql
+++ b/models/nft/chains/nft_polygon_transfers.sql
@@ -3,10 +3,6 @@
         schema = 'nft_polygon',
         alias =alias('transfers'),
         partition_by=['block_month'],
-        pre_hook = {
-            'sql': '{{ set_trino_session_property(is_partitioned(model), \'join_distribution_type\', \'PARTITIONED\') }}',
-            'transaction': True
-        },
         materialized='incremental',
         file_format = 'delta',
         unique_key = ['unique_transfer_id']

--- a/models/orca_whirlpool/orca_whirlpool_trades.sql
+++ b/models/orca_whirlpool/orca_whirlpool_trades.sql
@@ -4,10 +4,6 @@
         schema = 'orca_whirlpool',
         alias = alias('trades'),
         partition_by = ['block_month'],
-        pre_hook = {
-            'sql': '{{ set_trino_session_property(is_partitioned(model), \'join_distribution_type\', \'PARTITIONED\') }}',
-            'transaction': True
-        },
         materialized = 'incremental',
         file_format = 'delta',
         incremental_strategy = 'merge',


### PR DESCRIPTION
Set `join_distribution_type` session property on every model that is both materialized and partitioned on entire project.

Tested by running 

`dbt -d run  --select +nft_polygon_transfers,tag:dunesql -f`

The log `On model.spellbook.nft_polygon_transfers: SET SESSION join_distribution_type='PARTITIONED'` only appears before executing `nft_polygon_transfers`, and not on every introspection query like it did before.