### PR TITLE
Switch join order in prices_usd_forward_fill

### DIFF
--- a/models/prices/prices_usd_forward_fill.sql
+++ b/models/prices/prices_usd_forward_fill.sql
@@ -43,8 +43,8 @@ WITH
     ,decimals
     ,symbol
     ,price
-    from timeseries t
-    left join unfinalized p
+    from unfinalized p
+    right join timeseries t
     ON t.minute >= p.minute and (p.next_update_minute is null OR t.minute < p.next_update_minute) -- perform forward fill
 )
 


### PR DESCRIPTION
This improves the performance of the model by a lot. We should investigate why the planner did not figure this out on its own.

# Thank you for contributing to Spellbook!
Please refer to the top of the `readme` in the root of Spellbook to learn how to contribute to Spellbook on DuneSQL.