### PR TITLE
CI check for tag:remove

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -81,6 +81,12 @@ jobs:
           test=$(dbt --quiet --no-print ls $PROFILE --resource-type model --select state:modified --exclude tag:legacy tag:dunesql --output path --state .)
           [[ -z "$test" ]] && { echo "Success: No models without a tag"; exit 0; } || { echo "Found models with no dunesql or legacy tag:"; echo "$test"; exit 1; }
 
+      - name: check only tag:remove when no active children
+        if: matrix.engine == 'spark'
+        run: |
+          test=$(dbt --quiet --no-print ls $PROFILE --resource-type model --select tag:remove+ --exclude tag:remove --output path --state .)
+          [[ -z "$test" ]] && { echo "Success"; exit 0; } || { echo "Found non-removed child models from removed models:"; echo "$test"; exit 1; }
+
       - name: dbt seed
         run: "dbt seed $PROFILE --select state:modified$TAG --exclude tag:prod_exclude tag:remove --state ."
 


### PR DESCRIPTION
This checks there are no child models from `tag:remove` models that are still enabled (without the remove tag)