### PR TITLE
Fix ambiguity in cow_protocol batches models

### DIFF
--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_batches.sql
@@ -66,7 +66,7 @@ batch_values as (
 
 combined_batch_info as (
     select
-        block_date,
+        tx.block_date,
         evt_block_number                               as block_number,
         evt_block_time                                 as block_time,
         num_trades,

--- a/models/cow_protocol/ethereum/cow_protocol_ethereum_batches_legacy.sql
+++ b/models/cow_protocol/ethereum/cow_protocol_ethereum_batches_legacy.sql
@@ -66,7 +66,7 @@ batch_values as (
 
 combined_batch_info as (
     select
-        block_date,
+       tx.block_date,
         evt_block_number                               as block_number,
         evt_block_time                                 as block_time,
         num_trades,

--- a/models/cow_protocol/gnosis/cow_protocol_gnosis_batches.sql
+++ b/models/cow_protocol/gnosis/cow_protocol_gnosis_batches.sql
@@ -65,7 +65,7 @@ batch_values as (
 
 combined_batch_info as (
     select
-        block_date,
+        tx.block_date,
         evt_block_time                                 as block_time,
         num_trades,
         dex_swaps,

--- a/models/cow_protocol/gnosis/cow_protocol_gnosis_batches_legacy.sql
+++ b/models/cow_protocol/gnosis/cow_protocol_gnosis_batches_legacy.sql
@@ -65,7 +65,7 @@ batch_values as (
 
 combined_batch_info as (
     select
-        block_date,
+        tx.block_date,
         evt_block_time                                 as block_time,
         num_trades,
         CASE


### PR DESCRIPTION
Ambiguity introduced by the `block_date` column in the raw transaction tables