### PR TITLE
Add back velodrome to airdrop claims

### DIFF
--- a/models/airdrop/optimism/airdrop_optimism_claims.sql
+++ b/models/airdrop/optimism/airdrop_optimism_claims.sql
@@ -11,13 +11,8 @@
 
 {% set airdrop_claims_models = [
     ref('op_optimism_airdrop_1_claims')
-
+   ,ref('velodrome_optimism_airdrop_claims')
 ] %}
-
-{#
--- , ref('velodrome_optimism_airdrop_claims') model relies on dex_prices
-#}
-
 
 SELECT *
 FROM (


### PR DESCRIPTION
This was depending on dex prices and was removed but we can now add it back