### PR TITLE
exclude fees traces on spark

### DIFF
--- a/models/gas/arbitrum/gas_arbitrum_fees_traces_legacy.sql
+++ b/models/gas/arbitrum/gas_arbitrum_fees_traces_legacy.sql
@@ -1,13 +1,12 @@
 {{ config(
-	tags=['legacy'],
-	
-    schema = 'gas_arbitrum',
-    alias = alias('fees_traces', legacy_model=True),
-    partition_by = ['block_date'],
-    materialized = 'incremental',
-    file_format = 'delta',
-    incremental_strategy = 'merge',
-    unique_key = ['tx_hash', 'trace'],
+     tags=['legacy', 'prod_exclude', 'remove'],
+     schema = 'gas_arbitrum',
+     alias = alias('fees_traces', legacy_model=True),
+     partition_by = ['block_date'],
+     materialized = 'incremental',
+     file_format = 'delta',
+     incremental_strategy = 'merge',
+     unique_key = ['tx_hash', 'trace'],
     )
 }}
 

--- a/models/gas/avalanche_c/gas_avalanche_c_fees_traces_legacy.sql
+++ b/models/gas/avalanche_c/gas_avalanche_c_fees_traces_legacy.sql
@@ -1,13 +1,12 @@
 {{ config(
-	tags=['legacy'],
-	
-    schema = 'gas_avalanche_c',
-    alias = alias('fees_traces', legacy_model=True),
-    partition_by = ['block_date'],
-    materialized = 'incremental',
-    file_format = 'delta',
-    incremental_strategy = 'merge',
-    unique_key = ['tx_hash', 'trace'],
+     tags=['legacy', 'prod_exclude', 'remove'],
+     schema = 'gas_avalanche_c',
+     alias = alias('fees_traces', legacy_model=True),
+     partition_by = ['block_date'],
+     materialized = 'incremental',
+     file_format = 'delta',
+     incremental_strategy = 'merge',
+     unique_key = ['tx_hash', 'trace'],
     )
 }}
 

--- a/models/gas/ethereum/gas_ethereum_fees_traces_legacy.sql
+++ b/models/gas/ethereum/gas_ethereum_fees_traces_legacy.sql
@@ -1,13 +1,12 @@
 {{ config(
-	tags=['legacy'],
-	
-    schema = 'gas_ethereum',
-    alias = alias('fees_traces', legacy_model=True),
-    partition_by = ['block_date'],
-    materialized = 'incremental',
-    file_format = 'delta',
-    incremental_strategy = 'merge',
-    unique_key = ['tx_hash', 'trace'],
+     tags=['legacy', 'prod_exclude', 'remove'],
+     schema = 'gas_ethereum',
+     alias = alias('fees_traces', legacy_model=True),
+     partition_by = ['block_date'],
+     materialized = 'incremental',
+     file_format = 'delta',
+     incremental_strategy = 'merge',
+     unique_key = ['tx_hash', 'trace'],
     )
 }}
 

--- a/models/gas/fantom/gas_fantom_fees_traces_legacy.sql
+++ b/models/gas/fantom/gas_fantom_fees_traces_legacy.sql
@@ -1,13 +1,12 @@
 {{ config(
-	tags=['legacy'],
-	
-    schema = 'gas_fantom',
-    alias = alias('fees_traces', legacy_model=True),
-    partition_by = ['block_date'],
-    materialized = 'incremental',
-    file_format = 'delta',
-    incremental_strategy = 'merge',
-    unique_key = ['tx_hash', 'trace'],
+     tags=['legacy', 'prod_exclude', 'remove'],
+     schema = 'gas_fantom',
+     alias = alias('fees_traces', legacy_model=True),
+     partition_by = ['block_date'],
+     materialized = 'incremental',
+     file_format = 'delta',
+     incremental_strategy = 'merge',
+     unique_key = ['tx_hash', 'trace'],
     )
 }}
 

--- a/models/gas/gnosis/gas_gnosis_fees_traces_legacy.sql
+++ b/models/gas/gnosis/gas_gnosis_fees_traces_legacy.sql
@@ -1,13 +1,12 @@
 {{ config(
-	tags=['legacy'],
-	
-    schema = 'gas_gnosis',
-    alias = alias('fees_traces', legacy_model=True),
-    partition_by = ['block_date'],
-    materialized = 'incremental',
-    file_format = 'delta',
-    incremental_strategy = 'merge',
-    unique_key = ['tx_hash', 'trace'],
+     tags=['legacy', 'prod_exclude', 'remove'],
+     schema = 'gas_gnosis',
+     alias = alias('fees_traces', legacy_model=True),
+     partition_by = ['block_date'],
+     materialized = 'incremental',
+     file_format = 'delta',
+     incremental_strategy = 'merge',
+     unique_key = ['tx_hash', 'trace'],
     )
 }}
 

--- a/models/gas/optimism/gas_optimism_fees_traces_legacy.sql
+++ b/models/gas/optimism/gas_optimism_fees_traces_legacy.sql
@@ -1,13 +1,12 @@
 {{ config(
-	tags=['legacy'],
-	
-    schema = 'gas_optimism',
-    alias = alias('fees_traces', legacy_model=True),
-    partition_by = ['block_date'],
-    materialized = 'incremental',
-    file_format = 'delta',
-    incremental_strategy = 'merge',
-    unique_key = ['tx_hash', 'trace'],
+     tags=['legacy'],
+     schema = 'gas_optimism',
+     alias = alias('fees_traces', legacy_model=True),
+     partition_by = ['block_date'],
+     materialized = 'incremental',
+     file_format = 'delta',
+     incremental_strategy = 'merge',
+     unique_key = ['tx_hash', 'trace'],
     )
 }}
 

--- a/models/gas/optimism/gas_optimism_fees_traces_legacy.sql
+++ b/models/gas/optimism/gas_optimism_fees_traces_legacy.sql
@@ -6,6 +6,7 @@
      materialized = 'incremental',
      file_format = 'delta',
      incremental_strategy = 'merge',
+     incremental_predicates = ['DBT_INTERNAL_DEST.block_time >= date_trunc(\'day\', now() - interval \'1\' week)'],
      unique_key = ['tx_hash', 'trace'],
     )
 }}

--- a/models/gas/polygon/gas_polygon_fees_traces_legacy.sql
+++ b/models/gas/polygon/gas_polygon_fees_traces_legacy.sql
@@ -1,14 +1,13 @@
 {{ config(
-	tags=['legacy'],
-
-    schema = 'gas_polygon',
-    alias = alias('fees_traces', legacy_model=True),
-    partition_by = ['block_date'],
-    materialized = 'incremental',
-    file_format = 'delta',
-    incremental_strategy = 'merge',
-    incremental_predicates = ['DBT_INTERNAL_DEST.block_time >= date_trunc(\'day\', now() - interval \'1\' week)'],
-    unique_key = ['tx_hash', 'trace'],
+     tags=['legacy', 'prod_exclude', 'remove'],
+     schema = 'gas_polygon',
+     alias = alias('fees_traces', legacy_model=True),
+     partition_by = ['block_date'],
+     materialized = 'incremental',
+     file_format = 'delta',
+     incremental_strategy = 'merge',
+     incremental_predicates = ['DBT_INTERNAL_DEST.block_time >= date_trunc(\'day\', now() - interval \'1\' week)'],
+     unique_key = ['tx_hash', 'trace'],
     )
 }}
 


### PR DESCRIPTION
fyi @hildobby @MSilb7 
as discussed in gh discussion, excluding non-optimism fees traces spells on spark for now (they aren't migrated to dunesql)

we will continue to discuss together on how to best build on dunesql