### PR TITLE
Revert "RW-5: cleanup block_date in base trades models (#4416)"

### DIFF
--- a/macros/models/_sector/nft/enrich_trades.sql
+++ b/macros/models/_sector/nft/enrich_trades.sql
@@ -15,7 +15,7 @@ WITH base_union as (
         '{{ blockchain }}' as blockchain,
         '{{ nft_model[0] }}' as project,
         '{{ nft_model[1] }}' as project_version,
-        cast(date_trunc('day', block_time) as date) as block_date,
+        block_date,
         cast(date_trunc('month', block_time) as date) as block_month,
         block_time,
         block_number,

--- a/macros/models/_sector/nft/platforms/element_v1_base_trades.sql
+++ b/macros/models/_sector/nft/platforms/element_v1_base_trades.sql
@@ -3,6 +3,7 @@
 
 
 SELECT
+  cast(DATE_TRUNC('month', evt_block_time) as date) AS block_date,
   evt_block_time AS block_time,
   evt_block_number AS block_number,
   'Buy' AS trade_category,
@@ -32,6 +33,7 @@ WHERE evt_block_time >= date_trunc('day', now() - interval '7' day)
 UNION ALL
 
 SELECT
+  cast(date_trunc('month', evt_block_time) as date) AS block_date,
   evt_block_time AS block_time,
   evt_block_number AS block_number,
   'Sell' AS trade_category,
@@ -61,6 +63,7 @@ WHERE evt_block_time >= date_trunc('day', now() - interval '7' day)
 UNION ALL
 
 SELECT
+  cast(date_trunc('month', evt_block_time) as date) AS block_date,
   evt_block_time AS block_time,
   evt_block_number AS block_number,
   'Buy' AS trade_category,
@@ -90,6 +93,7 @@ WHERE evt_block_time >= date_trunc('day', now() - interval '7' day)
 UNION ALL
 
 SELECT
+  cast(date_trunc('month', evt_block_time) as date) AS block_date,
   evt_block_time AS block_time,
   evt_block_number AS block_number,
   'Buy' AS trade_category,

--- a/models/_sector/nft/trades/ethereum/platforms/archipelago_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/archipelago_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'archipelago_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -47,7 +48,8 @@ fee_events as (
 )
 
 SELECT
-    trade.evt_block_time as block_time
+    cast(date_trunc('month',trade.evt_block_time) as date) as block_date
+    ,trade.evt_block_time as block_time
     ,trade.evt_block_number as block_number
     ,trade.evt_tx_hash as tx_hash
     ,trade.contract_address as project_contract_address

--- a/models/_sector/nft/trades/ethereum/platforms/blur_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/blur_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'blur_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -14,7 +15,8 @@
 
 
 SELECT
-      bm.evt_block_time AS block_time
+        cast(date_trunc('month', bm.evt_block_time) as date) AS block_date
+    , bm.evt_block_time AS block_time
     , bm.evt_block_number AS block_number
     , from_hex(JSON_EXTRACT_SCALAR(bm.buy, '$.collection')) AS nft_contract_address
     , cast(JSON_EXTRACT_SCALAR(bm.sell, '$.tokenId') as uint256) AS nft_token_id

--- a/models/_sector/nft/trades/ethereum/platforms/blur_seaport_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/blur_seaport_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'blur_seaport_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -12,7 +13,8 @@
 {% set seaport_usage_start_date = "cast('2023-01-25' as timestamp)" %}
 
 SELECT
-      s.evt_block_time AS block_time
+      cast(date_trunc('month', s.evt_block_time) as date) AS block_date
+    , s.evt_block_time AS block_time
     , s.evt_block_number AS block_number
     , from_hex(JSON_EXTRACT_SCALAR(s.offer[1], '$.token')) AS nft_contract_address
     , cast(JSON_EXTRACT_SCALAR(s.offer[1], '$.identifier') as uint256) AS nft_token_id

--- a/models/_sector/nft/trades/ethereum/platforms/blur_v2_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/blur_v2_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'blur_v2_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -80,8 +81,8 @@ WITH blur_v2_trades AS (
     {% endif %}
     )
 
-SELECT
-  bt.block_time
+SELECT CAST(date_trunc('day', bt.block_time) AS date) AS block_date
+, bt.block_time
 , bt.block_number
 , bt.tx_hash
 , bt.evt_index AS sub_tx_trade_id

--- a/models/_sector/nft/trades/ethereum/platforms/collectionswap_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/collectionswap_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'collectionswap_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -98,7 +99,8 @@ base_trades as (
 
 -- results
 SELECT
-  block_time
+  cast(date_trunc('month',block_time ) as date) as block_date
+, block_time
 , block_number
 , tx_hash
 , project_contract_address

--- a/models/_sector/nft/trades/ethereum/platforms/cryptopunks_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/cryptopunks_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'cryptopunks_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -29,7 +30,8 @@ with accepted_bid_prices as (
     group by 1,2,3
 )
 
-select    evt.evt_block_time as block_time
+select  cast(date_trunc('month',evt.evt_block_time) as date) as block_date
+        , evt.evt_block_time as block_time
         , evt.evt_block_number as block_number
         , evt.evt_tx_hash as tx_hash
         , evt.contract_address as project_contract_address

--- a/models/_sector/nft/trades/ethereum/platforms/element_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/element_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'element_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/_sector/nft/trades/ethereum/platforms/foundation_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/foundation_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     tags = ['dunesql'],
     schema = 'foundation_ethereum',
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -102,7 +103,8 @@ WITH all_foundation_trades AS (
     )
 
 SELECT
-  t.block_time
+ cast(date_trunc('month', t.block_time) as date) AS block_date
+, t.block_time
 , t.block_number
 , t.nft_token_id
 , UINT256 '1' AS nft_amount

--- a/models/_sector/nft/trades/ethereum/platforms/legacy/looksrare_v2_ethereum_base_trades_legacy.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/legacy/looksrare_v2_ethereum_base_trades_legacy.sql
@@ -1,8 +1,9 @@
 {{ config(
 	tags=['legacy'],
-
+	
     schema = 'looksrare_v2_ethereum',
     alias = alias('base_trades', legacy_model=True),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/models/_sector/nft/trades/ethereum/platforms/looksrare_seaport_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/looksrare_seaport_ethereum_base_trades.sql
@@ -11,8 +11,8 @@
 
 {% set looksrare_seaport_start_date = "cast('2023-06-28' as timestamp)" %}
 
-SELECT
-  s.evt_block_time AS block_time
+SELECT CAST(date_trunc('day', s.evt_block_time) AS date) AS block_date
+, s.evt_block_time AS block_time
 , s.evt_block_number AS block_number
 , s.evt_tx_hash AS tx_hash
 , s.offerer AS seller

--- a/models/_sector/nft/trades/ethereum/platforms/looksrare_v1_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/looksrare_v1_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'looksrare_v1_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -94,7 +95,8 @@ WITH looksrare_trades AS (
 
 
 SELECT
-  lr.block_time
+  cast(date_trunc('month', lr.block_time) as date) AS block_date
+, lr.block_time
 , lr.block_number
 , lr.tx_hash
 , lr.project_contract_address

--- a/models/_sector/nft/trades/ethereum/platforms/looksrare_v2_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/looksrare_v2_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'looksrare_v2_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -64,7 +65,8 @@ WITH looksrare_v2_trades AS (
     )
 
 SELECT
-  block_time
+  cast(date_trunc('month', block_time) as date) AS block_date
+, block_time
 , block_number
 , tx_hash
 , project_contract_address

--- a/models/_sector/nft/trades/ethereum/platforms/sudoswap_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/sudoswap_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'sudoswap_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -223,7 +224,8 @@ WITH
 
     ,swaps_cleaned as (
         SELECT
-             call_block_time as block_time
+             cast(date_trunc('month', call_block_time) as date) AS block_date
+            , call_block_time as block_time
             , call_block_number as block_number
             , nft_token_id
             , cardinality(nft_token_id) as number_of_items
@@ -248,7 +250,8 @@ WITH
     )
 
 SELECT
-      block_time
+      block_date
+    , block_time
     , block_number
     , tx_hash
     , project_contract_address

--- a/models/_sector/nft/trades/ethereum/platforms/superrare_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/superrare_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'superrare_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -12,7 +13,7 @@
 
 -- raw data table with all sales on superrare platform -- both primary and secondary
 with all_superrare_sales as (
-    -- 0x2947f98c42597966a0ec25e92843c09ac17fbaa7 -- SuperRareMarketAuction
+    -- 0x2947f98c42597966a0ec25e92843c09ac17fbaa7 -- SuperRareMarketAuction 
     -- 0x65b49f7aee40347f5a90b714be4ef086f3fe5e2c -- SuperRareMarketAuction : V2 https://github.com/superrare/pixura-contracts/blob/66b39164255d29d07e00b4ad8df206c379bf35e7/contracts/build/SuperRareMarketAuctionV2.json
     select  evt_block_time as block_time
             , evt_block_number as block_number
@@ -151,6 +152,7 @@ with all_superrare_sales as (
 )
 
 SELECT
+    cast(date_trunc('month', a.block_time) AS date) AS block_date,
     a.block_time,
     a.block_number,
     a.nft_token_id,

--- a/models/_sector/nft/trades/ethereum/platforms/x2y2_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/x2y2_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'x2y2_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -15,7 +16,8 @@
 
 WITH src_evt_inventory as (
     SELECT
-     evt_block_time as block_time
+     cast(date_trunc('month',evt_block_time) as date) as block_date
+    ,evt_block_time as block_time
     ,evt_block_number as block_number
     ,evt_tx_hash as tx_hash
     ,contract_address as project_contract_address
@@ -60,7 +62,8 @@ WITH src_evt_inventory as (
 
 -- results
 SELECT
-  block_time
+  block_date
+, block_time
 , block_number
 , tx_hash
 , project_contract_address

--- a/models/_sector/nft/trades/ethereum/platforms/zora_v1_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/zora_v1_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'zora_v1_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -10,7 +11,8 @@
 }}
 
 SELECT
-      bf.evt_block_time AS block_time
+     cast(date_trunc('month',bf.evt_block_time) as date) AS block_date
+    , bf.evt_block_time AS block_time
     , bf.evt_block_number AS block_number
     , bf.contract_address AS project_contract_address
     , bf.evt_tx_hash AS tx_hash

--- a/models/_sector/nft/trades/ethereum/platforms/zora_v2_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/zora_v2_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'zora_v2_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -10,7 +11,8 @@
 }}
 
 SELECT
-      evt_block_time AS block_time
+      cast(date_trunc('month',evt_block_time) as date) AS block_date
+    , evt_block_time AS block_time
     , evt_block_number AS block_number
     , contract_address AS project_contract_address
     , evt_tx_hash AS tx_hash

--- a/models/_sector/nft/trades/ethereum/platforms/zora_v3_ethereum_base_trades.sql
+++ b/models/_sector/nft/trades/ethereum/platforms/zora_v3_ethereum_base_trades.sql
@@ -2,6 +2,7 @@
     schema = 'zora_v3_ethereum',
     tags = ['dunesql'],
     alias = alias('base_trades'),
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -148,7 +149,8 @@ WITH v3_trades as (
 )
 
 SELECT
-      block_time
+    cast(date_trunc('month',block_time) as date) as block_date
+    , block_time
     , block_number
     , project_contract_address
     , tx_hash

--- a/models/_sector/nft/trades/nft_ethereum_trades_beta.sql
+++ b/models/_sector/nft/trades/nft_ethereum_trades_beta.sql
@@ -2,7 +2,7 @@
     schema = 'nft_ethereum',
     tags = ['dunesql'],
     alias = alias('trades_beta'),
-    partition_by = ['block_month'],
+    partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/tests/generic/check_column_types.sql
+++ b/tests/generic/check_column_types.sql
@@ -5,6 +5,7 @@
 
 {% test check_columns_nft_base_trades(model) %}
     {%- set column_types = {
+        'block_date':'date',
         'block_time':'timestamp(3) with time zone',
         'block_number':'bigint',
         'tx_hash':'varbinary',


### PR DESCRIPTION
fyi @0xRobin 
have to revert for now, there are downstream spells which read from these and pull `block_date` and then fail
see here:
https://cloud.getdbt.com/deploy/58579/projects/259299/runs/201545703