### PR TITLE
Use writer_scaling_min_data_processed instead of writer_min_size after 423 upgrade

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -50,7 +50,7 @@ seeds:
 models:
   spellbook:
     +post-hook:
-      - sql: "{{ set_trino_session_property(is_materialized(model), 'writer_min_size', model.config.get('writer_min_size', '500MB')) }}"
+      - sql: "{{ set_trino_session_property(is_materialized(model), 'writer_scaling_min_data_processed', model.config.get('writer_min_size', '500MB')) }}"
         transaction: true
       - sql: "{{ set_trino_session_property(is_materialized(model), 'task_scale_writers_enabled', false) }}"
         transaction: true


### PR DESCRIPTION
writer_min_size is removed and replaced by writer_scaling_min_data_processed. Since we are doing multiple version bumps it does not look like we can do a graceful upgrade.

# Thank you for contributing to Spellbook!
Please refer to the top of the `readme` in the root of Spellbook to learn how to contribute to Spellbook on DuneSQL.