### PR TITLE
Lowercase `dex.flashloans` project names

### DIFF
--- a/models/aave/arbitrum/aave_v3_arbitrum_flashloans.sql
+++ b/models/aave/arbitrum/aave_v3_arbitrum_flashloans.sql
@@ -40,7 +40,7 @@ WITH flashloans AS (
     )
     
 SELECT 'arbitrum'                                                       AS blockchain
-     , 'Aave'                                                           AS project
+     , 'aave'                                                           AS project
      , '3'                                                              AS version
      , CAST(date_trunc('Month', flash.block_time) as date)              AS block_month
      , flash.block_time

--- a/models/aave/arbitrum/aave_v3_arbitrum_flashloans_legacy.sql
+++ b/models/aave/arbitrum/aave_v3_arbitrum_flashloans_legacy.sql
@@ -40,7 +40,7 @@ WITH flashloans AS (
     )
     
 SELECT 'arbitrum'                                                       AS blockchain
-     , 'Aave'                                                           AS project
+     , 'aave'                                                           AS project
      , '3'                                                              AS version
      , flash.block_time
      , flash.block_number

--- a/models/aave/avalanche_c/aave_v2_avalanche_c_flashloans.sql
+++ b/models/aave/avalanche_c/aave_v2_avalanche_c_flashloans.sql
@@ -39,7 +39,7 @@ WITH flashloans AS (
     )
     
 SELECT 'avalanche_c'                                                    AS blockchain
-     , 'Aave'                                                           AS project
+     , 'aave'                                                           AS project
      , '2'                                                              AS version
      , CAST(date_trunc('Month', flash.block_time) as date)              AS block_month
      , flash.block_time

--- a/models/aave/avalanche_c/aave_v2_avalanche_c_flashloans_legacy.sql
+++ b/models/aave/avalanche_c/aave_v2_avalanche_c_flashloans_legacy.sql
@@ -39,7 +39,7 @@ WITH flashloans AS (
     )
     
 SELECT 'avalanche_c'                                                    AS blockchain
-     , 'Aave'                                                           AS project
+     , 'aave'                                                           AS project
      , '2'                                                              AS version
      , flash.block_time
      , flash.block_number

--- a/models/aave/avalanche_c/aave_v3_avalanche_c_flashloans.sql
+++ b/models/aave/avalanche_c/aave_v3_avalanche_c_flashloans.sql
@@ -39,7 +39,7 @@ WITH flashloans AS (
     )
     
 SELECT 'avalanche_c' AS blockchain
-, 'Aave' AS project
+, 'aave' AS project
 , '3' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) AS block_month
 , flash.block_time

--- a/models/aave/optimism/aave_v3_optimism_flashloans.sql
+++ b/models/aave/optimism/aave_v3_optimism_flashloans.sql
@@ -39,7 +39,7 @@ WITH flashloans AS (
     )
     
 SELECT 'optimism' AS blockchain
-, 'Aave' AS project
+, 'aave' AS project
 , '3' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) AS block_month
 , flash.block_time

--- a/models/aave/polygon/aave_v2_polygon_flashloans.sql
+++ b/models/aave/polygon/aave_v2_polygon_flashloans.sql
@@ -39,7 +39,7 @@ WITH flashloans AS (
     )
     
 SELECT 'polygon' AS blockchain
-, 'Aave' AS project
+, 'aave' AS project
 , '2' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) AS block_month
 , flash.block_time

--- a/models/aave/polygon/aave_v3_polygon_flashloans.sql
+++ b/models/aave/polygon/aave_v3_polygon_flashloans.sql
@@ -39,7 +39,7 @@ WITH flashloans AS (
     )
     
 SELECT 'polygon' AS blockchain
-, 'Aave' AS project
+, 'aave' AS project
 , '3' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) AS block_month
 , flash.block_time

--- a/models/balancer/avalanche_c/balancer_v2_avalanche_c_flashloans.sql
+++ b/models/balancer/avalanche_c/balancer_v2_avalanche_c_flashloans.sql
@@ -33,7 +33,7 @@ WITH flashloans AS (
     )
 
 SELECT 'avalanche_c' AS blockchain
-, 'Balancer' AS project
+, 'balancer' AS project
 , '2' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) as block_month
 , flash.block_time

--- a/models/balancer/base/balancer_v2_base_flashloans.sql
+++ b/models/balancer/base/balancer_v2_base_flashloans.sql
@@ -33,7 +33,7 @@ WITH flashloans AS (
     )
 
 SELECT 'base' AS blockchain
-, 'Balancer' AS project
+, 'balancer' AS project
 , '2' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) as block_month
 , flash.block_time

--- a/models/balancer/ethereum/balancer_v2_ethereum_flashloans.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_flashloans.sql
@@ -33,7 +33,7 @@ WITH flashloans AS (
     )
 
 SELECT 'ethereum' AS blockchain
-, 'Balancer' AS project
+, 'balancer' AS project
 , '2' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) as block_month
 , flash.block_time

--- a/models/balancer/gnosis/balancer_v2_gnosis_flashloans.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_flashloans.sql
@@ -33,7 +33,7 @@ WITH flashloans AS (
     )
 
 SELECT 'gnosis' AS blockchain
-, 'Balancer' AS project
+, 'balancer' AS project
 , '2' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) as block_month
 , flash.block_time

--- a/models/balancer/optimism/balancer_v2_optimism_flashloans.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_flashloans.sql
@@ -33,7 +33,7 @@ WITH flashloans AS (
     )
 
 SELECT 'optimism' AS blockchain
-, 'Balancer' AS project
+, 'balancer' AS project
 , '2' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) as block_month
 , flash.block_time

--- a/models/balancer/polygon/balancer_v2_polygon_flashloans.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_flashloans.sql
@@ -33,7 +33,7 @@ WITH flashloans AS (
     )
 
 SELECT 'polygon' AS blockchain
-, 'Balancer' AS project
+, 'balancer' AS project
 , '2' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) as block_month
 , flash.block_time

--- a/models/dydx/ethereum/dydx_ethereum_flashloans.sql
+++ b/models/dydx/ethereum/dydx_ethereum_flashloans.sql
@@ -50,7 +50,7 @@ WITH flashloans AS (
     )
 
 SELECT 'ethereum'                                                       AS blockchain
-     , 'dYdX'                                                           AS project
+     , 'dydx'                                                           AS project
      , '1'                                                              AS version
      , CAST(date_trunc('Month', flash.block_time) as date)              AS block_month
      , flash.block_time

--- a/models/equalizer/bnb/equalizer_bnb_flashloans.sql
+++ b/models/equalizer/bnb/equalizer_bnb_flashloans.sql
@@ -14,7 +14,7 @@
 }}
 
 SELECT 'bnb' AS blockchain
-, 'Equalizer' AS project
+, 'equalizer' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) as date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/equalizer/ethereum/equalizer_ethereum_flashloans.sql
+++ b/models/equalizer/ethereum/equalizer_ethereum_flashloans.sql
@@ -14,7 +14,7 @@
 }}
 
 SELECT 'ethereum' AS blockchain
-, 'Equalizer' AS project
+, 'equalizer' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) as date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/equalizer/optimism/equalizer_optimism_flashloans.sql
+++ b/models/equalizer/optimism/equalizer_optimism_flashloans.sql
@@ -14,7 +14,7 @@
 }}
 
 SELECT 'optimism' AS blockchain
-, 'Equalizer' AS project
+, 'equalizer' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) as date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/equalizer/polygon/equalizer_polygon_flashloans.sql
+++ b/models/equalizer/polygon/equalizer_polygon_flashloans.sql
@@ -14,7 +14,7 @@
 }}
 
 SELECT 'polygon' AS blockchain
-, 'Equalizer' AS project
+, 'equalizer' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) as date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/euler/ethereum/euler_ethereum_flashloans.sql
+++ b/models/euler/ethereum/euler_ethereum_flashloans.sql
@@ -14,7 +14,7 @@
 }}
 
 SELECT 'ethereum' AS blockchain
-    , 'Euler' AS project
+    , 'euler' AS project
     , '1' AS version
     , CAST(date_trunc('Month', b.evt_block_time) as date) as block_month
     , b.evt_block_time AS block_time

--- a/models/fiat_dao/ethereum/fiat_dao_ethereum_flashloans.sql
+++ b/models/fiat_dao/ethereum/fiat_dao_ethereum_flashloans.sql
@@ -14,7 +14,7 @@
 }}
 
 SELECT 'ethereum' AS blockchain
-, 'Fiat DAO' AS project
+, 'fiat_dao' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) AS date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/maker/ethereum/maker_ethereum_flashloans.sql
+++ b/models/maker/ethereum/maker_ethereum_flashloans.sql
@@ -14,7 +14,7 @@
 }}
 
 SELECT 'ethereum' AS blockchain
-, 'Maker' AS project
+, 'maker' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) as date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/synapse/arbitrum/synapse_arbitrum_flashloans.sql
+++ b/models/synapse/arbitrum/synapse_arbitrum_flashloans.sql
@@ -14,7 +14,7 @@
 {% set weth_address = '0x82af49447d8a07e3bd95bd0d56f35241523fbab1' %}
 
 SELECT '{{blockchain}}' AS blockchain
-, 'Synapse' AS project
+, 'synapse' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) as date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/synapse/avalanche_c/synapse_avalanche_c_flashloans.sql
+++ b/models/synapse/avalanche_c/synapse_avalanche_c_flashloans.sql
@@ -14,7 +14,7 @@
 {% set weth_address = '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7' %}
 
 SELECT '{{blockchain}}' AS blockchain
-, 'Synapse' AS project
+, 'synapse' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) as date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/synapse/bnb/synapse_bnb_flashloans.sql
+++ b/models/synapse/bnb/synapse_bnb_flashloans.sql
@@ -14,7 +14,7 @@
 {% set weth_address = '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c' %}
 
 SELECT '{{blockchain}}' AS blockchain
-, 'Synapse' AS project
+, 'synapse' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) as date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/synapse/ethereum/synapse_ethereum_flashloans.sql
+++ b/models/synapse/ethereum/synapse_ethereum_flashloans.sql
@@ -14,7 +14,7 @@
 {% set weth_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' %}
 
 SELECT '{{blockchain}}' AS blockchain
-, 'Synapse' AS project
+, 'synapse' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) as date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/synapse/fantom/synapse_fantom_flashloans.sql
+++ b/models/synapse/fantom/synapse_fantom_flashloans.sql
@@ -14,7 +14,7 @@
 {% set weth_address = '0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83' %}
 
 SELECT '{{blockchain}}' AS blockchain
-, 'Synapse' AS project
+, 'synapse' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) as date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/synapse/optimism/synapse_optimism_flashloans.sql
+++ b/models/synapse/optimism/synapse_optimism_flashloans.sql
@@ -14,7 +14,7 @@
 {% set weth_address = '0x4200000000000000000000000000000000000006' %}
 
 SELECT '{{blockchain}}' AS blockchain
-, 'Synapse' AS project
+, 'synapse' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) as date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/synapse/polygon/synapse_polygon_flashloans.sql
+++ b/models/synapse/polygon/synapse_polygon_flashloans.sql
@@ -14,7 +14,7 @@
 {% set weth_address = '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270' %}
 
 SELECT '{{blockchain}}' AS blockchain
-, 'Synapse' AS project
+, 'synapse' AS project
 , '1' AS version
 , CAST(date_trunc('Month', flash.evt_block_time) as date) as block_month
 , flash.evt_block_time AS block_time

--- a/models/uniswap/arbitrum/uniswap_v3_arbitrum_flashloans.sql
+++ b/models/uniswap/arbitrum/uniswap_v3_arbitrum_flashloans.sql
@@ -37,7 +37,7 @@ WITH flashloans AS (
     )
 
 SELECT 'arbitrum' AS blockchain
-, 'Uniswap' AS project
+, 'uniswap' AS project
 , '3' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) as block_month
 , flash.block_time

--- a/models/uniswap/celo/uniswap_v3_celo_flashloans.sql
+++ b/models/uniswap/celo/uniswap_v3_celo_flashloans.sql
@@ -34,7 +34,7 @@ WITH flashloans AS (
     )
 
 SELECT 'celo' AS blockchain
-, 'Uniswap' AS project
+, 'uniswap' AS project
 , '3' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) as block_month
 , flash.block_time

--- a/models/uniswap/ethereum/uniswap_v3_ethereum_flashloans.sql
+++ b/models/uniswap/ethereum/uniswap_v3_ethereum_flashloans.sql
@@ -36,7 +36,7 @@ WITH flashloans AS (
     )
 
 SELECT 'ethereum' AS blockchain
-, 'Uniswap' AS project
+, 'uniswap' AS project
 , '3' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) as block_month
 , flash.block_time

--- a/models/uniswap/optimism/uniswap_v3_optimism_flashloans.sql
+++ b/models/uniswap/optimism/uniswap_v3_optimism_flashloans.sql
@@ -36,7 +36,7 @@ WITH flashloans AS (
     )
 
 SELECT 'optimism' AS blockchain
-, 'Uniswap' AS project
+, 'uniswap' AS project
 , '3' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) as block_month
 , flash.block_time

--- a/models/uniswap/polygon/uniswap_v3_polygon_flashloans.sql
+++ b/models/uniswap/polygon/uniswap_v3_polygon_flashloans.sql
@@ -36,7 +36,7 @@ WITH flashloans AS (
     )
 
 SELECT 'polygon' AS blockchain
-, 'Uniswap' AS project
+, 'uniswap' AS project
 , '3' AS version
 , CAST(date_trunc('Month', flash.block_time) as date) as block_month
 , flash.block_time


### PR DESCRIPTION
Making all project values lowercase for consistency (+ can now easily get proper name from `dex.info`). Looked into queries using dex.flashloans and there seem to be none that would be affected by this change as they are either broken temporary queries or don't use that column (other than mine but I'm fine with rugging myself if it's for a cleaner spellbook code across the board): https://dune.com/browse/queries?q=dex.flashloans