### PR TITLE
exclude failing models in prod

### DIFF
--- a/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_v2_pools.sql
+++ b/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_v2_pools.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema='lido_liquidity_arbitrum',
     alias = alias('kyberswap_v2_pools'),
-    tags = ['dunesql'],
+    tags = ['dunesql', 'prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/rollup_economics/ethereum/l1_data_fees.sql
+++ b/models/rollup_economics/ethereum/l1_data_fees.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'rollup_economics_ethereum',
     alias = alias('l1_data_fees'),
-    tags = ['dunesql'],
+    tags = ['dunesql', 'prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',


### PR DESCRIPTION
@ppclunghe note the lido spell being excluded here, it is failing on duplicates:
```
18:50:29  Database Error in model lido_liquidity_arbitrum_kyberswap_v2_pools (models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_v2_pools.sql)
18:50:29    TrinoUserError(type=USER_ERROR, name=MERGE_TARGET_ROW_MULTIPLE_MATCHES, message="One MERGE target table row matched more than one source row", query_id=20231004_180615_18809_zkh6g)
18:50:29    compiled Code at target/run/spellbook/models/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_v2_pools.sql
```

@Jam516 note the excluded rollup economic spell in this PR. it's failing in prod due to missing source table (a dune upload):
```
18:50:29  Database Error in model l1_data_fees (models/rollup_economics/ethereum/l1_data_fees.sql)
18:50:29    TrinoUserError(type=USER_ERROR, name=TABLE_NOT_FOUND, message="line 98:18: Table 'delta_prod.dune_upload.op_stack_chain_metadata' does not exist", query_id=20231004_180544_18714_zkh6g)
```