### PR TITLE
`tigris` exclude failing lineage spells

### DIFF
--- a/models/tigris/arbitrum/events/tigris_arbitrum_events_options_fees_distributed.sql
+++ b/models/tigris/arbitrum/events/tigris_arbitrum_events_options_fees_distributed.sql
@@ -1,5 +1,5 @@
 {{ config(
-    tags=['dunesql'],
+    tags=['dunesql', 'prod_exclude'],
     schema = 'tigris_arbitrum',
     alias = alias('options_fees_distributed'),
     partition_by = ['block_month'],

--- a/models/tigris/arbitrum/tigris_arbitrum_options_trades.sql
+++ b/models/tigris/arbitrum/tigris_arbitrum_options_trades.sql
@@ -1,5 +1,5 @@
 {{ config(
-    tags=['dunesql'],
+    tags=['dunesql', 'prod_exclude'],
     schema = 'tigris_arbitrum',
     alias = alias('options_trades'),
     partition_by = ['block_month'],

--- a/models/tigris/tigris_options_trades.sql
+++ b/models/tigris/tigris_options_trades.sql
@@ -1,5 +1,5 @@
 {{ config(
-	tags=['dunesql'],
+	tags=['dunesql', 'prod_exclude'],
 	alias = alias('options_trades'),
     post_hook='{{ expose_spells(\'["arbitrum", "polygon"]\',
                                 "project",


### PR DESCRIPTION
fyi @henrystats 

`tigris_arbitrum_events_options_fees_distributed` spell loaded duplciates into the spell, therefore incoming merges are failing and downstream spells are skipped.

the three spells in this PR are the lineage i found affected. the issue comes from `tigris_arbitrum_events_options_fees_distributed`, but the two downstream will read those duplicates and fail too.

here is quick query for troubled tx:
```
select
  evt_block_time,
  evt_tx_hash,
  version,
  protocol_version,
  count(1)
from
  tigris_arbitrum.options_fees_distributed
group by
  evt_block_time,
  evt_tx_hash,
  version,
  protocol_version
having
  count(1) > 1
```

feel free to open a PR with fix on the troubled spell, then in same PR we can remove `prod_exclude` tags and let them fully refresh in prod and continue on.