### PR TITLE
Stricter OpenSea attribution on Ethereum

### DIFF
--- a/models/opensea/ethereum/opensea_v3_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v3_ethereum_events.sql
@@ -38,4 +38,3 @@ where (
     fee_wallet_name = 'opensea'
     or right_hash = 0x360c6ebe
  )
-)

--- a/models/opensea/ethereum/opensea_v3_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v3_ethereum_events.sql
@@ -34,12 +34,8 @@ WITH fee_wallets as (
 
 select *
 from trades
-where
-( zone_address in (0xf397619df7bfd4d1657ea9bdd9df7ff888731a11
-          ,0x9b814233894cd227f561b78cc65891aa55c62ad2
-          ,0x004c00500000ad104d7dbd00e3ae0a5c00560c00
-          ,0x110b2b128a9ed1be5ef3232d8e4e41640df5c2cd
-          ,0x000000e7ec00e7b300774b00001314b8610022b8 -- newly added on seaport v1.4
-          )
- or  fee_wallet_name = 'opensea'
+where (
+    fee_wallet_name = 'opensea'
+    or right_hash = 0x360c6ebe
+ )
 )

--- a/models/opensea/ethereum/opensea_v4_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v4_ethereum_events.sql
@@ -35,11 +35,8 @@ WITH fee_wallets as (
 select *
 from trades
 where
-( zone_address in (0xf397619df7bfd4d1657ea9bdd9df7ff888731a11
-          ,0x9b814233894cd227f561b78cc65891aa55c62ad2
-          ,0x004c00500000ad104d7dbd00e3ae0a5c00560c00
-          ,0x110b2b128a9ed1be5ef3232d8e4e41640df5c2cd
-          ,0x000000e7ec00e7b300774b00001314b8610022b8 -- newly added on seaport v1.4
-          )
- or  fee_wallet_name = 'opensea'
+where (
+    fee_wallet_name = 'opensea'
+    or right_hash = 0x360c6ebe
+ )
 )

--- a/models/opensea/ethereum/opensea_v4_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v4_ethereum_events.sql
@@ -38,4 +38,3 @@ where (
     fee_wallet_name = 'opensea'
     or right_hash = 0x360c6ebe
  )
-)

--- a/models/opensea/ethereum/opensea_v4_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v4_ethereum_events.sql
@@ -34,7 +34,6 @@ WITH fee_wallets as (
 
 select *
 from trades
-where
 where (
     fee_wallet_name = 'opensea'
     or right_hash = 0x360c6ebe


### PR DESCRIPTION
This makes the OpenSea attribution on Ethereum stricter (and in line with the other chains).
Triggered by the incorrect attribution of this Flashloan trade of 50mil https://etherscan.io/tx/0xe0140cce28f3e23d08889d6640d22c61fd45061a104c063bbc918a7ea43a2af2