### PR TITLE
make token_accounts incremental

### DIFF
--- a/models/solana_utils/solana_utils_token_accounts.sql
+++ b/models/solana_utils/solana_utils_token_accounts.sql
@@ -5,7 +5,7 @@
         materialized = 'incremental',
         file_format = 'delta',
         incremental_strategy = 'merge',
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.created_at')],
         unique_key = ['token_mint_address','address'],
         post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",

--- a/models/solana_utils/solana_utils_token_accounts.sql
+++ b/models/solana_utils/solana_utils_token_accounts.sql
@@ -21,9 +21,7 @@ WITH
                   , max_by(aa.token_balance_owner, aa.block_time) as token_balance_owner --some account created before and then again after token owner schema change, so then it created dupes.
                   , min(aa.block_time) as created_at 
             FROM {{ source('solana','account_activity') }} aa
-            LEFT JOIN {{ this }} old ON old.address = aa.address AND old.token_mint_address = aa.token_mint_address
             WHERE aa.token_mint_address is not null
-            AND old.address is null --don't include accounts we already have
             {% if is_incremental() %}
             AND {{incremental_predicate('aa.block_time')}}
             {% endif %}

--- a/models/solana_utils/solana_utils_token_accounts.sql
+++ b/models/solana_utils/solana_utils_token_accounts.sql
@@ -2,8 +2,11 @@
   config(
         schema = 'solana_utils',
         alias = 'token_accounts',
-        materialized='table',
+        materialized = 'incremental',
         file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['token_mint_address','address'],
         post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",
                                     "solana_utils",
@@ -12,14 +15,18 @@
 
 WITH 
       distinct_accounts as (
-            --force
             SELECT
-                  token_mint_address
-                  , address 
-                  , max_by(token_balance_owner, block_time) as token_balance_owner --some account created before and then again after token owner schema change, so then it created dupes.
-                  , min(block_time) as created_at 
-            FROM {{ source('solana','account_activity') }}
-            WHERE token_mint_address is not null
+                  aa.token_mint_address
+                  , aa.address 
+                  , max_by(aa.token_balance_owner, aa.block_time) as token_balance_owner --some account created before and then again after token owner schema change, so then it created dupes.
+                  , min(aa.block_time) as created_at 
+            FROM {{ source('solana','account_activity') }} aa
+            LEFT JOIN {{ this }} old ON old.address = aa.address AND old.token_mint_address = aa.token_mint_address
+            WHERE aa.token_mint_address is not null
+            AND old.address is null --don't include accounts we already have
+            {% if is_incremental() %}
+            AND {{incremental_predicate('aa.block_time')}}
+            {% endif %}
             group by 1,2
       )
       


### PR DESCRIPTION
Pushing a fix to make token_accounts incremental and change the refresh to match up with dex_solana.trades

# Thank you for contributing to Spellbook!
Please refer to the top of the `readme` in the root of Spellbook to learn how to contribute to Spellbook on DuneSQL.