### PR TITLE
prices.usd -> change forward fill lookback and add a monitor

### DIFF
--- a/models/prices/prices_usd_forward_fill.sql
+++ b/models/prices/prices_usd_forward_fill.sql
@@ -11,7 +11,7 @@
 
 -- how much time we look back, anything before is considered finalized, anything after is forward filled.
 -- we could decrease this to optimize query performance but it's a tradeoff with resiliency to lateness.
-{%- set lookback_interval = "'2' day" %}
+{%- set lookback_interval = "'1' hour" %}
 
 
 WITH
@@ -25,7 +25,7 @@ WITH
     select *,
         lead(minute) over (partition by blockchain,contract_address,decimals,symbol order by minute asc) as next_update_minute
     FROM {{ source('prices', 'usd') }}
-    where minute > now() - interval {{lookback_interval}}
+    where minute >= now() - interval {{lookback_interval}}
 )
 
 , timeseries as (
@@ -65,4 +65,5 @@ SELECT
     ,symbol
     ,price
 FROM forward_fill
+where minute > now() - interval {{lookback_interval}}
 


### PR DESCRIPTION
Given that `prices.usd` has gotten a lot more stable (less latency)
we can decrease the lookback (and thus compute cost) of the forward fill model. 

This PR also adds a lightweight monitor table so we can go back and inspect quantile metrics on the latency of the different price tokens. 
more info on qdigest [here](https://trino.io/docs/current/functions/qdigest.html)