### PR TITLE
Fix balances schema name on Polygon

### DIFF
--- a/models/balances/polygon/erc20/balances_polygon_erc20_day.sql
+++ b/models/balances/polygon/erc20/balances_polygon_erc20_day.sql
@@ -1,5 +1,5 @@
 {{ config(
-        schema = 'balances_polygon_erc20',
+        schema = 'balances_polygon',
         tags = ['dunesql'],
         alias = alias('erc20_day'),
         post_hook='{{ expose_spells(\'["polygon"]\',

--- a/models/balances/polygon/erc20/balances_polygon_erc20_day_legacy.sql
+++ b/models/balances/polygon/erc20/balances_polygon_erc20_day_legacy.sql
@@ -1,5 +1,5 @@
 {{ config(
-        schema = 'balances_polygon_erc20',
+        schema = 'balances_polygon',
         tags = ['legacy'],
         alias = alias('erc20_day', legacy_model=True)
         )

--- a/models/balances/polygon/erc20/balances_polygon_erc20_hour.sql
+++ b/models/balances/polygon/erc20/balances_polygon_erc20_hour.sql
@@ -1,5 +1,5 @@
 {{ config(
-        schema = 'balances_polygon_erc20',
+        schema = 'balances_polygon',
         tags = ['dunesql'],
         alias = alias('erc20_hour'),
         post_hook='{{ expose_spells(\'["polygon"]\',

--- a/models/balances/polygon/erc20/balances_polygon_erc20_hour_legacy.sql
+++ b/models/balances/polygon/erc20/balances_polygon_erc20_hour_legacy.sql
@@ -1,5 +1,5 @@
 {{ config(
-        schema = 'balances_polygon_erc20',
+        schema = 'balances_polygon',
         tags = ['legacy'],
         alias = alias('erc20_hour', legacy_model=True)
         )

--- a/models/balances/polygon/erc20/balances_polygon_erc20_latest.sql
+++ b/models/balances/polygon/erc20/balances_polygon_erc20_latest.sql
@@ -1,5 +1,5 @@
 {{ config(
-        schema = 'balances_polygon_erc20',
+        schema = 'balances_polygon',
         tags = ['dunesql'],
         alias = alias('erc20_latest'),
         post_hook='{{ expose_spells(\'["polygon"]\',

--- a/models/balances/polygon/erc20/balances_polygon_erc20_latest_legacy.sql
+++ b/models/balances/polygon/erc20/balances_polygon_erc20_latest_legacy.sql
@@ -1,5 +1,5 @@
 {{ config(
-        schema = 'balances_polygon_erc20',
+        schema = 'balances_polygon',
         tags = ['legacy'],
         alias = alias('erc20_latest', legacy_model=True)
         )

--- a/models/balances/polygon/erc20/balances_polygon_erc20_noncompliant.sql
+++ b/models/balances/polygon/erc20/balances_polygon_erc20_noncompliant.sql
@@ -1,5 +1,5 @@
 {{ config(
-        schema = 'balances_polygon_erc20',
+        schema = 'balances_polygon',
         tags = ['dunesql'],
         alias = alias('erc20_noncompliant'),
         materialized ='table',

--- a/models/balances/polygon/erc20/balances_polygon_erc20_noncompliant_legacy.sql
+++ b/models/balances/polygon/erc20/balances_polygon_erc20_noncompliant_legacy.sql
@@ -1,5 +1,5 @@
 {{ config(
-        schema = 'balances_polygon_erc20',
+        schema = 'balances_polygon',
         tags = ['legacy'],
         alias = alias('erc20_noncompliant', legacy_model=True)
         )


### PR DESCRIPTION
This is what was causing the double columns to show up in the ui.

We want a schema calles `balances_{blockchain}` for now and then the `{standard}_{aggregation}` as table name.