### PR TITLE
Fix check_seeds macro

### DIFF
--- a/macros/test-helpers/check_seed_macro.sql
+++ b/macros/test-helpers/check_seed_macro.sql
@@ -96,5 +96,5 @@
         from equality_tests
     ) all
     -- equality check can be null so we have to check explicitly for nulls
-    where equality_check = false or equality_check is null
+    where equality_check is distinct from true
 {% endmacro %}

--- a/macros/test-helpers/check_seed_macro.sql
+++ b/macros/test-helpers/check_seed_macro.sql
@@ -95,5 +95,6 @@
         select *
         from equality_tests
     ) all
-    where equality_check != true
+    -- equality check can be null so we have to check explicitly for nulls
+    where equality_check = false or equality_check is null
 {% endmacro %}


### PR DESCRIPTION
We need to go through some tests and see if they are still correct. This type of error is very subtle since `NULL = false` in SQL becomes just `NULL`.