### PR TITLE
Solana balances fix again

### DIFF
--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -6,7 +6,7 @@
         materialized='incremental',
         file_format = 'delta',
         incremental_strategy='merge',
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
+        incremental_predicates = [DBT_INTERNAL_DEST.block_time >= date_trunc('day', now() - interval '1' day)],
         unique_key = ['token_mint_address', 'address','day'],
         post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",
@@ -41,7 +41,7 @@ WITH
                   WHERE tx_success 
                   AND block_time > now() - interval '1' day
                   {% if is_incremental() %}
-                  AND {{incremental_predicate('block_time')}}
+                  AND block_time >= date_trunc('day', now() - interval '1' day)
                   {% endif %}
             ) WHERE latest_tk = 1
       )

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -46,7 +46,6 @@ WITH
                         AND aa.token_mint_address is null --only join on the empty token mints
                         AND tk.created_at <= aa.block_time --only get token mints that were created at or before this account activity
                   WHERE tx_success
-                  AND block_time > now() - interval '1' day
                   {% if is_incremental() %}
                   AND block_time >= date_trunc('day', now() - interval '1' day)
                   {% endif %}

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -38,6 +38,7 @@ WITH
                         AND aa.token_mint_address is null --only join on the empty token mints
                         AND tk.created_at <= aa.block_time --only get token mints that were created at or before this account activity
                   WHERE tx_success 
+                  AND block_time > now() - interval '30' day
                   {% if is_incremental() %}
                   AND block_time >= date_trunc('day', now() - interval '1' day)
                   {% endif %}

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -38,7 +38,7 @@ WITH
                         AND aa.token_mint_address is null --only join on the empty token mints
                         AND tk.created_at <= aa.block_time --only get token mints that were created at or before this account activity
                   WHERE tx_success 
-                  AND block_time > now() - interval '30' day
+                  AND block_time > now() - interval '7' day
                   {% if is_incremental() %}
                   AND block_time >= date_trunc('day', now() - interval '1' day)
                   {% endif %}

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -6,7 +6,7 @@
         materialized='incremental',
         file_format = 'delta',
         incremental_strategy='merge',
-        incremental_predicates = ['DBT_INTERNAL_DEST.block_time >= date_trunc(\'day\', now() - interval \'1\' day)'],
+        incremental_predicates = ['DBT_INTERNAL_DEST.day >= date_trunc(\'day\', now() - interval \'1\' day)'],
         unique_key = ['token_mint_address', 'address','day'],
         post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -19,7 +19,7 @@ WITH
       updated_balances as (
             SELECT
                   date_trunc('day', block_time) as day
-                  cast(date_trunc('month', block_time) as date) as month
+                  , cast(date_trunc('month', block_time) as date) as month
                   , address
                   , coalesce(token_mint_address,original_token_mint_address) as token_mint_address
                   , cast(post_balance as double)/1e9 as sol_balance --lamport -> sol

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -6,6 +6,7 @@
         materialized='incremental',
         file_format = 'delta',
         incremental_strategy='merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
         unique_key = ['token_mint_address', 'address','day'],
         post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",
@@ -40,7 +41,7 @@ WITH
                   WHERE tx_success 
                   AND block_time > now() - interval '1' day
                   {% if is_incremental() %}
-                  AND block_time >= date_trunc('day', now() - interval '1' day)
+                  AND {{incremental_predicate('block_time')}}
                   {% endif %}
             ) WHERE latest_tk = 1
       )

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -14,13 +14,13 @@
                                     \'["ilemi"]\') }}')
 }}
 
-WITH 
+WITH
       updated_balances as (
             SELECT
                   date_trunc('day', block_time) as day
                   , address
                   , coalesce(token_mint_address,original_token_mint_address) as token_mint_address
-                  , cast(post_balance as double)/1e9 as sol_balance --lamport -> sol 
+                  , cast(post_balance as double)/1e9 as sol_balance --lamport -> sol
                   , coalesce(post_token_balance,0) as token_balance --tokens are already correct decimals in this table
                   , coalesce(token_balance_owner,original_token_balance_owner) as token_balance_owner
                   , block_time
@@ -40,26 +40,26 @@ WITH
                         , max_by(tk.token_balance_owner, tk.created_at) as original_token_balance_owner
                         -- , row_number() over (partition by aa.address, aa.block_slot, aa.tx_id, aa.tx_index order by tk.created_at desc) as latest_tk
                   FROM {{ source('solana','account_activity') }}  aa
-                  LEFT JOIN {{ ref('solana_utils_token_accounts')}} tk ON tk.address = aa.address 
+                  LEFT JOIN {{ ref('solana_utils_token_accounts')}} tk ON tk.address = aa.address
                         AND aa.token_mint_address is null --only join on the empty token mints
                         AND tk.created_at <= aa.block_time --only get token mints that were created at or before this account activity
-                  WHERE tx_success 
+                  WHERE tx_success
                   AND block_time > now() - interval '1' day
                   {% if is_incremental() %}
                   AND block_time >= date_trunc('day', now() - interval '1' day)
                   {% endif %}
                   group by 1,2,3,4,5,6,7
-            ) 
+            )
             -- WHERE latest_tk = 1
       )
 
-SELECT 
+SELECT
       day
       , address
       , sol_balance
       , token_mint_address
       , token_balance
       , token_balance_owner
-      , now() as updated_at 
+      , now() as updated_at
 FROM updated_balances
 WHERE latest_balance = 1

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -3,6 +3,7 @@
         tags=['dunesql'],
         schema = 'solana_utils',
         alias = alias('daily_balances'),
+        partition_by = ['month'],
         materialized='incremental',
         file_format = 'delta',
         incremental_strategy='merge',
@@ -18,6 +19,7 @@ WITH
       updated_balances as (
             SELECT
                   date_trunc('day', block_time) as day
+                  cast(date_trunc('month', block_time) as date) as month
                   , address
                   , coalesce(token_mint_address,original_token_mint_address) as token_mint_address
                   , cast(post_balance as double)/1e9 as sol_balance --lamport -> sol
@@ -55,6 +57,7 @@ WITH
 
 SELECT
       day
+      , month
       , address
       , sol_balance
       , token_mint_address

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -38,7 +38,7 @@ WITH
                         AND aa.token_mint_address is null --only join on the empty token mints
                         AND tk.created_at <= aa.block_time --only get token mints that were created at or before this account activity
                   WHERE tx_success 
-                  AND block_time > now() - interval '7' day
+                  AND block_time > now() - interval '1' day
                   {% if is_incremental() %}
                   AND block_time >= date_trunc('day', now() - interval '1' day)
                   {% endif %}

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -6,7 +6,7 @@
         materialized='incremental',
         file_format = 'delta',
         incremental_strategy='merge',
-        incremental_predicates = [DBT_INTERNAL_DEST.block_time >= date_trunc('day', now() - interval '1' day)],
+        incremental_predicates = ['DBT_INTERNAL_DEST.block_time >= date_trunc(\'day\', now() - interval \'1\' day)'],
         unique_key = ['token_mint_address', 'address','day'],
         post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",

--- a/models/solana_utils/solana_utils_daily_balances.sql
+++ b/models/solana_utils/solana_utils_daily_balances.sql
@@ -14,33 +14,34 @@
 }}
 
 WITH 
-      tokens_accounts as (
-            SELECT 
-            distinct address
-            FROM {{ source('solana','account_activity') }}
-            WHERE tx_success
-            AND token_mint_address is not null
-      )
-      
-      , updated_balances as (
+      updated_balances as (
             SELECT
-                  address 
-                  , date_trunc('day', block_time) as day
-                  , token_mint_address
+                  date_trunc('day', block_time) as day
+                  , address
+                  , coalesce(token_mint_address,original_token_mint_address) as token_mint_address
                   , cast(post_balance as double)/1e9 as sol_balance --lamport -> sol 
-                  , post_token_balance as token_balance --tokens are already correct decimals in this table
-                  , token_balance_owner
-                  , row_number() OVER (partition by address, date_trunc('day', block_time) order by block_slot desc) as latest_balance
-            FROM {{ source('solana','account_activity') }}
-            WHERE tx_success 
-            AND (
-                  --if the address is a token_mint_account, then mint_address should not be null
-                  (address NOT in (select address from tokens_accounts))
-                  or (address in (select address from tokens_accounts) AND token_mint_address is not null)
-                  )
-            {% if is_incremental() %}
-            AND block_time >= date_trunc('day', now() - interval '1' day)
-            {% endif %}
+                  , coalesce(post_token_balance,0) as token_balance --tokens are already correct decimals in this table
+                  , coalesce(token_balance_owner,original_token_balance_owner) as token_balance_owner
+                  , tx_id
+                  , block_time
+                  --could be one token mint closing and another opening on the same day. edge case but it exists.
+                  , row_number() OVER (partition by address, coalesce(token_mint_address,original_token_mint_address), date_trunc('day', block_time) order by block_slot desc) as latest_balance
+            FROM (
+                  SELECT
+                        tk.token_mint_address as original_token_mint_address
+                        , tk.token_balance_owner as original_token_balance_owner
+                        , tk.created_at
+                        , row_number() over (partition by aa.address, aa.block_slot, aa.tx_id, aa.tx_index order by tk.created_at desc) as latest_tk
+                        , aa.*
+                  FROM {{ source('solana','account_activity') }}  aa
+                  LEFT JOIN {{ ref('solana_utils_token_accounts')}} tk ON tk.address = aa.address 
+                        AND aa.token_mint_address is null --only join on the empty token mints
+                        AND tk.created_at <= aa.block_time --only get token mints that were created at or before this account activity
+                  WHERE tx_success 
+                  {% if is_incremental() %}
+                  AND block_time >= date_trunc('day', now() - interval '1' day)
+                  {% endif %}
+            ) WHERE latest_tk = 1
       )
 
 SELECT 

--- a/models/solana_utils/solana_utils_schema.yml
+++ b/models/solana_utils/solana_utils_schema.yml
@@ -36,9 +36,9 @@ models:
         name: sol_balance
       - &token_balance
         name: token_balance
-      - &token_balance_owner
-        name: token_balance_owner
-      - *updated_at
+      - *token_balance_owner
+      - &updated_at
+        name: updated_at
 
   - name: solana_utils_latest_balances
     meta:

--- a/models/solana_utils/solana_utils_schema.yml
+++ b/models/solana_utils/solana_utils_schema.yml
@@ -9,18 +9,15 @@ models:
       tags: ['solana','token_accounts']
     description: >
         unique token_mint_address and address pairs from solana.account_activity
-    tests:
-        - dbt_utils.unique_combination_of_columns:
-            combination_of_columns:
-                - token_mint_address
-                - address
     columns:
       - &token_mint_address
         name: token_mint_address
+      - &token_balance_owner
+        name: token_balance_owner
       - &address
         name: address
-      - &updated_at
-        name: updated_at
+      - &created_at
+        name: created_at
   
   - name: solana_utils_daily_balances
     meta:

--- a/models/solana_utils/solana_utils_token_accounts.sql
+++ b/models/solana_utils/solana_utils_token_accounts.sql
@@ -3,10 +3,8 @@
         schema = 'solana_utils',
         tags = ['dunesql'],
         alias = alias('token_accounts'),
-        materialized='incremental',
+        materialized='table',
         file_format = 'delta',
-        incremental_strategy='merge',
-        unique_key = ['token_mint_address', 'address'],
         post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",
                                     "solana_utils",
@@ -16,14 +14,13 @@
 WITH 
       distinct_accounts as (
             SELECT
-                  distinct 
                   token_mint_address
+                  , token_balance_owner
                   , address 
+                  , max(block_time) as created_at 
             FROM {{ source('solana','account_activity') }}
             WHERE token_mint_address is not null
-            {% if is_incremental() %}
-            AND block_time >= date_trunc('day', now() - interval '7' day)
-            {% endif %}
+            group by 1,2,3
       )
       
-SELECT *, now() as updated_at FROM distinct_accounts
+SELECT * FROM distinct_accounts


### PR DESCRIPTION
When accounts on solana get closed, they don't emit any post token balance. So, we have to do this odd join to get the token_mint_address of a closed account (detected by post_balance of sol = 0) to get this, so that we don't have a bunch of wrong balances where the state of 0 is not captured. 

annoying but no other workaround that I could find