### PR TITLE
Replace UNION with UNION ALL in transfers_bnb.bep20

### DIFF
--- a/models/transfers/bnb/bep20/transfers_bnb_bep20_legacy.sql
+++ b/models/transfers/bnb/bep20/transfers_bnb_bep20_legacy.sql
@@ -53,15 +53,15 @@ with
         from
             {{ source('bnb_bnb', 'WBNB_evt_Withdrawal') }}
     )
-    
+
 select unique_transfer_id, 'bnb' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100)) as amount_raw
 from sent_transfers
-union
+union all
 select unique_transfer_id, 'bnb' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100)) as amount_raw
 from received_transfers
-union
+union all
 select unique_transfer_id, 'bnb' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100)) as amount_raw
 from deposited_bnb
-union
+union all
 select unique_transfer_id, 'bnb' as blockchain, wallet_address, token_address, evt_block_time, CAST(amount_raw AS VARCHAR(100)) as amount_raw
 from withdrawn_bnb


### PR DESCRIPTION
The rows are already all distinct.
We should also consider dropping the unique_transfer_id.

# Thank you for contributing to Spellbook!
Please refer to the top of the `readme` in the root of Spellbook to learn how to contribute to Spellbook on DuneSQL.