### PR TITLE
Migrate gas_polygon_fees_traces

### DIFF
--- a/models/gas/polygon/gas_polygon_fees_traces.sql
+++ b/models/gas/polygon/gas_polygon_fees_traces.sql
@@ -1,4 +1,9 @@
 {{ config(
+     tags = ['dunesql'],
+    pre_hook = {
+            'sql': '{{ set_trino_session_property(is_partitioned(model), \'join_distribution_type\', \'PARTITIONED\') }}',
+            'transaction': True
+        },
     schema = 'gas_polygon',
     alias = alias('fees_traces'),
     partition_by = ['block_date'],
@@ -13,11 +18,11 @@ WITH traces AS (
      SELECT traces.block_time
      , traces.block_number
      , traces.tx_hash
-     , MAX(traces.from) AS trace_from
+     , MAX(traces."from") AS trace_from
      , MAX(traces.to) AS trace_to
      , traces.trace
      , MAX(traces.input) AS trace_input
-     , substring(MAX(traces.input),1,10) AS trace_method
+     , bytearray_substring(MAX(traces.input),0,5) AS trace_method
      , SUM(traces.gas_used_original) AS gas_used_original
      , SUM(traces.gas_used_trace) AS gas_used_trace
      , MAX(traces.trace_type) AS trace_type
@@ -25,7 +30,7 @@ WITH traces AS (
      , MAX(traces.trace_success) AS trace_success
      , MAX(traces.tx_success) AS tx_success
      FROM (
-          SELECT from
+          SELECT "from"
           , to
           , tx_hash
           , trace_address AS trace
@@ -40,28 +45,28 @@ WITH traces AS (
           , tx_success
           FROM {{ source('polygon','traces') }}
           {% if is_incremental() %}
-          WHERE block_time >= date_trunc("day", NOW() - interval '1 days')
+          WHERE block_time >= date_trunc('day', NOW() - interval '1 days')
           {% endif %}
           
           UNION ALL
           
-          SELECT CAST(NULL AS varchar(1)) AS from 
-          , CAST(NULL AS varchar(1)) AS to 
+          SELECT CAST(NULL AS VARBINARY) AS "from" 
+          , CAST(NULL AS VARBINARY) AS to 
           , tx_hash
           , slice(trace_address, 1, cardinality(trace_address) - 1) AS trace
           , CAST(NULL AS double) AS gas_used_original
           , -gas_used AS gas_used_trace
           , block_time
           , block_number
-          , CAST(NULL AS varchar(1)) AS input
+          , CAST(NULL AS VARBINARY) AS input
           , CAST(NULL AS varchar(1)) AS trace_type
-          , CAST(NULL AS varchar(1)) AS trace_value
+          , CAST(NULL AS UINT256) AS trace_value
           , CAST(NULL AS boolean) AS trace_success
           , CAST(NULL AS boolean) AS tx_success
           FROM {{ source('polygon','traces') }}
           WHERE cardinality(trace_address) > 0
           {% if is_incremental() %}
-          AND block_time >= date_trunc("day", NOW() - interval '1 days')
+          AND block_time >= date_trunc('day', NOW() - interval '1 days')
           {% endif %}
           ) traces
      GROUP BY traces.tx_hash, traces.trace, traces.block_time, traces.block_number
@@ -74,11 +79,11 @@ SELECT 'polygon' AS blockchain
 , traces.tx_hash
 , traces.trace_from
 , traces.trace_to
-, txs.from AS tx_from
+, txs."from" AS tx_from
 , txs.to AS tx_to
 , traces.trace
 , traces.trace_method
-, substring(txs.data,1,10) AS tx_method
+, bytearray_substring(txs.data,0,5) AS tx_method
 , traces.trace_input
 , traces.gas_used_original
 , traces.gas_used_trace
@@ -98,11 +103,11 @@ FROM traces
 INNER JOIN {{ source('polygon','transactions') }} txs ON txs.block_time=traces.block_time
      AND txs.hash=traces.tx_hash
      {% if is_incremental() %}
-     AND txs.block_time >= date_trunc("day", NOW() - interval '1 days')
+     AND txs.block_time >= date_trunc('day', NOW() - interval '1' day)
      {% endif %}
 LEFT JOIN {{ source('prices', 'usd') }} pu ON pu.minute=date_trunc('minute', traces.block_time)
      AND pu.blockchain='polygon'
-     AND pu.contract_address='0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'
+     AND pu.contract_address=0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270
      {% if is_incremental() %}
-     AND pu.minute >= date_trunc("day", NOW() - interval '1' week)
+     AND pu.minute >= date_trunc('day', NOW() - interval '7' day)
      {% endif %}

--- a/models/gas/polygon/gas_polygon_fees_traces.sql
+++ b/models/gas/polygon/gas_polygon_fees_traces.sql
@@ -6,7 +6,7 @@
         },
     schema = 'gas_polygon',
     alias = alias('fees_traces'),
-    partition_by = ['block_date'],
+    partition_by = ['block_month'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/gas/polygon/gas_polygon_fees_traces.sql
+++ b/models/gas/polygon/gas_polygon_fees_traces.sql
@@ -74,6 +74,7 @@ WITH traces AS (
 
 SELECT 'polygon' AS blockchain
 , traces.block_time
+, CAST(date_trunc('month', traces.block_time) AS date) as block_month
 , date_trunc('day', traces.block_time) AS block_date
 , traces.block_number
 , traces.tx_hash

--- a/models/gas/polygon/gas_polygon_fees_traces.sql
+++ b/models/gas/polygon/gas_polygon_fees_traces.sql
@@ -45,7 +45,7 @@ WITH traces AS (
           , tx_success
           FROM {{ source('polygon','traces') }}
           {% if is_incremental() %}
-          WHERE block_time >= date_trunc('day', NOW() - interval '1 days')
+          WHERE block_time >= date_trunc('day', NOW() - interval '1' day)
           {% endif %}
           
           UNION ALL
@@ -66,7 +66,7 @@ WITH traces AS (
           FROM {{ source('polygon','traces') }}
           WHERE cardinality(trace_address) > 0
           {% if is_incremental() %}
-          AND block_time >= date_trunc('day', NOW() - interval '1 days')
+          AND block_time >= date_trunc('day', NOW() - interval '1' day)
           {% endif %}
           ) traces
      GROUP BY traces.tx_hash, traces.trace, traces.block_time, traces.block_number


### PR DESCRIPTION
Trying to migrate gas_polygon_fees_traces because it's been failing on spark. The idea is to remove it from spark when it's migrated.