### PR TITLE
Add Zora to OP Chains Macro

### DIFF
--- a/macros/public/all_op_chains.sql
+++ b/macros/public/all_op_chains.sql
@@ -1,3 +1,3 @@
 {% macro all_op_chains() %}
-   {{ return( ('optimism', 'base') ) }}
+   {{ return( ('optimism', 'base', 'zora') ) }}
 {% endmacro %}


### PR DESCRIPTION
Adds Zora to the OP Chains Macro - currently used for when a spell needs to loop through OP Chains (i.e. predeploys) 