### PR TITLE
base: legacy trades & offers

### DIFF
--- a/models/rubicon/rubicon_offers_legacy.sql
+++ b/models/rubicon/rubicon_offers_legacy.sql
@@ -11,7 +11,8 @@
 
 {% set rubi_models = [
 ref('rubicon_optimism_offers_legacy'),
-ref('rubicon_arbitrum_offers_legacy')
+ref('rubicon_arbitrum_offers_legacy'),
+ref('rubicon_base_offers_legacy')
 ] %}
 
 SELECT * 

--- a/models/rubicon/rubicon_trades_legacy.sql
+++ b/models/rubicon/rubicon_trades_legacy.sql
@@ -11,7 +11,8 @@
 
 {% set rubi_models = [
 ref('rubicon_optimism_trades_legacy'),
-ref('rubicon_arbitrum_trades_legacy')
+ref('rubicon_arbitrum_trades_legacy'),
+ref('rubicon_base_trades_legacy')
 ] %}
 
 


### PR DESCRIPTION
because `dex.trades` and `dex.offers` are still driving off of `_legacy` versions, this adds `_legacy` support for Rubicon `base` data. this was accidentally excluded from #3997 