### PR TITLE
Uniswap block month partitioning

### DIFF
--- a/models/uniswap/arbitrum/uniswap_arbitrum_schema.yml
+++ b/models/uniswap/arbitrum/uniswap_arbitrum_schema.yml
@@ -28,12 +28,15 @@ models:
       - &blockchain
         name: blockchain
         description: "Blockchain which the DEX is deployed"
-      - &project 
+      - &project
         name: project
-        description: "Project name of the DEX"  
+        description: "Project name of the DEX"
       - &version
         name: version
         description: "Version of the contract built and deployed by the DEX project"
+      - &block_month
+        name: block_month
+        description: "UTC event block month of each DEX trade"
       - &block_date
         name: block_date
         description: "UTC event block date of each DEX trade"
@@ -105,7 +108,8 @@ models:
     columns:
       - *blockchain
       - *project
-      - *version  
+      - *version
+      - *block_month
       - *block_date
       - *block_time
       - *token_bought_symbol

--- a/models/uniswap/arbitrum/uniswap_arbitrum_trades.sql
+++ b/models/uniswap/arbitrum/uniswap_arbitrum_trades.sql
@@ -4,7 +4,7 @@
 }}
 
 {% set uniswap_models = [
-'uniswap_v3_arbitrum_trades'
+ref('uniswap_v3_arbitrum_trades')
 ] %}
 
 
@@ -15,6 +15,7 @@ FROM (
         blockchain,
         project,
         version,
+        block_month,
         block_date,
         block_time,
         token_bought_symbol,
@@ -33,9 +34,9 @@ FROM (
         tx_hash,
         tx_from,
         tx_to,
-        
+
         evt_index
-    FROM {{ ref(dex_model) }}
+    FROM {{ dex_model }}
     {% if not loop.last %}
     UNION ALL
     {% endif %}

--- a/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades.sql
+++ b/models/uniswap/arbitrum/uniswap_v3_arbitrum_trades.sql
@@ -1,7 +1,7 @@
 {{ config(tags=['dunesql'],
     schema = 'uniswap_v3_arbitrum',
     alias = alias('trades'),
-    partition_by = ['block_date'],
+    partition_by = ['block_month'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -29,11 +29,11 @@ WITH dexs AS
         ,CASE WHEN amount0 < INT256 '0' THEN f.token1 ELSE f.token0 END AS token_sold_address
         ,t.contract_address as project_contract_address
         ,t.evt_tx_hash AS tx_hash
-        
+
         ,t.evt_index
     FROM
         {{ source('uniswap_v3_arbitrum', 'Pair_evt_Swap') }} t
-    INNER JOIN 
+    INNER JOIN
         {{ source('uniswap_v3_arbitrum', 'Factory_evt_PoolCreated') }} f
         ON f.pool = t.contract_address
     {% if is_incremental() %}
@@ -44,7 +44,8 @@ SELECT DISTINCT
     'arbitrum' AS blockchain
     ,'uniswap' AS project
     ,'3' AS version
-    ,TRY_CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
+    ,CAST(date_trunc('month', dexs.block_time) AS date) AS block_month
+    ,CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
     ,dexs.block_time
     ,erc20a.symbol AS token_bought_symbol
     ,erc20b.symbol AS token_sold_symbol
@@ -69,10 +70,10 @@ SELECT DISTINCT
     ,dexs.tx_hash
     ,tx."from" AS tx_from
     ,tx.to AS tx_to
-    
+
     ,dexs.evt_index
 FROM dexs
-INNER JOIN 
+INNER JOIN
     {{ source('arbitrum', 'transactions') }} tx
     ON tx.hash = dexs.tx_hash
     {% if not is_incremental() %}
@@ -82,7 +83,7 @@ INNER JOIN
     AND tx.block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
 LEFT JOIN {{ ref('tokens_erc20') }} erc20a
-    ON erc20a.contract_address = dexs.token_bought_address 
+    ON erc20a.contract_address = dexs.token_bought_address
     AND erc20a.blockchain = 'arbitrum'
 LEFT JOIN {{ ref('tokens_erc20') }} erc20b
     ON erc20b.contract_address = dexs.token_sold_address

--- a/models/uniswap/bnb/uniswap_bnb_schema.yml
+++ b/models/uniswap/bnb/uniswap_bnb_schema.yml
@@ -28,12 +28,15 @@ models:
       - &blockchain
         name: blockchain
         description: "Blockchain which the DEX is deployed"
-      - &project 
+      - &project
         name: project
-        description: "Project name of the DEX"  
+        description: "Project name of the DEX"
       - &version
         name: version
         description: "Version of the contract built and deployed by the DEX project"
+      - &block_month
+        name: block_date
+        description: "UTC event block month of each DEX trade"
       - &block_date
         name: block_date
         description: "UTC event block date of each DEX trade"
@@ -105,7 +108,8 @@ models:
     columns:
       - *blockchain
       - *project
-      - *version  
+      - *version
+      - *block_month
       - *block_date
       - *block_time
       - *token_bought_symbol

--- a/models/uniswap/bnb/uniswap_bnb_trades.sql
+++ b/models/uniswap/bnb/uniswap_bnb_trades.sql
@@ -15,6 +15,7 @@ FROM (
         blockchain,
         project,
         version,
+        block_month,
         block_date,
         block_time,
         token_bought_symbol,

--- a/models/uniswap/bnb/uniswap_v3_bnb_trades.sql
+++ b/models/uniswap/bnb/uniswap_v3_bnb_trades.sql
@@ -1,7 +1,7 @@
 {{ config(tags=['dunesql'],
     schema = 'uniswap_v3_bnb',
     alias = alias('trades'),
-    partition_by = ['block_date'],
+    partition_by = ['block_month'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -29,11 +29,11 @@ WITH dexs AS
         ,CASE WHEN amount0 < INT256 '0' THEN f.token1 ELSE f.token0 END AS token_sold_address
         ,t.contract_address as project_contract_address
         ,t.evt_tx_hash AS tx_hash
-        
+
         ,t.evt_index
     FROM
         {{ source('uniswap_v3_bnb', 'Pair_evt_Swap') }} t
-    INNER JOIN 
+    INNER JOIN
         {{ source('uniswap_v3_bnb', 'Factory_evt_PoolCreated') }} f
         ON f.pool = t.contract_address
     {% if is_incremental() %}
@@ -44,7 +44,8 @@ SELECT
     'bnb' AS blockchain
     ,'uniswap' AS project
     ,'3' AS version
-    ,TRY_CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
+    ,CAST(date_trunc('month', dexs.block_time) AS date) AS block_month
+    ,CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
     ,dexs.block_time
     ,erc20a.symbol AS token_bought_symbol
     ,erc20b.symbol AS token_sold_symbol
@@ -69,10 +70,10 @@ SELECT
     ,dexs.tx_hash
     ,tx."from" AS tx_from
     ,tx.to AS tx_to
-    
+
     ,dexs.evt_index
 FROM dexs
-INNER JOIN 
+INNER JOIN
     {{ source('bnb', 'transactions') }} tx
     ON tx.hash = dexs.tx_hash
     {% if not is_incremental() %}
@@ -82,7 +83,7 @@ INNER JOIN
     AND tx.block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
 LEFT JOIN {{ ref('tokens_erc20') }} erc20a
-    ON erc20a.contract_address = dexs.token_bought_address 
+    ON erc20a.contract_address = dexs.token_bought_address
     AND erc20a.blockchain = 'bnb'
 LEFT JOIN {{ ref('tokens_erc20') }} erc20b
     ON erc20b.contract_address = dexs.token_sold_address

--- a/models/uniswap/ethereum/uniswap_ethereum_schema.yml
+++ b/models/uniswap/ethereum/uniswap_ethereum_schema.yml
@@ -34,6 +34,9 @@ models:
       - &version
         name: version
         description: "Version of the contract built and deployed by the DEX project"
+      - &block_month
+        name: block_month
+        description: "UTC event block month of each DEX trade"
       - &block_date
         name: block_date
         description: "UTC event block date of each DEX trade"
@@ -119,6 +122,7 @@ models:
       - *blockchain
       - *project
       - *version
+      - *block_month
       - *block_date
       - *block_time
       - *token_bought_symbol
@@ -166,6 +170,7 @@ models:
       - *blockchain
       - *project
       - *version
+      - *block_month
       - *block_date
       - *block_time
       - *token_bought_symbol
@@ -200,6 +205,7 @@ models:
       - *blockchain
       - *project
       - *version
+      - *block_month
       - *block_date
       - *block_time
       - *token_bought_symbol

--- a/models/uniswap/ethereum/uniswap_ethereum_trades.sql
+++ b/models/uniswap/ethereum/uniswap_ethereum_trades.sql
@@ -4,9 +4,9 @@
 }}
 
 {% set uniswap_models = [
-'uniswap_v1_ethereum_trades'
-,'uniswap_v2_ethereum_trades'
-,'uniswap_v3_ethereum_trades'
+ref('uniswap_v1_ethereum_trades')
+,ref('uniswap_v2_ethereum_trades')
+,ref('uniswap_v3_ethereum_trades')
 ] %}
 
 
@@ -17,6 +17,7 @@ FROM (
         blockchain,
         project,
         version,
+        block_month,
         block_date,
         block_time,
         token_bought_symbol,
@@ -35,9 +36,8 @@ FROM (
         tx_hash,
         tx_from,
         tx_to,
-        
         evt_index
-    FROM {{ ref(dex_model) }}
+    FROM {{ dex_model }}
     {% if not loop.last %}
     UNION ALL
     {% endif %}

--- a/models/uniswap/ethereum/uniswap_v1_ethereum_trades.sql
+++ b/models/uniswap/ethereum/uniswap_v1_ethereum_trades.sql
@@ -1,7 +1,7 @@
 {{ config(tags=['dunesql'],
     schema = 'uniswap_v1_ethereum',
     alias = alias('trades'),
-    partition_by = ['block_date'],
+    partition_by = ['block_month'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -30,7 +30,7 @@ WITH dexs AS
         ,{{weth_address}} AS token_sold_address --Using WETH for easier joining with USD price table
         ,t.contract_address AS project_contract_address
         ,t.evt_tx_hash AS tx_hash
-        
+
         ,t.evt_index
     FROM
         {{ source('uniswap_ethereum', 'Exchange_evt_TokenPurchase') }} t
@@ -54,7 +54,7 @@ WITH dexs AS
         ,f.token AS token_sold_address
         ,t.contract_address AS project_contract_address
         ,t.evt_tx_hash AS tx_hash
-        
+
         ,t.evt_index
     FROM
         {{ source('uniswap_ethereum', 'Exchange_evt_EthPurchase') }} t
@@ -68,7 +68,8 @@ SELECT
     'ethereum' AS blockchain
     ,'uniswap' AS project
     ,'1' AS version
-    ,TRY_CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
+    ,CAST(date_trunc('month', dexs.block_time) AS date) AS block_month
+    ,CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
     ,dexs.block_time
     ,erc20a.symbol AS token_bought_symbol
     ,erc20b.symbol AS token_sold_symbol
@@ -93,7 +94,7 @@ SELECT
     ,dexs.tx_hash
     ,tx."from" AS tx_from
     ,tx.to AS tx_to
-    
+
     ,dexs.evt_index
 FROM dexs
 INNER JOIN {{ source('ethereum', 'transactions') }} tx

--- a/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
+++ b/models/uniswap/ethereum/uniswap_v2_ethereum_trades.sql
@@ -1,7 +1,7 @@
 {{ config(tags=['dunesql'],
     schema = 'uniswap_v2_ethereum',
     alias = alias('trades'),
-    partition_by = ['block_date'],
+    partition_by = ['block_month'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -32,7 +32,7 @@ WITH dexs AS
         ,CASE WHEN amount0In = UINT256 '0' OR amount1Out = UINT256 '0' THEN f.token1 ELSE f.token0 END AS token_sold_address
         ,t.contract_address as project_contract_address
         ,t.evt_tx_hash AS tx_hash
-        
+
         ,t.evt_index
     FROM
         {{ source('uniswap_v2_ethereum', 'Pair_evt_Swap') }} t
@@ -50,7 +50,8 @@ SELECT
     'ethereum' AS blockchain
     ,'uniswap' AS project
     ,'2' AS version
-    ,TRY_CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
+    ,CAST(date_trunc('month', dexs.block_time) AS date) AS block_month
+    ,CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
     ,dexs.block_time
     ,erc20a.symbol AS token_bought_symbol
     ,erc20b.symbol AS token_sold_symbol
@@ -75,7 +76,7 @@ SELECT
     ,dexs.tx_hash
     ,tx."from" AS tx_from
     ,tx.to AS tx_to
-    
+
     ,dexs.evt_index
 FROM dexs
 INNER JOIN {{ source('ethereum', 'transactions') }} tx

--- a/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
+++ b/models/uniswap/ethereum/uniswap_v3_ethereum_trades.sql
@@ -1,7 +1,7 @@
 {{ config(tags=['dunesql'],
     schema = 'uniswap_v3_ethereum',
     alias = alias('trades'),
-    partition_by = ['block_date'],
+    partition_by = ['block_month'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -30,7 +30,7 @@ WITH dexs AS
         ,t.contract_address as project_contract_address
         ,f.fee
         ,t.evt_tx_hash AS tx_hash
-        
+
         ,t.evt_index
     FROM
         {{ source('uniswap_v3_ethereum', 'Pair_evt_Swap') }} t
@@ -44,7 +44,8 @@ SELECT
     'ethereum' AS blockchain
     ,'uniswap' AS project
     ,'3' AS version
-    ,TRY_CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
+    ,CAST(date_trunc('month', dexs.block_time) AS date) AS block_month
+    ,CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
     ,dexs.block_time
     ,erc20a.symbol AS token_bought_symbol
     ,erc20b.symbol AS token_sold_symbol
@@ -70,7 +71,7 @@ SELECT
     ,dexs.tx_hash
     ,tx."from" AS tx_from
     ,tx.to AS tx_to
-    
+
     ,dexs.evt_index
 FROM dexs
 INNER JOIN {{ source('ethereum', 'transactions') }} tx

--- a/models/uniswap/optimism/uniswap_optimism_schema.yml
+++ b/models/uniswap/optimism/uniswap_optimism_schema.yml
@@ -14,9 +14,9 @@ models:
       - &blockchain
         name: blockchain
         description: "Blockchain which the DEX is deployed"
-      - &project 
+      - &project
         name: project
-        description: "Project name of the DEX"  
+        description: "Project name of the DEX"
       - &version
         name: version
         description: "Version of the contract built and deployed by the DEX project"
@@ -42,7 +42,7 @@ models:
         description: "Block number of pool creation"
       - &contract_address
         name: contract_address
-        description: "Contract address used to create the pool"  
+        description: "Contract address used to create the pool"
 
   - name: uniswap_optimism_ovm1_pool_mapping
     meta:
@@ -95,6 +95,9 @@ models:
       - *blockchain
       - *project
       - *version
+      - &block_month
+        name: block_month
+        description: "UTC event block month of each DEX trade"
       - &block_date
         name: block_date
         description: "UTC event block date of each DEX trade"
@@ -165,6 +168,7 @@ models:
       - *blockchain
       - *project
       - *version
+      - *block_month
       - *block_date
       - *block_time
       - *token_bought_symbol

--- a/models/uniswap/optimism/uniswap_optimism_trades.sql
+++ b/models/uniswap/optimism/uniswap_optimism_trades.sql
@@ -4,7 +4,7 @@
 }}
 
 {% set uniswap_models = [
-'uniswap_v3_optimism_trades'
+ref('uniswap_v3_optimism_trades')
 ] %}
 
 
@@ -15,6 +15,7 @@ FROM (
         blockchain,
         project,
         version,
+        block_month,
         block_date,
         block_time,
         token_bought_symbol,
@@ -33,9 +34,9 @@ FROM (
         tx_hash,
         tx_from,
         tx_to,
-        
+
         evt_index
-    FROM {{ ref(dex_model) }}
+    FROM {{ dex_model }}
     {% if not loop.last %}
     UNION ALL
     {% endif %}

--- a/models/uniswap/optimism/uniswap_v3_optimism_trades.sql
+++ b/models/uniswap/optimism/uniswap_v3_optimism_trades.sql
@@ -1,7 +1,7 @@
 {{ config(tags=['dunesql'],
     schema = 'uniswap_v3_optimism',
     alias = alias('trades'),
-    partition_by = ['block_date'],
+    partition_by = ['block_month'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -30,7 +30,7 @@ WITH dexs AS
         ,CASE WHEN amount0 < INT256 '0' THEN f.token1 ELSE f.token0 END AS token_sold_address
         ,t.contract_address as project_contract_address
         ,t.evt_tx_hash AS tx_hash
-        
+
         ,t.evt_index
     FROM
         {{ source('uniswap_v3_optimism', 'Pair_evt_Swap') }} t
@@ -44,7 +44,8 @@ SELECT
     'optimism' AS blockchain
     ,'uniswap' AS project
     ,'3' AS version
-    ,TRY_CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
+    ,CAST(date_trunc('month', dexs.block_time) AS date) AS block_month
+    ,CAST(date_trunc('DAY', dexs.block_time) AS date) AS block_date
     ,dexs.block_time
     ,erc20a.symbol AS token_bought_symbol
     ,erc20b.symbol AS token_sold_symbol
@@ -69,7 +70,7 @@ SELECT
     ,dexs.tx_hash
     ,tx."from" AS tx_from
     ,tx.to AS tx_to
-    
+
     ,dexs.evt_index
 FROM dexs
 INNER JOIN {{ source('optimism', 'transactions') }} tx
@@ -82,7 +83,7 @@ INNER JOIN {{ source('optimism', 'transactions') }} tx
     AND tx.block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
 LEFT JOIN {{ ref('tokens_erc20') }} erc20a
-    ON erc20a.contract_address = dexs.token_bought_address 
+    ON erc20a.contract_address = dexs.token_bought_address
     AND erc20a.blockchain = 'optimism'
 LEFT JOIN {{ ref('tokens_erc20') }} erc20b
     ON erc20b.contract_address = dexs.token_sold_address

--- a/models/uniswap/polygon/uniswap_polygon_schema.yml
+++ b/models/uniswap/polygon/uniswap_polygon_schema.yml
@@ -28,12 +28,15 @@ models:
       - &blockchain
         name: blockchain
         description: "Blockchain which the DEX is deployed"
-      - &project 
+      - &project
         name: project
-        description: "Project name of the DEX"  
+        description: "Project name of the DEX"
       - &version
         name: version
         description: "Version of the contract built and deployed by the DEX project"
+      - &block_month
+        name: block_month
+        description: "UTC event block month of each DEX trade"
       - &block_date
         name: block_date
         description: "UTC event block date of each DEX trade"
@@ -105,7 +108,8 @@ models:
     columns:
       - *blockchain
       - *project
-      - *version  
+      - *version
+      - *block_month
       - *block_date
       - *block_time
       - *token_bought_symbol

--- a/models/uniswap/polygon/uniswap_polygon_trades.sql
+++ b/models/uniswap/polygon/uniswap_polygon_trades.sql
@@ -4,7 +4,7 @@
 }}
 
 {% set uniswap_polygon_models = [
-'uniswap_v3_polygon_trades'
+ref('uniswap_v3_polygon_trades')
 ] %}
 
 
@@ -15,6 +15,7 @@ FROM (
         blockchain,
         project,
         version,
+        block_month,
         block_date,
         block_time,
         token_bought_symbol,
@@ -33,9 +34,9 @@ FROM (
         tx_hash,
         tx_from,
         tx_to,
-        
+
         evt_index
-    FROM {{ ref(dex_model) }}
+    FROM {{ dex_model }}
     {% if not loop.last %}
     UNION ALL
     {% endif %}

--- a/models/uniswap/uniswap_schema.yml
+++ b/models/uniswap/uniswap_schema.yml
@@ -15,12 +15,15 @@ models:
       - &blockchain
         name: blockchain
         description: "Blockchain which the DEX is deployed"
-      - &project 
+      - &project
         name: project
-        description: "Project name of the DEX"  
+        description: "Project name of the DEX"
       - &version
         name: version
-        description: "Version of the contract built and deployed by the DEX project"  
+        description: "Version of the contract built and deployed by the DEX project"
+      - &block_month
+        name: block_month
+        description: "UTC event block month of each DEX trade"
       - &block_date
         name: block_date
         description: "UTC event block date of each DEX trade"

--- a/models/uniswap/uniswap_trades.sql
+++ b/models/uniswap/uniswap_trades.sql
@@ -23,6 +23,7 @@ FROM (
         blockchain,
         project,
         version,
+        block_month,
         block_date,
         block_time,
         token_bought_symbol,


### PR DESCRIPTION
This PR is a requirement for https://github.com/duneanalytics/spellbook/pull/4107.

I've done the following for the models
* Partition by `block_month`
* Added `CAST(date_trunc('month', dexs.block_time) AS date) AS block_month` to each model
* Added `block_month` to the yaml files
* Changed so that the models variables are defined using `ref` (this makes it possible to cmd + click in VSCode)
* There are a bunch of whitespace changes which is my editor removing it automatically