### PR TITLE
prod hotfix: fix incorrect column dependency on eth staking

### DIFF
--- a/models/labels/addresses/infrastructure/identifier/eth_stakers/labels_eth_stakers.sql
+++ b/models/labels/addresses/infrastructure/identifier/eth_stakers/labels_eth_stakers.sql
@@ -7,7 +7,7 @@
 
 WITH identified_stakers AS (
     SELECT 'ethereum' AS blockchain
-    , address
+    , depositor_address as address
     , entity AS name
     , 'infrastructure' AS category
     , 'hildobby' AS contributor


### PR DESCRIPTION
fyi @hildobby 
another reminder that we need to check downstream dependencies when changing column names. we will have to consider an automated test addition in the CI test gh action.