### PR TITLE
init dex.raw_pools

### DIFF
--- a/models/dex/dex_raw_pools.sql
+++ b/models/dex/dex_raw_pools.sql
@@ -1,0 +1,99 @@
+{{ config(
+        schema='dex',
+        alias = 'raw_pools',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['blockchain', 'pool'],
+        post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "celo", "base", "goerli", "zksync", "zora"]\',
+                                "sector",
+                                "dex",
+                                \'["grkhr"]\') }}'
+        )
+}}
+
+
+
+-- FYI:
+-- -- about 20 pools on fantom missing because of broken creation_traces table
+-- -- some of the pools on zksync are missing because of broken creation_traces table (known issue, node problems)
+
+-- TODO: 
+-- -- implement mento pools on celo. it's only 11 of them, but implementation is not trivial, so for now we'll just skip them
+
+
+-- {topic0: params}
+{%
+    set config = {
+        '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9': {
+            'type': 'uniswap_compatible',
+            'version': 'v2',
+            'pool_position': 13,
+        },
+        '0xc4805696c66d7cf352fc1d6bb633ad5ee82f6cb577c453024b6e0eb8306c6fc9': {
+            'type': 'uniswap_compatible',
+            'version': 'v2',
+            'pool_position': 45,
+        },
+        '0x783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118': {
+            'type': 'uniswap_compatible',
+            'version': 'v3',
+            'pool_position': 45,
+        },
+    }
+%}
+
+
+
+with 
+
+
+pool_created_logs as (
+    {% for topic0, data in config.items() %}
+        select 
+            blockchain
+            , '{{ data['type'] }}' as type
+            , '{{ data['version'] }}' as version
+            , substr(data, {{ config[topic0]['pool_position'] }}, 20) as pool
+            , substr(topic1, 13) as token0
+            , substr(topic2, 13) as token1
+            , block_number
+            , block_time
+            , contract_address
+            , tx_hash
+        from {{ ref('evms_logs') }}
+        where topic0 = {{ topic0 }}
+        {% if not loop.last %}
+            union all
+        {% endif %}
+    {% endfor %}
+)
+
+
+, creation_traces as (
+    select
+        blockchain
+        , address as pool
+        , block_time
+        , block_number
+        , tx_hash
+    from {{ ref('evms_creation_traces') }}
+)
+
+
+select 
+    blockchain
+    , type
+    , version
+    , pool
+    , token0
+    , token1
+    , block_time as creation_block_time
+    , block_number as creation_block_number
+    , contract_address
+from pool_created_logs
+join creation_traces using(blockchain, tx_hash, block_number, block_time, pool)
+where blockchain not in ('goerli') -- skip test chains due to incorrect data
+{% if is_incremental() %}
+    and {{ incremental_predicate('block_time') }}
+{% endif %} 

--- a/models/dex/dex_schema.yml
+++ b/models/dex/dex_schema.yml
@@ -236,6 +236,34 @@ models:
       - name: contract_address
         description: "Contract address used to create the pool"
 
+  - name: dex_raw_pools
+    meta:
+      blockchain: ethereum, polygon, bnb, avalanche_c, gnosis, fantom, optimism, arbitrum, celo, base, goerli, zksync, zora
+      sector: dex
+      contributors: grkhr
+    config:
+      tags: ['dex', 'cross-chain', 'pools']
+    description: >
+      DEX raw pools on all chains across all contracts and versions parsed from logs
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - pool
+    columns:
+      - *blockchain
+      - &type
+        name: type
+        description: "Pool implementation standard"
+      - *version
+      - *pool
+      - *token0
+      - *token1
+      - *creation_block_time
+      - *creation_block_number
+      - *contract_address
+      
+
   - name: dex_offers
     meta:
       blockchain: optimism


### PR DESCRIPTION
this table will help us to cover all pools created, not only these covered from events from submitted factory contracts in `dex.pools`. for now there will be only uniswap-compatible pools. coverage is almost 100%, measured on 1inch used pools. 

e.g.: `dex.pools` on BNB has **2,585**, `dex.raw_pools` will cover **1,737,060**


FYI:
- about 20 pools on fantom missing because of broken creation_traces table
- some of the pools on zksync are missing because of broken creation_traces table (known issue, node problems)


NEXT STEP: 
- implement **mento** pools on `celo`. it's only 11 of them, but implementation is not trivial, so for now i'll just skip them
