### PR TITLE
[EASY]Add new join condition to correct `nft.mints` value 

### DIFF
--- a/models/_sector/nft/mints/native/nft_optimism_native_mints.sql
+++ b/models/_sector/nft/mints/native/nft_optimism_native_mints.sql
@@ -139,6 +139,7 @@ left join {{ ref('tokens_optimism_nft_bridged_mapping') }} as bm
 left join {{ ref('transfers_optimism_eth') }} as tr
     on nft_mints.tx_hash = tr.tx_hash
     and nft_mints.block_number = tr.tx_block_number
+    and tr."from" = nft_mints.to
     and tr.value_decimal > 0
 left join {{ source('prices','usd') }} as pu_eth
     on pu_eth.blockchain='optimism'


### PR DESCRIPTION
Fixing https://github.com/duneanalytics/spellbook/issues/4815

Looks like the discrepancy only exists for OP Mainnet, which is a bug that I introduced in `nft_optimism_native_mints`. See the fixed version with example `tx_hash` in this query: https://dune.com/queries/3205783

