### PR TITLE
Fix bug causing wrong token_bought_amount_raw

### DIFF
--- a/models/shibaswap/ethereum/shibaswap_ethereum_trades.sql
+++ b/models/shibaswap/ethereum/shibaswap_ethereum_trades.sql
@@ -23,10 +23,10 @@ WITH dexs AS
         t.evt_block_time AS block_time
         ,t.to AS taker
         ,f.pair AS maker
-        ,CASE WHEN amount1Out = UINT256 '0' THEN amount1Out ELSE amount0Out END AS token_bought_amount_raw
+        ,CASE WHEN amount0Out = UINT256 '0' THEN amount1Out ELSE amount0Out END AS token_bought_amount_raw
         ,CASE WHEN amount0In = UINT256 '0' OR amount1Out = UINT256 '0' THEN amount1In ELSE amount0In END AS token_sold_amount_raw
         ,NULL AS amount_usd
-        ,CASE WHEN amount1Out = UINT256 '0' THEN f.token1 ELSE f.token0 END AS token_bought_address
+        ,CASE WHEN amount0Out = UINT256 '0' THEN f.token1 ELSE f.token0 END AS token_bought_address
         ,CASE WHEN amount0In = UINT256 '0' OR amount1Out = UINT256 '0' THEN f.token1 ELSE f.token0 END AS token_sold_address
         ,t.contract_address AS project_contract_address
         ,t.evt_tx_hash AS tx_hash


### PR DESCRIPTION
Fixing a typo that slipped through while migrating shibaswap. I replaced `amount0Out` with `amount1Out`, causing all `token_bought_amount` to be 0 in `shibaswap_ethereum.trades`