### PR TITLE
Revert "exclude OP (#4728)"

### DIFF
--- a/models/contracts/optimism/contracts_optimism_contract_mapping.sql
+++ b/models/contracts/optimism/contracts_optimism_contract_mapping.sql
@@ -1,6 +1,6 @@
  {{
   config(
-        tags = ['prod_exclude'],        
+        
         alias = 'contract_mapping',
         materialized ='incremental',
         file_format ='delta',


### PR DESCRIPTION
This reverts commit 8c06233e6a207922c0cd5f0454bbe08bceae3247.

# Thank you for contributing to Spellbook!
Please refer to the top of the `readme` in the root of Spellbook to learn how to contribute to Spellbook on DuneSQL.