### PR TITLE
Update Polygon and Matic balances design

### DIFF
--- a/models/balances/polygon/erc20/balances_polygon_erc20_day.sql
+++ b/models/balances/polygon/erc20/balances_polygon_erc20_day.sql
@@ -20,7 +20,7 @@ time_seq AS (
 
 days AS (
     SELECT 
-        time.time AS day 
+        time.time AS block_day 
     FROM time_seq
     CROSS JOIN unnest(time) AS time(time)
 ),
@@ -41,7 +41,8 @@ daily_balances as (
 
 SELECT
     b.blockchain,
-    d.day,
+    cast(date_trunc('month', d.block_day) as date) as block_month,
+    d.block_day,
     b.wallet_address,
     b.token_address,
     b.amount_raw,
@@ -52,12 +53,12 @@ FROM
 daily_balances b
 INNER JOIN 
 days d 
-    ON b.day <= d.day 
-    AND d.day < b.next_day
+    ON b.day <= d.block_day 
+    AND d.block_day < b.next_day
 LEFT JOIN 
 {{ source('prices', 'usd') }} p
     ON p.contract_address = b.token_address
-    AND d.day = p.minute
+    AND d.block_day = p.minute
     AND p.blockchain = 'polygon'
 -- Removes likely non-compliant tokens due to negative balances
 LEFT JOIN 

--- a/models/balances/polygon/erc20/balances_polygon_erc20_schema.yml
+++ b/models/balances/polygon/erc20/balances_polygon_erc20_schema.yml
@@ -16,8 +16,11 @@ models:
       - &blockchain
         name: blockchain
         description: "Blockchain"
-      - &hour
-        name: hour
+      - &block_month
+        name: block_month
+        description: "UTC event block time truncated to the month mark"
+      - &block_hour
+        name: block_hour
         description: "UTC event block time truncated to the hour mark"
       - &wallet_address
         name: wallet_address
@@ -51,8 +54,9 @@ models:
         Depends on erc20_polygon_transfers.
     columns:
       - *blockchain
-      - &day
-        name: day
+      - *block_month
+      - &block_day
+        name: block_day
         description: "UTC event block time truncated to the day mark"
       - *wallet_address
       - *token_address

--- a/models/balances/polygon/matic/balances_polygon_matic_day.sql
+++ b/models/balances/polygon/matic/balances_polygon_matic_day.sql
@@ -20,7 +20,7 @@ time_seq AS (
 
 days AS (
     SELECT 
-        time.time AS day 
+        time.time AS block_day
     FROM time_seq
     CROSS JOIN unnest(time) AS time(time)
 ),
@@ -41,7 +41,8 @@ daily_balances as (
 
 SELECT
     b.blockchain,
-    d.day,
+    cast(date_trunc('month', d.block_day) as date) as block_month,
+    d.block_day,
     b.wallet_address,
     b.token_address,
     b.amount_raw,
@@ -52,10 +53,10 @@ FROM
 daily_balances b
 INNER JOIN 
 days d 
-    ON b.day <= d.day 
-    AND d.day < b.next_day
+    ON b.day <= d.block_day 
+    AND d.block_day < b.next_day
 LEFT JOIN 
 {{ source('prices', 'usd') }} p
     ON p.contract_address = b.token_address
-    AND d.day = p.minute
+    AND d.block_day = p.minute
     AND p.blockchain = 'polygon'

--- a/models/balances/polygon/matic/balances_polygon_matic_hour.sql
+++ b/models/balances/polygon/matic/balances_polygon_matic_hour.sql
@@ -19,7 +19,7 @@ years as (
 ),
 
 hours as (
-    select date_add('hour', s.n, y.year) as hour
+    select date_add('hour', s.n, y.year) as block_hour
     from years y
       cross join unnest(sequence(0, 9000)) s(n)
     where s.n <= date_diff('hour', y.year, y.year + interval '1' year)
@@ -41,7 +41,8 @@ hourly_balances as (
 
 SELECT
     b.blockchain,
-    d.hour,
+    cast(date_trunc('month', d.block_hour) as date) as block_month,
+    d.block_hour,
     b.wallet_address,
     b.token_address,
     b.amount_raw,
@@ -52,11 +53,11 @@ FROM
 hourly_balances b
 INNER JOIN 
 hours d 
-    ON b.hour <= d.hour 
-    AND d.hour < b.next_hour
+    ON b.hour <= d.block_hour 
+    AND d.block_hour < b.next_hour
 LEFT JOIN 
 {{ source('prices', 'usd') }} p
     ON p.contract_address = b.token_address
-    AND d.hour = p.minute
+    AND d.block_hour = p.minute
     AND p.blockchain = 'polygon'
 

--- a/models/balances/polygon/matic/balances_polygon_matic_schema.yml
+++ b/models/balances/polygon/matic/balances_polygon_matic_schema.yml
@@ -16,8 +16,11 @@ models:
       - &blockchain
         name: blockchain
         description: "Blockchain"
-      - &hour
-        name: hour
+      - &block_month
+        name: block_month
+        description: "UTC event block time truncated to the month mark"
+      - &block_hour
+        name: block_hour
         description: "UTC event block time truncated to the hour mark"
       - &wallet_address
         name: wallet_address
@@ -51,8 +54,9 @@ models:
         Depends on transfers_polygon_matic.
     columns:
       - *blockchain
-      - &day
-        name: day
+      - *block_month
+      - &block_day
+        name: block_day
         description: "UTC event block time truncated to the day mark"
       - *wallet_address
       - *token_address


### PR DESCRIPTION
Changes implemented here:
- Renamed some variables:
  - `day` to `block_day`
  - `hour` to `block_hour`
- Added a new variable `block_month` to daily and hourly balances tables

Some notes @jeff-dude :
- Adding `block_month` will allow us to partition some of these spells easily if we decide to materialise them in the future. It also aligns nicely with dex.trades and nft.trades
- About prices, I didn't end up adding any extra CTE. I was checking [this](https://github.com/duneanalytics/spellbook/blob/9c360192574f965f7f2e90c618efd259affba8df/models/_sector/nft/trades/nft_ethereum_trades_beta.sql) example from nft.trades, and the more I thought about it the more I couldn't see how it was justified here. This is because of 2 reasons. First we only add prices as the last join in the balances lineage. Secondly, we join based on a specific minute of `prices.usd` so we already filter the prices there to a super small subset of rows.