### PR TITLE
Solana balances performance fix

### DIFF
--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -18,7 +18,7 @@ WITH
       tokens_accounts as (
             SELECT
             distinct address
-            FROM {{ ref('solana_utils','token_accounts') }}
+            FROM {{ ref('solana_utils_token_accounts') }}
       )
       , updated_balances as (
             SELECT

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -37,7 +37,7 @@ WITH
                   or (address in (select address from tokens_accounts) AND token_mint_address is not null)
                   )
             {% if is_incremental() %}
-            AND incremental_predicate('block_time')
+            AND {{incremental_predicate('block_time')}}
             {% endif %}
       )
 

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -6,6 +6,7 @@
         materialized='incremental',
         file_format = 'delta',
         incremental_strategy='merge',
+        incremental_predicates = [incremental_predicate('block_time')],
         unique_key = ['token_mint_address', 'address','day'],
         post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -18,7 +18,7 @@ WITH
       tokens_accounts as (
             SELECT
             distinct address
-            FROM {{ ref('solana_utils','token') }}
+            FROM {{ ref('solana_utils','token_accounts') }}
       )
       , updated_balances as (
             SELECT

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -6,7 +6,7 @@
         materialized='incremental',
         file_format = 'delta',
         incremental_strategy='merge',
-        incremental_predicates = [incremental_predicate('block_time')],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['token_mint_address', 'address','day'],
         post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -18,11 +18,8 @@ WITH
       tokens_accounts as (
             SELECT
             distinct address
-            FROM {{ ref('solana','account_activity') }}
-            WHERE tx_success
-            AND token_mint_address is not null
+            FROM {{ ref('solana_utils','token') }}
       )
-
       , updated_balances as (
             SELECT
                   address

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -39,7 +39,7 @@ WITH
                   or (address in (select address from tokens_accounts) AND token_mint_address is not null)
                   )
             {% if is_incremental() %}
-            AND block_time >= date_trunc('day', now() - interval '1' day)
+            AND incremental_predicate('block_time')
             {% endif %}
       )
 

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -6,7 +6,7 @@
         materialized='incremental',
         file_format = 'delta',
         incremental_strategy='merge',
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
         unique_key = ['token_mint_address', 'address','day'],
         post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",


### PR DESCRIPTION
This PR aims to improve performance for solana balances a bit. 

* Uses the `incremental_predicate` macro
* Uses `incremental_predicate` to limit the merge into scope
* Switches the token accounts to use the spell instead of fetching from account activity.