### PR TITLE
Add Chainlink OCR Model

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -821,8 +821,18 @@ models:
 
     chainlink:
       +schema: chainlink
+      arbitrum:
+        +schema: chainlink_arbitrum
+      avalanche_c:
+        +schema: chainlink_avalanche_c
       bnb:
         +schema: chainlink_bnb
+      ethereum:
+        +schema: chainlink_ethereum
+      fantom:
+        +schema: chainlink_fantom
+      gnosis:
+        +schema: chainlink_gnosis
       optimism:
         +schema: chainlink_optimism
       polygon:

--- a/models/chainlink/README.md
+++ b/models/chainlink/README.md
@@ -1,11 +1,110 @@
 # Price Feeds
 
-## Optimism 
+## About
 
-To add a new price feed, add a row to the `chainlink_optimism_price_feeds_oracle_addresses.sql` table with the following information:
-- **feed_name**: Sourced from [Chainlink Docs](https://docs.chain.link/docs/optimism-price-feeds/)
-- **decimals**: Sourced from [Chainlink Docs](https://docs.chain.link/docs/optimism-price-feeds/) (Note: This refers to the price feed decimals, not the underlying token's decimals)
-- **proxy_address**: Sourced from [Chainlink Docs](https://docs.chain.link/docs/optimism-price-feeds/)
-- **aggregator_address**: Sourced from opening the proxy address on Etherscan ([example](https://optimistic.etherscan.io/address/0x338ed6787f463394D24813b297401B9F05a8C9d1#readContract)), clicking 'Contract' -> 'Read Contract' and getting the address from the 'aggregator' field
+`chainlink.price_feeds*` models aggregate feed data from logs, add price answers, and truncate hourly and daily.
 
-*Open Research Area: Is there a way for us to deterministically build the oracle -> address -> feed name -> token links purely by reading on-chain events vs manually entering data from Chainlink docs?*
+## Maintenance
+
+The `oracle_addresses` and `oracle_token_mapping` models require periodic maintenance for adding or updating feeds. The process is currently manually but the LinkPool team is evaluating ways to automate this process. 
+
+## Flow of Tables
+
+- `price_feeds_oracle_addresses`: A meta file providing feed details based on the aggregator address.
+- `price_feeds_oracle_token_mapping`: A meta file providing feed details based on the underlying token address.
+- `price_feeds`: Selects logs filtered by an appropriate topic, joined by oracle_addresses. Adds a secondary join with token_mapping to get accurate price decimals. Truncated daily.
+- `price_feeds_hourly`: `price_feeds` truncated hourly.
+
+
+# OCR
+
+## About
+
+`chainlink.ocr*` models aggregate logs and transactions related to node operator gas usage, rewards, and requests and truncate daily. Ultimately, this is used to track financial performance, isolated by node operator and/or by network. Calculating OCR payments is inherently complex and requires intimate knowledge and understanding of the OCR payment system. This spellbook abstracts this complexity while still providing the ability for users to isolate at the lowest level (e.g., logs or transactions).
+
+## Maintenance
+
+The `ocr_operator_admin_meta` and `ocr_operator_node_meta` models require periodic maintenance for syncing with node details. The LinkPool team has built an automated internal tool that can be used to generate updated versions of these files periodically. Where possible, manual edits to these files should be avoided in favor of the automated generation script. Please mention @linkpool_ryan (gh: anon-r-7) or @linkpool_jon (gh: AnonJon) to request an update.
+
+## Flow of Tables
+
+### Node Operator Meta
+- `ocr_operator_node_meta`: Node operators spend gas from each node on a given network. This is a catalogue of all current and historical node_addresses used by node operators.
+- `ocr_operator_admin_meta`: Node operators receive payment to an `admin_address` per network for payment of all nodes run on that network. This is a catalogue of all current and historical admin_addresses used by node operators.
+- *Note: Node meta is ultimately used to calculate gas costs by operators, and admin meta rewards. Both meta tables define a source-controlled `operator_name` which can be used to join gas and rewards to calculate margin* (e.g., `margin = (rewards - gas) / rewards`).
+
+### Gas: Fulfilled Transactions
+- `ocr_gas_transmission_logs`: Selects logs from the OCR gas event.
+- `ocr_fulfilled_transactions`: Joins OCR logs with transactions and adds USD price to the closest minute.
+
+### Gas: Reverted Transactions
+- `ocr_reverted_transactions`: Isolates all failed transactions on nodes and adds USD price to the closest minute.
+
+### Rewards
+- `ocr_reward_transmission_logs`: Selects logs from the OCR reward event.
+- `ocr_reward_evt_transfer`: Joins `reward_transmission_logs` to ERC20 event transfer to obtain token value for each log and injects operator details.
+- `ocr_reward_evt_transfer_daily`: Truncates event transfers daily and calculates the sum of token value.
+
+### Daily Summary
+- `ocr_gas_daily`: Joins fulfilled and reverted transactions, truncates to daily calculating total gas in token and USD for each of fulfilled, reverted, and total, and injects operator details.
+- `ocr_request_daily`: Joins fulfilled and reverted transactions, truncates to daily calculating the number of transactions in each of fulfilled, reverted, and total, and injects operator details.
+- `ocr_reward_daily`: Distributes payments from `ocr_reward_evt_transfer_daily` over the number of days since the last payment (the closest methodology available to mirror intended payment schedules by OCR). Adds price USD per day and truncates results daily, including token and USD amounts with node operator details included.
+
+## Usage Example
+
+### Use Case A: Display OCR metrics for a given node operator on a monthly basis for the last N months
+
+```sql
+WITH 
+  reward AS (
+    SELECT
+      date_month,
+      operator_name,
+      SUM(token_amount) AS reward_token,
+      SUM(usd_amount) AS reward_usd
+    FROM chainlink_ocr_reward_daily
+    WHERE date_month >= CAST('2023-01-01' AS date)
+    AND operator_name = 'LinkPool'
+    GROUP BY 1, 2
+  ),
+  gas AS (
+    SELECT
+      date_month,
+      operator_name,
+      SUM(total_token_amount) AS gas_token,
+      SUM(total_usd_amount) AS gas_usd
+    FROM chainlink_ocr_gas_daily
+    GROUP BY 1, 2
+  ),
+  request AS (
+    SELECT
+      date_month,
+      operator_name,
+      SUM(fulfilled_requests) AS fulfilled_requests,
+      SUM(reverted_requests) AS reverted_requests,
+      SUM(total_requests) AS total_requests
+    FROM chainlink_ocr_request_daily
+    GROUP BY 1, 2
+  )
+SELECT 
+  reward.date_month,
+  reward.operator_name,
+  reward.reward_token,
+  reward.reward_usd,
+  gas.gas_token,
+  gas.gas_usd,
+  (reward.reward_usd - gas.gas_usd) AS margin_usd,
+  (reward.reward_usd - gas.gas_usd) / reward.reward_usd AS margin_rate,
+  request.fulfilled_requests,
+  request.reverted_requests,
+  request.total_requests,
+  CAST(request.reverted_requests AS REAL) / request.total_requests AS revert_rate
+FROM 
+  reward
+LEFT JOIN gas ON
+  gas.date_month = reward.date_month AND
+  gas.operator_name = reward.operator_name
+LEFT JOIN request ON
+  request.date_month = reward.date_month AND
+  request.operator_name = reward.operator_name
+ORDER BY 1, 2

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_fulfilled_transactions.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_fulfilled_transactions.sql
@@ -1,0 +1,65 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_fulfilled_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  arbitrum_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'ETH'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_fulfilled_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX(
+        (cast((gas_used) as double) / 1e18) * effective_gas_price
+      ) as token_amount,
+      MAX(arbitrum_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('arbitrum', 'transactions') }} tx
+      RIGHT JOIN {{ ref('chainlink_arbitrum_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
+      LEFT JOIN arbitrum_usd ON date_trunc('minute', tx.block_time) = arbitrum_usd.block_time
+    {% if is_incremental() %}
+      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'arbitrum' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_fulfilled_transactions

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_fulfilled_transactions_legacy.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_fulfilled_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_fulfilled_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_daily.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_daily.sql
@@ -1,0 +1,81 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_gas_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(SUM(fulfilled.token_amount), 0) as fulfilled_token_amount,
+      COALESCE(SUM(reverted.token_amount), 0) as reverted_token_amount,
+      COALESCE(SUM(fulfilled.token_amount * fulfilled.usd_amount), 0) as fulfilled_usd_amount,
+      COALESCE(SUM(reverted.token_amount * reverted.usd_amount), 0) as reverted_usd_amount
+    FROM
+      {{ ref('chainlink_arbitrum_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_arbitrum_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_gas_daily AS (
+    SELECT
+      'arbitrum' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_gas_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_token_amount,
+      fulfilled_usd_amount,
+      reverted_token_amount,
+      reverted_usd_amount,
+      fulfilled_token_amount + reverted_token_amount as total_token_amount,
+      fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
+    FROM ocr_gas_daily_meta
+    LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_token_amount,
+  fulfilled_usd_amount,
+  reverted_token_amount,
+  reverted_usd_amount,
+  total_token_amount,
+  total_usd_amount    
+FROM
+  ocr_gas_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_daily_legacy.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_transmission_logs.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'arbitrum' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('arbitrum', 'logs') }} logs
+WHERE
+  topic0 = 0xf6a97944f31ea060dfde0566e4167c1a1082551e64b60ecb14d599a9d023d451

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_transmission_logs_legacy.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_operator_admin_meta.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_operator_admin_meta.sql
@@ -1,0 +1,47 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_admin_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set chainlayer = 'Chainlayer' %}
+{% set dextrac = 'DexTrac' %}
+{% set fiews = 'Fiews' %}
+{% set frameworkventures = 'Framework Ventures' %}
+{% set inotel = 'Inotel' %}
+{% set linkforest = 'LinkForest' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set matrixedlink = 'Matrixed.Link' %}
+{% set mycelium = 'Mycelium' %}
+{% set northwestnodes = 'NorthWest Nodes' %}
+{% set simplyvc = 'Simply VC' %}
+{% set snzpool = 'SNZPool' %}
+{% set validationcloud = 'Validation Cloud' %}
+{% set vulcan = 'Vulcan Link' %}
+
+SELECT admin_address, operator_name FROM (VALUES
+  (0x4a3dF8cAe46765d33c2551ff5438a5C5FC44347c, '{{chainlayer}}'),
+  (0x9efa0A617C0552F1558c95993aA8b8A68b3e709C, '{{dextrac}}'),
+  (0x15918ff7f6C44592C81d999B442956B07D26CC44, '{{fiews}}'),
+  (0x6eF38c3d1D85B710A9e160aD41B912Cb8CAc2589, '{{frameworkventures}}'),
+  (0xB8C6E43f37E04A2411562a13c1C48B3ad5975cf4, '{{inotel}}'),
+  (0x4564A9c6061f6f1F2Eadb954B1b3C241D2DC984e, '{{linkforest}}'),
+  (0x797de2909991C66C66D8e730C8385bbab8D18eA6, '{{linkpool}}'),
+  (0x14f94049397C3F1807c45B6f854Cb5F36bC4393B, '{{linkriver}}'),
+  (0x4dc81f63CB356c1420D4620414f366794072A3a8, '{{matrixedlink}}'),
+  (0x3FB4600736d306Ee2A89EdF0356D4272fb095768, '{{mycelium}}'),
+  (0x0921E157b690c4F89F7C2a210cFd8bF3964F6776, '{{northwestnodes}}'),
+  (0x4fBefaf1BFf0130945C61603B97D38DD6e21f5Cf, '{{simplyvc}}'),
+  (0x0446B8d5d3F3fA74eDbd32154b023FD8da172f05, '{{snzpool}}'),
+  (0x9cCbFD17FA284f36c2ff503546160B256d1CD3D1, '{{snzpool}}'),
+  (0x183A96629fF566e7AA8AfA38980Cd037EB40A59A, '{{validationcloud}}'),
+  (0x4E28977d71f148ae2c523e8Aa4b6F3071d81Add1, '{{vulcan}}'),
+  (0x7D0f8dd25135047967bA6C50309b567957dd52c3, '{{vulcan}}')
+) AS tmp_node_meta(admin_address, operator_name)

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_operator_admin_meta_legacy.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_operator_admin_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_admin_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_operator_node_meta.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_operator_node_meta.sql
@@ -1,0 +1,46 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_node_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set chainlayer = 'Chainlayer' %}
+{% set dextrac = 'DexTrac' %}
+{% set fiews = 'Fiews' %}
+{% set frameworkventures = 'Framework Ventures' %}
+{% set inotel = 'Inotel' %}
+{% set linkforest = 'LinkForest' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set matrixedlink = 'Matrixed.Link' %}
+{% set mycelium = 'Mycelium' %}
+{% set northwestnodes = 'NorthWest Nodes' %}
+{% set simplyvc = 'Simply VC' %}
+{% set snzpool = 'SNZPool' %}
+{% set validationcloud = 'Validation Cloud' %}
+{% set vulcan = 'Vulcan Link' %}
+
+SELECT node_address, operator_name FROM (VALUES
+  (0x1a6d5C4396EaF8ED93Ec77bf1aF9B43ffeD7814d, '{{chainlayer}}'),
+  (0x5616CAABa92cdf656E7d1bA36Fe1bd878E51c174, '{{dextrac}}'),
+  (0xC7310123914f624Da9C376f8eC590055e62733c1, '{{dextrac}}'),
+  (0xA82d4EdB72dD3D167D00058F2404658F4E9A010A, '{{fiews}}'),
+  (0xe870848FEb433FBE423b08791c44D8bf31B2D4Dc, '{{frameworkventures}}'),
+  (0xC76b9d4B13717f959ea45Ec6e3Db9C3F9304d7d5, '{{inotel}}'),
+  (0x51c5C8e2267582562f6cF08cF641A1A174946A50, '{{linkforest}}'),
+  (0x27C56A6d40F20A33349F0822201fbc10d455Be66, '{{linkpool}}'),
+  (0xb6d51122E3473a2A463f2F8752660570237C30a4, '{{linkriver}}'),
+  (0x64AE501217d502Be8a1d9D4a4f669fbAC6a0c062, '{{matrixedlink}}'),
+  (0xbD620be125abf8b569B9A3CC132aad0bcF1Ff0E7, '{{mycelium}}'),
+  (0xEB1a8834cF6CA6d721E5CB1A8Ad472BBF62eEf8E, '{{northwestnodes}}'),
+  (0xD596389948247b582317a1EfA76cD7741A134191, '{{simplyvc}}'),
+  (0x01f4e56D5ee46e84Edf8595ca7A7B62a3306De76, '{{snzpool}}'),
+  (0xB0576808343819a21B9171B018b87da204967B6F, '{{validationcloud}}'),
+  (0x3cae103213dB7673072E138A622bD17b20bc7ad4, '{{vulcan}}')
+) AS tmp_node_meta(node_address, operator_name)

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_operator_node_meta_legacy.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_operator_node_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_node_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_request_daily.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_request_daily.sql
@@ -1,0 +1,74 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_request_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_request_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(COUNT(fulfilled.token_amount), 0) as fulfilled_requests,
+      COALESCE(COUNT(reverted.token_amount), 0) as reverted_requests,
+      COALESCE(COUNT(fulfilled.token_amount), 0) + COALESCE(COUNT(reverted.token_amount), 0) as total_requests
+    FROM
+      {{ ref('chainlink_arbitrum_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_arbitrum_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_request_daily AS (
+    SELECT
+      'arbitrum' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_request_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_requests,
+      reverted_requests,
+      total_requests
+    FROM ocr_request_daily_meta
+    LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_requests,
+  reverted_requests,
+  total_requests
+FROM
+  ocr_request_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_request_daily_legacy.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_request_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_request_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reverted_transactions.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reverted_transactions.sql
@@ -1,0 +1,66 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reverted_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  arbitrum_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'ETH'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_reverted_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX(
+        (cast((gas_used) as double) / 1e18) * effective_gas_price
+      ) as token_amount,
+      MAX(arbitrum_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('arbitrum', 'transactions') }} tx
+      LEFT JOIN arbitrum_usd ON date_trunc('minute', tx.block_time) = arbitrum_usd.block_time
+    WHERE
+      success = false
+      {% if is_incremental() %}
+        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'arbitrum' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_reverted_transactions

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reverted_transactions_legacy.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reverted_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reverted_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_daily.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_daily.sql
@@ -1,0 +1,111 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_daily'),
+    partition_by = ['date_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  admin_address_meta as (
+    SELECT DISTINCT
+      admin_address
+    FROM
+      {{ref('chainlink_arbitrum_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+  ),
+  link_usd_daily AS (
+    SELECT
+      cast(date_trunc('day', price.minute) as date) as "date_start",
+      MAX(price.price) as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      price.symbol = 'LINK'
+      {% if is_incremental() %}
+        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      1
+    ORDER BY
+      1
+  ),
+  link_usd_daily_expanded_by_admin_address AS (
+    SELECT
+      date_start,
+      usd_amount,
+      admin_address
+    FROM
+      link_usd_daily
+    CROSS JOIN
+      admin_address_meta
+    ORDER BY
+      date_start,
+      admin_address
+  ),
+  payment_meta AS (
+    SELECT
+      date_start,
+      link_usd_daily_expanded_by_admin_address.admin_address as admin_address,
+      usd_amount,
+      (
+        SELECT
+          MAX(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_arbitrum_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start <= link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as prev_payment_date,
+      (
+        SELECT
+          MIN(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_arbitrum_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start > link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as next_payment_date
+    FROM
+      link_usd_daily_expanded_by_admin_address
+    ORDER BY
+      1, 2
+  ),
+  ocr_reward_daily AS (
+    SELECT 
+      payment_meta.date_start,
+      cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
+      payment_meta.admin_address,
+      ocr_operator_admin_meta.operator_name,      
+      COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
+      (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
+    FROM 
+      payment_meta
+    LEFT JOIN 
+      {{ref('chainlink_arbitrum_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
+        payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
+        payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    ORDER BY date_start
+  )
+SELECT
+  'arbitrum' as blockchain,
+  date_start,
+  date_month,
+  admin_address,
+  operator_name,
+  token_amount,
+  usd_amount
+FROM 
+  ocr_reward_daily
+ORDER BY
+  2, 4

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_daily_legacy.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'arbitrum' as blockchain,
+  to as admin_address,
+  MAX(operator_name) as operator_name,
+  MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+  MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+FROM
+  {{ source('erc20_arbitrum', 'evt_Transfer') }} reward_evt_transfer
+  RIGHT JOIN {{ ref('chainlink_arbitrum_ocr_reward_transmission_logs') }} ocr_reward_transmission_logs ON ocr_reward_transmission_logs.contract_address = reward_evt_transfer."from"
+  LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+WHERE
+  reward_evt_transfer."from" IN (ocr_reward_transmission_logs.contract_address)
+GROUP BY
+  evt_tx_hash,
+  evt_index,
+  to

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer_daily.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer_daily.sql
@@ -1,0 +1,35 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+SELECT
+  'arbitrum' as blockchain,
+  cast(date_trunc('day', evt_block_time) AS date) AS date_start,
+  MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
+  ocr_reward_evt_transfer.admin_address as admin_address,
+  MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
+  SUM(token_value) as token_amount
+FROM
+  {{ref('chainlink_arbitrum_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
+{% if is_incremental() %}
+  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+{% endif %}      
+GROUP BY
+  2, 4
+ORDER BY
+  2, 4

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer_daily_legacy.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer_legacy.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_transmission_logs.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'arbitrum' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('arbitrum', 'logs') }} logs
+WHERE
+  topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_transmission_logs_legacy.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/arbitrum/chainlink_arbitrum_schema.yml
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_schema.yml
@@ -1,0 +1,256 @@
+version: 2
+
+models:
+  - name: chainlink_arbitrum_ocr_gas_transmission_logs
+    meta:
+      blockchain: arbitrum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'gas', 'transmission', 'logs', 'arbitrum']
+    description: >
+      Chainlink OCR Gas Transmission Logs
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - block_number
+              - tx_hash
+              - tx_index
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain"
+      - &block_hash
+        name: block_hash
+        description: "Block Hash"
+      - &contract_address
+        name: contract_address
+        description: "Contract Address"
+      - &data
+        name: data
+        description: "Data"
+      - &topic0
+        name: topic0
+        description: "Topic 0"
+      - &topic1
+        name: topic1
+        description: "Topic 1"
+      - &topic2
+        name: topic2
+        description: "Topic 2"
+      - &topic3
+        name: topic3
+        description: "Topic 3"
+      - &tx_hash
+        name: tx_hash
+        description: "Transaction Hash"
+      - &block_number
+        name: block_number
+        description: "Block Number"
+      - &block_time
+        name: block_time
+        description: "Block Time"
+      - &index
+        name: index
+        description: "Index"
+      - &tx_index
+        name: tx_index
+        description: "Transaction Index"
+
+  - name: chainlink_arbitrum_ocr_fulfilled_transactions
+    meta:
+      blockchain: arbitrum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'arbitrum']
+    description: >
+      Chainlink OCR Fulfilled Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - &date_month
+        name: date_month
+        description: "Date truncated by month"
+      - &node_address
+        name: node_address
+        description: "Node Address"
+      - &token_amount
+        name: token_amount
+        description: "Token Amount"
+      - &usd_amount
+        name: usd_amount
+        description: "USD Amount"
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_arbitrum_ocr_reverted_transactions
+    meta:
+      blockchain: arbitrum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'arbitrum']
+    description: >
+      Chainlink OCR Reverted Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - *date_month
+      - *node_address
+      - *token_amount
+      - *usd_amount
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_arbitrum_ocr_gas_daily
+    meta:
+      blockchain: arbitrum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'gas', 'daily', 'arbitrum']
+    description: >
+        Chainlink OCR Gas Daily
+    columns:
+      - *blockchain
+      - &date_start
+        name: date_start
+        description: "Date Start"
+      - *date_month
+      - *node_address
+      - &operator_name
+        name: operator_name
+        description: "Operator Name"
+      - &fulfilled_token_amount
+        name: fulfilled_token_amount
+        description: "Fulfilled Token Amount"
+      - &fulfilled_usd_amount
+        name: fulfilled_usd_amount
+        description: "Fulfilled USD Amount"
+      - &reverted_token_amount
+        name: reverted_token_amount
+        description: "Reverted Token Amount"
+      - &reverted_usd_amount
+        name: reverted_usd_amount
+        description: "Reverted USD Amount"
+      - &total_token_amount
+        name: total_token_amount
+        description: "Total Token Amount"
+      - &total_usd_amount
+        name: total_usd_amount
+        description: "Total USD Amount"
+
+  - name: chainlink_arbitrum_ocr_request_daily
+    meta:
+      blockchain: arbitrum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'request', 'daily', 'arbitrum']
+    description: >
+        Chainlink OCR Request Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *node_address
+      - *operator_name
+      - &fulfilled_requests
+        name: fulfilled_requests
+        description: "Fulfilled Requests"
+      - &reverted_requests
+        name: reverted_requests
+        description: "Reverted Requests"
+      - &total_requests
+        name: total_requests
+        description: "Total Requests"
+
+  - name: chainlink_arbitrum_ocr_reward_transmission_logs
+    meta:
+      blockchain: arbitrum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'transmission', 'logs', 'arbitrum']
+    description: >
+      Chainlink OCR Reward Transmission Logs
+    columns:
+      - *blockchain
+      - *block_hash
+      - *contract_address
+      - *data
+      - *topic0
+      - *topic1
+      - *topic2
+      - *topic3
+      - *tx_hash
+      - *block_number
+      - *block_time
+      - *index
+      - *tx_index
+
+  - name: chainlink_arbitrum_ocr_reward_evt_transfer
+    meta:
+      blockchain: arbitrum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'arbitrum']
+    description: >
+      Chainlink OCR Reward Event Transfers
+    columns:
+      - *blockchain
+      - &evt_block_time
+        name: evt_block_time
+        description: "Event Block Time"
+      - &admin_address
+        name: admin_address
+        description: "Admin Address"
+      - *operator_name
+      - &token_value
+        name: token_value
+        description: "Token Value"
+
+  - name: chainlink_arbitrum_ocr_reward_evt_transfer_daily
+    meta:
+      blockchain: arbitrum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'daily', 'arbitrum']
+    description: >
+      Chainlink OCR Reward Event Transfers Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address      
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_value
+
+  - name: chainlink_arbitrum_ocr_reward_daily
+    meta:
+      blockchain: arbitrum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'reward', 'daily', 'arbitrum']
+    description: >
+        Chainlink OCR Reward Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_amount
+      - *usd_amount
+

--- a/models/chainlink/arbitrum/chainlink_arbitrum_schema.yml
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_schema.yml
@@ -67,6 +67,13 @@ models:
       tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'arbitrum']
     description: >
       Chainlink OCR Fulfilled Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -94,6 +101,13 @@ models:
       tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'arbitrum']
     description: >
       Chainlink OCR Reverted Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -113,6 +127,12 @@ models:
       tags: ['chainlink','ocr', 'gas', 'daily', 'arbitrum']
     description: >
         Chainlink OCR Gas Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - &date_start
@@ -151,6 +171,12 @@ models:
       tags: ['chainlink','ocr', 'request', 'daily', 'arbitrum']
     description: >
         Chainlink OCR Request Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - *date_start
@@ -227,7 +253,7 @@ models:
           combination_of_columns:
               - blockchain
               - date_start
-              - admin_address      
+              - admin_address
     columns:
       - *blockchain
       - *date_start
@@ -245,6 +271,12 @@ models:
       tags: ['chainlink','ocr', 'reward', 'daily', 'arbitrum']
     description: >
         Chainlink OCR Reward Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address
     columns:
       - *blockchain
       - *date_start

--- a/models/chainlink/arbitrum/chainlink_arbitrum_sources.yml
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_sources.yml
@@ -1,0 +1,34 @@
+version: 2
+
+sources:
+  - name: erc20_arbitrum
+    description: "Transfers events for ERC20 tokens on arbitrum."
+    tables:
+      - name: evt_Transfer
+        loaded_at_field: evt_block_time
+        description: "Transfers events for ERC20 tokens on arbitrum."
+        columns:
+          - &contract_address
+            name: contract_address
+            description: "ERC20 token contract address"
+          - &evt_block_number
+            name: evt_block_number
+            description: "Block event number"
+          - &evt_block_time
+            name: evt_block_time
+            description: "Timestamp for block event time in UTC"
+          - &evt_index
+            name: evt_index
+            description: "Event index"
+          - &evt_tx_hash
+            name: evt_tx_hash
+            description: "Event transaction hash"
+          - &from
+            name: from
+            description: "Wallet address for ERC20 token transfer from"
+          - &to
+            name: to
+            description: "Wallet address for ERC20 token transfer to"
+          - &value
+            name: value
+            description: "Raw amount of ERC20 token"

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_fulfilled_transactions.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_fulfilled_transactions.sql
@@ -1,0 +1,63 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_fulfilled_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  avalanche_c_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'AVAX'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_fulfilled_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX((cast((gas_used) as double) / 1e18) * gas_price) as token_amount,
+      MAX(avalanche_c_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('avalanche_c', 'transactions') }} tx
+      RIGHT JOIN {{ ref('chainlink_avalanche_c_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
+      LEFT JOIN avalanche_c_usd ON date_trunc('minute', tx.block_time) = avalanche_c_usd.block_time
+    {% if is_incremental() %}
+      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'avalanche_c' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_fulfilled_transactions

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_fulfilled_transactions_legacy.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_fulfilled_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_fulfilled_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_daily.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_daily.sql
@@ -1,0 +1,81 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_gas_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(SUM(fulfilled.token_amount), 0) as fulfilled_token_amount,
+      COALESCE(SUM(reverted.token_amount), 0) as reverted_token_amount,
+      COALESCE(SUM(fulfilled.token_amount * fulfilled.usd_amount), 0) as fulfilled_usd_amount,
+      COALESCE(SUM(reverted.token_amount * reverted.usd_amount), 0) as reverted_usd_amount
+    FROM
+      {{ ref('chainlink_avalanche_c_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_avalanche_c_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_gas_daily AS (
+    SELECT
+      'avalanche_c' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_gas_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_token_amount,
+      fulfilled_usd_amount,
+      reverted_token_amount,
+      reverted_usd_amount,
+      fulfilled_token_amount + reverted_token_amount as total_token_amount,
+      fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
+    FROM ocr_gas_daily_meta
+    LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_token_amount,
+  fulfilled_usd_amount,
+  reverted_token_amount,
+  reverted_usd_amount,
+  total_token_amount,
+  total_usd_amount    
+FROM
+  ocr_gas_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_daily_legacy.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_transmission_logs.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'avalanche_c' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('avalanche_c', 'logs') }} logs
+WHERE
+  topic0 = 0xf6a97944f31ea060dfde0566e4167c1a1082551e64b60ecb14d599a9d023d451

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_transmission_logs_legacy.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_operator_admin_meta.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_operator_admin_meta.sql
@@ -1,0 +1,48 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_admin_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set alphachain = 'Alpha Chain' %}
+{% set blockdaemon = 'Blockdaemon' %}
+{% set blocksizecapital = 'Blocksize Capital' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set dextrac = 'DexTrac' %}
+{% set fiews = 'Fiews' %}
+{% set inotel = 'Inotel' %}
+{% set lexisnexis = 'LexisNexis' %}
+{% set linkforest = 'LinkForest' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set northwestnodes = 'NorthWest Nodes' %}
+{% set p2porg = 'P2P.org' %}
+{% set simplyvc = 'Simply VC' %}
+{% set validationcloud = 'Validation Cloud' %}
+
+SELECT admin_address, operator_name FROM (VALUES
+  (0xD9459cc85E78e0336aDb349EAbF257Dbaf9d5a2B, '{{a01node}}'),
+  (0xa5D0084A766203b463b3164DFc49D91509C12daB, '{{alphachain}}'),
+  (0x3615Fa045f00ae0eD60Dc0141911757c2AdC5E03, '{{blockdaemon}}'),
+  (0x7CC60c9C24E9A290Db55b1017AF477E5c87a7550, '{{blocksizecapital}}'),
+  (0x4a3dF8cAe46765d33c2551ff5438a5C5FC44347c, '{{chainlayer}}'),
+  (0x9efa0A617C0552F1558c95993aA8b8A68b3e709C, '{{dextrac}}'),
+  (0x15918ff7f6C44592C81d999B442956B07D26CC44, '{{fiews}}'),
+  (0xB8C6E43f37E04A2411562a13c1C48B3ad5975cf4, '{{inotel}}'),
+  (0xD290AA3098882ccAdEeec86F6857d3CFA29BCf3b, '{{lexisnexis}}'),
+  (0x098a4C7ceCbfb8534e5Ab3f9c8F6C87845Fc5109, '{{lexisnexis}}'),
+  (0x4564A9c6061f6f1F2Eadb954B1b3C241D2DC984e, '{{linkforest}}'),
+  (0x797de2909991C66C66D8e730C8385bbab8D18eA6, '{{linkpool}}'),
+  (0x14f94049397C3F1807c45B6f854Cb5F36bC4393B, '{{linkriver}}'),
+  (0x0921E157b690c4F89F7C2a210cFd8bF3964F6776, '{{northwestnodes}}'),
+  (0xCDa423ee5A7A886eF113b181469581306fC8B607, '{{p2porg}}'),
+  (0x4fBefaf1BFf0130945C61603B97D38DD6e21f5Cf, '{{simplyvc}}'),
+  (0x183A96629fF566e7AA8AfA38980Cd037EB40A59A, '{{validationcloud}}')
+) AS tmp_node_meta(admin_address, operator_name)

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_operator_admin_meta_legacy.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_operator_admin_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_admin_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_operator_node_meta.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_operator_node_meta.sql
@@ -1,0 +1,47 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_node_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set alphachain = 'Alpha Chain' %}
+{% set blockdaemon = 'Blockdaemon' %}
+{% set blocksizecapital = 'Blocksize Capital' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set dextrac = 'DexTrac' %}
+{% set fiews = 'Fiews' %}
+{% set inotel = 'Inotel' %}
+{% set lexisnexis = 'LexisNexis' %}
+{% set linkforest = 'LinkForest' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set northwestnodes = 'NorthWest Nodes' %}
+{% set p2porg = 'P2P.org' %}
+{% set simplyvc = 'Simply VC' %}
+{% set validationcloud = 'Validation Cloud' %}
+
+SELECT node_address, operator_name FROM (VALUES
+  (0x7666D648f6D0909DbCb010218d713c5CE576149A, '{{a01node}}'),
+  (0x89da56e409dDef3C52BdCfBeFC9b595870880bAA, '{{alphachain}}'),
+  (0x5b17Db9668BB9CbFe87F416b4da1132b5193959D, '{{blockdaemon}}'),
+  (0xe5b37dc608C73852F9c0f56E30f8d74D89b51C55, '{{blocksizecapital}}'),
+  (0xd877d01d972D28dBd28ed138c63173D07A024E5C, '{{chainlayer}}'),
+  (0x8772Ecc810a04627d58eBC1Db2bBc27bF90F6bb2, '{{dextrac}}'),
+  (0x0499BEA33347cb62D79A9C0b1EDA01d8d329894c, '{{fiews}}'),
+  (0x8EF62f0B88286AAF46142cacBB0058bf1F74607d, '{{inotel}}'),
+  (0xD59D1073d5A1B77d4Cf36C6D4a287DDF7F67F348, '{{lexisnexis}}'),
+  (0x574A2f48049D962cF2e66d4381823Af93817Cd81, '{{linkforest}}'),
+  (0x69Dd5981be8F53828b9A305666F91133dfc0FdD2, '{{linkpool}}'),
+  (0x00B1943fFB046aC69E9618361f1eAd3ccE112fEa, '{{linkriver}}'),
+  (0xa6cd0E363740069e4570a0dA03e7258108B399Ab, '{{northwestnodes}}'),
+  (0xfDA44C0BaE0ACFa9eEAaB91d6C103eDaE6001876, '{{p2porg}}'),
+  (0xFb821dfde8F43ed6fbf970153585038b0b3B49CC, '{{simplyvc}}'),
+  (0xA317eBD3dA5C29b6EA01742bbEa6BaCCEB10A297, '{{validationcloud}}')
+) AS tmp_node_meta(node_address, operator_name)

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_operator_node_meta_legacy.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_operator_node_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_node_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_request_daily.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_request_daily.sql
@@ -1,0 +1,74 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_request_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_request_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(COUNT(fulfilled.token_amount), 0) as fulfilled_requests,
+      COALESCE(COUNT(reverted.token_amount), 0) as reverted_requests,
+      COALESCE(COUNT(fulfilled.token_amount), 0) + COALESCE(COUNT(reverted.token_amount), 0) as total_requests
+    FROM
+      {{ ref('chainlink_avalanche_c_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_avalanche_c_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_request_daily AS (
+    SELECT
+      'avalanche_c' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_request_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_requests,
+      reverted_requests,
+      total_requests
+    FROM ocr_request_daily_meta
+    LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_requests,
+  reverted_requests,
+  total_requests
+FROM
+  ocr_request_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_request_daily_legacy.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_request_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_request_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reverted_transactions.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reverted_transactions.sql
@@ -1,0 +1,64 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reverted_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  avalanche_c_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'AVAX'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_reverted_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX((cast((gas_used) as double) / 1e18) * gas_price) as token_amount,
+      MAX(avalanche_c_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('avalanche_c', 'transactions') }} tx
+      LEFT JOIN avalanche_c_usd ON date_trunc('minute', tx.block_time) = avalanche_c_usd.block_time
+    WHERE
+      success = false
+      {% if is_incremental() %}
+        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'avalanche_c' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_reverted_transactions

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reverted_transactions_legacy.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reverted_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reverted_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_daily.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_daily.sql
@@ -1,0 +1,111 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_daily'),
+    partition_by = ['date_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  admin_address_meta as (
+    SELECT DISTINCT
+      admin_address
+    FROM
+      {{ref('chainlink_avalanche_c_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+  ),
+  link_usd_daily AS (
+    SELECT
+      cast(date_trunc('day', price.minute) as date) as "date_start",
+      MAX(price.price) as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      price.symbol = 'LINK'
+      {% if is_incremental() %}
+        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      1
+    ORDER BY
+      1
+  ),
+  link_usd_daily_expanded_by_admin_address AS (
+    SELECT
+      date_start,
+      usd_amount,
+      admin_address
+    FROM
+      link_usd_daily
+    CROSS JOIN
+      admin_address_meta
+    ORDER BY
+      date_start,
+      admin_address
+  ),
+  payment_meta AS (
+    SELECT
+      date_start,
+      link_usd_daily_expanded_by_admin_address.admin_address as admin_address,
+      usd_amount,
+      (
+        SELECT
+          MAX(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_avalanche_c_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start <= link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as prev_payment_date,
+      (
+        SELECT
+          MIN(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_avalanche_c_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start > link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as next_payment_date
+    FROM
+      link_usd_daily_expanded_by_admin_address
+    ORDER BY
+      1, 2
+  ),
+  ocr_reward_daily AS (
+    SELECT 
+      payment_meta.date_start,
+      cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
+      payment_meta.admin_address,
+      ocr_operator_admin_meta.operator_name,      
+      COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
+      (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
+    FROM 
+      payment_meta
+    LEFT JOIN 
+      {{ref('chainlink_avalanche_c_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
+        payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
+        payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    ORDER BY date_start
+  )
+SELECT
+  'avalanche_c' as blockchain,
+  date_start,
+  date_month,
+  admin_address,
+  operator_name,
+  token_amount,
+  usd_amount
+FROM 
+  ocr_reward_daily
+ORDER BY
+  2, 4

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_daily_legacy.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'avalanche_c' as blockchain,
+  to as admin_address,
+  MAX(operator_name) as operator_name,
+  MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+  MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+FROM
+  {{ source('erc20_avalanche_c', 'evt_Transfer') }} reward_evt_transfer
+  RIGHT JOIN {{ ref('chainlink_avalanche_c_ocr_reward_transmission_logs') }} ocr_reward_transmission_logs ON ocr_reward_transmission_logs.contract_address = reward_evt_transfer."from"
+  LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+WHERE
+  reward_evt_transfer."from" IN (ocr_reward_transmission_logs.contract_address)
+GROUP BY
+  evt_tx_hash,
+  evt_index,
+  to

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer_daily.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer_daily.sql
@@ -1,0 +1,38 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+SELECT
+  'avalanche_c' as blockchain,
+  cast(date_trunc('day', evt_block_time) AS date) AS date_start,
+  MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
+  ocr_reward_evt_transfer.admin_address as admin_address,
+  MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
+  SUM(token_value) as token_amount
+FROM
+  {{ref('chainlink_avalanche_c_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
+{% if is_incremental() %}
+  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+{% endif %}      
+GROUP BY
+  2, 4
+ORDER BY
+  2, 4
+
+
+

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer_daily_legacy.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer_legacy.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_transmission_logs.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'avalanche_c' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('avalanche_c', 'logs') }} logs
+WHERE
+  topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_transmission_logs_legacy.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_schema.yml
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_schema.yml
@@ -1,0 +1,256 @@
+version: 2
+
+models:
+  - name: chainlink_avalanche_c_ocr_gas_transmission_logs
+    meta:
+      blockchain: avalanche_c
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'gas', 'transmission', 'logs', 'avalanche_c']
+    description: >
+      Chainlink OCR Gas Transmission Logs
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - block_number
+              - tx_hash
+              - tx_index
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain"
+      - &block_hash
+        name: block_hash
+        description: "Block Hash"
+      - &contract_address
+        name: contract_address
+        description: "Contract Address"
+      - &data
+        name: data
+        description: "Data"
+      - &topic0
+        name: topic0
+        description: "Topic 0"
+      - &topic1
+        name: topic1
+        description: "Topic 1"
+      - &topic2
+        name: topic2
+        description: "Topic 2"
+      - &topic3
+        name: topic3
+        description: "Topic 3"
+      - &tx_hash
+        name: tx_hash
+        description: "Transaction Hash"
+      - &block_number
+        name: block_number
+        description: "Block Number"
+      - &block_time
+        name: block_time
+        description: "Block Time"
+      - &index
+        name: index
+        description: "Index"
+      - &tx_index
+        name: tx_index
+        description: "Transaction Index"
+
+  - name: chainlink_avalanche_c_ocr_fulfilled_transactions
+    meta:
+      blockchain: avalanche_c
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'avalanche_c']
+    description: >
+      Chainlink OCR Fulfilled Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - &date_month
+        name: date_month
+        description: "Date truncated by month"
+      - &node_address
+        name: node_address
+        description: "Node Address"
+      - &token_amount
+        name: token_amount
+        description: "Token Amount"
+      - &usd_amount
+        name: usd_amount
+        description: "USD Amount"
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_avalanche_c_ocr_reverted_transactions
+    meta:
+      blockchain: avalanche_c
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'avalanche_c']
+    description: >
+      Chainlink OCR Reverted Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - *date_month
+      - *node_address
+      - *token_amount
+      - *usd_amount
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_avalanche_c_ocr_gas_daily
+    meta:
+      blockchain: avalanche_c
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'gas', 'daily', 'avalanche_c']
+    description: >
+        Chainlink OCR Gas Daily
+    columns:
+      - *blockchain
+      - &date_start
+        name: date_start
+        description: "Date Start"
+      - *date_month
+      - *node_address
+      - &operator_name
+        name: operator_name
+        description: "Operator Name"
+      - &fulfilled_token_amount
+        name: fulfilled_token_amount
+        description: "Fulfilled Token Amount"
+      - &fulfilled_usd_amount
+        name: fulfilled_usd_amount
+        description: "Fulfilled USD Amount"
+      - &reverted_token_amount
+        name: reverted_token_amount
+        description: "Reverted Token Amount"
+      - &reverted_usd_amount
+        name: reverted_usd_amount
+        description: "Reverted USD Amount"
+      - &total_token_amount
+        name: total_token_amount
+        description: "Total Token Amount"
+      - &total_usd_amount
+        name: total_usd_amount
+        description: "Total USD Amount"
+
+  - name: chainlink_avalanche_c_ocr_request_daily
+    meta:
+      blockchain: avalanche_c
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'request', 'daily', 'avalanche_c']
+    description: >
+        Chainlink OCR Request Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *node_address
+      - *operator_name
+      - &fulfilled_requests
+        name: fulfilled_requests
+        description: "Fulfilled Requests"
+      - &reverted_requests
+        name: reverted_requests
+        description: "Reverted Requests"
+      - &total_requests
+        name: total_requests
+        description: "Total Requests"
+
+  - name: chainlink_avalanche_c_ocr_reward_transmission_logs
+    meta:
+      blockchain: avalanche_c
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'transmission', 'logs', 'avalanche_c']
+    description: >
+      Chainlink OCR Reward Transmission Logs
+    columns:
+      - *blockchain
+      - *block_hash
+      - *contract_address
+      - *data
+      - *topic0
+      - *topic1
+      - *topic2
+      - *topic3
+      - *tx_hash
+      - *block_number
+      - *block_time
+      - *index
+      - *tx_index
+
+  - name: chainlink_avalanche_c_ocr_reward_evt_transfer
+    meta:
+      blockchain: avalanche_c
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'avalanche_c']
+    description: >
+      Chainlink OCR Reward Event Transfers
+    columns:
+      - *blockchain
+      - &evt_block_time
+        name: evt_block_time
+        description: "Event Block Time"
+      - &admin_address
+        name: admin_address
+        description: "Admin Address"
+      - *operator_name
+      - &token_value
+        name: token_value
+        description: "Token Value"
+
+  - name: chainlink_avalanche_c_ocr_reward_evt_transfer_daily
+    meta:
+      blockchain: avalanche_c
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'daily', 'avalanche_c']
+    description: >
+      Chainlink OCR Reward Event Transfers Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address      
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_value
+
+  - name: chainlink_avalanche_c_ocr_reward_daily
+    meta:
+      blockchain: avalanche_c
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'reward', 'daily', 'avalanche_c']
+    description: >
+        Chainlink OCR Reward Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_amount
+      - *usd_amount
+

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_schema.yml
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_schema.yml
@@ -67,6 +67,13 @@ models:
       tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'avalanche_c']
     description: >
       Chainlink OCR Fulfilled Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -94,6 +101,13 @@ models:
       tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'avalanche_c']
     description: >
       Chainlink OCR Reverted Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -113,6 +127,12 @@ models:
       tags: ['chainlink','ocr', 'gas', 'daily', 'avalanche_c']
     description: >
         Chainlink OCR Gas Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - &date_start
@@ -151,6 +171,12 @@ models:
       tags: ['chainlink','ocr', 'request', 'daily', 'avalanche_c']
     description: >
         Chainlink OCR Request Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - *date_start
@@ -227,7 +253,7 @@ models:
           combination_of_columns:
               - blockchain
               - date_start
-              - admin_address      
+              - admin_address
     columns:
       - *blockchain
       - *date_start
@@ -245,6 +271,12 @@ models:
       tags: ['chainlink','ocr', 'reward', 'daily', 'avalanche_c']
     description: >
         Chainlink OCR Reward Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address
     columns:
       - *blockchain
       - *date_start

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_sources.yml
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_sources.yml
@@ -1,0 +1,34 @@
+version: 2
+
+sources:
+  - name: erc20_avalanche_c
+    description: "Transfers events for ERC20 tokens on avalanche_c."
+    tables:
+      - name: evt_Transfer
+        loaded_at_field: evt_block_time
+        description: "Transfers events for ERC20 tokens on avalanche_c."
+        columns:
+          - &contract_address
+            name: contract_address
+            description: "ERC20 token contract address"
+          - &evt_block_number
+            name: evt_block_number
+            description: "Block event number"
+          - &evt_block_time
+            name: evt_block_time
+            description: "Timestamp for block event time in UTC"
+          - &evt_index
+            name: evt_index
+            description: "Event index"
+          - &evt_tx_hash
+            name: evt_tx_hash
+            description: "Event transaction hash"
+          - &from
+            name: from
+            description: "Wallet address for ERC20 token transfer from"
+          - &to
+            name: to
+            description: "Wallet address for ERC20 token transfer to"
+          - &value
+            name: value
+            description: "Raw amount of ERC20 token"

--- a/models/chainlink/bnb/chainlink_bnb_ocr_fulfilled_transactions.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_fulfilled_transactions.sql
@@ -1,0 +1,63 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_fulfilled_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  bnb_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'BNB'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_fulfilled_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX((cast((gas_used) as double) / 1e18) * gas_price) as token_amount,
+      MAX(bnb_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('bnb', 'transactions') }} tx
+      RIGHT JOIN {{ ref('chainlink_bnb_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
+      LEFT JOIN bnb_usd ON date_trunc('minute', tx.block_time) = bnb_usd.block_time
+    {% if is_incremental() %}
+      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'bnb' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_fulfilled_transactions

--- a/models/chainlink/bnb/chainlink_bnb_ocr_fulfilled_transactions_legacy.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_fulfilled_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_fulfilled_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/bnb/chainlink_bnb_ocr_gas_daily.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_gas_daily.sql
@@ -1,0 +1,81 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_gas_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(SUM(fulfilled.token_amount), 0) as fulfilled_token_amount,
+      COALESCE(SUM(reverted.token_amount), 0) as reverted_token_amount,
+      COALESCE(SUM(fulfilled.token_amount * fulfilled.usd_amount), 0) as fulfilled_usd_amount,
+      COALESCE(SUM(reverted.token_amount * reverted.usd_amount), 0) as reverted_usd_amount
+    FROM
+      {{ ref('chainlink_bnb_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_bnb_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_gas_daily AS (
+    SELECT
+      'bnb' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_gas_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_token_amount,
+      fulfilled_usd_amount,
+      reverted_token_amount,
+      reverted_usd_amount,
+      fulfilled_token_amount + reverted_token_amount as total_token_amount,
+      fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
+    FROM ocr_gas_daily_meta
+    LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_token_amount,
+  fulfilled_usd_amount,
+  reverted_token_amount,
+  reverted_usd_amount,
+  total_token_amount,
+  total_usd_amount    
+FROM
+  ocr_gas_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/bnb/chainlink_bnb_ocr_gas_daily_legacy.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_gas_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/bnb/chainlink_bnb_ocr_gas_transmission_logs.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_gas_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'bnb' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('bnb', 'logs') }} logs
+WHERE
+  topic0 = 0xf6a97944f31ea060dfde0566e4167c1a1082551e64b60ecb14d599a9d023d451

--- a/models/chainlink/bnb/chainlink_bnb_ocr_gas_transmission_logs_legacy.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_gas_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/bnb/chainlink_bnb_ocr_operator_admin_meta.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_operator_admin_meta.sql
@@ -1,0 +1,70 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_admin_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set alphachain = 'Alpha Chain' %}
+{% set blockdaemon = 'Blockdaemon' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set cosmostation = 'Cosmostation' %}
+{% set cryptomanufaktur = 'CryptoManufaktur' %}
+{% set dmakers = 'dMakers' %}
+{% set dextrac = 'DexTrac' %}
+{% set dxfeed = 'dxFeed' %}
+{% set easy2stake = 'Easy 2 stake' %}
+{% set fiews = 'Fiews' %}
+{% set frameworkventures = 'Framework Ventures' %}
+{% set inotel = 'Inotel' %}
+{% set linkforest = 'LinkForest' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set mycelium = 'Mycelium' %}
+{% set onchaintech = 'On-chain Tech' %}
+{% set simplyvc = 'Simply VC' %}
+{% set snzpool = 'SNZPool' %}
+{% set syncnode = 'SyncNode' %}
+{% set tiingo = 'Tiingo' %}
+{% set validationcloud = 'Validation Cloud' %}
+{% set xbto = 'XBTO' %}
+{% set ztake = 'Ztake.org' %}
+
+SELECT admin_address, operator_name FROM (VALUES
+  (0xD9459cc85E78e0336aDb349EAbF257Dbaf9d5a2B, '{{a01node}}'),
+  (0xa5D0084A766203b463b3164DFc49D91509C12daB, '{{alphachain}}'),
+  (0x3615Fa045f00ae0eD60Dc0141911757c2AdC5E03, '{{blockdaemon}}'),
+  (0x4a3dF8cAe46765d33c2551ff5438a5C5FC44347c, '{{chainlayer}}'),
+  (0x1B17eB8FAE3C28CB2463235F9D407b527ba4e6Dd, '{{cosmostation}}'),
+  (0x59eCf48345A221E0731E785ED79eD40d0A94E2A5, '{{cryptomanufaktur}}'),
+  (0xB98DA55e3E72BabF18c4f421Ea5B653519e79f2B, '{{dmakers}}'),
+  (0x9efa0A617C0552F1558c95993aA8b8A68b3e709C, '{{dextrac}}'),
+  (0xb284a468522663F6219f2912ca10145B52b13503, '{{dxfeed}}'),
+  (0x991812566f6E14897Fc1e401D24de19845c0442f, '{{dxfeed}}'),
+  (0xFdC770353dC0bFCE80a17Ab8a6a2E7d80590f1Ba, '{{easy2stake}}'),
+  (0x38a75E2A093d8F9b815AAE9cA6A5Eb0c2901329b, '{{fiews}}'),
+  (0x15918ff7f6C44592C81d999B442956B07D26CC44, '{{fiews}}'),
+  (0x6eF38c3d1D85B710A9e160aD41B912Cb8CAc2589, '{{frameworkventures}}'),
+  (0xB8C6E43f37E04A2411562a13c1C48B3ad5975cf4, '{{inotel}}'),
+  (0x4564A9c6061f6f1F2Eadb954B1b3C241D2DC984e, '{{linkforest}}'),
+  (0xD48fc6E2B73C2988fA50C994181C0CdCa850D62a, '{{linkforest}}'),
+  (0x797de2909991C66C66D8e730C8385bbab8D18eA6, '{{linkpool}}'),
+  (0x97b7CF748f1eb0B451f4464B4Aebc639d18Ddb48, '{{linkpool}}'),
+  (0x14f94049397C3F1807c45B6f854Cb5F36bC4393B, '{{linkriver}}'),
+  (0x3FB4600736d306Ee2A89EdF0356D4272fb095768, '{{mycelium}}'),
+  (0x35DaC078fC9E6e45d89a6CBc78A776BA719b485D, '{{onchaintech}}'),
+  (0x4fBefaf1BFf0130945C61603B97D38DD6e21f5Cf, '{{simplyvc}}'),
+  (0x9cCbFD17FA284f36c2ff503546160B256d1CD3D1, '{{snzpool}}'),
+  (0xC51D3470693BC049809A1c515606124c7C75908d, '{{syncnode}}'),
+  (0xfAE26207ab74ee528214ee92f94427f8Cdbb6A32, '{{tiingo}}'),
+  (0x183A96629fF566e7AA8AfA38980Cd037EB40A59A, '{{validationcloud}}'),
+  (0x0b16EC1044F60F03B0e815f863bd4d27638cbD0A, '{{xbto}}'),
+  (0x0039F22efB07A647557C7C5d17854CFD6D489eF3, '{{ztake}}'),
+  (0x9d69B0fcbcf9a7e513E947Cd7ce2019904e2E764, '{{ztake}}')
+) AS tmp_node_meta(admin_address, operator_name)

--- a/models/chainlink/bnb/chainlink_bnb_ocr_operator_admin_meta_legacy.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_operator_admin_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_admin_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/bnb/chainlink_bnb_ocr_operator_node_meta.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_operator_node_meta.sql
@@ -1,0 +1,97 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_node_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set alphachain = 'Alpha Chain' %}
+{% set blockdaemon = 'Blockdaemon' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set cosmostation = 'Cosmostation' %}
+{% set cryptomanufaktur = 'CryptoManufaktur' %}
+{% set dmakers = 'dMakers' %}
+{% set dextrac = 'DexTrac' %}
+{% set dxfeed = 'dxFeed' %}
+{% set easy2stake = 'Easy 2 stake' %}
+{% set fiews = 'Fiews' %}
+{% set frameworkventures = 'Framework Ventures' %}
+{% set inotel = 'Inotel' %}
+{% set linkforest = 'LinkForest' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set mycelium = 'Mycelium' %}
+{% set onchaintech = 'On-chain Tech' %}
+{% set simplyvc = 'Simply VC' %}
+{% set snzpool = 'SNZPool' %}
+{% set syncnode = 'SyncNode' %}
+{% set tiingo = 'Tiingo' %}
+{% set validationcloud = 'Validation Cloud' %}
+{% set xbto = 'XBTO' %}
+{% set ztake = 'Ztake.org' %}
+
+SELECT node_address, operator_name FROM (VALUES
+  (0x39D36fD647a933Fe51670c1eB6b0e6b8b4a69f07, '{{a01node}}'),
+  (0xF133B7B7EEb70B1156e7ca6A76C4bbbf1fEE85De, '{{a01node}}'),
+  (0x52bDfF084C524148cA4A44524EB88D2b995Ee7C5, '{{a01node}}'),
+  (0x17721D492b7EFdcf7365e541EdEFDDE552A1360F, '{{alphachain}}'),
+  (0xC2dC5B1836F7ad85B62ff8e22F0a766d3E07DAE6, '{{alphachain}}'),
+  (0xed3A0ac63d7e48399D05d9a25925e8FCb0Cd98D0, '{{blockdaemon}}'),
+  (0x428986fbc3D27AC7D6b0cf4cfB133b3e0788B825, '{{blockdaemon}}'),
+  (0xAd28531021eB793874E8Dfb84b9e7b862C9e0e53, '{{chainlayer}}'),
+  (0x5AAbed10758A5B4b76Ba29F70ED77a967cc1eF2F, '{{chainlayer}}'),
+  (0xd46f50ba5bD6e4a2AB3FAd8207FCd94c7ba0DEa7, '{{cosmostation}}'),
+  (0xc3f5e64C83f0aE4e8dF53553f8C2DbAcBB89Ff3C, '{{cosmostation}}'),
+  (0xbe863D7Fd1C2fD020047498fD4EFdd915fc39053, '{{cryptomanufaktur}}'),
+  (0x19588eFd97DD4a5D412352047334Ed6Fdf1b8eb9, '{{dmakers}}'),
+  (0x8b18a1A5BF514AA94298804fb4D839Bb51B85Da6, '{{dmakers}}'),
+  (0xa53bdb1522a58dEe57B89e0579C13B15825B8D77, '{{dextrac}}'),
+  (0x3c5a0cb6433Cc3B8c492961Dd4dEFb5a94465a67, '{{dextrac}}'),
+  (0xfB6C19672B2C929333A5c2eC7B768c671FA5D12F, '{{dextrac}}'),
+  (0x3446f7897f9f0B376a8E60984CC3dF97C3c9c292, '{{dxfeed}}'),
+  (0x0693e34cf4f26076677B3Be609d5cc95955DF74d, '{{dxfeed}}'),
+  (0xA1e96Ecaab9d97Bd17583966963C486cf856B639, '{{easy2stake}}'),
+  (0x7a8cB388CEf668201aE8d213f87227007D39cC9C, '{{easy2stake}}'),
+  (0xE6E6D6b5Fb5688e41aaB43686c87ea24Ef4b76A8, '{{fiews}}'),
+  (0x981816992ca910B8D00d88db0217b07c199E995a, '{{fiews}}'),
+  (0x6Ad15e7cC3456858544cBe885d20c54B44c881e8, '{{fiews}}'),
+  (0xC5aaf1525Dd8E1A5a01273C3d59C47426F426756, '{{frameworkventures}}'),
+  (0x74855Fa4418449D15380A3e289D417Ee3200550b, '{{frameworkventures}}'),
+  (0x5901B2B3B48e5310605fc1bb4a51B1001680a05B, '{{inotel}}'),
+  (0xf0E4ec934D377319C44a0A1417682508Fc52942F, '{{inotel}}'),
+  (0x58C34A3a7E4b9C61e802deE3d31C834705c01978, '{{inotel}}'),
+  (0xa6b40a7Bcc64E813C22561c921B81bc7A6b43eF9, '{{linkforest}}'),
+  (0xDa1cC1c3Fb19E19eb055bd028EEa7d0EC6EE9AC9, '{{linkforest}}'),
+  (0x42223207FA6ffA0795219EA658876E89E40cAd02, '{{linkforest}}'),
+  (0x37Fc26312b831f7efb494cDB192c9aE91Fd27597, '{{linkpool}}'),
+  (0xe4e2582d95cB7D8F5B3E746C44d26f8DC1265cAE, '{{linkpool}}'),
+  (0x3B5398B508a26b43822456b0D3Ad78B649011dA6, '{{linkpool}}'),
+  (0xEBbc95fB63ad3e0D66169297c029BCd8e86fdc71, '{{linkriver}}'),
+  (0x05870Ef2194ea1dfa246Ff464AA53fDe8544a9A5, '{{linkriver}}'),
+  (0xB35F4988074F14dC1F1d27062346D6123F46A41B, '{{mycelium}}'),
+  (0xDC31322087d6B250C0264FEebF34F6F7BA6D5A21, '{{mycelium}}'),
+  (0x6D9df15c54B4654De0263e82Fd92C577FeD47e64, '{{mycelium}}'),
+  (0xD46a5604CA9fEe830e291248701F616f53Bf174B, '{{onchaintech}}'),
+  (0x3A86052b4926CB0aeCB5d155Ef2389243dB3c22c, '{{onchaintech}}'),
+  (0xBF44AcA665062a696b2d4c72663CFefD87769A10, '{{simplyvc}}'),
+  (0xaDb83Abbf7A8987AfB76DB33Ed2855A07f5497C7, '{{simplyvc}}'),
+  (0x2f53d676770Cf2Ab6A094109132b70f9ab282C12, '{{simplyvc}}'),
+  (0x573352F3FD171FB103Fd9107D04D5025660f1B8a, '{{snzpool}}'),
+  (0x7CDDCB63bA13edd23Ed948ea0D25Fa6ed0683945, '{{snzpool}}'),
+  (0x5ce038429e4d6025F94Ae271759d63bcfdCCb6cC, '{{syncnode}}'),
+  (0xaE7e8B829f1aE0c2EA04a68041B1eEBB4c527fdc, '{{syncnode}}'),
+  (0xfD9fd7dcA91fB4C17f2c389C318911162cf623A6, '{{tiingo}}'),
+  (0x3866D3B9a156F8ecdADF7Eb5b3f0362A13d1c51E, '{{tiingo}}'),
+  (0x3032cE567c21329fC95B150022d50753ecCB4F1d, '{{validationcloud}}'),
+  (0x50fEa67C2C3C53BDa421e6eA1Def30224559b293, '{{validationcloud}}'),
+  (0x4D447f5479DF06Bf630bf836237352AfDB7680B0, '{{xbto}}'),
+  (0x6b6b1b0F7Cf88Ba887B9a67E091Cc6C552e473b1, '{{xbto}}'),
+  (0xC7B702ee7C5b63BD5fF534FaAA82320CaB2B2c0F, '{{ztake}}'),
+  (0x4E21fc375a0567A3Ce4F76a05add6CDbd6C61014, '{{ztake}}')
+) AS tmp_node_meta(node_address, operator_name)

--- a/models/chainlink/bnb/chainlink_bnb_ocr_operator_node_meta_legacy.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_operator_node_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_node_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/bnb/chainlink_bnb_ocr_request_daily.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_request_daily.sql
@@ -1,0 +1,74 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_request_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_request_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(COUNT(fulfilled.token_amount), 0) as fulfilled_requests,
+      COALESCE(COUNT(reverted.token_amount), 0) as reverted_requests,
+      COALESCE(COUNT(fulfilled.token_amount), 0) + COALESCE(COUNT(reverted.token_amount), 0) as total_requests
+    FROM
+      {{ ref('chainlink_bnb_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_bnb_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_request_daily AS (
+    SELECT
+      'bnb' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_request_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_requests,
+      reverted_requests,
+      total_requests
+    FROM ocr_request_daily_meta
+    LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_requests,
+  reverted_requests,
+  total_requests
+FROM
+  ocr_request_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/bnb/chainlink_bnb_ocr_request_daily_legacy.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_request_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_request_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/bnb/chainlink_bnb_ocr_reverted_transactions.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_reverted_transactions.sql
@@ -1,0 +1,64 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reverted_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  bnb_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'BNB'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_reverted_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX((cast((gas_used) as double) / 1e18) * gas_price) as token_amount,
+      MAX(bnb_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('bnb', 'transactions') }} tx
+      LEFT JOIN bnb_usd ON date_trunc('minute', tx.block_time) = bnb_usd.block_time
+    WHERE
+      success = false
+      {% if is_incremental() %}
+        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'bnb' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_reverted_transactions

--- a/models/chainlink/bnb/chainlink_bnb_ocr_reverted_transactions_legacy.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_reverted_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reverted_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/bnb/chainlink_bnb_ocr_reward_daily.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_reward_daily.sql
@@ -1,0 +1,111 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_daily'),
+    partition_by = ['date_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  admin_address_meta as (
+    SELECT DISTINCT
+      admin_address
+    FROM
+      {{ref('chainlink_bnb_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+  ),
+  link_usd_daily AS (
+    SELECT
+      cast(date_trunc('day', price.minute) as date) as "date_start",
+      MAX(price.price) as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      price.symbol = 'LINK'
+      {% if is_incremental() %}
+        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      1
+    ORDER BY
+      1
+  ),
+  link_usd_daily_expanded_by_admin_address AS (
+    SELECT
+      date_start,
+      usd_amount,
+      admin_address
+    FROM
+      link_usd_daily
+    CROSS JOIN
+      admin_address_meta
+    ORDER BY
+      date_start,
+      admin_address
+  ),
+  payment_meta AS (
+    SELECT
+      date_start,
+      link_usd_daily_expanded_by_admin_address.admin_address as admin_address,
+      usd_amount,
+      (
+        SELECT
+          MAX(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_bnb_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start <= link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as prev_payment_date,
+      (
+        SELECT
+          MIN(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_bnb_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start > link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as next_payment_date
+    FROM
+      link_usd_daily_expanded_by_admin_address
+    ORDER BY
+      1, 2
+  ),
+  ocr_reward_daily AS (
+    SELECT 
+      payment_meta.date_start,
+      cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
+      payment_meta.admin_address,
+      ocr_operator_admin_meta.operator_name,      
+      COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
+      (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
+    FROM 
+      payment_meta
+    LEFT JOIN 
+      {{ref('chainlink_bnb_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
+        payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
+        payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    ORDER BY date_start
+  )
+SELECT
+  'bnb' as blockchain,
+  date_start,
+  date_month,
+  admin_address,
+  operator_name,
+  token_amount,
+  usd_amount
+FROM 
+  ocr_reward_daily
+ORDER BY
+  2, 4

--- a/models/chainlink/bnb/chainlink_bnb_ocr_reward_daily_legacy.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_reward_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'bnb' as blockchain,
+  to as admin_address,
+  MAX(operator_name) as operator_name,
+  MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+  MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+FROM
+  {{ source('erc20_bnb', 'evt_Transfer') }} reward_evt_transfer
+  RIGHT JOIN {{ ref('chainlink_bnb_ocr_reward_transmission_logs') }} ocr_reward_transmission_logs ON ocr_reward_transmission_logs.contract_address = reward_evt_transfer."from"
+  LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+WHERE
+  reward_evt_transfer."from" IN (ocr_reward_transmission_logs.contract_address)
+GROUP BY
+  evt_tx_hash,
+  evt_index,
+  to

--- a/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer_daily.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer_daily.sql
@@ -1,0 +1,38 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+SELECT
+  'bnb' as blockchain,
+  cast(date_trunc('day', evt_block_time) AS date) AS date_start,
+  MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
+  ocr_reward_evt_transfer.admin_address as admin_address,
+  MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
+  SUM(token_value) as token_amount
+FROM
+  {{ref('chainlink_bnb_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
+{% if is_incremental() %}
+  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+{% endif %}      
+GROUP BY
+  2, 4
+ORDER BY
+  2, 4
+
+
+

--- a/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer_daily_legacy.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer_legacy.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/bnb/chainlink_bnb_ocr_reward_transmission_logs.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_reward_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'bnb' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('bnb', 'logs') }} logs
+WHERE
+  topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6

--- a/models/chainlink/bnb/chainlink_bnb_ocr_reward_transmission_logs_legacy.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_reward_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/bnb/chainlink_bnb_schema.yml
+++ b/models/chainlink/bnb/chainlink_bnb_schema.yml
@@ -193,6 +193,13 @@ models:
       tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'bnb']
     description: >
       Chainlink OCR Fulfilled Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -220,6 +227,13 @@ models:
       tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'bnb']
     description: >
       Chainlink OCR Reverted Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -239,6 +253,12 @@ models:
       tags: ['chainlink','ocr', 'gas', 'daily', 'bnb']
     description: >
         Chainlink OCR Gas Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - &date_start
@@ -277,6 +297,12 @@ models:
       tags: ['chainlink','ocr', 'request', 'daily', 'bnb']
     description: >
         Chainlink OCR Request Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - *date_start
@@ -353,7 +379,7 @@ models:
           combination_of_columns:
               - blockchain
               - date_start
-              - admin_address      
+              - admin_address
     columns:
       - *blockchain
       - *date_start
@@ -371,6 +397,12 @@ models:
       tags: ['chainlink','ocr', 'reward', 'daily', 'bnb']
     description: >
         Chainlink OCR Reward Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address
     columns:
       - *blockchain
       - *date_start

--- a/models/chainlink/bnb/chainlink_bnb_schema.yml
+++ b/models/chainlink/bnb/chainlink_bnb_schema.yml
@@ -132,3 +132,250 @@ models:
         description: "Decimal adjustment for the oracle answer"
       - *proxy_address
       - *aggregator_address
+
+  - name: chainlink_bnb_ocr_gas_transmission_logs
+    meta:
+      blockchain: bnb
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'gas', 'transmission', 'logs', 'bnb']
+    description: >
+      Chainlink OCR Gas Transmission Logs
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - block_number
+              - tx_hash
+              - tx_index
+    columns:
+      - *blockchain
+      - &block_hash
+        name: block_hash
+        description: "Block Hash"
+      - &contract_address
+        name: contract_address
+        description: "Contract Address"
+      - &data
+        name: data
+        description: "Data"
+      - &topic0
+        name: topic0
+        description: "Topic 0"
+      - &topic1
+        name: topic1
+        description: "Topic 1"
+      - &topic2
+        name: topic2
+        description: "Topic 2"
+      - &topic3
+        name: topic3
+        description: "Topic 3"
+      - &tx_hash
+        name: tx_hash
+        description: "Transaction Hash"
+      - *block_number
+      - *block_time
+      - &index
+        name: index
+        description: "Index"
+      - &tx_index
+        name: tx_index
+        description: "Transaction Index"
+
+  - name: chainlink_bnb_ocr_fulfilled_transactions
+    meta:
+      blockchain: bnb
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'bnb']
+    description: >
+      Chainlink OCR Fulfilled Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - &date_month
+        name: date_month
+        description: "Date truncated by month"
+      - &node_address
+        name: node_address
+        description: "Node Address"
+      - &token_amount
+        name: token_amount
+        description: "Token Amount"
+      - &usd_amount
+        name: usd_amount
+        description: "USD Amount"
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_bnb_ocr_reverted_transactions
+    meta:
+      blockchain: bnb
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'bnb']
+    description: >
+      Chainlink OCR Reverted Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - *date_month
+      - *node_address
+      - *token_amount
+      - *usd_amount
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_bnb_ocr_gas_daily
+    meta:
+      blockchain: bnb
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'gas', 'daily', 'bnb']
+    description: >
+        Chainlink OCR Gas Daily
+    columns:
+      - *blockchain
+      - &date_start
+        name: date_start
+        description: "Date Start"
+      - *date_month
+      - *node_address
+      - &operator_name
+        name: operator_name
+        description: "Operator Name"
+      - &fulfilled_token_amount
+        name: fulfilled_token_amount
+        description: "Fulfilled Token Amount"
+      - &fulfilled_usd_amount
+        name: fulfilled_usd_amount
+        description: "Fulfilled USD Amount"
+      - &reverted_token_amount
+        name: reverted_token_amount
+        description: "Reverted Token Amount"
+      - &reverted_usd_amount
+        name: reverted_usd_amount
+        description: "Reverted USD Amount"
+      - &total_token_amount
+        name: total_token_amount
+        description: "Total Token Amount"
+      - &total_usd_amount
+        name: total_usd_amount
+        description: "Total USD Amount"
+
+  - name: chainlink_bnb_ocr_request_daily
+    meta:
+      blockchain: bnb
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'request', 'daily', 'bnb']
+    description: >
+        Chainlink OCR Request Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *node_address
+      - *operator_name
+      - &fulfilled_requests
+        name: fulfilled_requests
+        description: "Fulfilled Requests"
+      - &reverted_requests
+        name: reverted_requests
+        description: "Reverted Requests"
+      - &total_requests
+        name: total_requests
+        description: "Total Requests"
+
+  - name: chainlink_bnb_ocr_reward_transmission_logs
+    meta:
+      blockchain: bnb
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'transmission', 'logs', 'bnb']
+    description: >
+      Chainlink OCR Reward Transmission Logs
+    columns:
+      - *blockchain
+      - *block_hash
+      - *contract_address
+      - *data
+      - *topic0
+      - *topic1
+      - *topic2
+      - *topic3
+      - *tx_hash
+      - *block_number
+      - *block_time
+      - *index
+      - *tx_index
+
+  - name: chainlink_bnb_ocr_reward_evt_transfer
+    meta:
+      blockchain: bnb
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'bnb']
+    description: >
+      Chainlink OCR Reward Event Transfers
+    columns:
+      - *blockchain
+      - &evt_block_time
+        name: evt_block_time
+        description: "Event Block Time"
+      - &admin_address
+        name: admin_address
+        description: "Admin Address"
+      - *operator_name
+      - &token_value
+        name: token_value
+        description: "Token Value"
+
+  - name: chainlink_bnb_ocr_reward_evt_transfer_daily
+    meta:
+      blockchain: bnb
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'daily', 'bnb']
+    description: >
+      Chainlink OCR Reward Event Transfers Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address      
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_value
+
+  - name: chainlink_bnb_ocr_reward_daily
+    meta:
+      blockchain: bnb
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'reward', 'daily', 'bnb']
+    description: >
+        Chainlink OCR Reward Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_amount
+      - *usd_amount

--- a/models/chainlink/chainlink_ocr_fulfilled_transactions.sql
+++ b/models/chainlink/chainlink_ocr_fulfilled_transactions.sql
@@ -29,7 +29,9 @@ FROM (
       date_month,
       node_address,
       token_amount,
-      usd_amount
+      usd_amount,
+      tx_hash,
+      tx_index
     FROM {{ ref(model) }}
     {% if not loop.last %}
     UNION ALL

--- a/models/chainlink/chainlink_ocr_fulfilled_transactions.sql
+++ b/models/chainlink/chainlink_ocr_fulfilled_transactions.sql
@@ -1,0 +1,38 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_fulfilled_transactions'),
+    post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","bnb","ethereum","fantom","gnosis","optimism","polygon"]\',
+                            "project",
+                            "chainlink",
+                            \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set models = [
+  'chainlink_arbitrum_ocr_fulfilled_transactions',
+  'chainlink_avalanche_c_ocr_fulfilled_transactions',
+  'chainlink_bnb_ocr_fulfilled_transactions',
+  'chainlink_ethereum_ocr_fulfilled_transactions',
+  'chainlink_fantom_ocr_fulfilled_transactions',
+  'chainlink_gnosis_ocr_fulfilled_transactions',
+  'chainlink_optimism_ocr_fulfilled_transactions',
+  'chainlink_polygon_ocr_fulfilled_transactions'
+] %}
+
+SELECT *
+FROM (
+    {% for model in models %}
+    SELECT
+      blockchain,
+      block_time,
+      date_month,
+      node_address,
+      token_amount,
+      usd_amount
+    FROM {{ ref(model) }}
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+)

--- a/models/chainlink/chainlink_ocr_gas_daily.sql
+++ b/models/chainlink/chainlink_ocr_gas_daily.sql
@@ -1,0 +1,43 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_daily'),
+    post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","bnb","ethereum","fantom","gnosis","optimism","polygon"]\',
+                            "project",
+                            "chainlink",
+                            \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set models = [
+  'chainlink_arbitrum_ocr_gas_daily',
+  'chainlink_avalanche_c_ocr_gas_daily',
+  'chainlink_bnb_ocr_gas_daily',
+  'chainlink_ethereum_ocr_gas_daily',
+  'chainlink_fantom_ocr_gas_daily',
+  'chainlink_gnosis_ocr_gas_daily',
+  'chainlink_optimism_ocr_gas_daily',
+  'chainlink_polygon_ocr_gas_daily'
+] %}
+
+SELECT *
+FROM (
+    {% for model in models %}
+    SELECT
+      blockchain,
+      date_start,
+      date_month,
+      node_address,
+      operator_name,
+      fulfilled_token_amount,
+      fulfilled_usd_amount,
+      reverted_token_amount,
+      reverted_usd_amount,
+      total_token_amount,
+      total_usd_amount        
+    FROM {{ ref(model) }}
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+)

--- a/models/chainlink/chainlink_ocr_gas_transmission_logs.sql
+++ b/models/chainlink/chainlink_ocr_gas_transmission_logs.sql
@@ -1,0 +1,45 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_transmission_logs'),
+    post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","bnb","ethereum","fantom","gnosis","optimism","polygon"]\',
+                            "project",
+                            "chainlink",
+                            \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set models = [
+  'chainlink_arbitrum_ocr_gas_transmission_logs',
+  'chainlink_avalanche_c_ocr_gas_transmission_logs',
+  'chainlink_bnb_ocr_gas_transmission_logs',
+  'chainlink_ethereum_ocr_gas_transmission_logs',
+  'chainlink_fantom_ocr_gas_transmission_logs',
+  'chainlink_gnosis_ocr_gas_transmission_logs',
+  'chainlink_optimism_ocr_gas_transmission_logs',
+  'chainlink_polygon_ocr_gas_transmission_logs'
+] %}
+
+SELECT *
+FROM (
+    {% for model in models %}
+    SELECT
+      blockchain,
+      block_hash,
+      contract_address,
+      data,
+      topic0,
+      topic1,
+      topic2,
+      topic3,
+      tx_hash,
+      block_number,
+      block_time,
+      index,
+      tx_index
+    FROM {{ ref(model) }}
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+)

--- a/models/chainlink/chainlink_ocr_request_daily.sql
+++ b/models/chainlink/chainlink_ocr_request_daily.sql
@@ -1,0 +1,40 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_request_daily'),
+    post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","bnb","ethereum","fantom","gnosis","optimism","polygon"]\',
+                            "project",
+                            "chainlink",
+                            \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set models = [
+  'chainlink_arbitrum_ocr_request_daily',
+  'chainlink_avalanche_c_ocr_request_daily',
+  'chainlink_bnb_ocr_request_daily',
+  'chainlink_ethereum_ocr_request_daily',
+  'chainlink_fantom_ocr_request_daily',
+  'chainlink_gnosis_ocr_request_daily',
+  'chainlink_optimism_ocr_request_daily',
+  'chainlink_polygon_ocr_request_daily'
+] %}
+
+SELECT *
+FROM (
+    {% for model in models %}
+    SELECT
+      blockchain,
+      date_start,
+      date_month,
+      node_address,
+      operator_name,
+      fulfilled_requests,
+      reverted_requests,
+      total_requests
+    FROM {{ ref(model) }}
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+)

--- a/models/chainlink/chainlink_ocr_reverted_transactions.sql
+++ b/models/chainlink/chainlink_ocr_reverted_transactions.sql
@@ -1,0 +1,38 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reverted_transactions'),
+    post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","bnb","ethereum","fantom","gnosis","optimism","polygon"]\',
+                            "project",
+                            "chainlink",
+                            \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set models = [
+  'chainlink_arbitrum_ocr_reverted_transactions',
+  'chainlink_avalanche_c_ocr_reverted_transactions',
+  'chainlink_bnb_ocr_reverted_transactions',
+  'chainlink_ethereum_ocr_reverted_transactions',
+  'chainlink_fantom_ocr_reverted_transactions',
+  'chainlink_gnosis_ocr_reverted_transactions',
+  'chainlink_optimism_ocr_reverted_transactions',
+  'chainlink_polygon_ocr_reverted_transactions'
+] %}
+
+SELECT *
+FROM (
+    {% for model in models %}
+    SELECT
+      blockchain,
+      block_time,
+      date_month,
+      node_address,
+      token_amount,
+      usd_amount
+    FROM {{ ref(model) }}
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+)

--- a/models/chainlink/chainlink_ocr_reverted_transactions.sql
+++ b/models/chainlink/chainlink_ocr_reverted_transactions.sql
@@ -29,7 +29,9 @@ FROM (
       date_month,
       node_address,
       token_amount,
-      usd_amount
+      usd_amount,
+      tx_hash,
+      tx_index
     FROM {{ ref(model) }}
     {% if not loop.last %}
     UNION ALL

--- a/models/chainlink/chainlink_ocr_reward_daily.sql
+++ b/models/chainlink/chainlink_ocr_reward_daily.sql
@@ -1,0 +1,39 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_daily'),
+    post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","bnb","ethereum","fantom","gnosis","optimism","polygon"]\',
+                            "project",
+                            "chainlink",
+                            \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set models = [
+  'chainlink_arbitrum_ocr_reward_daily',
+  'chainlink_avalanche_c_ocr_reward_daily',
+  'chainlink_bnb_ocr_reward_daily',
+  'chainlink_ethereum_ocr_reward_daily',
+  'chainlink_fantom_ocr_reward_daily',
+  'chainlink_gnosis_ocr_reward_daily',
+  'chainlink_optimism_ocr_reward_daily',
+  'chainlink_polygon_ocr_reward_daily'
+] %}
+
+SELECT *
+FROM (
+    {% for model in models %}
+    SELECT
+      blockchain,
+      date_start,
+      date_month,
+      admin_address,
+      operator_name,
+      token_amount,
+      usd_amount
+    FROM {{ ref(model) }}
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+)

--- a/models/chainlink/chainlink_ocr_reward_evt_transfer.sql
+++ b/models/chainlink/chainlink_ocr_reward_evt_transfer.sql
@@ -1,0 +1,37 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer'),
+    post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","bnb","ethereum","fantom","gnosis","optimism","polygon"]\',
+                            "project",
+                            "chainlink",
+                            \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set models = [
+  'chainlink_arbitrum_ocr_reward_evt_transfer',
+  'chainlink_avalanche_c_ocr_reward_evt_transfer',
+  'chainlink_bnb_ocr_reward_evt_transfer',
+  'chainlink_ethereum_ocr_reward_evt_transfer',
+  'chainlink_fantom_ocr_reward_evt_transfer',
+  'chainlink_gnosis_ocr_reward_evt_transfer',
+  'chainlink_optimism_ocr_reward_evt_transfer',
+  'chainlink_polygon_ocr_reward_evt_transfer'
+] %}
+
+SELECT *
+FROM (
+    {% for model in models %}
+    SELECT
+      blockchain,
+      evt_block_time,
+      admin_address,
+      operator_name,
+      token_value       
+    FROM {{ ref(model) }}
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+)

--- a/models/chainlink/chainlink_ocr_reward_evt_transfer_daily.sql
+++ b/models/chainlink/chainlink_ocr_reward_evt_transfer_daily.sql
@@ -1,0 +1,38 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer_daily'),
+    post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","bnb","ethereum","fantom","gnosis","optimism","polygon"]\',
+                            "project",
+                            "chainlink",
+                            \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set models = [
+  'chainlink_arbitrum_ocr_reward_evt_transfer_daily',
+  'chainlink_avalanche_c_ocr_reward_evt_transfer_daily',
+  'chainlink_bnb_ocr_reward_evt_transfer_daily',
+  'chainlink_ethereum_ocr_reward_evt_transfer_daily',
+  'chainlink_fantom_ocr_reward_evt_transfer_daily',
+  'chainlink_gnosis_ocr_reward_evt_transfer_daily',
+  'chainlink_optimism_ocr_reward_evt_transfer_daily',
+  'chainlink_polygon_ocr_reward_evt_transfer_daily'
+] %}
+
+SELECT *
+FROM (
+    {% for model in models %}
+    SELECT
+      blockchain,
+      date_start,
+      date_month,
+      admin_address,
+      operator_name,
+      token_amount       
+    FROM {{ ref(model) }}
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+)

--- a/models/chainlink/chainlink_ocr_reward_transmission_logs.sql
+++ b/models/chainlink/chainlink_ocr_reward_transmission_logs.sql
@@ -1,0 +1,45 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_transmission_logs'),
+    post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","bnb","ethereum","fantom","gnosis","optimism","polygon"]\',
+                            "project",
+                            "chainlink",
+                            \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set models = [
+  'chainlink_arbitrum_ocr_reward_transmission_logs',
+  'chainlink_avalanche_c_ocr_reward_transmission_logs',
+  'chainlink_bnb_ocr_reward_transmission_logs',
+  'chainlink_ethereum_ocr_reward_transmission_logs',
+  'chainlink_fantom_ocr_reward_transmission_logs',
+  'chainlink_gnosis_ocr_reward_transmission_logs',
+  'chainlink_optimism_ocr_reward_transmission_logs',
+  'chainlink_polygon_ocr_reward_transmission_logs'
+] %}
+
+SELECT *
+FROM (
+    {% for model in models %}
+    SELECT
+      blockchain,
+      block_hash,
+      contract_address,
+      data,
+      topic0,
+      topic1,
+      topic2,
+      topic3,
+      tx_hash,
+      block_number,
+      block_time,
+      index,
+      tx_index
+    FROM {{ ref(model) }}
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+)

--- a/models/chainlink/chainlink_schema.yml
+++ b/models/chainlink/chainlink_schema.yml
@@ -4,19 +4,13 @@ models:
   - name: chainlink_price_feeds
     meta:
       blockchain: ['bnb','optimism','polygon']
+      sector: oracle
       project: chainlink
       contributors: ['msilb7','0xroll','linkpool_ryan']
     config:
       tags: ['chainlink', 'price', 'feed', 'bnb', 'optimism', 'polygon']
     description: >
         Table pulling price updates for known Chainlink oracle addresses
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-              - blockchain
-              - block_number
-              - proxy_address
-              - underlying_token_address
     columns:
       - &blockchain
         name: blockchain
@@ -62,14 +56,6 @@ models:
       tags: ['chainlink', 'price', 'feed', 'bnb', 'optimism', 'polygon']
     description: >
         Hourly chainlink price feed updates
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-              - blockchain
-              - hour
-              - proxy_address
-              - aggregator_address
-              - underlying_token_address
     columns:
       - *blockchain
       - name: hour
@@ -84,3 +70,259 @@ models:
       - *underlying_token_address
       - name: underlying_token_price_avg
         description: "Price of the underlying token, with extra decimal adjustments if needed"
+
+  - name: chainlink_ocr_gas_transmission_logs
+    meta:
+      blockchain: ['arbitrum','avalanche_c','bnb','ethereum','fantom','gnosis','optimism','polygon']
+      sector: oracle
+      project: chainlink
+      contributors: ['linkpool_ryan','linkpool_jon']
+    config:
+      tags: ['chainlink', 'ocr', 'gas', 'transmission', 'logs', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
+    description: >
+      Chainlink OCR Gas Transmission Logs
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - block_number
+              - tx_hash
+              - tx_index
+    columns:
+      - *blockchain
+      - &block_hash
+        name: block_hash
+        description: "Block Hash"
+      - &contract_address
+        name: contract_address
+        description: "Contract Address"
+      - &data
+        name: data
+        description: "Data"
+      - &topic0
+        name: topic0
+        description: "Topic 0"
+      - &topic1
+        name: topic1
+        description: "Topic 1"
+      - &topic2
+        name: topic2
+        description: "Topic 2"
+      - &topic3
+        name: topic3
+        description: "Topic 3"
+      - &tx_hash
+        name: tx_hash
+        description: "Transaction Hash"
+      - *block_number
+      - *block_time
+      - &index
+        name: index
+        description: "Index"
+      - &tx_index
+        name: tx_index
+        description: "Transaction Index"
+
+  - name: chainlink_ocr_fulfilled_transactions
+    meta:
+      blockchain: ['arbitrum','avalanche_c','bnb','ethereum','fantom','gnosis','optimism','polygon']
+      sector: oracle
+      project: chainlink
+      contributors: ['linkpool_ryan','linkpool_jon']
+    config:
+      tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
+    description: >
+      Chainlink OCR Fulfilled Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - &date_month
+        name: date_month
+        description: "Date truncated by month"
+      - &node_address
+        name: node_address
+        description: "Node Address"
+      - &token_amount
+        name: token_amount
+        description: "Token Amount"
+      - &usd_amount
+        name: usd_amount
+        description: "USD Amount"
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_ocr_reverted_transactions
+    meta:
+      blockchain: ['arbitrum','avalanche_c','bnb','ethereum','fantom','gnosis','optimism','polygon']
+      sector: oracle
+      project: chainlink
+      contributors: ['linkpool_ryan','linkpool_jon']
+    config:
+      tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
+    description: >
+      Chainlink OCR Reverted Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - *date_month
+      - *node_address
+      - *token_amount
+      - *usd_amount
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_ocr_gas_daily
+    meta:
+      blockchain: ['arbitrum','avalanche_c','bnb','ethereum','fantom','gnosis','optimism','polygon']
+      sector: oracle
+      project: chainlink
+      contributors: ['linkpool_ryan','linkpool_jon']
+    config:
+      tags: ['chainlink','ocr', 'gas', 'daily', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
+    description: >
+        Chainlink OCR Gas Daily
+    columns:
+      - *blockchain
+      - &date_start
+        name: date_start
+        description: "Date Start"
+      - *date_month
+      - *node_address
+      - &operator_name
+        name: operator_name
+        description: "Operator Name"
+      - &fulfilled_token_amount
+        name: fulfilled_token_amount
+        description: "Fulfilled Token Amount"
+      - &fulfilled_usd_amount
+        name: fulfilled_usd_amount
+        description: "Fulfilled USD Amount"
+      - &reverted_token_amount
+        name: reverted_token_amount
+        description: "Reverted Token Amount"
+      - &reverted_usd_amount
+        name: reverted_usd_amount
+        description: "Reverted USD Amount"
+      - &total_token_amount
+        name: total_token_amount
+        description: "Total Token Amount"
+      - &total_usd_amount
+        name: total_usd_amount
+        description: "Total USD Amount"
+
+  - name: chainlink_ocr_request_daily
+    meta:
+      blockchain: ['arbitrum','avalanche_c','bnb','ethereum','fantom','gnosis','optimism','polygon']
+      sector: oracle
+      project: chainlink
+      contributors: ['linkpool_ryan','linkpool_jon']
+    config:
+      tags: ['chainlink','ocr', 'request', 'daily', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
+    description: >
+        Chainlink OCR Request Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *node_address
+      - *operator_name
+      - &fulfilled_requests
+        name: fulfilled_requests
+        description: "Fulfilled Requests"
+      - &reverted_requests
+        name: reverted_requests
+        description: "Reverted Requests"
+      - &total_requests
+        name: total_requests
+        description: "Total Requests"
+
+  - name: chainlink_ocr_reward_transmission_logs
+    meta:
+      blockchain: ['arbitrum','avalanche_c','bnb','ethereum','fantom','gnosis','optimism','polygon']
+      sector: oracle
+      project: chainlink
+      contributors: ['linkpool_ryan','linkpool_jon']
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'transmission', 'logs', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
+    description: >
+      Chainlink OCR Reward Transmission Logs
+    columns:
+      - *blockchain
+      - *block_hash
+      - *contract_address
+      - *data
+      - *topic0
+      - *topic1
+      - *topic2
+      - *topic3
+      - *tx_hash
+      - *block_number
+      - *block_time
+      - *index
+      - *tx_index
+
+  - name: chainlink_ocr_reward_evt_transfer
+    meta:
+      blockchain: ['arbitrum','avalanche_c','bnb','ethereum','fantom','gnosis','optimism','polygon']
+      sector: oracle
+      project: chainlink
+      contributors: ['linkpool_ryan','linkpool_jon']
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
+    description: >
+      Chainlink OCR Reward Event Transfers
+    columns:
+      - *blockchain
+      - &evt_block_time
+        name: evt_block_time
+        description: "Event Block Time"
+      - &admin_address
+        name: admin_address
+        description: "Admin Address"
+      - *operator_name
+      - &token_value
+        name: token_value
+        description: "Token Value"
+
+  - name: chainlink_ocr_reward_evt_transfer_daily
+    meta:
+      blockchain: ['arbitrum','avalanche_c','bnb','ethereum','fantom','gnosis','optimism','polygon']
+      sector: oracle
+      project: chainlink
+      contributors: ['linkpool_ryan','linkpool_jon']
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'daily', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
+    description: >
+      Chainlink OCR Reward Event Transfers Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address      
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_value
+
+  - name: chainlink_ocr_reward_daily
+    meta:
+      blockchain: ['arbitrum','avalanche_c','bnb','ethereum','fantom','gnosis','optimism','polygon']
+      sector: oracle
+      project: chainlink
+      contributors: ['linkpool_ryan','linkpool_jon']
+    config:
+      tags: ['chainlink','ocr', 'reward', 'daily', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
+    description: >
+        Chainlink OCR Reward Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_amount
+      - *usd_amount

--- a/models/chainlink/chainlink_schema.yml
+++ b/models/chainlink/chainlink_schema.yml
@@ -133,6 +133,13 @@ models:
       tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
     description: >
       Chainlink OCR Fulfilled Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -161,6 +168,13 @@ models:
       tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
     description: >
       Chainlink OCR Reverted Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -181,6 +195,12 @@ models:
       tags: ['chainlink','ocr', 'gas', 'daily', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
     description: >
         Chainlink OCR Gas Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - &date_start
@@ -220,6 +240,12 @@ models:
       tags: ['chainlink','ocr', 'request', 'daily', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
     description: >
         Chainlink OCR Request Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - *date_start
@@ -299,7 +325,7 @@ models:
           combination_of_columns:
               - blockchain
               - date_start
-              - admin_address      
+              - admin_address
     columns:
       - *blockchain
       - *date_start
@@ -318,6 +344,12 @@ models:
       tags: ['chainlink','ocr', 'reward', 'daily', 'arbitrum', 'avalanche_c', 'bnb', 'ethereum', 'fantom', 'gnosis', 'optimism', 'polygon']
     description: >
         Chainlink OCR Reward Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address
     columns:
       - *blockchain
       - *date_start

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_fulfilled_transactions.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_fulfilled_transactions.sql
@@ -1,0 +1,63 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_fulfilled_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  ethereum_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'ETH'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_fulfilled_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX((cast((gas_used) as double) / 1e18) * gas_price) as token_amount,
+      MAX(ethereum_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('ethereum', 'transactions') }} tx
+      RIGHT JOIN {{ ref('chainlink_ethereum_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
+      LEFT JOIN ethereum_usd ON date_trunc('minute', tx.block_time) = ethereum_usd.block_time
+    {% if is_incremental() %}
+      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'ethereum' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_fulfilled_transactions

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_fulfilled_transactions_legacy.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_fulfilled_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_fulfilled_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_daily.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_daily.sql
@@ -1,0 +1,81 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_gas_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(SUM(fulfilled.token_amount), 0) as fulfilled_token_amount,
+      COALESCE(SUM(reverted.token_amount), 0) as reverted_token_amount,
+      COALESCE(SUM(fulfilled.token_amount * fulfilled.usd_amount), 0) as fulfilled_usd_amount,
+      COALESCE(SUM(reverted.token_amount * reverted.usd_amount), 0) as reverted_usd_amount
+    FROM
+      {{ ref('chainlink_ethereum_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_ethereum_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_gas_daily AS (
+    SELECT
+      'ethereum' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_gas_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_token_amount,
+      fulfilled_usd_amount,
+      reverted_token_amount,
+      reverted_usd_amount,
+      fulfilled_token_amount + reverted_token_amount as total_token_amount,
+      fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
+    FROM ocr_gas_daily_meta
+    LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_token_amount,
+  fulfilled_usd_amount,
+  reverted_token_amount,
+  reverted_usd_amount,
+  total_token_amount,
+  total_usd_amount    
+FROM
+  ocr_gas_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_daily_legacy.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_transmission_logs.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'ethereum' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('ethereum', 'logs') }} logs
+WHERE
+  topic0 = 0xf6a97944f31ea060dfde0566e4167c1a1082551e64b60ecb14d599a9d023d451

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_transmission_logs_legacy.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_operator_admin_meta.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_operator_admin_meta.sql
@@ -1,0 +1,159 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_admin_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set tsystems = 'Deutsche Telekom MMS' %}
+{% set alphachain = 'Alpha Chain' %}
+{% set artifact = 'Artifact' %}
+{% set bharvest = 'B Harvest' %}
+{% set blockdaemon = 'Blockdaemon' %}
+{% set blocksizecapital = 'Blocksize Capital' %}
+{% set certusone = 'Certus One' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set chainlink = 'Chainlink' %}
+{% set chorusone = 'Chorus One' %}
+{% set coinbase = 'Coinbase' %}
+{% set cosmostation = 'Cosmostation' %}
+{% set cryptomanufaktur = 'CryptoManufaktur' %}
+{% set dmakers = 'dMakers' %}
+{% set dextrac = 'DexTrac' %}
+{% set dxfeed = 'dxFeed' %}
+{% set easy2stake = 'Easy 2 stake' %}
+{% set everstake = 'Everstake' %}
+{% set fiews = 'Fiews' %}
+{% set figmentnetworks = 'Figment Networks' %}
+{% set frameworkventures = 'Framework Ventures' %}
+{% set honeycomb = 'Honeycomb.market' %}
+{% set huobi = 'Huobi' %}
+{% set infinitystones = 'Infinity Stones' %}
+{% set infura = 'Infura' %}
+{% set inotel = 'Inotel' %}
+{% set kaiko = 'Kaiko' %}
+{% set kyber = 'Kyber' %}
+{% set kytzu = 'Kytzu' %}
+{% set lexisnexis = 'LexisNexis' %}
+{% set linkforest = 'LinkForest' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set matrixedlink = 'Matrixed.Link' %}
+{% set newroad = 'Newroad Network' %}
+{% set nomics = 'Nomics.com' %}
+{% set northwestnodes = 'NorthWest Nodes' %}
+{% set omniscience = 'Omniscience' %}
+{% set onchaintech = 'On-chain Tech' %}
+{% set orionmoney = 'Orion.Money' %}
+{% set p2porg = 'P2P.org' %}
+{% set paradigm = 'Paradigm Citadel' %}
+{% set prophet = 'Prophet' %}
+{% set rhino = 'RHINO' %}
+{% set securedatalinks = 'Secure Data Links' %}
+{% set simplyvc = 'Simply VC' %}
+{% set snzpool = 'SNZPool' %}
+{% set stakefish = 'stake.fish' %}
+{% set stakesystems = 'Stake Systems' %}
+{% set staked = 'Staked' %}
+{% set stakin = 'Stakin' %}
+{% set stakingfacilities = 'Staking Facilities' %}
+{% set swisscom = 'Swisscom' %}
+{% set syncnode = 'SyncNode' %}
+{% set thenetworkfirm = 'The Network Firm' %}
+{% set tiingo = 'Tiingo' %}
+{% set validationcloud = 'Validation Cloud' %}
+{% set vulcan = 'Vulcan Link' %}
+{% set wetez = 'Wetez' %}
+{% set xbto = 'XBTO' %}
+{% set youbi = 'Youbi' %}
+{% set ztake = 'Ztake.org' %}
+
+SELECT admin_address, operator_name FROM (VALUES
+  (0xD9459cc85E78e0336aDb349EAbF257Dbaf9d5a2B, '{{a01node}}'),
+  (0x89177B9c203bA0A9294aecf2f3806d98907bec6f, '{{tsystems}}'),
+  (0xa5D0084A766203b463b3164DFc49D91509C12daB, '{{alphachain}}'),
+  (0xfA3430d84324ABC9ac8AAf30B2D26260F5172ad0, '{{alphachain}}'),
+  (0xba8Bcb4EB9a90D5A0eAe0098496703b49f909cB2, '{{artifact}}'),
+  (0x6cDC3Efa3bAa392fAF3E5c1Ca802E15B6185E0e8, '{{bharvest}}'),
+  (0x3615Fa045f00ae0eD60Dc0141911757c2AdC5E03, '{{blockdaemon}}'),
+  (0x7CC60c9C24E9A290Db55b1017AF477E5c87a7550, '{{blocksizecapital}}'),
+  (0xdF0df748c782f0B9A52aEcb223Bf60e23f261283, '{{certusone}}'),
+  (0x8D689476EB446a1FB0065bFFAc32398Ed7F89165, '{{certusone}}'),
+  (0x9D219125a0CE10241b4eC1280c2F880475f172f1, '{{chainlayer}}'),
+  (0x56aCCE2EE3f86c0057C4ddfa7Bba1C8D99c83565, '{{chainlink}}'),
+  (0x304D69727DD28ad6E1aa2c01Db301dB556C7b725, '{{chainlink}}'),
+  (0x29fC5aACd613410b68c9c08d4e1656e3c890E482, '{{chorusone}}'),
+  (0xb44A46a7B245D82e15F07Cb352Fd5f1d3dBF65F6, '{{coinbase}}'),
+  (0x1B17eB8FAE3C28CB2463235F9D407b527ba4e6Dd, '{{cosmostation}}'),
+  (0x59eCf48345A221E0731E785ED79eD40d0A94E2A5, '{{cryptomanufaktur}}'),
+  (0x3b74c27115965ba74D695E3AEdb615F991F3f310, '{{dmakers}}'),
+  (0x9efa0A617C0552F1558c95993aA8b8A68b3e709C, '{{dextrac}}'),
+  (0xb284a468522663F6219f2912ca10145B52b13503, '{{dxfeed}}'),
+  (0x991812566f6E14897Fc1e401D24de19845c0442f, '{{dxfeed}}'),
+  (0xFdC770353dC0bFCE80a17Ab8a6a2E7d80590f1Ba, '{{easy2stake}}'),
+  (0x039fDFDb14911608a34eBCDa6009a80EF5D16e50, '{{everstake}}'),
+  (0x15918ff7f6C44592C81d999B442956B07D26CC44, '{{fiews}}'),
+  (0x95c98112bd9635A3159518401Ae227D5a296e994, '{{figmentnetworks}}'),
+  (0x6eF38c3d1D85B710A9e160aD41B912Cb8CAc2589, '{{frameworkventures}}'),
+  (0x47adCDcaA250C257C6e4db6dD091C6A6739333C9, '{{honeycomb}}'),
+  (0xC65c57A04e2cD361E7049f6c182ce1b62c7A92b3, '{{huobi}}'),
+  (0xDFBfB73f3013bc1584CcAa0CD2D9621194aEd29B, '{{infinitystones}}'),
+  (0xe6B12850b3979C50d221fb84d40FB94AeFBaB867, '{{infura}}'),
+  (0xdD831352762e9de7ad5a264990e1bB9F87A6Fc21, '{{inotel}}'),
+  (0xB8C6E43f37E04A2411562a13c1C48B3ad5975cf4, '{{inotel}}'),
+  (0xaA71518e7895C933f60EB2F02359cC40Ad6ef670, '{{kaiko}}'),
+  (0xAb5176dd2891dC01f5f8EC786263d85ee0690eC2, '{{kaiko}}'),
+  (0x54919167e0389b07a99e7cE9F66F1fd9f8C75d77, '{{kyber}}'),
+  (0x001E0d294383d5b4136476648aCc8D04a6461Ae3, '{{kytzu}}'),
+  (0x57F7f85C151A8A96CC20fEa6a43622334C335fe4, '{{kytzu}}'),
+  (0x098a4C7ceCbfb8534e5Ab3f9c8F6C87845Fc5109, '{{lexisnexis}}'),
+  (0x4564A9c6061f6f1F2Eadb954B1b3C241D2DC984e, '{{linkforest}}'),
+  (0x69f0fB5f300C45AfEbBBCd85E930EDBB142c0D48, '{{linkforest}}'),
+  (0xD48fc6E2B73C2988fA50C994181C0CdCa850D62a, '{{linkforest}}'),
+  (0x797de2909991C66C66D8e730C8385bbab8D18eA6, '{{linkpool}}'),
+  (0xCa878CF4a27690637c07B39ae06D26f7679Be4FC, '{{linkpool}}'),
+  (0xe9E11963f61322299f9919ff1dda01a825E82dBC, '{{linkpool}}'),
+  (0x14f94049397C3F1807c45B6f854Cb5F36bC4393B, '{{linkriver}}'),
+  (0x4dc81f63CB356c1420D4620414f366794072A3a8, '{{matrixedlink}}'),
+  (0xAB35418fB9f8B13E3e6857c36A0769b9F94a87EC, '{{newroad}}'),
+  (0x425f682362b2b1032A212226a474Fa7D3703f2a8, '{{nomics}}'),
+  (0x0921E157b690c4F89F7C2a210cFd8bF3964F6776, '{{northwestnodes}}'),
+  (0x47044eE2F23001F8a03FB2f7d2ce6645aDA4D12A, '{{omniscience}}'),
+  (0x70Ba986EF5a805A7019415eDF342eD4365331fF1, '{{omniscience}}'),
+  (0x35DaC078fC9E6e45d89a6CBc78A776BA719b485D, '{{onchaintech}}'),
+  (0xE2063AA95B35f8121A5E2f58BfE6a985270ABA77, '{{orionmoney}}'),
+  (0xa0181758B14EfB2DAdfec66d58251Ae631e2B942, '{{orionmoney}}'),
+  (0xCDa423ee5A7A886eF113b181469581306fC8B607, '{{p2porg}}'),
+  (0xB45A43e998286ab3Be4106b4c381f01dccE772a4, '{{p2porg}}'),
+  (0xfb390441fF968F7569cd6F3CF01cb7214DFeed31, '{{paradigm}}'),
+  (0xBDB624CD1051F687f116bB0c642330B2aBdfcc06, '{{prophet}}'),
+  (0xDA80050Ed4F50033949608208f79EE43Ab91dF55, '{{rhino}}'),
+  (0x3FB4600736d306Ee2A89EdF0356D4272fb095768, '{{securedatalinks}}'),
+  (0x4fBefaf1BFf0130945C61603B97D38DD6e21f5Cf, '{{simplyvc}}'),
+  (0x9cCbFD17FA284f36c2ff503546160B256d1CD3D1, '{{snzpool}}'),
+  (0x21F1dB6E4B5e1dF5c68bC1dfB58c28942Ed4737D, '{{stakefish}}'),
+  (0x61C808D82A3Ac53231750daDc13c777b59310bD9, '{{stakefish}}'),
+  (0xA68F8E34B775aA1f0c0E9028b13BdB481eCf486c, '{{stakesystems}}'),
+  (0x87BCD34B45784081fda93a10797e2dB51B8466Aa, '{{staked}}'),
+  (0x5823D12aD85Ef11f4e5508AB3559a37D87CF507A, '{{stakin}}'),
+  (0xdD4Bc51496dc93A0c47008E820e0d80745476f22, '{{stakingfacilities}}'),
+  (0xcc3F2FB70B5941FBdB9F97fD6Df6997A01229ecE, '{{swisscom}}'),
+  (0xC51D3470693BC049809A1c515606124c7C75908d, '{{syncnode}}'),
+  (0x7c9998a91AEA813Ea8340b47B27259D74896d136, '{{thenetworkfirm}}'),
+  (0xfAE26207ab74ee528214ee92f94427f8Cdbb6A32, '{{tiingo}}'),
+  (0x183A96629fF566e7AA8AfA38980Cd037EB40A59A, '{{validationcloud}}'),
+  (0x7D0f8dd25135047967bA6C50309b567957dd52c3, '{{vulcan}}'),
+  (0x4E28977d71f148ae2c523e8Aa4b6F3071d81Add1, '{{vulcan}}'),
+  (0x111f1B41f702c20707686769a4b7f25c56C533B2, '{{wetez}}'),
+  (0x0b16EC1044F60F03B0e815f863bd4d27638cbD0A, '{{xbto}}'),
+  (0x3331452b9D6f76E35951f3B8C5881D5801f08612, '{{youbi}}'),
+  (0x41EdD305eABFd3497C98341F8D0849F3C520b896, '{{ztake}}'),
+  (0xC8c30Fa803833dD1Fd6DBCDd91Ed0b301EFf87cF, '{{ztake}}'),
+  (0x9d69B0fcbcf9a7e513E947Cd7ce2019904e2E764, '{{ztake}}')
+) AS tmp_node_meta(admin_address, operator_name)

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_operator_admin_meta_legacy.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_operator_admin_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_admin_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_operator_node_meta.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_operator_node_meta.sql
@@ -1,0 +1,158 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_node_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set tsystems = 'Deutsche Telekom MMS' %}
+{% set alphachain = 'Alpha Chain' %}
+{% set artifact = 'Artifact' %}
+{% set bharvest = 'B Harvest' %}
+{% set blockdaemon = 'Blockdaemon' %}
+{% set blocksizecapital = 'Blocksize Capital' %}
+{% set certusone = 'Certus One' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set chainlink = 'Chainlink' %}
+{% set chorusone = 'Chorus One' %}
+{% set coinbase = 'Coinbase' %}
+{% set cosmostation = 'Cosmostation' %}
+{% set cryptomanufaktur = 'CryptoManufaktur' %}
+{% set dmakers = 'dMakers' %}
+{% set dextrac = 'DexTrac' %}
+{% set dxfeed = 'dxFeed' %}
+{% set easy2stake = 'Easy 2 stake' %}
+{% set everstake = 'Everstake' %}
+{% set fiews = 'Fiews' %}
+{% set figmentnetworks = 'Figment Networks' %}
+{% set frameworkventures = 'Framework Ventures' %}
+{% set honeycomb = 'Honeycomb.market' %}
+{% set huobi = 'Huobi' %}
+{% set infinitystones = 'Infinity Stones' %}
+{% set infura = 'Infura' %}
+{% set inotel = 'Inotel' %}
+{% set kaiko = 'Kaiko' %}
+{% set kyber = 'Kyber' %}
+{% set kytzu = 'Kytzu' %}
+{% set lexisnexis = 'LexisNexis' %}
+{% set linkforest = 'LinkForest' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set matrixedlink = 'Matrixed.Link' %}
+{% set newroad = 'Newroad Network' %}
+{% set nomics = 'Nomics.com' %}
+{% set northwestnodes = 'NorthWest Nodes' %}
+{% set omniscience = 'Omniscience' %}
+{% set onchaintech = 'On-chain Tech' %}
+{% set orionmoney = 'Orion.Money' %}
+{% set p2porg = 'P2P.org' %}
+{% set paradigm = 'Paradigm Citadel' %}
+{% set prophet = 'Prophet' %}
+{% set rhino = 'RHINO' %}
+{% set securedatalinks = 'Secure Data Links' %}
+{% set simplyvc = 'Simply VC' %}
+{% set snzpool = 'SNZPool' %}
+{% set stakefish = 'stake.fish' %}
+{% set stakesystems = 'Stake Systems' %}
+{% set staked = 'Staked' %}
+{% set stakin = 'Stakin' %}
+{% set stakingfacilities = 'Staking Facilities' %}
+{% set swisscom = 'Swisscom' %}
+{% set syncnode = 'SyncNode' %}
+{% set thenetworkfirm = 'The Network Firm' %}
+{% set tiingo = 'Tiingo' %}
+{% set validationcloud = 'Validation Cloud' %}
+{% set vulcan = 'Vulcan Link' %}
+{% set wetez = 'Wetez' %}
+{% set xbto = 'XBTO' %}
+{% set youbi = 'Youbi' %}
+{% set ztake = 'Ztake.org' %}
+
+SELECT node_address, operator_name FROM (VALUES
+  (0xCF4Be57aA078Dc7568C631BE7A73adc1cdA992F8, '{{a01node}}'),
+  (0x7147333c6d821612577481458E512560bfA12ebD, '{{a01node}}'),
+  (0xddEB598fe902A13Cc523aaff5240e9988eDCE170, '{{tsystems}}'),
+  (0xA2C13eafA8417d5eE8f1B5D50b99D42CbFe910bA, '{{alphachain}}'),
+  (0x5a8216a9c47ee2E8Df1c874252fDEe467215C25b, '{{alphachain}}'),
+  (0x165Ff6730D449Af03B4eE1E48122227a3328A1fc, '{{alphachain}}'),
+  (0xF585A4aE338bC165D96E8126e8BBcAcAE725d79E, '{{artifact}}'),
+  (0xc61a7e5a04A5d32ffe8e01f77Cb39253bf21D2aC, '{{bharvest}}'),
+  (0x57CD4848b12469618b689163f507817940AccA02, '{{blockdaemon}}'),
+  (0x47b9161Daf189017BF1b499455c65F9234DF3FA3, '{{blockdaemon}}'),
+  (0x7663C5790E1eBf04197245d541279D13f3c2f362, '{{blocksizecapital}}'),
+  (0x11B6E91E5f8E9f2bC3d09d5c5113134Cc85754a6, '{{certusone}}'),
+  (0xc74cE67BfC623c803D48AFc74a09A6FF6b599003, '{{chainlayer}}'),
+  (0x18c930d5EA5e33A4b633Cf52d5e83278a6080347, '{{chainlayer}}'),
+  (0x6B056837e1968e495d05d7CC0114E9693d2C9002, '{{chainlink}}'),
+  (0x64c735D72EAB90C04da523B6b9895773ACb60F5D, '{{chorusone}}'),
+  (0xd461DCb175C22b31250f2D21d8034710853547Cb, '{{coinbase}}'),
+  (0x70bC61658615725A82D5e78FF0066BFCb1b98988, '{{cosmostation}}'),
+  (0x9741569DEDB1E0cB204f2dF7f43f7a52bB49ba3A, '{{cryptomanufaktur}}'),
+  (0xCe859E48f6cE9834a119Ba04FdC53c1D4F1082A7, '{{dmakers}}'),
+  (0xb976d01275B809333E3EfD76D1d31fE9264466D0, '{{dextrac}}'),
+  (0x1e1956cAfdB99f8A757EF902B2A4C67F3122ffcc, '{{dextrac}}'),
+  (0x620249ff124b6c62FeA908C27292461ceB9874B2, '{{dxfeed}}'),
+  (0xf6BfDBAFf15E778CbaA0C71CDb752810868a176f, '{{dxfeed}}'),
+  (0x5565b5362FF9f468bA2f144f38b87187C9a010A8, '{{easy2stake}}'),
+  (0x66E3dCA826b04B5d4988F7a37c91c9b1041e579D, '{{easy2stake}}'),
+  (0xa938d77590aF1d98BaB7dc4a0bde594fC3F9c403, '{{everstake}}'),
+  (0x218B5a7861dBf368D09A84E0dBfF6C6DDbf99DB8, '{{fiews}}'),
+  (0xd156C977cB92Fc00E3A44f7856Db3fCc9a0f28A7, '{{fiews}}'),
+  (0xEdBED9F5dEA03dD0ec484577C41502af68B7c46a, '{{figmentnetworks}}'),
+  (0x2a4a7afA40a9D03B425752fb4cFd5f0FF5b3964C, '{{frameworkventures}}'),
+  (0x6878fb222FfF9A2fE3C0Cde77D281916f8D296b3, '{{huobi}}'),
+  (0xe4327d547F8C02e57451b2472B8f9a853D855839, '{{huobi}}'),
+  (0x982fa4d5F5C8C0063493AbE58967cA3B7639F10F, '{{infinitystones}}'),
+  (0x8C4BC738c709BE322Fe4C078032850Cd10ab0032, '{{infura}}'),
+  (0xddA14A7c503341Fc6Fe9C002CA7524bF74ec8918, '{{inotel}}'),
+  (0xDbfea8D5822141c13f92CaA06EB94d0F3d67C243, '{{inotel}}'),
+  (0x9850E11D2c33B43AB80d478CCC69042b46ab3857, '{{kaiko}}'),
+  (0xF42336e35D5C1D1D0DB3140E174BcFc3945f6822, '{{kyber}}'),
+  (0xf16e77a989529AA4C58318acEe8A1548Df3fcCc1, '{{kytzu}}'),
+  (0xf6E7Dba31369024F0044F24ce5dc2C612B298EDd, '{{lexisnexis}}'),
+  (0x3C4ad65F5b4884397e1F09596c7ac7F8F95b3fF3, '{{linkforest}}'),
+  (0x3DAbA1A7508c9de6039fCFDA35B5c6D1C103c68f, '{{linkforest}}'),
+  (0xcC29be4Ca92D4Ecc43C8451fBA94C200B83991f6, '{{linkpool}}'),
+  (0x1589d072aC911a55c2010D97839a1f61b1e3323A, '{{linkpool}}'),
+  (0x686beC83b59F8b23A6129f03550A3Aad245a543C, '{{linkriver}}'),
+  (0xd0fF3C55A27c930069Cb4EFA32921B89792CA8CC, '{{linkriver}}'),
+  (0x1feEc90f63B1927d1078D123A57f940E680a3AbF, '{{matrixedlink}}'),
+  (0x9cFAb1513FFA293E7023159B3C7A4C984B6a3480, '{{newroad}}'),
+  (0xE3cd128883f2954D78923487B67Ea7C4F25C7C46, '{{nomics}}'),
+  (0x632f869a26Ab4DA58e2Da476EE74800f2BAE060A, '{{northwestnodes}}'),
+  (0xF07131F578a5F708AE2CCB9faF98458099E0FFB4, '{{omniscience}}'),
+  (0xB5b90F596341127dE460465dEA9b28b8a6Bd1984, '{{onchaintech}}'),
+  (0x0D785c33bCe2D09e521BFc433efe42Da53d3A898, '{{orionmoney}}'),
+  (0x8F3Ab0e87B70a57bD4980111a99a1b2c4b8334F4, '{{p2porg}}'),
+  (0x23c8Fbd5E14A9565707D8D1a88045F2fA5648968, '{{p2porg}}'),
+  (0x8b1d49a93A84B5dA0917a1ed42D8a3E191C28524, '{{prophet}}'),
+  (0xF1595809dE873a363d1647853C37dA5506Ed8Da6, '{{prophet}}'),
+  (0x634438d879a90a25437B87168252c2b983734391, '{{rhino}}'),
+  (0xF7C7AEaECD2349b129d5d15790241c32eeE4607B, '{{securedatalinks}}'),
+  (0x61317C73d0225b2E37140fb9664d607B450613C6, '{{simplyvc}}'),
+  (0x3E70292211fDe00095408442766C7E56Eb91176c, '{{simplyvc}}'),
+  (0x7BFb89db2d7217c57C3Ad3d4B55826eFD17dC2e9, '{{snzpool}}'),
+  (0xFa0E4F48a369BB3eCBCEe0B5119379EA8D1bcF29, '{{stakefish}}'),
+  (0x9e1735D07F77ABA85415fbE19fdb371a56Cabf07, '{{stakesystems}}'),
+  (0xBbf078A8849D74623e36E6DBBdC8e0a35E657C26, '{{staked}}'),
+  (0x3aE9D0B74E3968CFCf89A4dE4f0D8B2A326a1Dfd, '{{stakin}}'),
+  (0x43793ee58E0a3D920e3e4a115A9FA07dc4B09715, '{{stakingfacilities}}'),
+  (0x571476978D2eE5493199A3458Df3aA14afeAdED8, '{{swisscom}}'),
+  (0x0312EA121df0a323fF535B753172736cc9d53d13, '{{syncnode}}'),
+  (0xa7767CDb3252397d9D6050acD84819AFaBcd2Ff1, '{{syncnode}}'),
+  (0xD084c90d0e486ade2c045374dB447b99f94811Ee, '{{thenetworkfirm}}'),
+  (0x265b3Aaeb858F32Fe18CFc28EEA21977Fc379F3C, '{{tiingo}}'),
+  (0xC4b732Fd121F2f3783A9Ac2a6C62fD535FD13FdA, '{{validationcloud}}'),
+  (0x52e77F4356bB39cBA841dC3E9c28eCe86900d68A, '{{validationcloud}}'),
+  (0xD22c87Dc7a3F12dcBB75CEbDA2e96f6766AE114F, '{{vulcan}}'),
+  (0x5a6fCc02D8c50eA58a22115A7c4608b723030016, '{{wetez}}'),
+  (0xe3E0596AC55Ae6044b757baB27426F7dC9e018d4, '{{xbto}}'),
+  (0x7744F58E29849Bc7C804e4F4b88d0CE12f068513, '{{youbi}}'),
+  (0xDdE59ceeC7A2cC8B2bD78199877BA22018966813, '{{ztake}}')
+) AS tmp_node_meta(node_address, operator_name)

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_operator_node_meta_legacy.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_operator_node_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_node_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_request_daily.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_request_daily.sql
@@ -1,0 +1,74 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_request_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_request_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(COUNT(fulfilled.token_amount), 0) as fulfilled_requests,
+      COALESCE(COUNT(reverted.token_amount), 0) as reverted_requests,
+      COALESCE(COUNT(fulfilled.token_amount), 0) + COALESCE(COUNT(reverted.token_amount), 0) as total_requests
+    FROM
+      {{ ref('chainlink_ethereum_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_ethereum_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_request_daily AS (
+    SELECT
+      'ethereum' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_request_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_requests,
+      reverted_requests,
+      total_requests
+    FROM ocr_request_daily_meta
+    LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_requests,
+  reverted_requests,
+  total_requests
+FROM
+  ocr_request_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_request_daily_legacy.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_request_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_request_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_reverted_transactions.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_reverted_transactions.sql
@@ -1,0 +1,64 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reverted_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  ethereum_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'ETH'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_reverted_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX((cast((gas_used) as double) / 1e18) * gas_price) as token_amount,
+      MAX(ethereum_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('ethereum', 'transactions') }} tx
+      LEFT JOIN ethereum_usd ON date_trunc('minute', tx.block_time) = ethereum_usd.block_time
+    WHERE
+      success = false
+      {% if is_incremental() %}
+        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'ethereum' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_reverted_transactions

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_reverted_transactions_legacy.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_reverted_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reverted_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_daily.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_daily.sql
@@ -1,0 +1,111 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_daily'),
+    partition_by = ['date_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  admin_address_meta as (
+    SELECT DISTINCT
+      admin_address
+    FROM
+      {{ref('chainlink_ethereum_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+  ),
+  link_usd_daily AS (
+    SELECT
+      cast(date_trunc('day', price.minute) as date) as "date_start",
+      MAX(price.price) as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      price.symbol = 'LINK'
+      {% if is_incremental() %}
+        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      1
+    ORDER BY
+      1
+  ),
+  link_usd_daily_expanded_by_admin_address AS (
+    SELECT
+      date_start,
+      usd_amount,
+      admin_address
+    FROM
+      link_usd_daily
+    CROSS JOIN
+      admin_address_meta
+    ORDER BY
+      date_start,
+      admin_address
+  ),
+  payment_meta AS (
+    SELECT
+      date_start,
+      link_usd_daily_expanded_by_admin_address.admin_address as admin_address,
+      usd_amount,
+      (
+        SELECT
+          MAX(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_ethereum_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start <= link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as prev_payment_date,
+      (
+        SELECT
+          MIN(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_ethereum_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start > link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as next_payment_date
+    FROM
+      link_usd_daily_expanded_by_admin_address
+    ORDER BY
+      1, 2
+  ),
+  ocr_reward_daily AS (
+    SELECT 
+      payment_meta.date_start,
+      cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
+      payment_meta.admin_address,
+      ocr_operator_admin_meta.operator_name,      
+      COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
+      (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
+    FROM 
+      payment_meta
+    LEFT JOIN 
+      {{ref('chainlink_ethereum_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
+        payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
+        payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    ORDER BY date_start
+  )
+SELECT
+  'ethereum' as blockchain,
+  date_start,
+  date_month,
+  admin_address,
+  operator_name,
+  token_amount,
+  usd_amount
+FROM 
+  ocr_reward_daily
+ORDER BY
+  2, 4

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_daily_legacy.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'ethereum' as blockchain,
+  to as admin_address,
+  MAX(operator_name) as operator_name,
+  MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+  MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+FROM
+  {{ source('erc20_ethereum', 'evt_Transfer') }} reward_evt_transfer
+  RIGHT JOIN {{ ref('chainlink_ethereum_ocr_reward_transmission_logs') }} ocr_reward_transmission_logs ON ocr_reward_transmission_logs.contract_address = reward_evt_transfer."from"
+  LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+WHERE
+  reward_evt_transfer."from" IN (ocr_reward_transmission_logs.contract_address)
+GROUP BY
+  evt_tx_hash,
+  evt_index,
+  to

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer_daily.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer_daily.sql
@@ -1,0 +1,38 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+SELECT
+  'ethereum' as blockchain,
+  cast(date_trunc('day', evt_block_time) AS date) AS date_start,
+  MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
+  ocr_reward_evt_transfer.admin_address as admin_address,
+  MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
+  SUM(token_value) as token_amount
+FROM
+  {{ref('chainlink_ethereum_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
+{% if is_incremental() %}
+  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+{% endif %}      
+GROUP BY
+  2, 4
+ORDER BY
+  2, 4
+
+
+

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer_daily_legacy.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer_legacy.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_transmission_logs.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'ethereum' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('ethereum', 'logs') }} logs
+WHERE
+  topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_transmission_logs_legacy.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/ethereum/chainlink_ethereum_schema.yml
+++ b/models/chainlink/ethereum/chainlink_ethereum_schema.yml
@@ -67,6 +67,13 @@ models:
       tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'ethereum']
     description: >
       Chainlink OCR Fulfilled Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -94,6 +101,13 @@ models:
       tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'ethereum']
     description: >
       Chainlink OCR Reverted Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -113,6 +127,12 @@ models:
       tags: ['chainlink','ocr', 'gas', 'daily', 'ethereum']
     description: >
         Chainlink OCR Gas Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - &date_start
@@ -151,6 +171,12 @@ models:
       tags: ['chainlink','ocr', 'request', 'daily', 'ethereum']
     description: >
         Chainlink OCR Request Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - *date_start
@@ -227,7 +253,7 @@ models:
           combination_of_columns:
               - blockchain
               - date_start
-              - admin_address      
+              - admin_address
     columns:
       - *blockchain
       - *date_start
@@ -245,6 +271,12 @@ models:
       tags: ['chainlink','ocr', 'reward', 'daily', 'ethereum']
     description: >
         Chainlink OCR Reward Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address
     columns:
       - *blockchain
       - *date_start

--- a/models/chainlink/ethereum/chainlink_ethereum_schema.yml
+++ b/models/chainlink/ethereum/chainlink_ethereum_schema.yml
@@ -1,0 +1,256 @@
+version: 2
+
+models:
+  - name: chainlink_ethereum_ocr_gas_transmission_logs
+    meta:
+      blockchain: ethereum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'gas', 'transmission', 'logs', 'ethereum']
+    description: >
+      Chainlink OCR Gas Transmission Logs
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - block_number
+              - tx_hash
+              - tx_index
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain"
+      - &block_hash
+        name: block_hash
+        description: "Block Hash"
+      - &contract_address
+        name: contract_address
+        description: "Contract Address"
+      - &data
+        name: data
+        description: "Data"
+      - &topic0
+        name: topic0
+        description: "Topic 0"
+      - &topic1
+        name: topic1
+        description: "Topic 1"
+      - &topic2
+        name: topic2
+        description: "Topic 2"
+      - &topic3
+        name: topic3
+        description: "Topic 3"
+      - &tx_hash
+        name: tx_hash
+        description: "Transaction Hash"
+      - &block_number
+        name: block_number
+        description: "Block Number"
+      - &block_time
+        name: block_time
+        description: "Block Time"
+      - &index
+        name: index
+        description: "Index"
+      - &tx_index
+        name: tx_index
+        description: "Transaction Index"
+
+  - name: chainlink_ethereum_ocr_fulfilled_transactions
+    meta:
+      blockchain: ethereum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'ethereum']
+    description: >
+      Chainlink OCR Fulfilled Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - &date_month
+        name: date_month
+        description: "Date truncated by month"
+      - &node_address
+        name: node_address
+        description: "Node Address"
+      - &token_amount
+        name: token_amount
+        description: "Token Amount"
+      - &usd_amount
+        name: usd_amount
+        description: "USD Amount"
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_ethereum_ocr_reverted_transactions
+    meta:
+      blockchain: ethereum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'ethereum']
+    description: >
+      Chainlink OCR Reverted Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - *date_month
+      - *node_address
+      - *token_amount
+      - *usd_amount
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_ethereum_ocr_gas_daily
+    meta:
+      blockchain: ethereum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'gas', 'daily', 'ethereum']
+    description: >
+        Chainlink OCR Gas Daily
+    columns:
+      - *blockchain
+      - &date_start
+        name: date_start
+        description: "Date Start"
+      - *date_month
+      - *node_address
+      - &operator_name
+        name: operator_name
+        description: "Operator Name"
+      - &fulfilled_token_amount
+        name: fulfilled_token_amount
+        description: "Fulfilled Token Amount"
+      - &fulfilled_usd_amount
+        name: fulfilled_usd_amount
+        description: "Fulfilled USD Amount"
+      - &reverted_token_amount
+        name: reverted_token_amount
+        description: "Reverted Token Amount"
+      - &reverted_usd_amount
+        name: reverted_usd_amount
+        description: "Reverted USD Amount"
+      - &total_token_amount
+        name: total_token_amount
+        description: "Total Token Amount"
+      - &total_usd_amount
+        name: total_usd_amount
+        description: "Total USD Amount"
+
+  - name: chainlink_ethereum_ocr_request_daily
+    meta:
+      blockchain: ethereum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'request', 'daily', 'ethereum']
+    description: >
+        Chainlink OCR Request Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *node_address
+      - *operator_name
+      - &fulfilled_requests
+        name: fulfilled_requests
+        description: "Fulfilled Requests"
+      - &reverted_requests
+        name: reverted_requests
+        description: "Reverted Requests"
+      - &total_requests
+        name: total_requests
+        description: "Total Requests"
+
+  - name: chainlink_ethereum_ocr_reward_transmission_logs
+    meta:
+      blockchain: ethereum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'transmission', 'logs', 'ethereum']
+    description: >
+      Chainlink OCR Reward Transmission Logs
+    columns:
+      - *blockchain
+      - *block_hash
+      - *contract_address
+      - *data
+      - *topic0
+      - *topic1
+      - *topic2
+      - *topic3
+      - *tx_hash
+      - *block_number
+      - *block_time
+      - *index
+      - *tx_index
+
+  - name: chainlink_ethereum_ocr_reward_evt_transfer
+    meta:
+      blockchain: ethereum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'ethereum']
+    description: >
+      Chainlink OCR Reward Event Transfers
+    columns:
+      - *blockchain
+      - &evt_block_time
+        name: evt_block_time
+        description: "Event Block Time"
+      - &admin_address
+        name: admin_address
+        description: "Admin Address"
+      - *operator_name
+      - &token_value
+        name: token_value
+        description: "Token Value"
+
+  - name: chainlink_ethereum_ocr_reward_evt_transfer_daily
+    meta:
+      blockchain: ethereum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'daily', 'ethereum']
+    description: >
+      Chainlink OCR Reward Event Transfers Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address      
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_value
+
+  - name: chainlink_ethereum_ocr_reward_daily
+    meta:
+      blockchain: ethereum
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'reward', 'daily', 'ethereum']
+    description: >
+        Chainlink OCR Reward Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_amount
+      - *usd_amount
+

--- a/models/chainlink/fantom/chainlink_fantom_ocr_fulfilled_transactions.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_fulfilled_transactions.sql
@@ -1,0 +1,63 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_fulfilled_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  fantom_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'FTM'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_fulfilled_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX((cast((gas_used) as double) / 1e18) * gas_price) as token_amount,
+      MAX(fantom_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('fantom', 'transactions') }} tx
+      RIGHT JOIN {{ ref('chainlink_fantom_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
+      LEFT JOIN fantom_usd ON date_trunc('minute', tx.block_time) = fantom_usd.block_time
+    {% if is_incremental() %}
+      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'fantom' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_fulfilled_transactions

--- a/models/chainlink/fantom/chainlink_fantom_ocr_fulfilled_transactions_legacy.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_fulfilled_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_fulfilled_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/fantom/chainlink_fantom_ocr_gas_daily.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_gas_daily.sql
@@ -1,0 +1,81 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_gas_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(SUM(fulfilled.token_amount), 0) as fulfilled_token_amount,
+      COALESCE(SUM(reverted.token_amount), 0) as reverted_token_amount,
+      COALESCE(SUM(fulfilled.token_amount * fulfilled.usd_amount), 0) as fulfilled_usd_amount,
+      COALESCE(SUM(reverted.token_amount * reverted.usd_amount), 0) as reverted_usd_amount
+    FROM
+      {{ ref('chainlink_fantom_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_fantom_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_gas_daily AS (
+    SELECT
+      'fantom' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_gas_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_token_amount,
+      fulfilled_usd_amount,
+      reverted_token_amount,
+      reverted_usd_amount,
+      fulfilled_token_amount + reverted_token_amount as total_token_amount,
+      fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
+    FROM ocr_gas_daily_meta
+    LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_token_amount,
+  fulfilled_usd_amount,
+  reverted_token_amount,
+  reverted_usd_amount,
+  total_token_amount,
+  total_usd_amount    
+FROM
+  ocr_gas_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/fantom/chainlink_fantom_ocr_gas_daily_legacy.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_gas_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/fantom/chainlink_fantom_ocr_gas_transmission_logs.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_gas_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'fantom' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('fantom', 'logs') }} logs
+WHERE
+  topic0 = 0xf6a97944f31ea060dfde0566e4167c1a1082551e64b60ecb14d599a9d023d451

--- a/models/chainlink/fantom/chainlink_fantom_ocr_gas_transmission_logs_legacy.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_gas_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/fantom/chainlink_fantom_ocr_operator_admin_meta.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_operator_admin_meta.sql
@@ -1,0 +1,50 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_admin_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set cryptomanufaktur = 'CryptoManufaktur' %}
+{% set dextrac = 'DexTrac' %}
+{% set easy2stake = 'Easy 2 stake' %}
+{% set fiews = 'Fiews' %}
+{% set inotel = 'Inotel' %}
+{% set kytzu = 'Kytzu' %}
+{% set linkforest = 'LinkForest' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set newroad = 'Newroad Network' %}
+{% set p2porg = 'P2P.org' %}
+{% set prophet = 'Prophet' %}
+{% set syncnode = 'SyncNode' %}
+{% set tiingo = 'Tiingo' %}
+{% set vulcan = 'Vulcan Link' %}
+
+SELECT admin_address, operator_name FROM (VALUES
+  (0xD9459cc85E78e0336aDb349EAbF257Dbaf9d5a2B, '{{a01node}}'),
+  (0x4a3dF8cAe46765d33c2551ff5438a5C5FC44347c, '{{chainlayer}}'),
+  (0x59eCf48345A221E0731E785ED79eD40d0A94E2A5, '{{cryptomanufaktur}}'),
+  (0x9efa0A617C0552F1558c95993aA8b8A68b3e709C, '{{dextrac}}'),
+  (0xFdC770353dC0bFCE80a17Ab8a6a2E7d80590f1Ba, '{{easy2stake}}'),
+  (0x15918ff7f6C44592C81d999B442956B07D26CC44, '{{fiews}}'),
+  (0xB8C6E43f37E04A2411562a13c1C48B3ad5975cf4, '{{inotel}}'),
+  (0x57F7f85C151A8A96CC20fEa6a43622334C335fe4, '{{kytzu}}'),
+  (0x001E0d294383d5b4136476648aCc8D04a6461Ae3, '{{kytzu}}'),
+  (0x4564A9c6061f6f1F2Eadb954B1b3C241D2DC984e, '{{linkforest}}'),
+  (0x797de2909991C66C66D8e730C8385bbab8D18eA6, '{{linkpool}}'),
+  (0x14f94049397C3F1807c45B6f854Cb5F36bC4393B, '{{linkriver}}'),
+  (0xAB35418fB9f8B13E3e6857c36A0769b9F94a87EC, '{{newroad}}'),
+  (0xCDa423ee5A7A886eF113b181469581306fC8B607, '{{p2porg}}'),
+  (0xBDB624CD1051F687f116bB0c642330B2aBdfcc06, '{{prophet}}'),
+  (0xC51D3470693BC049809A1c515606124c7C75908d, '{{syncnode}}'),
+  (0xfAE26207ab74ee528214ee92f94427f8Cdbb6A32, '{{tiingo}}'),
+  (0x7D0f8dd25135047967bA6C50309b567957dd52c3, '{{vulcan}}')
+) AS tmp_node_meta(admin_address, operator_name)

--- a/models/chainlink/fantom/chainlink_fantom_ocr_operator_admin_meta_legacy.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_operator_admin_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_admin_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/fantom/chainlink_fantom_ocr_operator_node_meta.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_operator_node_meta.sql
@@ -1,0 +1,49 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_node_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set cryptomanufaktur = 'CryptoManufaktur' %}
+{% set dextrac = 'DexTrac' %}
+{% set easy2stake = 'Easy 2 stake' %}
+{% set fiews = 'Fiews' %}
+{% set inotel = 'Inotel' %}
+{% set kytzu = 'Kytzu' %}
+{% set linkforest = 'LinkForest' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set newroad = 'Newroad Network' %}
+{% set p2porg = 'P2P.org' %}
+{% set prophet = 'Prophet' %}
+{% set syncnode = 'SyncNode' %}
+{% set tiingo = 'Tiingo' %}
+{% set vulcan = 'Vulcan Link' %}
+
+SELECT node_address, operator_name FROM (VALUES
+  (0x09285FBb87B75FBA9400683233C0BC1DE53afCa8, '{{a01node}}'),
+  (0xCC4c922db2EF8c911F37E73c03B632DD1585Ad0E, '{{chainlayer}}'),
+  (0xB2ffBb538558196e5Db351b33B647eFe654a9647, '{{cryptomanufaktur}}'),
+  (0xF3C4a8041c62146350C83d593D4ecccD3C1D8F86, '{{dextrac}}'),
+  (0x05Ee5882122A86C8D15D8D5ECB42830503A7d0d8, '{{easy2stake}}'),
+  (0x31C67a7132DB4347CAe91B93427C27E2d9a2d624, '{{fiews}}'),
+  (0x13bd632d6Ff4Cb8738172A3b43BdEbf618E580C0, '{{inotel}}'),
+  (0x9482f1C1a7Be7376373cc17274c573085059bFEE, '{{kytzu}}'),
+  (0xE9300E1dADA80A7178B14F3980616D2657e706d5, '{{linkforest}}'),
+  (0x89123981e8bcc9532A8c3f6C6EF5ad08A67eFA1d, '{{linkpool}}'),
+  (0x9C53F322F40C90A978E282850dFb445EE7a46975, '{{linkriver}}'),
+  (0x0C37dFf392f202447946fe7F45f950b5E456A13a, '{{newroad}}'),
+  (0x120Af64d9B7bB555cd2Abc47A945d126ddeD0376, '{{p2porg}}'),
+  (0x8A8530344e4ABd4C4C34E4DB68BA88C8Bea69254, '{{prophet}}'),
+  (0x7dAeEC3B738C130ea78d4EaBDCE3b791c44555db, '{{syncnode}}'),
+  (0x991340a2A87db4397339e913E7bBdc1847b61414, '{{tiingo}}'),
+  (0xC87DD1D817018102B313514E497293E8878795d8, '{{vulcan}}')
+) AS tmp_node_meta(node_address, operator_name)

--- a/models/chainlink/fantom/chainlink_fantom_ocr_operator_node_meta_legacy.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_operator_node_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_node_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/fantom/chainlink_fantom_ocr_request_daily.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_request_daily.sql
@@ -1,0 +1,74 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_request_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_request_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(COUNT(fulfilled.token_amount), 0) as fulfilled_requests,
+      COALESCE(COUNT(reverted.token_amount), 0) as reverted_requests,
+      COALESCE(COUNT(fulfilled.token_amount), 0) + COALESCE(COUNT(reverted.token_amount), 0) as total_requests
+    FROM
+      {{ ref('chainlink_fantom_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_fantom_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_request_daily AS (
+    SELECT
+      'fantom' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_request_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_requests,
+      reverted_requests,
+      total_requests
+    FROM ocr_request_daily_meta
+    LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_requests,
+  reverted_requests,
+  total_requests
+FROM
+  ocr_request_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/fantom/chainlink_fantom_ocr_request_daily_legacy.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_request_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_request_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/fantom/chainlink_fantom_ocr_reverted_transactions.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_reverted_transactions.sql
@@ -1,0 +1,64 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reverted_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  fantom_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'FTM'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_reverted_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX((cast((gas_used) as double) / 1e18) * gas_price) as token_amount,
+      MAX(fantom_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('fantom', 'transactions') }} tx
+      LEFT JOIN fantom_usd ON date_trunc('minute', tx.block_time) = fantom_usd.block_time
+    WHERE
+      success = false
+      {% if is_incremental() %}
+        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'fantom' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_reverted_transactions

--- a/models/chainlink/fantom/chainlink_fantom_ocr_reverted_transactions_legacy.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_reverted_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reverted_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/fantom/chainlink_fantom_ocr_reward_daily.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_reward_daily.sql
@@ -1,0 +1,111 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_daily'),
+    partition_by = ['date_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  admin_address_meta as (
+    SELECT DISTINCT
+      admin_address
+    FROM
+      {{ref('chainlink_fantom_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+  ),
+  link_usd_daily AS (
+    SELECT
+      cast(date_trunc('day', price.minute) as date) as "date_start",
+      MAX(price.price) as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      price.symbol = 'LINK'
+      {% if is_incremental() %}
+        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      1
+    ORDER BY
+      1
+  ),
+  link_usd_daily_expanded_by_admin_address AS (
+    SELECT
+      date_start,
+      usd_amount,
+      admin_address
+    FROM
+      link_usd_daily
+    CROSS JOIN
+      admin_address_meta
+    ORDER BY
+      date_start,
+      admin_address
+  ),
+  payment_meta AS (
+    SELECT
+      date_start,
+      link_usd_daily_expanded_by_admin_address.admin_address as admin_address,
+      usd_amount,
+      (
+        SELECT
+          MAX(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_fantom_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start <= link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as prev_payment_date,
+      (
+        SELECT
+          MIN(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_fantom_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start > link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as next_payment_date
+    FROM
+      link_usd_daily_expanded_by_admin_address
+    ORDER BY
+      1, 2
+  ),
+  ocr_reward_daily AS (
+    SELECT 
+      payment_meta.date_start,
+      cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
+      payment_meta.admin_address,
+      ocr_operator_admin_meta.operator_name,      
+      COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
+      (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
+    FROM 
+      payment_meta
+    LEFT JOIN 
+      {{ref('chainlink_fantom_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
+        payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
+        payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    ORDER BY date_start
+  )
+SELECT
+  'fantom' as blockchain,
+  date_start,
+  date_month,
+  admin_address,
+  operator_name,
+  token_amount,
+  usd_amount
+FROM 
+  ocr_reward_daily
+ORDER BY
+  2, 4

--- a/models/chainlink/fantom/chainlink_fantom_ocr_reward_daily_legacy.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_reward_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'fantom' as blockchain,
+  to as admin_address,
+  MAX(operator_name) as operator_name,
+  MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+  MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+FROM
+  {{ source('erc20_fantom', 'evt_Transfer') }} reward_evt_transfer
+  RIGHT JOIN {{ ref('chainlink_fantom_ocr_reward_transmission_logs') }} ocr_reward_transmission_logs ON ocr_reward_transmission_logs.contract_address = reward_evt_transfer."from"
+  LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+WHERE
+  reward_evt_transfer."from" IN (ocr_reward_transmission_logs.contract_address)
+GROUP BY
+  evt_tx_hash,
+  evt_index,
+  to

--- a/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer_daily.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer_daily.sql
@@ -1,0 +1,38 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+SELECT
+  'fantom' as blockchain,
+  cast(date_trunc('day', evt_block_time) AS date) AS date_start,
+  MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
+  ocr_reward_evt_transfer.admin_address as admin_address,
+  MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
+  SUM(token_value) as token_amount
+FROM
+  {{ref('chainlink_fantom_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
+{% if is_incremental() %}
+  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+{% endif %}      
+GROUP BY
+  2, 4
+ORDER BY
+  2, 4
+
+
+

--- a/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer_daily_legacy.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer_legacy.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/fantom/chainlink_fantom_ocr_reward_transmission_logs.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_reward_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'fantom' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('fantom', 'logs') }} logs
+WHERE
+  topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6

--- a/models/chainlink/fantom/chainlink_fantom_ocr_reward_transmission_logs_legacy.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_reward_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/fantom/chainlink_fantom_schema.yml
+++ b/models/chainlink/fantom/chainlink_fantom_schema.yml
@@ -67,6 +67,13 @@ models:
       tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'fantom']
     description: >
       Chainlink OCR Fulfilled Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -94,6 +101,13 @@ models:
       tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'fantom']
     description: >
       Chainlink OCR Reverted Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -113,6 +127,12 @@ models:
       tags: ['chainlink','ocr', 'gas', 'daily', 'fantom']
     description: >
         Chainlink OCR Gas Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - &date_start
@@ -151,6 +171,12 @@ models:
       tags: ['chainlink','ocr', 'request', 'daily', 'fantom']
     description: >
         Chainlink OCR Request Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - *date_start
@@ -227,7 +253,7 @@ models:
           combination_of_columns:
               - blockchain
               - date_start
-              - admin_address      
+              - admin_address
     columns:
       - *blockchain
       - *date_start
@@ -245,6 +271,12 @@ models:
       tags: ['chainlink','ocr', 'reward', 'daily', 'fantom']
     description: >
         Chainlink OCR Reward Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address
     columns:
       - *blockchain
       - *date_start

--- a/models/chainlink/fantom/chainlink_fantom_schema.yml
+++ b/models/chainlink/fantom/chainlink_fantom_schema.yml
@@ -1,0 +1,256 @@
+version: 2
+
+models:
+  - name: chainlink_fantom_ocr_gas_transmission_logs
+    meta:
+      blockchain: fantom
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'gas', 'transmission', 'logs', 'fantom']
+    description: >
+      Chainlink OCR Gas Transmission Logs
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - block_number
+              - tx_hash
+              - tx_index
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain"
+      - &block_hash
+        name: block_hash
+        description: "Block Hash"
+      - &contract_address
+        name: contract_address
+        description: "Contract Address"
+      - &data
+        name: data
+        description: "Data"
+      - &topic0
+        name: topic0
+        description: "Topic 0"
+      - &topic1
+        name: topic1
+        description: "Topic 1"
+      - &topic2
+        name: topic2
+        description: "Topic 2"
+      - &topic3
+        name: topic3
+        description: "Topic 3"
+      - &tx_hash
+        name: tx_hash
+        description: "Transaction Hash"
+      - &block_number
+        name: block_number
+        description: "Block Number"
+      - &block_time
+        name: block_time
+        description: "Block Time"
+      - &index
+        name: index
+        description: "Index"
+      - &tx_index
+        name: tx_index
+        description: "Transaction Index"
+
+  - name: chainlink_fantom_ocr_fulfilled_transactions
+    meta:
+      blockchain: fantom
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'fantom']
+    description: >
+      Chainlink OCR Fulfilled Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - &date_month
+        name: date_month
+        description: "Date truncated by month"
+      - &node_address
+        name: node_address
+        description: "Node Address"
+      - &token_amount
+        name: token_amount
+        description: "Token Amount"
+      - &usd_amount
+        name: usd_amount
+        description: "USD Amount"
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_fantom_ocr_reverted_transactions
+    meta:
+      blockchain: fantom
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'fantom']
+    description: >
+      Chainlink OCR Reverted Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - *date_month
+      - *node_address
+      - *token_amount
+      - *usd_amount
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_fantom_ocr_gas_daily
+    meta:
+      blockchain: fantom
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'gas', 'daily', 'fantom']
+    description: >
+        Chainlink OCR Gas Daily
+    columns:
+      - *blockchain
+      - &date_start
+        name: date_start
+        description: "Date Start"
+      - *date_month
+      - *node_address
+      - &operator_name
+        name: operator_name
+        description: "Operator Name"
+      - &fulfilled_token_amount
+        name: fulfilled_token_amount
+        description: "Fulfilled Token Amount"
+      - &fulfilled_usd_amount
+        name: fulfilled_usd_amount
+        description: "Fulfilled USD Amount"
+      - &reverted_token_amount
+        name: reverted_token_amount
+        description: "Reverted Token Amount"
+      - &reverted_usd_amount
+        name: reverted_usd_amount
+        description: "Reverted USD Amount"
+      - &total_token_amount
+        name: total_token_amount
+        description: "Total Token Amount"
+      - &total_usd_amount
+        name: total_usd_amount
+        description: "Total USD Amount"
+
+  - name: chainlink_fantom_ocr_request_daily
+    meta:
+      blockchain: fantom
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'request', 'daily', 'fantom']
+    description: >
+        Chainlink OCR Request Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *node_address
+      - *operator_name
+      - &fulfilled_requests
+        name: fulfilled_requests
+        description: "Fulfilled Requests"
+      - &reverted_requests
+        name: reverted_requests
+        description: "Reverted Requests"
+      - &total_requests
+        name: total_requests
+        description: "Total Requests"
+
+  - name: chainlink_fantom_ocr_reward_transmission_logs
+    meta:
+      blockchain: fantom
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'transmission', 'logs', 'fantom']
+    description: >
+      Chainlink OCR Reward Transmission Logs
+    columns:
+      - *blockchain
+      - *block_hash
+      - *contract_address
+      - *data
+      - *topic0
+      - *topic1
+      - *topic2
+      - *topic3
+      - *tx_hash
+      - *block_number
+      - *block_time
+      - *index
+      - *tx_index
+
+  - name: chainlink_fantom_ocr_reward_evt_transfer
+    meta:
+      blockchain: fantom
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'fantom']
+    description: >
+      Chainlink OCR Reward Event Transfers
+    columns:
+      - *blockchain
+      - &evt_block_time
+        name: evt_block_time
+        description: "Event Block Time"
+      - &admin_address
+        name: admin_address
+        description: "Admin Address"
+      - *operator_name
+      - &token_value
+        name: token_value
+        description: "Token Value"
+
+  - name: chainlink_fantom_ocr_reward_evt_transfer_daily
+    meta:
+      blockchain: fantom
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'daily', 'fantom']
+    description: >
+      Chainlink OCR Reward Event Transfers Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address      
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_value
+
+  - name: chainlink_fantom_ocr_reward_daily
+    meta:
+      blockchain: fantom
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'reward', 'daily', 'fantom']
+    description: >
+        Chainlink OCR Reward Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_amount
+      - *usd_amount
+

--- a/models/chainlink/fantom/chainlink_fantom_sources.yml
+++ b/models/chainlink/fantom/chainlink_fantom_sources.yml
@@ -1,0 +1,34 @@
+version: 2
+
+sources:
+  - name: erc20_fantom
+    description: "Transfers events for ERC20 tokens on fantom."
+    tables:
+      - name: evt_Transfer
+        loaded_at_field: evt_block_time
+        description: "Transfers events for ERC20 tokens on fantom."
+        columns:
+          - &contract_address
+            name: contract_address
+            description: "ERC20 token contract address"
+          - &evt_block_number
+            name: evt_block_number
+            description: "Block event number"
+          - &evt_block_time
+            name: evt_block_time
+            description: "Timestamp for block event time in UTC"
+          - &evt_index
+            name: evt_index
+            description: "Event index"
+          - &evt_tx_hash
+            name: evt_tx_hash
+            description: "Event transaction hash"
+          - &from
+            name: from
+            description: "Wallet address for ERC20 token transfer from"
+          - &to
+            name: to
+            description: "Wallet address for ERC20 token transfer to"
+          - &value
+            name: value
+            description: "Raw amount of ERC20 token"

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_fulfilled_transactions.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_fulfilled_transactions.sql
@@ -1,0 +1,63 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_fulfilled_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["gnosis"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  gnosis_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'ETH'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_fulfilled_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX((cast((gas_used) as double) / 1e18) * gas_price) as token_amount,
+      MAX(gnosis_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('gnosis', 'transactions') }} tx
+      RIGHT JOIN {{ ref('chainlink_gnosis_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
+      LEFT JOIN gnosis_usd ON date_trunc('minute', tx.block_time) = gnosis_usd.block_time
+    {% if is_incremental() %}
+      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'gnosis' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_fulfilled_transactions

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_fulfilled_transactions_legacy.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_fulfilled_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_fulfilled_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_daily.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_daily.sql
@@ -1,0 +1,81 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["gnosis"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_gas_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(SUM(fulfilled.token_amount), 0) as fulfilled_token_amount,
+      COALESCE(SUM(reverted.token_amount), 0) as reverted_token_amount,
+      COALESCE(SUM(fulfilled.token_amount * fulfilled.usd_amount), 0) as fulfilled_usd_amount,
+      COALESCE(SUM(reverted.token_amount * reverted.usd_amount), 0) as reverted_usd_amount
+    FROM
+      {{ ref('chainlink_gnosis_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_gnosis_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_gas_daily AS (
+    SELECT
+      'gnosis' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_gas_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_token_amount,
+      fulfilled_usd_amount,
+      reverted_token_amount,
+      reverted_usd_amount,
+      fulfilled_token_amount + reverted_token_amount as total_token_amount,
+      fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
+    FROM ocr_gas_daily_meta
+    LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_token_amount,
+  fulfilled_usd_amount,
+  reverted_token_amount,
+  reverted_usd_amount,
+  total_token_amount,
+  total_usd_amount    
+FROM
+  ocr_gas_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_daily_legacy.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_transmission_logs.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["gnosis"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'gnosis' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('gnosis', 'logs') }} logs
+WHERE
+  topic0 = 0xf6a97944f31ea060dfde0566e4167c1a1082551e64b60ecb14d599a9d023d451

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_transmission_logs_legacy.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_operator_admin_meta.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_operator_admin_meta.sql
@@ -1,0 +1,39 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_admin_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["gnosis"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set blockdaemon = 'Blockdaemon' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set dmakers = 'dMakers' %}
+{% set dextrac = 'DexTrac' %}
+{% set fiews = 'Fiews' %}
+{% set inotel = 'Inotel' %}
+{% set linkpool = 'LinkPool' %}
+{% set securedatalinks = 'Secure Data Links' %}
+{% set simplyvc = 'Simply VC' %}
+{% set snzpool = 'SNZPool' %}
+{% set ztake = 'Ztake.org' %}
+
+SELECT admin_address, operator_name FROM (VALUES
+  (0xD9459cc85E78e0336aDb349EAbF257Dbaf9d5a2B, '{{a01node}}'),
+  (0x3615Fa045f00ae0eD60Dc0141911757c2AdC5E03, '{{blockdaemon}}'),
+  (0x4a3dF8cAe46765d33c2551ff5438a5C5FC44347c, '{{chainlayer}}'),
+  (0xEaF7dC88d11E81Bb60e3bC5272558041227D16FA, '{{dmakers}}'),
+  (0x9efa0A617C0552F1558c95993aA8b8A68b3e709C, '{{dextrac}}'),
+  (0x15918ff7f6C44592C81d999B442956B07D26CC44, '{{fiews}}'),
+  (0xB8C6E43f37E04A2411562a13c1C48B3ad5975cf4, '{{inotel}}'),
+  (0x797de2909991C66C66D8e730C8385bbab8D18eA6, '{{linkpool}}'),
+  (0x3FB4600736d306Ee2A89EdF0356D4272fb095768, '{{securedatalinks}}'),
+  (0x4fBefaf1BFf0130945C61603B97D38DD6e21f5Cf, '{{simplyvc}}'),
+  (0x9cCbFD17FA284f36c2ff503546160B256d1CD3D1, '{{snzpool}}'),
+  (0x0039F22efB07A647557C7C5d17854CFD6D489eF3, '{{ztake}}')
+) AS tmp_node_meta(admin_address, operator_name)

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_operator_admin_meta_legacy.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_operator_admin_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_admin_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_operator_node_meta.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_operator_node_meta.sql
@@ -1,0 +1,50 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_node_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["gnosis"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set blockdaemon = 'Blockdaemon' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set dmakers = 'dMakers' %}
+{% set dextrac = 'DexTrac' %}
+{% set fiews = 'Fiews' %}
+{% set inotel = 'Inotel' %}
+{% set linkpool = 'LinkPool' %}
+{% set securedatalinks = 'Secure Data Links' %}
+{% set simplyvc = 'Simply VC' %}
+{% set snzpool = 'SNZPool' %}
+{% set ztake = 'Ztake.org' %}
+
+SELECT node_address, operator_name FROM (VALUES
+  (0x4FB3376d5bF6AD8947FCf737A2C7e793CC245fDa, '{{a01node}}'),
+  (0xb5f0EfcB8a426ffAc5F92BbE6fCd6b4255b4E1aa, '{{a01node}}'),
+  (0x3036c926cCc3096beCF584E7523A1a57fdebba77, '{{blockdaemon}}'),
+  (0x577b17c9A02B7A360e0cf945D623D6C1ace6074c, '{{blockdaemon}}'),
+  (0xE769724C9295458b026875ff964aCCb964B13D50, '{{chainlayer}}'),
+  (0x582067f4b986775EAF8949Cc6370B8b75B836572, '{{chainlayer}}'),
+  (0x88f578278381B8eFC04558D0017D06E818170EBb, '{{dmakers}}'),
+  (0xCd906f0467eFaB9f0A59DF479e873B4A5320D1Be, '{{dmakers}}'),
+  (0x4407E5caC83a1397741fEB1ACcAF6C23968180f4, '{{dextrac}}'),
+  (0x4562845F37813A201b9DDB52E57A902659b7AE6A, '{{dextrac}}'),
+  (0x16F5c3Dc347A5814B81553c7725D4ed9214C8A3c, '{{fiews}}'),
+  (0x0184Ee351E270fb0942C5Cb66f0Ff37bF4d37D3e, '{{fiews}}'),
+  (0x45a3983bD8b0D7a77Bb00F1C86AD794515D96f34, '{{inotel}}'),
+  (0x2607E6F021922A5483D64935F87e15EA797FE8d4, '{{inotel}}'),
+  (0x11eB6a69A56DF3a89b99c4b1484691Af4AB0c508, '{{linkpool}}'),
+  (0x6D04B8dB14B5a891f9aA1e32C093584815291551, '{{linkpool}}'),
+  (0xFc7C442154C04C31203e2b94B96fd57C44ac003D, '{{securedatalinks}}'),
+  (0x82e2dE20848E58CDDfea53Ad56cAB0471AE8BDcF, '{{securedatalinks}}'),
+  (0xC8a9A5b3517071f582b50b18633E522F6F4f38f5, '{{simplyvc}}'),
+  (0x12d61a95CF55e18D267C2F1AA67d8e42ae1368f8, '{{simplyvc}}'),
+  (0x9d3A9b7cadc14dA9cB57E9e9E83eD13ea1D36d40, '{{snzpool}}'),
+  (0x5C73E956A8B4cE22D898AB18eeA2C3921Edc5fED, '{{snzpool}}'),
+  (0x32cbe102400A1B8a430232d7cCAD3E75AB73C1F2, '{{ztake}}')
+) AS tmp_node_meta(node_address, operator_name)

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_operator_node_meta_legacy.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_operator_node_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_node_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_request_daily.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_request_daily.sql
@@ -1,0 +1,74 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_request_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["gnosis"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_request_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(COUNT(fulfilled.token_amount), 0) as fulfilled_requests,
+      COALESCE(COUNT(reverted.token_amount), 0) as reverted_requests,
+      COALESCE(COUNT(fulfilled.token_amount), 0) + COALESCE(COUNT(reverted.token_amount), 0) as total_requests
+    FROM
+      {{ ref('chainlink_gnosis_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_gnosis_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_request_daily AS (
+    SELECT
+      'gnosis' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_request_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_requests,
+      reverted_requests,
+      total_requests
+    FROM ocr_request_daily_meta
+    LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_requests,
+  reverted_requests,
+  total_requests
+FROM
+  ocr_request_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_request_daily_legacy.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_request_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_request_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_reverted_transactions.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_reverted_transactions.sql
@@ -1,0 +1,64 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reverted_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["gnosis"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  gnosis_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'ETH'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_reverted_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX((cast((gas_used) as double) / 1e18) * gas_price) as token_amount,
+      MAX(gnosis_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('gnosis', 'transactions') }} tx
+      LEFT JOIN gnosis_usd ON date_trunc('minute', tx.block_time) = gnosis_usd.block_time
+    WHERE
+      success = false
+      {% if is_incremental() %}
+        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'gnosis' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_reverted_transactions

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_reverted_transactions_legacy.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_reverted_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reverted_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_daily.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_daily.sql
@@ -1,0 +1,111 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_daily'),
+    partition_by = ['date_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["gnosis"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  admin_address_meta as (
+    SELECT DISTINCT
+      admin_address
+    FROM
+      {{ref('chainlink_gnosis_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+  ),
+  link_usd_daily AS (
+    SELECT
+      cast(date_trunc('day', price.minute) as date) as "date_start",
+      MAX(price.price) as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      price.symbol = 'LINK'
+      {% if is_incremental() %}
+        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      1
+    ORDER BY
+      1
+  ),
+  link_usd_daily_expanded_by_admin_address AS (
+    SELECT
+      date_start,
+      usd_amount,
+      admin_address
+    FROM
+      link_usd_daily
+    CROSS JOIN
+      admin_address_meta
+    ORDER BY
+      date_start,
+      admin_address
+  ),
+  payment_meta AS (
+    SELECT
+      date_start,
+      link_usd_daily_expanded_by_admin_address.admin_address as admin_address,
+      usd_amount,
+      (
+        SELECT
+          MAX(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_gnosis_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start <= link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as prev_payment_date,
+      (
+        SELECT
+          MIN(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_gnosis_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start > link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as next_payment_date
+    FROM
+      link_usd_daily_expanded_by_admin_address
+    ORDER BY
+      1, 2
+  ),
+  ocr_reward_daily AS (
+    SELECT 
+      payment_meta.date_start,
+      cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
+      payment_meta.admin_address,
+      ocr_operator_admin_meta.operator_name,      
+      COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
+      (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
+    FROM 
+      payment_meta
+    LEFT JOIN 
+      {{ref('chainlink_gnosis_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
+        payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
+        payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    ORDER BY date_start
+  )
+SELECT
+  'gnosis' as blockchain,
+  date_start,
+  date_month,
+  admin_address,
+  operator_name,
+  token_amount,
+  usd_amount
+FROM 
+  ocr_reward_daily
+ORDER BY
+  2, 4

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_daily_legacy.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["gnosis"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'gnosis' as blockchain,
+  to as admin_address,
+  MAX(operator_name) as operator_name,
+  MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+  MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+FROM
+  {{ source('erc20_gnosis', 'evt_Transfer') }} reward_evt_transfer
+  RIGHT JOIN {{ ref('chainlink_gnosis_ocr_reward_transmission_logs') }} ocr_reward_transmission_logs ON ocr_reward_transmission_logs.contract_address = reward_evt_transfer."from"
+  LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+WHERE
+  reward_evt_transfer."from" IN (ocr_reward_transmission_logs.contract_address)
+GROUP BY
+  evt_tx_hash,
+  evt_index,
+  to

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer_daily.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer_daily.sql
@@ -1,0 +1,38 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["gnosis"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+SELECT
+  'gnosis' as blockchain,
+  cast(date_trunc('day', evt_block_time) AS date) AS date_start,
+  MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
+  ocr_reward_evt_transfer.admin_address as admin_address,
+  MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
+  SUM(token_value) as token_amount
+FROM
+  {{ref('chainlink_gnosis_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
+{% if is_incremental() %}
+  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+{% endif %}      
+GROUP BY
+  2, 4
+ORDER BY
+  2, 4
+
+
+

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer_daily_legacy.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer_legacy.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_transmission_logs.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["gnosis"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'gnosis' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('gnosis', 'logs') }} logs
+WHERE
+  topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_transmission_logs_legacy.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/gnosis/chainlink_gnosis_schema.yml
+++ b/models/chainlink/gnosis/chainlink_gnosis_schema.yml
@@ -67,6 +67,13 @@ models:
       tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'gnosis']
     description: >
       Chainlink OCR Fulfilled Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -94,6 +101,13 @@ models:
       tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'gnosis']
     description: >
       Chainlink OCR Reverted Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -113,6 +127,12 @@ models:
       tags: ['chainlink','ocr', 'gas', 'daily', 'gnosis']
     description: >
         Chainlink OCR Gas Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - &date_start
@@ -151,6 +171,12 @@ models:
       tags: ['chainlink','ocr', 'request', 'daily', 'gnosis']
     description: >
         Chainlink OCR Request Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - *date_start
@@ -227,7 +253,7 @@ models:
           combination_of_columns:
               - blockchain
               - date_start
-              - admin_address      
+              - admin_address
     columns:
       - *blockchain
       - *date_start
@@ -245,6 +271,12 @@ models:
       tags: ['chainlink','ocr', 'reward', 'daily', 'gnosis']
     description: >
         Chainlink OCR Reward Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address
     columns:
       - *blockchain
       - *date_start

--- a/models/chainlink/gnosis/chainlink_gnosis_schema.yml
+++ b/models/chainlink/gnosis/chainlink_gnosis_schema.yml
@@ -1,0 +1,256 @@
+version: 2
+
+models:
+  - name: chainlink_gnosis_ocr_gas_transmission_logs
+    meta:
+      blockchain: gnosis
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'gas', 'transmission', 'logs', 'gnosis']
+    description: >
+      Chainlink OCR Gas Transmission Logs
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - block_number
+              - tx_hash
+              - tx_index
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain"
+      - &block_hash
+        name: block_hash
+        description: "Block Hash"
+      - &contract_address
+        name: contract_address
+        description: "Contract Address"
+      - &data
+        name: data
+        description: "Data"
+      - &topic0
+        name: topic0
+        description: "Topic 0"
+      - &topic1
+        name: topic1
+        description: "Topic 1"
+      - &topic2
+        name: topic2
+        description: "Topic 2"
+      - &topic3
+        name: topic3
+        description: "Topic 3"
+      - &tx_hash
+        name: tx_hash
+        description: "Transaction Hash"
+      - &block_number
+        name: block_number
+        description: "Block Number"
+      - &block_time
+        name: block_time
+        description: "Block Time"
+      - &index
+        name: index
+        description: "Index"
+      - &tx_index
+        name: tx_index
+        description: "Transaction Index"
+
+  - name: chainlink_gnosis_ocr_fulfilled_transactions
+    meta:
+      blockchain: gnosis
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'gnosis']
+    description: >
+      Chainlink OCR Fulfilled Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - &date_month
+        name: date_month
+        description: "Date truncated by month"
+      - &node_address
+        name: node_address
+        description: "Node Address"
+      - &token_amount
+        name: token_amount
+        description: "Token Amount"
+      - &usd_amount
+        name: usd_amount
+        description: "USD Amount"
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_gnosis_ocr_reverted_transactions
+    meta:
+      blockchain: gnosis
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'gnosis']
+    description: >
+      Chainlink OCR Reverted Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - *date_month
+      - *node_address
+      - *token_amount
+      - *usd_amount
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_gnosis_ocr_gas_daily
+    meta:
+      blockchain: gnosis
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'gas', 'daily', 'gnosis']
+    description: >
+        Chainlink OCR Gas Daily
+    columns:
+      - *blockchain
+      - &date_start
+        name: date_start
+        description: "Date Start"
+      - *date_month
+      - *node_address
+      - &operator_name
+        name: operator_name
+        description: "Operator Name"
+      - &fulfilled_token_amount
+        name: fulfilled_token_amount
+        description: "Fulfilled Token Amount"
+      - &fulfilled_usd_amount
+        name: fulfilled_usd_amount
+        description: "Fulfilled USD Amount"
+      - &reverted_token_amount
+        name: reverted_token_amount
+        description: "Reverted Token Amount"
+      - &reverted_usd_amount
+        name: reverted_usd_amount
+        description: "Reverted USD Amount"
+      - &total_token_amount
+        name: total_token_amount
+        description: "Total Token Amount"
+      - &total_usd_amount
+        name: total_usd_amount
+        description: "Total USD Amount"
+
+  - name: chainlink_gnosis_ocr_request_daily
+    meta:
+      blockchain: gnosis
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'request', 'daily', 'gnosis']
+    description: >
+        Chainlink OCR Request Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *node_address
+      - *operator_name
+      - &fulfilled_requests
+        name: fulfilled_requests
+        description: "Fulfilled Requests"
+      - &reverted_requests
+        name: reverted_requests
+        description: "Reverted Requests"
+      - &total_requests
+        name: total_requests
+        description: "Total Requests"
+
+  - name: chainlink_gnosis_ocr_reward_transmission_logs
+    meta:
+      blockchain: gnosis
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'transmission', 'logs', 'gnosis']
+    description: >
+      Chainlink OCR Reward Transmission Logs
+    columns:
+      - *blockchain
+      - *block_hash
+      - *contract_address
+      - *data
+      - *topic0
+      - *topic1
+      - *topic2
+      - *topic3
+      - *tx_hash
+      - *block_number
+      - *block_time
+      - *index
+      - *tx_index
+
+  - name: chainlink_gnosis_ocr_reward_evt_transfer
+    meta:
+      blockchain: gnosis
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'gnosis']
+    description: >
+      Chainlink OCR Reward Event Transfers
+    columns:
+      - *blockchain
+      - &evt_block_time
+        name: evt_block_time
+        description: "Event Block Time"
+      - &admin_address
+        name: admin_address
+        description: "Admin Address"
+      - *operator_name
+      - &token_value
+        name: token_value
+        description: "Token Value"
+
+  - name: chainlink_gnosis_ocr_reward_evt_transfer_daily
+    meta:
+      blockchain: gnosis
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'daily', 'gnosis']
+    description: >
+      Chainlink OCR Reward Event Transfers Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address      
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_value
+
+  - name: chainlink_gnosis_ocr_reward_daily
+    meta:
+      blockchain: gnosis
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'reward', 'daily', 'gnosis']
+    description: >
+        Chainlink OCR Reward Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_amount
+      - *usd_amount
+

--- a/models/chainlink/gnosis/chainlink_gnosis_sources.yml
+++ b/models/chainlink/gnosis/chainlink_gnosis_sources.yml
@@ -1,0 +1,34 @@
+version: 2
+
+sources:
+  - name: erc20_gnosis
+    description: "Transfers events for ERC20 tokens on gnosis."
+    tables:
+      - name: evt_Transfer
+        loaded_at_field: evt_block_time
+        description: "Transfers events for ERC20 tokens on gnosis."
+        columns:
+          - &contract_address
+            name: contract_address
+            description: "ERC20 token contract address"
+          - &evt_block_number
+            name: evt_block_number
+            description: "Block event number"
+          - &evt_block_time
+            name: evt_block_time
+            description: "Timestamp for block event time in UTC"
+          - &evt_index
+            name: evt_index
+            description: "Event index"
+          - &evt_tx_hash
+            name: evt_tx_hash
+            description: "Event transaction hash"
+          - &from
+            name: from
+            description: "Wallet address for ERC20 token transfer from"
+          - &to
+            name: to
+            description: "Wallet address for ERC20 token transfer to"
+          - &value
+            name: value
+            description: "Raw amount of ERC20 token"

--- a/models/chainlink/optimism/chainlink_optimism_ocr_fulfilled_transactions.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_fulfilled_transactions.sql
@@ -1,0 +1,65 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_fulfilled_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  optimism_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'ETH'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_fulfilled_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX(
+        (cast((l1_gas_used) as double) / 1e18) * l1_gas_price
+      ) as token_amount,
+      MAX(optimism_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('optimism', 'transactions') }} tx
+      RIGHT JOIN {{ ref('chainlink_optimism_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
+      LEFT JOIN optimism_usd ON date_trunc('minute', tx.block_time) = optimism_usd.block_time
+    {% if is_incremental() %}
+      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'optimism' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_fulfilled_transactions

--- a/models/chainlink/optimism/chainlink_optimism_ocr_fulfilled_transactions_legacy.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_fulfilled_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_fulfilled_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/optimism/chainlink_optimism_ocr_gas_daily.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_gas_daily.sql
@@ -1,0 +1,81 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_gas_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(SUM(fulfilled.token_amount), 0) as fulfilled_token_amount,
+      COALESCE(SUM(reverted.token_amount), 0) as reverted_token_amount,
+      COALESCE(SUM(fulfilled.token_amount * fulfilled.usd_amount), 0) as fulfilled_usd_amount,
+      COALESCE(SUM(reverted.token_amount * reverted.usd_amount), 0) as reverted_usd_amount
+    FROM
+      {{ ref('chainlink_optimism_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_optimism_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_gas_daily AS (
+    SELECT
+      'optimism' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_gas_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_token_amount,
+      fulfilled_usd_amount,
+      reverted_token_amount,
+      reverted_usd_amount,
+      fulfilled_token_amount + reverted_token_amount as total_token_amount,
+      fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
+    FROM ocr_gas_daily_meta
+    LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_token_amount,
+  fulfilled_usd_amount,
+  reverted_token_amount,
+  reverted_usd_amount,
+  total_token_amount,
+  total_usd_amount    
+FROM
+  ocr_gas_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/optimism/chainlink_optimism_ocr_gas_daily_legacy.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_gas_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/optimism/chainlink_optimism_ocr_gas_transmission_logs.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_gas_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'optimism' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('optimism', 'logs') }} logs
+WHERE
+  topic0 = 0xf6a97944f31ea060dfde0566e4167c1a1082551e64b60ecb14d599a9d023d451

--- a/models/chainlink/optimism/chainlink_optimism_ocr_gas_transmission_logs_legacy.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_gas_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/optimism/chainlink_optimism_ocr_operator_admin_meta.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_operator_admin_meta.sql
@@ -1,0 +1,38 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_admin_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set blockdaemon = 'Blockdaemon' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set cryptomanufaktur = 'CryptoManufaktur' %}
+{% set dextrac = 'DexTrac' %}
+{% set fiews = 'Fiews' %}
+{% set inotel = 'Inotel' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set securedatalinks = 'Secure Data Links' %}
+{% set simplyvc = 'Simply VC' %}
+
+SELECT admin_address, operator_name FROM (VALUES
+  (0xD9459cc85E78e0336aDb349EAbF257Dbaf9d5a2B, '{{a01node}}'),
+  (0x3615Fa045f00ae0eD60Dc0141911757c2AdC5E03, '{{blockdaemon}}'),
+  (0x4a3dF8cAe46765d33c2551ff5438a5C5FC44347c, '{{chainlayer}}'),
+  (0x59eCf48345A221E0731E785ED79eD40d0A94E2A5, '{{cryptomanufaktur}}'),
+  (0x9efa0A617C0552F1558c95993aA8b8A68b3e709C, '{{dextrac}}'),
+  (0x15918ff7f6C44592C81d999B442956B07D26CC44, '{{fiews}}'),
+  (0xB8C6E43f37E04A2411562a13c1C48B3ad5975cf4, '{{inotel}}'),
+  (0x797de2909991C66C66D8e730C8385bbab8D18eA6, '{{linkpool}}'),
+  (0x14f94049397C3F1807c45B6f854Cb5F36bC4393B, '{{linkriver}}'),
+  (0x69F89eFbB5e5519EAf93a0Af3dbA3f3101350b0d, '{{linkriver}}'),
+  (0x3FB4600736d306Ee2A89EdF0356D4272fb095768, '{{securedatalinks}}'),
+  (0x4fBefaf1BFf0130945C61603B97D38DD6e21f5Cf, '{{simplyvc}}')
+) AS tmp_node_meta(admin_address, operator_name)

--- a/models/chainlink/optimism/chainlink_optimism_ocr_operator_admin_meta_legacy.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_operator_admin_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_admin_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/optimism/chainlink_optimism_ocr_operator_node_meta.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_operator_node_meta.sql
@@ -1,0 +1,48 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_node_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set blockdaemon = 'Blockdaemon' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set cryptomanufaktur = 'CryptoManufaktur' %}
+{% set dextrac = 'DexTrac' %}
+{% set fiews = 'Fiews' %}
+{% set inotel = 'Inotel' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set securedatalinks = 'Secure Data Links' %}
+{% set simplyvc = 'Simply VC' %}
+
+SELECT node_address, operator_name FROM (VALUES
+  (0xf9b9fbeB0512283a445F1A948a78AF8f954b3343, '{{a01node}}'),
+  (0x2539ffc9DeD82926A5AAEe065E800C7d1DE02454, '{{a01node}}'),
+  (0xB834eD914228B68b0E1f3E4F1e168Ed2b580a35c, '{{blockdaemon}}'),
+  (0xF69D0bBc95db6287ef02F19E5B2789972f776C2F, '{{blockdaemon}}'),
+  (0x2878c587eba4C4251f97784cE124f7387305Ab32, '{{chainlayer}}'),
+  (0xaE00F7474dCc5A0E9f4D7a65DFb938c275f75dB6, '{{chainlayer}}'),
+  (0x2bdF9249c350C68a43a9714c1b9153af54751b1C, '{{cryptomanufaktur}}'),
+  (0xFA011d8d6C26F13Abe2CEFEd38226E401B2b8a99, '{{cryptomanufaktur}}'),
+  (0x6CA4166EeFd64B5f607f12Fb0C3fbAe233897757, '{{dextrac}}'),
+  (0xA6C37c771d81CeB7Dda952cc5625e06444067e2f, '{{dextrac}}'),
+  (0x85C8aAA2232D12158C4cA731543470bc9e9bb29D, '{{fiews}}'),
+  (0xd44Fd1c1fE3F3F0d93a8867AF4041AB231783FcB, '{{fiews}}'),
+  (0x8CFc4459394801D2EA78F9cEeB31a7f58B8CdDDe, '{{inotel}}'),
+  (0x57fe8051B897a14b4cbF84c22e7EEEA0b30bA903, '{{inotel}}'),
+  (0xa04163e4033a941A3446c33e432A1da7ecc8898A, '{{linkpool}}'),
+  (0x70B17C0Fe982aB4A7AC17A4c25485643151A1F2d, '{{linkpool}}'),
+  (0xD46acbA18e4f3C8b8b6c501DF1a6B05609a642Bd, '{{linkriver}}'),
+  (0x689d0367b9D654Aae886982894896f3A826840ED, '{{linkriver}}'),
+  (0xB1f0D485227DbeCFf6F1c0F28a58bBa1a97D4D81, '{{securedatalinks}}'),
+  (0x56873b5E7299d2C0d4ab28d9128D734CF3bf8398, '{{securedatalinks}}'),
+  (0x91722db88a8810e2e4AE2E4549aeE9eb2B9A4e8A, '{{simplyvc}}'),
+  (0xE5e7492282FD1E3bfAC337A0BecCD29b15B7B240, '{{simplyvc}}')
+) AS tmp_node_meta(node_address, operator_name)

--- a/models/chainlink/optimism/chainlink_optimism_ocr_operator_node_meta_legacy.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_operator_node_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_node_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/optimism/chainlink_optimism_ocr_request_daily.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_request_daily.sql
@@ -1,0 +1,74 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_request_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_request_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(COUNT(fulfilled.token_amount), 0) as fulfilled_requests,
+      COALESCE(COUNT(reverted.token_amount), 0) as reverted_requests,
+      COALESCE(COUNT(fulfilled.token_amount), 0) + COALESCE(COUNT(reverted.token_amount), 0) as total_requests
+    FROM
+      {{ ref('chainlink_optimism_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_optimism_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_request_daily AS (
+    SELECT
+      'optimism' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_request_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_requests,
+      reverted_requests,
+      total_requests
+    FROM ocr_request_daily_meta
+    LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_requests,
+  reverted_requests,
+  total_requests
+FROM
+  ocr_request_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/optimism/chainlink_optimism_ocr_request_daily_legacy.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_request_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_request_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/optimism/chainlink_optimism_ocr_reverted_transactions.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_reverted_transactions.sql
@@ -1,0 +1,66 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reverted_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  optimism_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'ETH'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_reverted_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX(
+        (cast((l1_gas_used) as double) / 1e18) * l1_gas_price
+      ) as token_amount,
+      MAX(optimism_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('optimism', 'transactions') }} tx
+      LEFT JOIN optimism_usd ON date_trunc('minute', tx.block_time) = optimism_usd.block_time
+    WHERE
+      success = false
+      {% if is_incremental() %}
+        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'optimism' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_reverted_transactions

--- a/models/chainlink/optimism/chainlink_optimism_ocr_reverted_transactions_legacy.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_reverted_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reverted_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/optimism/chainlink_optimism_ocr_reward_daily.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_reward_daily.sql
@@ -1,0 +1,111 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_daily'),
+    partition_by = ['date_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  admin_address_meta as (
+    SELECT DISTINCT
+      admin_address
+    FROM
+      {{ref('chainlink_optimism_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+  ),
+  link_usd_daily AS (
+    SELECT
+      cast(date_trunc('day', price.minute) as date) as "date_start",
+      MAX(price.price) as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      price.symbol = 'LINK'
+      {% if is_incremental() %}
+        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      1
+    ORDER BY
+      1
+  ),
+  link_usd_daily_expanded_by_admin_address AS (
+    SELECT
+      date_start,
+      usd_amount,
+      admin_address
+    FROM
+      link_usd_daily
+    CROSS JOIN
+      admin_address_meta
+    ORDER BY
+      date_start,
+      admin_address
+  ),
+  payment_meta AS (
+    SELECT
+      date_start,
+      link_usd_daily_expanded_by_admin_address.admin_address as admin_address,
+      usd_amount,
+      (
+        SELECT
+          MAX(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_optimism_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start <= link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as prev_payment_date,
+      (
+        SELECT
+          MIN(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_optimism_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start > link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as next_payment_date
+    FROM
+      link_usd_daily_expanded_by_admin_address
+    ORDER BY
+      1, 2
+  ),
+  ocr_reward_daily AS (
+    SELECT 
+      payment_meta.date_start,
+      cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
+      payment_meta.admin_address,
+      ocr_operator_admin_meta.operator_name,      
+      COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
+      (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
+    FROM 
+      payment_meta
+    LEFT JOIN 
+      {{ref('chainlink_optimism_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
+        payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
+        payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    ORDER BY date_start
+  )
+SELECT
+  'optimism' as blockchain,
+  date_start,
+  date_month,
+  admin_address,
+  operator_name,
+  token_amount,
+  usd_amount
+FROM 
+  ocr_reward_daily
+ORDER BY
+  2, 4

--- a/models/chainlink/optimism/chainlink_optimism_ocr_reward_daily_legacy.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_reward_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'optimism' as blockchain,
+  to as admin_address,
+  MAX(operator_name) as operator_name,
+  MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+  MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+FROM
+  {{ source('erc20_optimism', 'evt_Transfer') }} reward_evt_transfer
+  RIGHT JOIN {{ ref('chainlink_optimism_ocr_reward_transmission_logs') }} ocr_reward_transmission_logs ON ocr_reward_transmission_logs.contract_address = reward_evt_transfer."from"
+  LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+WHERE
+  reward_evt_transfer."from" IN (ocr_reward_transmission_logs.contract_address)
+GROUP BY
+  evt_tx_hash,
+  evt_index,
+  to

--- a/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer_daily.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer_daily.sql
@@ -1,0 +1,38 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+SELECT
+  'optimism' as blockchain,
+  cast(date_trunc('day', evt_block_time) AS date) AS date_start,
+  MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
+  ocr_reward_evt_transfer.admin_address as admin_address,
+  MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
+  SUM(token_value) as token_amount
+FROM
+  {{ref('chainlink_optimism_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
+{% if is_incremental() %}
+  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+{% endif %}      
+GROUP BY
+  2, 4
+ORDER BY
+  2, 4
+
+
+

--- a/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer_daily_legacy.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer_legacy.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/optimism/chainlink_optimism_ocr_reward_transmission_logs.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_reward_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'optimism' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('optimism', 'logs') }} logs
+WHERE
+  topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6

--- a/models/chainlink/optimism/chainlink_optimism_ocr_reward_transmission_logs_legacy.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_reward_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/optimism/chainlink_optimism_schema.yml
+++ b/models/chainlink/optimism/chainlink_optimism_schema.yml
@@ -132,3 +132,250 @@ models:
         description: "Decimal adjustment for the oracle answer"
       - *proxy_address
       - *aggregator_address
+
+  - name: chainlink_optimism_ocr_gas_transmission_logs
+    meta:
+      blockchain: optimism
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'gas', 'transmission', 'logs', 'optimism']
+    description: >
+      Chainlink OCR Gas Transmission Logs
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - block_number
+              - tx_hash
+              - tx_index
+    columns:
+      - *blockchain
+      - &block_hash
+        name: block_hash
+        description: "Block Hash"
+      - &contract_address
+        name: contract_address
+        description: "Contract Address"
+      - &data
+        name: data
+        description: "Data"
+      - &topic0
+        name: topic0
+        description: "Topic 0"
+      - &topic1
+        name: topic1
+        description: "Topic 1"
+      - &topic2
+        name: topic2
+        description: "Topic 2"
+      - &topic3
+        name: topic3
+        description: "Topic 3"
+      - &tx_hash
+        name: tx_hash
+        description: "Transaction Hash"
+      - *block_number
+      - *block_time
+      - &index
+        name: index
+        description: "Index"
+      - &tx_index
+        name: tx_index
+        description: "Transaction Index"
+
+  - name: chainlink_optimism_ocr_fulfilled_transactions
+    meta:
+      blockchain: optimism
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'optimism']
+    description: >
+      Chainlink OCR Fulfilled Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - &date_month
+        name: date_month
+        description: "Date truncated by month"
+      - &node_address
+        name: node_address
+        description: "Node Address"
+      - &token_amount
+        name: token_amount
+        description: "Token Amount"
+      - &usd_amount
+        name: usd_amount
+        description: "USD Amount"
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_optimism_ocr_reverted_transactions
+    meta:
+      blockchain: optimism
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'optimism']
+    description: >
+      Chainlink OCR Reverted Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - *date_month
+      - *node_address
+      - *token_amount
+      - *usd_amount
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_optimism_ocr_gas_daily
+    meta:
+      blockchain: optimism
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'gas', 'daily', 'optimism']
+    description: >
+        Chainlink OCR Gas Daily
+    columns:
+      - *blockchain
+      - &date_start
+        name: date_start
+        description: "Date Start"
+      - *date_month
+      - *node_address
+      - &operator_name
+        name: operator_name
+        description: "Operator Name"
+      - &fulfilled_token_amount
+        name: fulfilled_token_amount
+        description: "Fulfilled Token Amount"
+      - &fulfilled_usd_amount
+        name: fulfilled_usd_amount
+        description: "Fulfilled USD Amount"
+      - &reverted_token_amount
+        name: reverted_token_amount
+        description: "Reverted Token Amount"
+      - &reverted_usd_amount
+        name: reverted_usd_amount
+        description: "Reverted USD Amount"
+      - &total_token_amount
+        name: total_token_amount
+        description: "Total Token Amount"
+      - &total_usd_amount
+        name: total_usd_amount
+        description: "Total USD Amount"
+
+  - name: chainlink_optimism_ocr_request_daily
+    meta:
+      blockchain: optimism
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'request', 'daily', 'optimism']
+    description: >
+        Chainlink OCR Request Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *node_address
+      - *operator_name
+      - &fulfilled_requests
+        name: fulfilled_requests
+        description: "Fulfilled Requests"
+      - &reverted_requests
+        name: reverted_requests
+        description: "Reverted Requests"
+      - &total_requests
+        name: total_requests
+        description: "Total Requests"
+
+  - name: chainlink_optimism_ocr_reward_transmission_logs
+    meta:
+      blockchain: optimism
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'transmission', 'logs', 'optimism']
+    description: >
+      Chainlink OCR Reward Transmission Logs
+    columns:
+      - *blockchain
+      - *block_hash
+      - *contract_address
+      - *data
+      - *topic0
+      - *topic1
+      - *topic2
+      - *topic3
+      - *tx_hash
+      - *block_number
+      - *block_time
+      - *index
+      - *tx_index
+
+  - name: chainlink_optimism_ocr_reward_evt_transfer
+    meta:
+      blockchain: optimism
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'optimism']
+    description: >
+      Chainlink OCR Reward Event Transfers
+    columns:
+      - *blockchain
+      - &evt_block_time
+        name: evt_block_time
+        description: "Event Block Time"
+      - &admin_address
+        name: admin_address
+        description: "Admin Address"
+      - *operator_name
+      - &token_value
+        name: token_value
+        description: "Token Value"
+
+  - name: chainlink_optimism_ocr_reward_evt_transfer_daily
+    meta:
+      blockchain: optimism
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'daily', 'optimism']
+    description: >
+      Chainlink OCR Reward Event Transfers Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address      
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_value
+
+  - name: chainlink_optimism_ocr_reward_daily
+    meta:
+      blockchain: optimism
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'reward', 'daily', 'optimism']
+    description: >
+        Chainlink OCR Reward Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_amount
+      - *usd_amount

--- a/models/chainlink/optimism/chainlink_optimism_schema.yml
+++ b/models/chainlink/optimism/chainlink_optimism_schema.yml
@@ -193,6 +193,13 @@ models:
       tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'optimism']
     description: >
       Chainlink OCR Fulfilled Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -220,6 +227,13 @@ models:
       tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'optimism']
     description: >
       Chainlink OCR Reverted Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -239,6 +253,12 @@ models:
       tags: ['chainlink','ocr', 'gas', 'daily', 'optimism']
     description: >
         Chainlink OCR Gas Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - &date_start
@@ -277,6 +297,12 @@ models:
       tags: ['chainlink','ocr', 'request', 'daily', 'optimism']
     description: >
         Chainlink OCR Request Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - *date_start
@@ -353,7 +379,7 @@ models:
           combination_of_columns:
               - blockchain
               - date_start
-              - admin_address      
+              - admin_address
     columns:
       - *blockchain
       - *date_start
@@ -371,6 +397,12 @@ models:
       tags: ['chainlink','ocr', 'reward', 'daily', 'optimism']
     description: >
         Chainlink OCR Reward Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address
     columns:
       - *blockchain
       - *date_start

--- a/models/chainlink/polygon/chainlink_polygon_ocr_fulfilled_transactions.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_fulfilled_transactions.sql
@@ -1,0 +1,63 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_fulfilled_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  polygon_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'MATIC'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_fulfilled_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX((cast((gas_used) as double) / 1e18) * gas_price) as token_amount,
+      MAX(polygon_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('polygon', 'transactions') }} tx
+      RIGHT JOIN {{ ref('chainlink_polygon_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
+      LEFT JOIN polygon_usd ON date_trunc('minute', tx.block_time) = polygon_usd.block_time
+    {% if is_incremental() %}
+      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'polygon' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_fulfilled_transactions

--- a/models/chainlink/polygon/chainlink_polygon_ocr_fulfilled_transactions_legacy.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_fulfilled_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_fulfilled_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/polygon/chainlink_polygon_ocr_gas_daily.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_gas_daily.sql
@@ -1,0 +1,81 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_gas_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(SUM(fulfilled.token_amount), 0) as fulfilled_token_amount,
+      COALESCE(SUM(reverted.token_amount), 0) as reverted_token_amount,
+      COALESCE(SUM(fulfilled.token_amount * fulfilled.usd_amount), 0) as fulfilled_usd_amount,
+      COALESCE(SUM(reverted.token_amount * reverted.usd_amount), 0) as reverted_usd_amount
+    FROM
+      {{ ref('chainlink_polygon_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_polygon_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_gas_daily AS (
+    SELECT
+      'polygon' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_gas_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_token_amount,
+      fulfilled_usd_amount,
+      reverted_token_amount,
+      reverted_usd_amount,
+      fulfilled_token_amount + reverted_token_amount as total_token_amount,
+      fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
+    FROM ocr_gas_daily_meta
+    LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_token_amount,
+  fulfilled_usd_amount,
+  reverted_token_amount,
+  reverted_usd_amount,
+  total_token_amount,
+  total_usd_amount    
+FROM
+  ocr_gas_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/polygon/chainlink_polygon_ocr_gas_daily_legacy.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_gas_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/polygon/chainlink_polygon_ocr_gas_transmission_logs.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_gas_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_gas_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'polygon' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('polygon', 'logs') }} logs
+WHERE
+  topic0 = 0xf6a97944f31ea060dfde0566e4167c1a1082551e64b60ecb14d599a9d023d451

--- a/models/chainlink/polygon/chainlink_polygon_ocr_gas_transmission_logs_legacy.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_gas_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_gas_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/polygon/chainlink_polygon_ocr_operator_admin_meta.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_operator_admin_meta.sql
@@ -1,0 +1,61 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_admin_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set alphachain = 'Alphachain' %}
+{% set bharvest = 'B Harvest' %}
+{% set blocksizecapital = 'BlocksizeCapital' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set cryptomanufaktur = 'CryptoManufaktur' %}
+{% set dmakers = 'dMakers' %}
+{% set dextrac = 'DexTrac' %}
+{% set fiews = 'Fiews' %}
+{% set inotel = 'Inotel' %}
+{% set linkforest = 'LinkForest' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set matrixedlink = 'Matrixed.Link' %}
+{% set mycelium = 'Mycelium' %}
+{% set newroad = 'Newroad Network' %}
+{% set simplyvc = 'Simply VC' %}
+{% set snzpool = 'SNZPool' %}
+{% set stakingfacilities = 'Staking Facilities' %}
+{% set vulcan = 'Vulcan Link' %}
+{% set ztake = 'Ztake.org' %}
+
+SELECT admin_address, operator_name FROM (VALUES
+  (0xD9459cc85E78e0336aDb349EAbF257Dbaf9d5a2B, '{{a01node}}'),
+  (0xa5D0084A766203b463b3164DFc49D91509C12daB, '{{alphachain}}'),
+  (0x6cDC3Efa3bAa392fAF3E5c1Ca802E15B6185E0e8, '{{bharvest}}'),
+  (0x7CC60c9C24E9A290Db55b1017AF477E5c87a7550, '{{blocksizecapital}}'),
+  (0x4a3dF8cAe46765d33c2551ff5438a5C5FC44347c, '{{chainlayer}}'),
+  (0x59eCf48345A221E0731E785ED79eD40d0A94E2A5, '{{cryptomanufaktur}}'),
+  (0xB9e62F6a14aC8BabB7f99993bdc3182a1976c22E, '{{dmakers}}'),
+  (0x9efa0A617C0552F1558c95993aA8b8A68b3e709C, '{{dextrac}}'),
+  (0x15918ff7f6C44592C81d999B442956B07D26CC44, '{{fiews}}'),
+  (0xB97a32D95A31a504C3dB28dDd574F21c700EDbee, '{{fiews}}'),
+  (0xB8C6E43f37E04A2411562a13c1C48B3ad5975cf4, '{{inotel}}'),
+  (0x4564A9c6061f6f1F2Eadb954B1b3C241D2DC984e, '{{linkforest}}'),
+  (0xD56FBFF05D2e1cdbeb5CB50e8055dAD0cf864792, '{{linkforest}}'),
+  (0xD48fc6E2B73C2988fA50C994181C0CdCa850D62a, '{{linkforest}}'),
+  (0x797de2909991C66C66D8e730C8385bbab8D18eA6, '{{linkpool}}'),
+  (0x14f94049397C3F1807c45B6f854Cb5F36bC4393B, '{{linkriver}}'),
+  (0x4dc81f63CB356c1420D4620414f366794072A3a8, '{{matrixedlink}}'),
+  (0x3FB4600736d306Ee2A89EdF0356D4272fb095768, '{{mycelium}}'),
+  (0xAB35418fB9f8B13E3e6857c36A0769b9F94a87EC, '{{newroad}}'),
+  (0x4fBefaf1BFf0130945C61603B97D38DD6e21f5Cf, '{{simplyvc}}'),
+  (0x1f11134A80aEd1FF47E3ee97A4d3f978A0629669, '{{simplyvc}}'),
+  (0x9cCbFD17FA284f36c2ff503546160B256d1CD3D1, '{{snzpool}}'),
+  (0x3D65be029c949F52cABa2d8E8270c098256697d9, '{{stakingfacilities}}'),
+  (0x7D0f8dd25135047967bA6C50309b567957dd52c3, '{{vulcan}}'),
+  (0x0039F22efB07A647557C7C5d17854CFD6D489eF3, '{{ztake}}')
+) AS tmp_node_meta(admin_address, operator_name)

--- a/models/chainlink/polygon/chainlink_polygon_ocr_operator_admin_meta_legacy.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_operator_admin_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_admin_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/polygon/chainlink_polygon_ocr_operator_node_meta.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_operator_node_meta.sql
@@ -1,0 +1,88 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_operator_node_meta'),
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan", "linkpool_jon"]\') }}'
+  )
+}}
+
+{% set a01node = '01Node' %}
+{% set alphachain = 'Alphachain' %}
+{% set bharvest = 'B Harvest' %}
+{% set blocksizecapital = 'BlocksizeCapital' %}
+{% set chainlayer = 'Chainlayer' %}
+{% set cryptomanufaktur = 'CryptoManufaktur' %}
+{% set dmakers = 'dMakers' %}
+{% set dextrac = 'DexTrac' %}
+{% set fiews = 'Fiews' %}
+{% set inotel = 'Inotel' %}
+{% set linkforest = 'LinkForest' %}
+{% set linkpool = 'LinkPool' %}
+{% set linkriver = 'LinkRiver' %}
+{% set matrixedlink = 'Matrixed.Link' %}
+{% set mycelium = 'Mycelium' %}
+{% set newroad = 'Newroad Network' %}
+{% set simplyvc = 'Simply VC' %}
+{% set snzpool = 'SNZPool' %}
+{% set stakingfacilities = 'Staking Facilities' %}
+{% set vulcan = 'Vulcan Link' %}
+{% set ztake = 'Ztake.org' %}
+
+SELECT node_address, operator_name FROM (VALUES
+  (0xe0Ed2A6CAd84df5191Fe337e7Dc9685d03bA3eD0, '{{a01node}}'),
+  (0x8867ca28d5dD0E3eD9bc86f889322395715b5A27, '{{a01node}}'),
+  (0x777225197088C54997Ff8904eBF01382825def85, '{{a01node}}'),
+  (0xED5cBf90D90eCcF2a846a1DA6D966A4B7E0A3269, '{{alphachain}}'),
+  (0x51FAfb35f31C434066267fc86EA24D8424115d2a, '{{bharvest}}'),
+  (0x50D6BDfc451314fB162D7D3322bFB4a005Cf192f, '{{bharvest}}'),
+  (0x4Da725FE670aD0610e06378b9B91F4f0a2a74128, '{{blocksizecapital}}'),
+  (0x7537cB7b7E8083ff8E68cb5c0cA18553Ab54946f, '{{chainlayer}}'),
+  (0xb1A9Fe770D7bD542feD4Ef9b5eA7B936D7786D0E, '{{chainlayer}}'),
+  (0x23FF32EE34c4b43daf478cF6205FF3d342b0719b, '{{chainlayer}}'),
+  (0xE6c27255Fbb9d3a9718Fb5E2DC313Cd6EbA10b78, '{{cryptomanufaktur}}'),
+  (0x51FD7E0b225095A8826686aBf6C45fB739d2Bb7E, '{{cryptomanufaktur}}'),
+  (0x1516288E09975CC53c04505380dc81B13142C91d, '{{cryptomanufaktur}}'),
+  (0x229306CB192f2cf1edC712eAA16006fBd5F9B008, '{{cryptomanufaktur}}'),
+  (0x21148F81D302442c34D39cB65B82f5e7138F9bE6, '{{dmakers}}'),
+  (0xd588b2470D0E78A170383148ae83327338e3c61A, '{{dmakers}}'),
+  (0x7BF377f69Da0E46Da1502D5F2bcf9fB00c3B610b, '{{dextrac}}'),
+  (0x5a0aAF39C78939eda540f8D50C2F5eF5A087E7AA, '{{dextrac}}'),
+  (0xaEf8567821859bF21BaB20Ae1A1Afec8C89Ed2bb, '{{dextrac}}'),
+  (0x550365027554bD20D750f9361e460C7428ffBd75, '{{fiews}}'),
+  (0xFCE3E6b1739812cdDa335964f281E9A0472B6047, '{{fiews}}'),
+  (0xC1DCB8AC71bd771D37dF807F34323A005A515326, '{{fiews}}'),
+  (0x52Add4435c81a4e0fB2eC494966863e48BF9302E, '{{inotel}}'),
+  (0x9DF75B14905FCe7bf38add3021aC6a48Ed8569C8, '{{inotel}}'),
+  (0x8f3f684efA5cc45DFD739cd9efdcaC79d27fbe4b, '{{inotel}}'),
+  (0x250ABd1D4EBC8e70a4981677D5525f827660bDE4, '{{linkforest}}'),
+  (0xd9f89292a21941826b62460009d9c634c4fA0069, '{{linkforest}}'),
+  (0x2D4799D475c9da5Da53013cC284F34D2424A8a28, '{{linkforest}}'),
+  (0xa1ab1c841898Fe94900d00d9312ba954e4F81501, '{{linkpool}}'),
+  (0x9F9922d4bBa463EfBBcF8563282723d98587f7eb, '{{linkpool}}'),
+  (0xf03b7095B089A4e601fB13F2BF6af518eb199a0b, '{{linkpool}}'),
+  (0x8eD47843e5030b6F06e6F204Fcf2725378BB837a, '{{linkriver}}'),
+  (0xf5EEc17396c5e8A0047ee169d74D3c1066e6908B, '{{linkriver}}'),
+  (0x0517395146AB8b43Fa3f8940A57d03177710E278, '{{linkriver}}'),
+  (0xd0fF3C55A27c930069Cb4EFA32921B89792CA8CC, '{{linkriver}}'),
+  (0x5543FF441d3B0fCce59Aa08eb52f15d27294AF21, '{{matrixedlink}}'),
+  (0xd0A8Cb58efcee1CAeE48F3c357074862cA8210dc, '{{mycelium}}'),
+  (0x5c51C26bfE38a58c89c78142D20aA538e2D45DF5, '{{mycelium}}'),
+  (0x205Ad86aeA1F7A3B035F9fcd38B359Ba40f3EBb3, '{{mycelium}}'),
+  (0x983D0e1d23D3109D15e833fB800A51ba154DEfD3, '{{newroad}}'),
+  (0x875fc6a5Ff9090435EE197717F7eeD5a05d747e5, '{{newroad}}'),
+  (0x777Ad55EFc465052d6A4AB7bc75B6A15175bB399, '{{simplyvc}}'),
+  (0x7d2264a1203c625001fe56011240794228CdB346, '{{simplyvc}}'),
+  (0x313b80977344FA0FBA3912B710072E3eDd9faA18, '{{simplyvc}}'),
+  (0x84A611B71254F5fCCb1E5a619aD723CAD8a03638, '{{snzpool}}'),
+  (0xf23971dE39a087cFf61EB54f77A1951983F90723, '{{snzpool}}'),
+  (0x7ba865F70E32C9f46f67E33FE06139c8C31a2fAd, '{{stakingfacilities}}'),
+  (0x4e791FEC7329738Fb7D3a8caEf80D1201Bb12C14, '{{stakingfacilities}}'),
+  (0x3Dd12EB5aE0F1A106fB358C8B99830ab5690a7a2, '{{vulcan}}'),
+  (0xC1aaF3D6e0189C4f6D5CF35514328e6F747a2472, '{{vulcan}}'),
+  (0xcDee224d35860622A61F59D06daFe76d93f8db7c, '{{ztake}}'),
+  (0x36C3891112B381538b2B7Cb5650da6C89bB48FFF, '{{ztake}}')
+) AS tmp_node_meta(node_address, operator_name)

--- a/models/chainlink/polygon/chainlink_polygon_ocr_operator_node_meta_legacy.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_operator_node_meta_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_operator_node_meta', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/polygon/chainlink_polygon_ocr_request_daily.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_request_daily.sql
@@ -1,0 +1,74 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_request_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'node_address'],
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+{% set truncate_by = 'day' %}
+
+WITH
+  ocr_request_daily_meta AS (
+    SELECT
+      COALESCE(
+        cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
+        cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
+      ) AS "date_start",      
+      COALESCE(
+        fulfilled.node_address,
+        reverted.node_address
+      ) AS "node_address",
+      COALESCE(COUNT(fulfilled.token_amount), 0) as fulfilled_requests,
+      COALESCE(COUNT(reverted.token_amount), 0) as reverted_requests,
+      COALESCE(COUNT(fulfilled.token_amount), 0) + COALESCE(COUNT(reverted.token_amount), 0) as total_requests
+    FROM
+      {{ ref('chainlink_polygon_ocr_fulfilled_transactions') }} fulfilled
+      FULL OUTER JOIN {{ ref('chainlink_polygon_ocr_reverted_transactions') }} reverted ON
+        reverted.block_time = fulfilled.block_time AND
+        reverted.node_address = fulfilled.node_address
+    {% if is_incremental() %}
+      WHERE
+        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+    {% endif %}
+    GROUP BY
+      1, 2
+    ORDER BY
+      1, 2
+  ),
+  ocr_request_daily AS (
+    SELECT
+      'polygon' as blockchain,
+      date_start,
+      cast(date_trunc('month', date_start) as date) as date_month,
+      ocr_request_daily_meta.node_address as node_address,
+      operator_name,
+      fulfilled_requests,
+      reverted_requests,
+      total_requests
+    FROM ocr_request_daily_meta
+    LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
+  )
+SELECT 
+  blockchain,
+  date_start,
+  date_month,
+  node_address,
+  operator_name,
+  fulfilled_requests,
+  reverted_requests,
+  total_requests
+FROM
+  ocr_request_daily
+ORDER BY
+  "date_start"

--- a/models/chainlink/polygon/chainlink_polygon_ocr_request_daily_legacy.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_request_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_request_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/polygon/chainlink_polygon_ocr_reverted_transactions.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_reverted_transactions.sql
@@ -1,0 +1,64 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reverted_transactions'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  polygon_usd AS (
+    SELECT
+      minute as block_time,
+      price as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      symbol = 'MATIC'
+      {% if is_incremental() %}
+        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+  ),
+  ocr_reverted_transactions AS (
+    SELECT
+      tx.hash as tx_hash,
+      tx.index as tx_index,
+      MAX(tx.block_time) as block_time,
+      cast(date_trunc('month', MAX(tx.block_time)) as date) as date_month,
+      tx."from" as "node_address",
+      MAX((cast((gas_used) as double) / 1e18) * gas_price) as token_amount,
+      MAX(polygon_usd.usd_amount) as usd_amount
+    FROM
+      {{ source('polygon', 'transactions') }} tx
+      LEFT JOIN polygon_usd ON date_trunc('minute', tx.block_time) = polygon_usd.block_time
+    WHERE
+      success = false
+      {% if is_incremental() %}
+        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      tx.hash,
+      tx.index,
+      tx."from"
+  )
+SELECT
+ 'polygon' as blockchain,
+  block_time,
+  date_month,
+  node_address,
+  token_amount,
+  usd_amount,
+  tx_hash,
+  tx_index
+FROM
+  ocr_reverted_transactions

--- a/models/chainlink/polygon/chainlink_polygon_ocr_reverted_transactions_legacy.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_reverted_transactions_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reverted_transactions', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/polygon/chainlink_polygon_ocr_reward_daily.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_reward_daily.sql
@@ -1,0 +1,111 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_daily'),
+    partition_by = ['date_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+WITH
+  admin_address_meta as (
+    SELECT DISTINCT
+      admin_address
+    FROM
+      {{ref('chainlink_polygon_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+  ),
+  link_usd_daily AS (
+    SELECT
+      cast(date_trunc('day', price.minute) as date) as "date_start",
+      MAX(price.price) as usd_amount
+    FROM
+      {{ source('prices', 'usd') }} price
+    WHERE
+      price.symbol = 'LINK'
+      {% if is_incremental() %}
+        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+      {% endif %}      
+    GROUP BY
+      1
+    ORDER BY
+      1
+  ),
+  link_usd_daily_expanded_by_admin_address AS (
+    SELECT
+      date_start,
+      usd_amount,
+      admin_address
+    FROM
+      link_usd_daily
+    CROSS JOIN
+      admin_address_meta
+    ORDER BY
+      date_start,
+      admin_address
+  ),
+  payment_meta AS (
+    SELECT
+      date_start,
+      link_usd_daily_expanded_by_admin_address.admin_address as admin_address,
+      usd_amount,
+      (
+        SELECT
+          MAX(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_polygon_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start <= link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as prev_payment_date,
+      (
+        SELECT
+          MIN(ocr_reward_evt_transfer_daily.date_start)
+        FROM
+          {{ref('chainlink_polygon_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily
+        WHERE
+          ocr_reward_evt_transfer_daily.date_start > link_usd_daily_expanded_by_admin_address.date_start
+          AND ocr_reward_evt_transfer_daily.admin_address = link_usd_daily_expanded_by_admin_address.admin_address
+      ) as next_payment_date
+    FROM
+      link_usd_daily_expanded_by_admin_address
+    ORDER BY
+      1, 2
+  ),
+  ocr_reward_daily AS (
+    SELECT 
+      payment_meta.date_start,
+      cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
+      payment_meta.admin_address,
+      ocr_operator_admin_meta.operator_name,      
+      COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
+      (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
+    FROM 
+      payment_meta
+    LEFT JOIN 
+      {{ref('chainlink_polygon_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
+        payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
+        payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
+    ORDER BY date_start
+  )
+SELECT
+  'polygon' as blockchain,
+  date_start,
+  date_month,
+  admin_address,
+  operator_name,
+  token_amount,
+  usd_amount
+FROM 
+  ocr_reward_daily
+ORDER BY
+  2, 4

--- a/models/chainlink/polygon/chainlink_polygon_ocr_reward_daily_legacy.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_reward_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'polygon' as blockchain,
+  to as admin_address,
+  MAX(operator_name) as operator_name,
+  MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+  MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+FROM
+  {{ source('erc20_polygon', 'evt_Transfer') }} reward_evt_transfer
+  RIGHT JOIN {{ ref('chainlink_polygon_ocr_reward_transmission_logs') }} ocr_reward_transmission_logs ON ocr_reward_transmission_logs.contract_address = reward_evt_transfer."from"
+  LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+WHERE
+  reward_evt_transfer."from" IN (ocr_reward_transmission_logs.contract_address)
+GROUP BY
+  evt_tx_hash,
+  evt_index,
+  to

--- a/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer_daily.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer_daily.sql
@@ -1,0 +1,38 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_evt_transfer_daily'),
+    partition_by=['date_month'],
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['date_start', 'admin_address'],
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+{% set incremental_interval = '7' %}
+
+SELECT
+  'polygon' as blockchain,
+  cast(date_trunc('day', evt_block_time) AS date) AS date_start,
+  MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
+  ocr_reward_evt_transfer.admin_address as admin_address,
+  MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
+  SUM(token_value) as token_amount
+FROM
+  {{ref('chainlink_polygon_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
+{% if is_incremental() %}
+  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+{% endif %}      
+GROUP BY
+  2, 4
+ORDER BY
+  2, 4
+
+
+

--- a/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer_daily_legacy.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer_daily_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer_daily', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer_legacy.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_evt_transfer', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/polygon/chainlink_polygon_ocr_reward_transmission_logs.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_reward_transmission_logs.sql
@@ -1,0 +1,30 @@
+{{
+  config(
+    tags=['dunesql'],
+    alias=alias('ocr_reward_transmission_logs'),
+    materialized='view',
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "chainlink",
+                                \'["linkpool_ryan"]\') }}'
+  )
+}}
+
+SELECT
+  'polygon' as blockchain,
+  block_hash,
+  contract_address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  tx_hash,
+  block_number,
+  block_time,
+  index,
+  tx_index
+FROM
+  {{ source('polygon', 'logs') }} logs
+WHERE
+  topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6

--- a/models/chainlink/polygon/chainlink_polygon_ocr_reward_transmission_logs_legacy.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_reward_transmission_logs_legacy.sql
@@ -1,0 +1,9 @@
+{{ config( 
+  alias = alias('ocr_reward_transmission_logs', legacy_model=True),
+  tags = ['legacy']
+  )
+}}
+
+-- TODO: Remove Dummy Table
+SELECT
+  1

--- a/models/chainlink/polygon/chainlink_polygon_schema.yml
+++ b/models/chainlink/polygon/chainlink_polygon_schema.yml
@@ -132,3 +132,250 @@ models:
         description: "Decimal adjustment for the oracle answer"
       - *proxy_address
       - *aggregator_address
+
+  - name: chainlink_polygon_ocr_gas_transmission_logs
+    meta:
+      blockchain: polygon
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'gas', 'transmission', 'logs', 'polygon']
+    description: >
+      Chainlink OCR Gas Transmission Logs
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - block_number
+              - tx_hash
+              - tx_index
+    columns:
+      - *blockchain
+      - &block_hash
+        name: block_hash
+        description: "Block Hash"
+      - &contract_address
+        name: contract_address
+        description: "Contract Address"
+      - &data
+        name: data
+        description: "Data"
+      - &topic0
+        name: topic0
+        description: "Topic 0"
+      - &topic1
+        name: topic1
+        description: "Topic 1"
+      - &topic2
+        name: topic2
+        description: "Topic 2"
+      - &topic3
+        name: topic3
+        description: "Topic 3"
+      - &tx_hash
+        name: tx_hash
+        description: "Transaction Hash"
+      - *block_number
+      - *block_time
+      - &index
+        name: index
+        description: "Index"
+      - &tx_index
+        name: tx_index
+        description: "Transaction Index"
+
+  - name: chainlink_polygon_ocr_fulfilled_transactions
+    meta:
+      blockchain: polygon
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'polygon']
+    description: >
+      Chainlink OCR Fulfilled Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - &date_month
+        name: date_month
+        description: "Date truncated by month"
+      - &node_address
+        name: node_address
+        description: "Node Address"
+      - &token_amount
+        name: token_amount
+        description: "Token Amount"
+      - &usd_amount
+        name: usd_amount
+        description: "USD Amount"
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_polygon_ocr_reverted_transactions
+    meta:
+      blockchain: polygon
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'polygon']
+    description: >
+      Chainlink OCR Reverted Transactions
+    columns:
+      - *blockchain
+      - *block_time
+      - *date_month
+      - *node_address
+      - *token_amount
+      - *usd_amount
+      - *tx_hash
+      - *tx_index
+
+  - name: chainlink_polygon_ocr_gas_daily
+    meta:
+      blockchain: polygon
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'gas', 'daily', 'polygon']
+    description: >
+        Chainlink OCR Gas Daily
+    columns:
+      - *blockchain
+      - &date_start
+        name: date_start
+        description: "Date Start"
+      - *date_month
+      - *node_address
+      - &operator_name
+        name: operator_name
+        description: "Operator Name"
+      - &fulfilled_token_amount
+        name: fulfilled_token_amount
+        description: "Fulfilled Token Amount"
+      - &fulfilled_usd_amount
+        name: fulfilled_usd_amount
+        description: "Fulfilled USD Amount"
+      - &reverted_token_amount
+        name: reverted_token_amount
+        description: "Reverted Token Amount"
+      - &reverted_usd_amount
+        name: reverted_usd_amount
+        description: "Reverted USD Amount"
+      - &total_token_amount
+        name: total_token_amount
+        description: "Total Token Amount"
+      - &total_usd_amount
+        name: total_usd_amount
+        description: "Total USD Amount"
+
+  - name: chainlink_polygon_ocr_request_daily
+    meta:
+      blockchain: polygon
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'request', 'daily', 'polygon']
+    description: >
+        Chainlink OCR Request Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *node_address
+      - *operator_name
+      - &fulfilled_requests
+        name: fulfilled_requests
+        description: "Fulfilled Requests"
+      - &reverted_requests
+        name: reverted_requests
+        description: "Reverted Requests"
+      - &total_requests
+        name: total_requests
+        description: "Total Requests"
+
+  - name: chainlink_polygon_ocr_reward_transmission_logs
+    meta:
+      blockchain: polygon
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'transmission', 'logs', 'polygon']
+    description: >
+      Chainlink OCR Reward Transmission Logs
+    columns:
+      - *blockchain
+      - *block_hash
+      - *contract_address
+      - *data
+      - *topic0
+      - *topic1
+      - *topic2
+      - *topic3
+      - *tx_hash
+      - *block_number
+      - *block_time
+      - *index
+      - *tx_index
+
+  - name: chainlink_polygon_ocr_reward_evt_transfer
+    meta:
+      blockchain: polygon
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'polygon']
+    description: >
+      Chainlink OCR Reward Event Transfers
+    columns:
+      - *blockchain
+      - &evt_block_time
+        name: evt_block_time
+        description: "Event Block Time"
+      - &admin_address
+        name: admin_address
+        description: "Admin Address"
+      - *operator_name
+      - &token_value
+        name: token_value
+        description: "Token Value"
+
+  - name: chainlink_polygon_ocr_reward_evt_transfer_daily
+    meta:
+      blockchain: polygon
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink', 'ocr', 'reward', 'evt', 'transfer', 'daily', 'polygon']
+    description: >
+      Chainlink OCR Reward Event Transfers Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address      
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_value
+
+  - name: chainlink_polygon_ocr_reward_daily
+    meta:
+      blockchain: polygon
+      sector: chainlink
+      contributors: linkpool_ryan
+    config:
+      tags: ['chainlink','ocr', 'reward', 'daily', 'polygon']
+    description: >
+        Chainlink OCR Reward Daily
+    columns:
+      - *blockchain
+      - *date_start
+      - *date_month
+      - *admin_address
+      - *operator_name
+      - *token_amount
+      - *usd_amount

--- a/models/chainlink/polygon/chainlink_polygon_schema.yml
+++ b/models/chainlink/polygon/chainlink_polygon_schema.yml
@@ -193,6 +193,13 @@ models:
       tags: ['chainlink', 'ocr', 'fulfilled', 'transactions', 'polygon']
     description: >
       Chainlink OCR Fulfilled Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -220,6 +227,13 @@ models:
       tags: ['chainlink', 'ocr', 'reverted', 'transactions', 'polygon']
     description: >
       Chainlink OCR Reverted Transactions
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - tx_hash
+              - tx_index
+              - node_address
     columns:
       - *blockchain
       - *block_time
@@ -239,6 +253,12 @@ models:
       tags: ['chainlink','ocr', 'gas', 'daily', 'polygon']
     description: >
         Chainlink OCR Gas Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - &date_start
@@ -277,6 +297,12 @@ models:
       tags: ['chainlink','ocr', 'request', 'daily', 'polygon']
     description: >
         Chainlink OCR Request Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - node_address
     columns:
       - *blockchain
       - *date_start
@@ -353,7 +379,7 @@ models:
           combination_of_columns:
               - blockchain
               - date_start
-              - admin_address      
+              - admin_address
     columns:
       - *blockchain
       - *date_start
@@ -371,6 +397,12 @@ models:
       tags: ['chainlink','ocr', 'reward', 'daily', 'polygon']
     description: >
         Chainlink OCR Reward Daily
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+              - blockchain
+              - date_start
+              - admin_address
     columns:
       - *blockchain
       - *date_start

--- a/models/chainlink/polygon/chainlink_polygon_sources.yml
+++ b/models/chainlink/polygon/chainlink_polygon_sources.yml
@@ -1,0 +1,34 @@
+version: 2
+
+sources:
+  - name: erc20_polygon
+    description: "Transfers events for ERC20 tokens on polygon."
+    tables:
+      - name: evt_Transfer
+        loaded_at_field: evt_block_time
+        description: "Transfers events for ERC20 tokens on polygon."
+        columns:
+          - &contract_address
+            name: contract_address
+            description: "ERC20 token contract address"
+          - &evt_block_number
+            name: evt_block_number
+            description: "Block event number"
+          - &evt_block_time
+            name: evt_block_time
+            description: "Timestamp for block event time in UTC"
+          - &evt_index
+            name: evt_index
+            description: "Event index"
+          - &evt_tx_hash
+            name: evt_tx_hash
+            description: "Event transaction hash"
+          - &from
+            name: from
+            description: "Wallet address for ERC20 token transfer from"
+          - &to
+            name: to
+            description: "Wallet address for ERC20 token transfer to"
+          - &value
+            name: value
+            description: "Raw amount of ERC20 token"


### PR DESCRIPTION
## Status

Ready for review @jeff-dude 

## Background

In reference to this correlated PR which was recently merged: https://github.com/duneanalytics/spellbook/pull/3832

## About

This is the second PR mentioned in the aforementioned PR, to add the OCR metrics. This will be the most complex of any Chainlink metrics to add (eg., FM, VRF, Keepers, Automation, CCIP, LLO) given the complexity of OCR metrics.

## Review Process

- I recommend reviewing the "README.md" at the root of project to get a better understand of what OCR is, why it exists, and therefore why we've split the tables accordingly.
- Let's focus feedback on just ethereum in this PR. All other networks have nearly identical implementation with the exception of different network tables and meta data
- Special note: a dummy legacy file was added for each new model on each chain, resulting in 88 dummy files generated (per official CI guidance). Naturally, this make this PR look unnecessarily larger than it really is, as you are able to ignore all _legacy files in this PR. We did create these in one distinct commit that can simply be reverted when the CI bug with new schemas is fixed. 

## Example use cases of the model

- Query one row per month per node operator per chain YTD with distinct columns for each metric - https://dune.com/queries/2812872
- Query one row per month per node operator YTD with distinct columns for each metric for each chain - https://dune.com/queries/2812658
- Query one row per month per node operator YTD with a sum of all chains for each metric - https://dune.com/queries/2812594

## What's next?

As per the previous PR, we expect the following PRs to come after this one:

- PR#3: Extend PriceFeeds (WIP): Add support for all evm chains and update the meta data to include all known price feeds per network
- PR#4: FM for all EVM chains
- PR#5: Keeper for all EVM chains
- PR#6: VRF for all EVM chains