### PR TITLE
exclude 0x bnb until issues are resolved for high `volume_usd` due to maker/taker address switches

### DIFF
--- a/models/zeroex/bnb/zeroex_bnb_api_fills.sql
+++ b/models/zeroex/bnb/zeroex_bnb_api_fills.sql
@@ -1,5 +1,5 @@
 {{  config(
-        tags=['dunesql'],
+        tags=['dunesql', 'prod_exclude'],
         alias = alias('api_fills'),
         materialized='incremental',
         partition_by = ['block_month'],

--- a/models/zeroex/bnb/zeroex_bnb_api_fills_deduped.sql
+++ b/models/zeroex/bnb/zeroex_bnb_api_fills_deduped.sql
@@ -1,5 +1,5 @@
 {{  config(
-        tags=['dunesql'],
+        tags=['dunesql', 'prod_exclude'],
         alias = alias('api_fills_deduped'),
         materialized='incremental',
         partition_by = ['block_month'],

--- a/models/zeroex/zeroex_api_fills_deduped.sql
+++ b/models/zeroex/zeroex_api_fills_deduped.sql
@@ -9,11 +9,14 @@
         )
 }}
 
+/*
+  remove ref('zeroex_bnb_api_fills_deduped') until bnb model is fixed and live in prod again
+*/
+
 {% set zeroex_models = [  
   ref('zeroex_arbitrum_api_fills_deduped')
   ,ref('zeroex_avalanche_c_api_fills_deduped')
   ,ref('zeroex_base_api_fills_deduped')
-  ,ref('zeroex_bnb_api_fills_deduped')
   ,ref('zeroex_celo_api_fills_deduped')
   ,ref('zeroex_ethereum_api_fills_deduped')
   ,ref('zeroex_fantom_api_fills_deduped')


### PR DESCRIPTION
fyi @RantumBits 
until we get bnb resolved, let's keep the metrics for others clean on downstream dashboards
reference:
![image](https://github.com/duneanalytics/spellbook/assets/102681548/465b76d9-1166-4087-973c-2db189a9c69d)
