### PR TITLE
Fix chainlink ocr incremental error on gas_daily and request_daily

### DIFF
--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_daily.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_daily.sql
@@ -40,7 +40,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/arbitrum/chainlink_arbitrum_ocr_request_daily.sql
+++ b/models/chainlink/arbitrum/chainlink_arbitrum_ocr_request_daily.sql
@@ -39,7 +39,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_daily.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_daily.sql
@@ -40,7 +40,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_request_daily.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_request_daily.sql
@@ -39,7 +39,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/bnb/chainlink_bnb_ocr_gas_daily.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_gas_daily.sql
@@ -40,7 +40,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/bnb/chainlink_bnb_ocr_request_daily.sql
+++ b/models/chainlink/bnb/chainlink_bnb_ocr_request_daily.sql
@@ -39,7 +39,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_daily.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_daily.sql
@@ -40,7 +40,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/ethereum/chainlink_ethereum_ocr_request_daily.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_ocr_request_daily.sql
@@ -39,7 +39,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/fantom/chainlink_fantom_ocr_gas_daily.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_gas_daily.sql
@@ -40,7 +40,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/fantom/chainlink_fantom_ocr_request_daily.sql
+++ b/models/chainlink/fantom/chainlink_fantom_ocr_request_daily.sql
@@ -39,7 +39,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_daily.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_daily.sql
@@ -40,7 +40,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/gnosis/chainlink_gnosis_ocr_request_daily.sql
+++ b/models/chainlink/gnosis/chainlink_gnosis_ocr_request_daily.sql
@@ -39,7 +39,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/optimism/chainlink_optimism_ocr_gas_daily.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_gas_daily.sql
@@ -40,7 +40,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/optimism/chainlink_optimism_ocr_request_daily.sql
+++ b/models/chainlink/optimism/chainlink_optimism_ocr_request_daily.sql
@@ -39,7 +39,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/polygon/chainlink_polygon_ocr_gas_daily.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_gas_daily.sql
@@ -40,7 +40,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2

--- a/models/chainlink/polygon/chainlink_polygon_ocr_request_daily.sql
+++ b/models/chainlink/polygon/chainlink_polygon_ocr_request_daily.sql
@@ -39,7 +39,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
     {% endif %}
     GROUP BY
       1, 2


### PR DESCRIPTION
Fixes an issue on Chainlink OCR with incremental views for <chain>_gas_daily and <chain>_request_daily where the "AND" clause incorrectly results in fewer results than expected and the "OR" clause corrects this by pulling transactions from fulfilled OR reverted transactions, with a FULL OUTER JOIN.