### PR TITLE
dex/nft `amount_usd` test: upgrade severity to fail

### DIFF
--- a/models/dex/dex_schema.yml
+++ b/models/dex/dex_schema.yml
@@ -65,7 +65,6 @@ models:
         tests:
           - dbt_utils.accepted_range:
               max_value: 1000000000 # $1b is an arbitrary number, intended to flag outlier amounts early
-              severity: warn
       - &token_bought_address
         name: token_bought_address
         description: "Contract address of the token bought"


### PR DESCRIPTION
fyi @Hosuke @0xRobin 
upgrading to fail, as we run this test in prod now and want failures/notifications
if there are side effects on PRs, we will need to adapt CI test step(s) to workaround it