### PR TITLE
new CI cluster setup: add is_legacy in alias macro

### DIFF
--- a/models/test/trigger_scale.sql
+++ b/models/test/trigger_scale.sql
@@ -5,4 +5,9 @@
         )
 }}
 
+/*
+this dummy model is intended only to be used in the gh action for PR CI tests
+the goal is to run this on loop until the cluster is spun up, as a model run helps turn the cluster back on after auto-shutdown
+*/
+
 SELECT 1 as test

--- a/models/test/trigger_scale_legacy.sql
+++ b/models/test/trigger_scale_legacy.sql
@@ -1,6 +1,6 @@
 {{ config(
         schema='test',
-        alias = alias('trigger_scale_legacy'),
+        alias = alias('trigger_scale_legacy', legacy_model=True),
         tags= ['legacy','prod_exclude']
         )
 }}


### PR DESCRIPTION
i'm not 100% sure if it'll break prod or not without the `legacy_model=True` param in the alias macro, so i'm playing it safe here

also added a quick comment in the test model for clarity to anyone poking around