### PR TITLE
experimental: Adapt nft.transfers to support denormalization

### DIFF
--- a/macros/models/_sector/nft/nft_transfers.sql
+++ b/macros/models/_sector/nft/nft_transfers.sql
@@ -2,6 +2,7 @@
 {%- set token_standard_721 = 'bep721' if blockchain == 'bnb' else 'erc721' -%}
 {%- set token_standard_1155 = 'bep1155' if blockchain == 'bnb' else 'erc1155' -%}
 {%- set spark_mode = True -%} {# TODO: Potential bug. Consider disabling #}
+{%- set denormalized = True if blockchain in ['base'] else False -%}
 SELECT
     *
 FROM(
@@ -18,19 +19,25 @@ FROM(
     , cast(1 as uint256) AS amount
     , t."from"
     , t.to
+    {%- if denormalized == True -%}
+    , t.tx_from AS executed_by
+    {%- else -%}
     , et."from" AS executed_by
+    {%- endif -%}
     , t.evt_tx_hash AS tx_hash
     , '{{blockchain}}' || cast(t.evt_tx_hash as varchar) || '-{{token_standard_721}}-' || cast(t.contract_address as varchar) || '-' || cast(t.tokenId as varchar) || '-' || cast(t."from" as varchar) || '-' || cast(t.to as varchar) || '-1-' || cast(t.evt_index as varchar) AS unique_transfer_id
     FROM {{ erc721_transfers }} t
         {% if is_incremental() %}
             LEFT JOIN {{this}} anti_table
                 ON t.evt_tx_hash = anti_table.tx_hash
-        {% endif %}
+        {% endif %}%
+    {%- if denormalized == True -%}
     INNER JOIN {{ base_transactions }} et ON et.block_number = t.evt_block_number
         AND et.hash = t.evt_tx_hash
         {% if is_incremental() %}
         AND et.block_time >= date_trunc('day', now() - interval '7' day)
         {% endif %}
+    {%- endif -%}
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc('day', now() - interval '7' day)
     AND anti_table.tx_hash is null
@@ -51,7 +58,11 @@ FROM(
     , t.value AS amount
     , t."from"
     , t.to
+    {%- if denormalized == True -%}
+    , t.tx_from AS executed_by
+    {%- else -%}
     , et."from" AS executed_by
+    {%- endif -%}
     , t.evt_tx_hash AS tx_hash
     , '{{blockchain}}' || cast(t.evt_tx_hash as varchar) || '-{{token_standard_1155}}-' || cast(t.contract_address as varchar) || '-' || cast(t.id as varchar) || '-' || cast(t."from" as varchar) || '-' || cast(t.to as varchar) || '-' || cast(t.value as varchar) || '-' || cast(t.evt_index as varchar) AS unique_transfer_id
     FROM {{ erc1155_single }} t
@@ -59,11 +70,13 @@ FROM(
             LEFT JOIN {{this}} anti_table
                 ON t.evt_tx_hash = anti_table.tx_hash
         {% endif %}
+    {%- if denormalized == True -%}
     INNER JOIN {{ base_transactions }} et ON et.block_number = t.evt_block_number
         AND et.hash = t.evt_tx_hash
         {% if is_incremental() %}
         AND et.block_time >= date_trunc('day', now() - interval '7' day)
         {% endif %}
+    {%- endif -%}
     {% if is_incremental() %}
     WHERE t.evt_block_time >= date_trunc('day', now() - interval '7' day)
     AND anti_table.tx_hash is null
@@ -84,7 +97,11 @@ FROM(
     , cast(t.value as uint256) AS amount
     , t."from"
     , t.to
+    {%- if denormalized == True -%}
+    , t.tx_from AS executed_by
+    {%- else -%}
     , et."from" AS executed_by
+    {%- endif -%}
     , t.evt_tx_hash AS tx_hash
     , '{{blockchain}}' || cast(t.evt_tx_hash as varchar) || '-{{token_standard_1155}}-' || cast(t.contract_address as varchar) || '-' || cast(t.id as varchar) || '-' || cast(t."from" as varchar) || '-' || cast(t.to as varchar) || '-' || cast(t.value as varchar) || '-' || cast(t.evt_index as varchar) AS unique_transfer_id
     FROM (
@@ -103,11 +120,13 @@ FROM(
         GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9
         {% endif %}
         ) t
+    {%- if denormalized == True -%}
     INNER JOIN {{ base_transactions }} et ON et.block_number = t.evt_block_number
         AND et.hash = t.evt_tx_hash
         {% if is_incremental() %}
         AND et.block_time >= date_trunc('day', now() - interval '7' day)
         {% endif %}
+    {%- endif -%}
     {% if spark_mode == True %}
     {# TODO: This is a bug. In the comparsion t.value > 0, spark converts t.value to an integer before the comparison,
     or null (i.e., false) if it overflows) #}


### PR DESCRIPTION
Since we now have `tx_from` on base decoded tables I wanted to try this and see the speedup we can get. 