### PR TITLE
hack to refresh all seeds by using the PR body

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -87,7 +87,12 @@ jobs:
           [[ -z "$test" ]] && { echo "Success"; exit 0; } || { echo "Found active child models of removed models:"; echo "$test"; exit 1; }
 
       - name: dbt seed
+        if: ${{ !contains(github.event.pull_request.body,'CI:refresh-all-seeds') }}
         run: "dbt seed $PROFILE --select state:modified$TAG --exclude tag:prod_exclude tag:remove --state ."
+
+      - name: dbt seed @
+        if: ${{ contains(github.event.pull_request.body,'CI:refresh-all-seeds') }}
+        run: "dbt seed $PROFILE --select @state:modified$TAG --exclude tag:prod_exclude tag:remove --state ."
 
       - name: dbt run initial model(s)
         run: "dbt -x run $PROFILE --select state:modified$TAG --exclude tag:prod_exclude tag:remove --defer --state ."


### PR DESCRIPTION
This allows people to add the following string to the PR body: `CI:refresh-all-seeds`
This removes the need to manually fabricate changes in seeds (by swapping ros) to get them to run in the CI, The `@` operator does overshoot a bit (runs more seeds than necessary). Hence the conditional to only run it with a specific string in the PR body. 
See it in action here: https://github.com/duneanalytics/spellbook/pull/4427