### PR TITLE
Balancer pools labels fix

### DIFF
--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_arbitrum.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_arbitrum.sql
@@ -29,8 +29,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_arbitrum', 'WeightedPoolFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.weights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -56,8 +57,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_arbitrum', 'WeightedPoolFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.normalizedWeights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -83,8 +85,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_arbitrum', 'WeightedPoolV2Factory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.normalizedWeights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -110,8 +113,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_arbitrum', 'InvestmentPoolFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.weights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -137,8 +141,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_arbitrum', 'WeightedPool2TokensFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.weights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -286,10 +291,12 @@ settings AS (
 SELECT 
   'arbitrum' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE
-    WHEN pool_type IN ('SP.LP.LBP') THEN lower(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_agg(token_symbol)), '/'), ' ', array_join(array_sort(array_agg(cast(norm_weight AS varchar))), '/')))
+  CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
+  THEN LOWER(pool_symbol)
+  ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
+  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
   END AS name,
+  pool_type,
   'balancer_v2_pool' AS category,
   'balancerlabs' AS contributor,
   'query' AS source,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_arbitrum.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_arbitrum.sql
@@ -292,9 +292,9 @@ SELECT
   'arbitrum' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
   CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
-  THEN LOWER(pool_symbol)
-  ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
-  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
+  THEN lower(pool_symbol)
+    ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
+    array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))
   END AS name,
   pool_type,
   'balancer_v2_pool' AS category,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_arbitrum.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_arbitrum.sql
@@ -33,7 +33,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -61,7 +61,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -89,7 +89,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -117,7 +117,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -145,7 +145,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_avalanche_c.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_avalanche_c.sql
@@ -33,7 +33,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_avalanche_c.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_avalanche_c.sql
@@ -29,8 +29,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_avalanche_c', 'WeightedPoolFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.normalizedWeights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -124,10 +125,12 @@ settings AS (
 SELECT 
   'avalanche_c' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE
-    WHEN pool_type IN ('SP.LP.LBP') THEN lower(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_agg(token_symbol)), '/'), ' ', array_join(array_sort(array_agg(cast(norm_weight AS varchar))), '/')))
+  CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
+    THEN LOWER(pool_symbol)
+    ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
+  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
   END AS name,
+  pool_type,
   'balancer_v2_pool' AS category,
   'balancerlabs' AS contributor,
   'query' AS source,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_avalanche_c.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_avalanche_c.sql
@@ -126,9 +126,9 @@ SELECT
   'avalanche_c' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
   CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
-    THEN LOWER(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
-  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
+  THEN lower(pool_symbol)
+    ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
+    array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))
   END AS name,
   pool_type,
   'balancer_v2_pool' AS category,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_base.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_base.sql
@@ -33,7 +33,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_base.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_base.sql
@@ -29,8 +29,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_base', 'WeightedPoolFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.normalizedWeights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -124,10 +125,12 @@ settings AS (
 SELECT 
   'base' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE
-    WHEN pool_type IN ('SP.LP.LBP') THEN lower(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_agg(token_symbol)), '/'), ' ', array_join(array_sort(array_agg(cast(norm_weight AS varchar))), '/')))
+  CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
+    THEN LOWER(pool_symbol)
+    ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
+  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
   END AS name,
+  pool_type,
   'balancer_v2_pool' AS category,
   'balancerlabs' AS contributor,
   'query' AS source,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_base.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_base.sql
@@ -126,9 +126,9 @@ SELECT
   'base' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
   CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
-    THEN LOWER(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
-  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
+  THEN lower(pool_symbol)
+    ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
+    array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))
   END AS name,
   pool_type,
   'balancer_v2_pool' AS category,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_ethereum.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_ethereum.sql
@@ -293,9 +293,9 @@ SELECT
   'ethereum' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
   CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
-    THEN LOWER(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
-  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
+  THEN lower(pool_symbol)
+    ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
+    array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))
   END AS name,
   pool_type,
   'balancer_v2_pool' AS category,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_ethereum.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_ethereum.sql
@@ -33,7 +33,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -61,7 +61,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -89,7 +89,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -117,7 +117,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -145,7 +145,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_ethereum.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_ethereum.sql
@@ -29,8 +29,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_ethereum', 'WeightedPoolFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.weights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -56,8 +57,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_ethereum', 'WeightedPoolFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.normalizedWeights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -83,8 +85,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_ethereum', 'WeightedPoolV2Factory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.normalizedWeights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -110,8 +113,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_ethereum', 'WeightedPool2TokensFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.weights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -137,8 +141,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_ethereum', 'InvestmentPoolFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.weights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -287,10 +292,12 @@ settings AS (
 SELECT 
   'ethereum' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE
-    WHEN pool_type IN ('SP.LP.LBP') THEN lower(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_agg(token_symbol)), '/'), ' ', array_join(array_sort(array_agg(cast(norm_weight AS varchar))), '/')))
+  CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
+    THEN LOWER(pool_symbol)
+    ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
+  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
   END AS name,
+  pool_type,
   'balancer_v2_pool' AS category,
   'balancerlabs' AS contributor,
   'query' AS source,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_gnosis.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_gnosis.sql
@@ -33,7 +33,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_gnosis.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_gnosis.sql
@@ -162,9 +162,9 @@ SELECT
   'gnosis' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
   CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
-    THEN LOWER(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
-  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
+  THEN lower(pool_symbol)
+    ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
+    array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))
   END AS name,
   pool_type,
   'balancer_v2_pool' AS category,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_gnosis.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_gnosis.sql
@@ -29,8 +29,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_gnosis', 'WeightedPoolV2Factory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.normalizedWeights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -160,10 +161,12 @@ settings AS (
 SELECT 
   'gnosis' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE
-    WHEN pool_type IN ('SP.LP.LBP') THEN lower(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_agg(token_symbol)), '/'), ' ', array_join(array_sort(array_agg(cast(norm_weight AS varchar))), '/')))
+  CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
+    THEN LOWER(pool_symbol)
+    ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
+  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
   END AS name,
+  pool_type,
   'balancer_v2_pool' AS category,
   'balancerlabs' AS contributor,
   'query' AS source,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_optimism.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_optimism.sql
@@ -29,8 +29,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_optimism', 'WeightedPoolFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.weights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -56,8 +57,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_optimism', 'WeightedPoolV2Factory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.normalizedWeights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -83,8 +85,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_optimism', 'WeightedPool2TokensFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.weights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -196,10 +199,12 @@ settings AS (
 SELECT 
   'optimism' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE
-    WHEN pool_type IN ('SP.LP.LBP') THEN lower(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_agg(token_symbol)), '/'), ' ', array_join(array_sort(array_agg(cast(norm_weight AS varchar))), '/')))
+  CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
+    THEN LOWER(pool_symbol)
+    ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
+  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
   END AS name,
+  pool_type,
   'balancer_v2_pool' AS category,
   'balancerlabs' AS contributor,
   'query' AS source,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_optimism.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_optimism.sql
@@ -33,7 +33,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -61,7 +61,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -89,7 +89,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_optimism.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_optimism.sql
@@ -201,8 +201,8 @@ SELECT
   bytearray_substring(pool_id, 1, 20) AS address,
   CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
     THEN LOWER(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
-  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
+    ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
+    array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))
   END AS name,
   pool_type,
   'balancer_v2_pool' AS category,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_polygon.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_polygon.sql
@@ -33,7 +33,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -61,7 +61,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -89,7 +89,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -117,7 +117,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip
@@ -145,7 +145,7 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
     {% if is_incremental() %}
-    WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
     {% endif %}
   ) zip

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_polygon.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_polygon.sql
@@ -293,8 +293,8 @@ SELECT
   bytearray_substring(pool_id, 1, 20) AS address,
   CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
     THEN LOWER(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
-  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
+    ELSE lower(concat(array_join(array_agg(token_symbol ORDER BY token_symbol), '/'), ' ', 
+    array_join(array_agg(cast(norm_weight AS varchar) ORDER BY token_symbol), '/')))
   END AS name,
   pool_type,
   'balancer_v2_pool' AS category,

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_polygon.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_polygon.sql
@@ -29,8 +29,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_polygon', 'WeightedPoolFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.weights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -56,8 +57,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_polygon', 'WeightedPoolFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.normalizedWeights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -83,8 +85,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_polygon', 'WeightedPoolV2Factory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.normalizedWeights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -110,8 +113,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_polygon', 'WeightedPool2TokensFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.weights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -137,8 +141,9 @@ WITH pools AS (
     INNER JOIN {{ source('balancer_v2_polygon', 'InvestmentPoolFactory_call_create') }} cc
       ON c.evt_tx_hash = cc.call_tx_hash
       AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-    CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-    CROSS JOIN UNNEST(cc.weights) AS w(weights)
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
     {% if is_incremental() %}
     WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
       AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
@@ -286,10 +291,12 @@ settings AS (
 SELECT 
   'polygon' AS blockchain,
   bytearray_substring(pool_id, 1, 20) AS address,
-  CASE
-    WHEN pool_type IN ('SP.LP.LBP') THEN lower(pool_symbol)
-    ELSE lower(concat(array_join(array_sort(array_agg(token_symbol)), '/'), ' ', array_join(array_sort(array_agg(cast(norm_weight AS varchar))), '/')))
+  CASE WHEN pool_type IN ('SP', 'LP', 'LBP') 
+    THEN LOWER(pool_symbol)
+    ELSE lower(concat(array_join(array_sort(array_distinct(array_agg(token_symbol))), '/'), ' ', 
+  SUBSTRING(array_join(array_agg(cast(norm_weight AS varchar)), '/'),1,5)))
   END AS name,
+  pool_type,
   'balancer_v2_pool' AS category,
   'balancerlabs' AS contributor,
   'query' AS source,


### PR DESCRIPTION
This PR:
1) Fixes pool labels for weighted pools on all chains. Example: The RDNT/WETH 80/20 pool on Arbitrum (0x32df62dc3aed2cd6224193052ce665dc18165841) was being labelled as rdnt/rdnt/weth/weth 20/20/80/80
2) Adds the pool_type field to the final select statement, which will help us build pool type specific dashboards.

@mendesfabio @thetroyharris 
