### PR TITLE
Cryptopunk fix

### DIFF
--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_current_bids.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_current_bids.sql
@@ -2,7 +2,7 @@
         tags=['dunesql'],
         alias = alias('current_bids'),
         unique_key='punk_id',
-        post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",
                                     "cryptopunks",
                                     \'["cat"]\') }}'

--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_floor_price_over_time.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_floor_price_over_time.sql
@@ -2,7 +2,7 @@
         tags=['dunesql'],
         alias = alias('floor_price_over_time'),
         unique_key='day',
-        post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",
                                     "cryptopunks",
                                     \'["cat"]\') }}'

--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_listings_over_time.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_listings_over_time.sql
@@ -2,7 +2,7 @@
         tags=['dunesql'],
         alias = alias('listings_over_time'),
         unique_key='day',
-        post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",
                                     "cryptopunks",
                                     \'["cat"]\') }}'

--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_metadata.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_metadata.sql
@@ -2,7 +2,7 @@
         tags=['dunesql'],
         alias = alias('metadata'),
         unique_key='punk_id',
-        post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",
                                     "cryptopunks",
                                     \'["cat"]\') }}'

--- a/models/cryptopunks/ethereum/cryptopunks_ethereum_owners_over_time.sql
+++ b/models/cryptopunks/ethereum/cryptopunks_ethereum_owners_over_time.sql
@@ -2,7 +2,7 @@
         tags=['dunesql'],
         alias = alias('owners_over_time'),
         unique_key='day',
-        post_hook='{{ expose_spells_hide_trino(\'["ethereum"]\',
+        post_hook='{{ expose_spells(\'["ethereum"]\',
                                     "project",
                                     "cryptopunks",
                                     \'["cat"]\') }}'


### PR DESCRIPTION
`cryptopunks_ethereum_metadata` failed because of `expose_spells_hide_trino` post hook 