### PR TITLE
Balancer Pool Labels fix

### DIFF
--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_ethereum.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_ethereum.sql
@@ -53,6 +53,33 @@ WITH pools AS (
       cc.symbol,
       'WP' AS pool_type
     FROM {{ source('balancer_v2_ethereum', 'Vault_evt_PoolRegistered') }} c
+    INNER JOIN {{ source('balancer_v2_ethereum', 'WeightedPoolFactory_call_create') }} cc
+      ON c.evt_tx_hash = cc.call_tx_hash
+      AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
+    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
+    CROSS JOIN UNNEST(cc.normalizedWeights) AS w(weights)
+    {% if is_incremental() %}
+    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+  ) zip
+
+  UNION ALL
+
+  SELECT
+    pool_id,
+    zip.tokens AS token_address,
+    zip.weights / pow(10, 18) AS normalized_weight,
+    symbol,
+    pool_type
+  FROM (
+    SELECT
+      c.poolId AS pool_id,
+      t.tokens,
+      w.weights,
+      cc.symbol,
+      'WP' AS pool_type
+    FROM {{ source('balancer_v2_ethereum', 'Vault_evt_PoolRegistered') }} c
     INNER JOIN {{ source('balancer_v2_ethereum', 'WeightedPoolV2Factory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_polygon.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_polygon.sql
@@ -53,6 +53,33 @@ WITH pools AS (
       cc.symbol,
       'WP' AS pool_type
     FROM {{ source('balancer_v2_polygon', 'Vault_evt_PoolRegistered') }} c
+    INNER JOIN {{ source('balancer_v2_polygon', 'WeightedPoolFactory_call_create') }} cc
+      ON c.evt_tx_hash = cc.call_tx_hash
+      AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
+    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
+    CROSS JOIN UNNEST(cc.normalizedWeights) AS w(weights)
+    {% if is_incremental() %}
+    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+  ) zip
+
+  UNION ALL
+
+  SELECT
+    pool_id,
+    zip.tokens AS token_address,
+    zip.weights / pow(10, 18) AS normalized_weight,
+    symbol,
+    pool_type
+  FROM (
+    SELECT
+      c.poolId AS pool_id,
+      t.tokens,
+      w.weights,
+      cc.symbol,
+      'WP' AS pool_type
+    FROM {{ source('balancer_v2_polygon', 'Vault_evt_PoolRegistered') }} c
     INNER JOIN {{ source('balancer_v2_polygon', 'WeightedPoolV2Factory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0


### PR DESCRIPTION
This PR fixes weighted pool labels on arbitrum, ethereum, and polygon, given that the weighted pool factories for these chains allow for both `weights` and `normalizedWeights`. Previously, only the  `weights` field was being considered, which was causing some pools to be missing.

@mendesfabio @thetroyharris 
