### PR TITLE
change dodo aggregator project name to DODO X

### DIFF
--- a/models/dodo/arbitrum/dodo_aggregator_arbitrum_trades.sql
+++ b/models/dodo/arbitrum/dodo_aggregator_arbitrum_trades.sql
@@ -20,7 +20,7 @@ WITH dexs AS
         -- dodo proxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -44,7 +44,7 @@ WITH dexs AS
         -- DODORouteProxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -68,7 +68,7 @@ WITH dexs AS
         -- DODOFeeRouteProxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,

--- a/models/dodo/bnb/dodo_aggregator_bnb_trades.sql
+++ b/models/dodo/bnb/dodo_aggregator_bnb_trades.sql
@@ -20,7 +20,7 @@ WITH dexs AS
         -- dodo proxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -44,7 +44,7 @@ WITH dexs AS
         -- DODORouteProxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -68,7 +68,7 @@ WITH dexs AS
         -- DODOFeeRouteProxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,

--- a/models/dodo/ethereum/dodo_aggregator_ethereum_trades.sql
+++ b/models/dodo/ethereum/dodo_aggregator_ethereum_trades.sql
@@ -20,7 +20,7 @@ WITH dexs AS
         -- dodo proxy01
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -44,7 +44,7 @@ WITH dexs AS
         -- dodo proxy02
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -68,7 +68,7 @@ WITH dexs AS
         -- dodo proxy03
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -92,7 +92,7 @@ WITH dexs AS
         -- dodo proxy04
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -116,7 +116,7 @@ WITH dexs AS
         -- dodov2 proxy02
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -140,7 +140,7 @@ WITH dexs AS
         -- DODORouteProxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -164,7 +164,7 @@ WITH dexs AS
         -- DODOFeeRouteProxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,

--- a/models/dodo/optimism/dodo_aggregator_optimism_trades.sql
+++ b/models/dodo/optimism/dodo_aggregator_optimism_trades.sql
@@ -20,7 +20,7 @@ WITH dexs AS
         -- dodo proxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -44,7 +44,7 @@ WITH dexs AS
         -- DODORouteProxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -68,7 +68,7 @@ WITH dexs AS
         -- DODOFeeRouteProxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,

--- a/models/dodo/polygon/dodo_aggregator_polygon_trades.sql
+++ b/models/dodo/polygon/dodo_aggregator_polygon_trades.sql
@@ -20,7 +20,7 @@ WITH dexs AS
         -- dodo proxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -44,7 +44,7 @@ WITH dexs AS
         -- DODORouteProxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,
@@ -68,7 +68,7 @@ WITH dexs AS
         -- DODOFeeRouteProxy
         SELECT
             evt_block_time AS block_time,
-            'DODO' AS project,
+            'DODO X' AS project,
             '0' AS version,
             sender AS taker,
             '' AS maker,


### PR DESCRIPTION
Only Change the brand name of "DODO Aggregator" to "DODO X"

# Thank you for contributing to Spellbook!
Please refer to the top of the `readme` in the root of Spellbook to learn how to contribute to Spellbook on DuneSQL.