### PR TITLE
remove lido partitions

### DIFF
--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_buffer_inflow.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_buffer_inflow.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('buffer_inflow'),
         tags = ['dunesql'], 
-        partition_by = ['day'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_buffer_outflow.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_buffer_outflow.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('buffer_outflow'),
         tags = ['dunesql'], 
-        partition_by = ['day'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_dai_referral_payment.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_dai_referral_payment.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('dai_referral_payment'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_deposits.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_deposits.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('deposits'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'incremental',
         file_format = 'delta',
         incremental_strategy = 'merge',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_fundraising.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_fundraising.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('fundraising'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_ldo_referral_payment.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_ldo_referral_payment.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('ldo_referral_payment'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_lego_expenses.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_lego_expenses.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('lego_expenses'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_liquidity_incentives.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_liquidity_incentives.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('liquidity_incentives'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_lox_incentives.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_lox_incentives.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('lox_incentives'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_operating_expenses.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_operating_expenses.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('operating_expenses'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_other_expenses.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_other_expenses.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('other_expenses'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_other_income.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_other_income.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('other_income'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_revenue.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_revenue.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('revenue'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_steth_referral_payment.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_steth_referral_payment.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('steth_referral_payment'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_trp_expenses.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_trp_expenses.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('trp_expenses'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_withdrawals.sql
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_withdrawals.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('withdrawals'),
         tags = ['dunesql'], 
-        partition_by = ['day'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/lido_accounting.sql
+++ b/models/lido/lido_accounting.sql
@@ -1,7 +1,6 @@
 {{ config(
         alias = alias('accounting'),
         tags = ['dunesql'], 
-        partition_by = ['period'],
         materialized = 'table',
         file_format = 'delta',
         post_hook='{{ expose_spells(\'["ethereum"]\',

--- a/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_balancer_pools.sql
+++ b/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_balancer_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_arbitrum',
     alias = alias('balancer_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_camelot_pools.sql
+++ b/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_camelot_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_arbitrum',
     alias = alias('camelot_pools'),
     tags = ['dunesql'],
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_curve_pools.sql
+++ b/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_curve_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_arbitrum',
     alias = alias('curve_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_pools.sql
+++ b/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_arbitrum',
     alias = alias('kyberswap_pools'),
     tags = ['dunesql'],
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_v2_pools.sql
+++ b/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_v2_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_arbitrum',
     alias = alias('kyberswap_v2_pools'),
     tags = ['dunesql'],
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_uniswap_v3_pools.sql
+++ b/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_uniswap_v3_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_arbitrum',
     alias = alias('uniswap_v3_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_wombat_pools.sql
+++ b/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_wombat_pools.sql
@@ -1,7 +1,6 @@
 {{ config(
     schema='lido_liquidity_arbitrum',
     alias = alias('wombat_pools'),
-    partition_by = ['time'],
     tags = ['dunesql'],
     materialized = 'incremental',
     file_format = 'delta',

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_balancer_pools.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_balancer_pools.sql
@@ -1,7 +1,6 @@
 {{ config(
     alias = alias('balancer_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_conc_pool.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_conc_pool.sql
@@ -1,7 +1,6 @@
 {{ config(
     alias = alias('curve_steth_conc_pool'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_frxeth_pool.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_frxeth_pool.sql
@@ -1,7 +1,6 @@
 {{ config(
     alias = alias('curve_steth_frxeth_pool'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_ng_pool.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_ng_pool.sql
@@ -1,7 +1,6 @@
 {{ config(
     alias = alias('curve_steth_ng_pool'),
-    tags = ['dunesql'],     
-    partition_by = ['time'],
+    tags = ['dunesql'], 
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_pool.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_pool.sql
@@ -1,7 +1,6 @@
 {{ config(
     alias = alias('curve_steth_pool'),
     tags = ['dunesql'],         
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_wsteth_reth_pool.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_wsteth_reth_pool.sql
@@ -1,8 +1,7 @@
 {{ config(
 
     alias = alias('curve_wsteth_reth_pool'),
-    tags = ['dunesql'],             
-    partition_by = ['time'],
+    tags = ['dunesql'],           
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_kyberswap_pools.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_kyberswap_pools.sql
@@ -1,7 +1,6 @@
 {{ config(
     alias = alias('kyberswap_pools'),
-    tags = ['dunesql'],             
-    partition_by = ['time'],
+    tags = ['dunesql'],        
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_kyberswap_v2_pools.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_kyberswap_v2_pools.sql
@@ -1,7 +1,6 @@
 {{ config(
     alias = alias('kyberswap_v2_pools'),
     tags = ['dunesql'],             
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_maverick_pools.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_maverick_pools.sql
@@ -1,7 +1,6 @@
 {{ config(
     alias = alias('maverick_pools'),
     tags = ['dunesql'],             
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_pancakeswap_v3_pools.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_pancakeswap_v3_pools.sql
@@ -1,7 +1,6 @@
 {{ config(
     alias = alias('pancakeswap_v3_pools'),
-    tags = ['dunesql'],             
-    partition_by = ['time'],
+    tags = ['dunesql'],        
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_uniswap_v3_pools.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_uniswap_v3_pools.sql
@@ -1,7 +1,6 @@
 {{ config(
     alias = alias('uniswap_v3_pools'),
     tags = ['dunesql'],             
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_balancer_pools.sql
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_balancer_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_optimism',
     alias = alias('balancer_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_curve_pools.sql
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_curve_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_optimism',
     alias = alias('curve_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_kyberswap_pools.sql
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_kyberswap_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_optimism',
     alias = alias('kyberswap_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_kyberswap_v2_pools.sql
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_kyberswap_v2_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_optimism',
     alias = alias('kyberswap_v2_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_uniswap_v3_pools.sql
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_uniswap_v3_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_optimism',
     alias = alias('uniswap_v3_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_velodrome_pools.sql
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_velodrome_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_optimism',
     alias = alias('velodrome_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/optimism/lido_liquidity_optimism_velodrome_v2_pools.sql
+++ b/models/lido/liquidity/optimism/lido_liquidity_optimism_velodrome_v2_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_optimism',
     alias = alias('velodrome_v2_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/polygon/lido_liquidity_polygon_balancer_pools.sql
+++ b/models/lido/liquidity/polygon/lido_liquidity_polygon_balancer_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_polygon', 
     alias = alias('balancer_pools'), 
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/polygon/lido_liquidity_polygon_kyberswap_v2_pools.sql
+++ b/models/lido/liquidity/polygon/lido_liquidity_polygon_kyberswap_v2_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_polygon',
     alias = alias('kyberswap_v2_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/lido/liquidity/polygon/lido_liquidity_polygon_uniswap_v3_pools.sql
+++ b/models/lido/liquidity/polygon/lido_liquidity_polygon_uniswap_v3_pools.sql
@@ -2,7 +2,6 @@
     schema='lido_liquidity_polygon',
     alias = alias('uniswap_v3_pools'),
     tags = ['dunesql'], 
-    partition_by = ['time'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',


### PR DESCRIPTION
fyi @ppclunghe 
we will remove partitions for now, as many are much too small or inefficient data types and cause downstream performance issues / prod failures. in the future, we will propose a universal approach to partitions, and can revisit then. this should have no impact on your usage of the spells on the app.