### PR TITLE
fix 0x bnb `api_fills` maker & taker token

### DIFF
--- a/models/zeroex/bnb/zeroex_bnb_api_fills.sql
+++ b/models/zeroex/bnb/zeroex_bnb_api_fills.sql
@@ -323,8 +323,8 @@ uni_v2_swap as (
 , uni_v2_pair_creation as (
     SELECT
         bytearray_substring(data,13,20) as pair,
-        bytearray_substring(topic2, 13, 20) AS makerToken,
-        bytearray_substring(topic1, 13, 20) AS takerToken,
+        bytearray_substring(topic1, 13, 20) AS makerToken,
+        bytearray_substring(topic2, 13, 20) AS takerToken,
         rank() over (partition by bytearray_substring(data,13,20) order by block_time asc) rnk
     FROM {{ source('bnb', 'logs') }} creation
     WHERE creation.topic0 = 0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9  -- all the uni v2 pair creation event

--- a/models/zeroex/bnb/zeroex_bnb_api_fills_deduped.sql
+++ b/models/zeroex/bnb/zeroex_bnb_api_fills_deduped.sql
@@ -15,8 +15,9 @@
 WITH fills_with_tx_fill_number
 AS
 (
-    SELECT   row_number() OVER ( partition BY tx_hash ORDER BY evt_index ASC ) AS tx_fill_number
-           , *
+    SELECT
+        row_number() OVER ( partition BY tx_hash ORDER BY evt_index ASC ) AS tx_fill_number
+        , *
     FROM {{ ref('zeroex_bnb_api_fills') }}
     WHERE 1=1
     AND swap_flag = true


### PR DESCRIPTION
fyi @RantumBits @Hosuke @aalan3 @andrewhong5297 

i compiled the spell and ran it on both dunesql and spark (removed some of the code that didn't focus on uni_v2). only the dune team has access to run directly on spark atm, so it helps for us to step in here.

i noticed this issue exists on spark as well, but we never noticed because the `volume_usd` defaults to `NULL` due to a missing `0x` concat at the front of maker/taker token.
![image](https://github.com/duneanalytics/spellbook/assets/102681548/332a9a3e-5fba-4912-bec5-1556dc732232)
notice the maker token address is `WBNB` but the amount is massive, which should actually be flipped to the taker token (imagine it's an altcoin).

it looks like `topic2` and `topic3` need to be flipped (on spark that is, on dunesql it's `topic1` and `topic2`)

when i flipped them, the query on dunesql showed `volume_usd` to be:
`2.6709849819945e-7`
fraction of a cent, which the block explorer shows:
https://bscscan.com/tx/0x4870e8b93cac7cc25dbdd40d0858f6f73518b635a3e32a8e76fc4bdb74711f48