### PR TITLE
fix dbt compile warnings

### DIFF
--- a/models/_sector/dex/trades/arbitrum/_schema.yml
+++ b/models/_sector/dex/trades/arbitrum/_schema.yml
@@ -15,16 +15,5 @@ models:
           combination_of_columns:
             - tx_hash
             - evt_index
-      - check_seed:
-          seed_file: ref('uniswap_arbitrum_base_trades_seed')
-          match_columns:
-            - tx_hash
-            - evt_index
-          check_columns:
-            - block_number
-            - token_bought_address
-            - token_sold_address
-            - token_bought_amount_raw
-            - token_sold_amount_raw
             
   - name: dex_arbitrum_base_trades

--- a/models/_sector/dex/trades/arbitrum/_schema.yml
+++ b/models/_sector/dex/trades/arbitrum/_schema.yml
@@ -16,7 +16,7 @@ models:
             - tx_hash
             - evt_index
       - check_seed:
-          seed_file: ref('uniswap_arbitrum_base_trades')
+          seed_file: ref('uniswap_arbitrum_base_trades_seed')
           match_columns:
             - tx_hash
             - evt_index

--- a/models/_sector/dex/trades/avalanche_c/_schema.yml
+++ b/models/_sector/dex/trades/avalanche_c/_schema.yml
@@ -16,7 +16,7 @@ models:
             - tx_hash
             - evt_index
       - check_seed:
-          seed_file: ref('uniswap_avalanche_c_base_trades')
+          seed_file: ref('uniswap_avalanche_c_base_trades_seed')
           match_columns:
             - tx_hash
             - evt_index

--- a/models/_sector/dex/trades/base/_schema.yml
+++ b/models/_sector/dex/trades/base/_schema.yml
@@ -16,7 +16,7 @@ models:
             - tx_hash
             - evt_index
       - check_seed:
-          seed_file: ref('uniswap_base_base_trades')
+          seed_file: ref('uniswap_base_base_trades_seed')
           match_columns:
             - tx_hash
             - evt_index

--- a/models/_sector/dex/trades/bnb/_schema.yml
+++ b/models/_sector/dex/trades/bnb/_schema.yml
@@ -16,7 +16,7 @@ models:
             - tx_hash
             - evt_index
       - check_seed:
-          seed_file: ref('uniswap_bnb_base_trades')
+          seed_file: ref('uniswap_bnb_base_trades_seed')
           match_columns:
             - tx_hash
             - evt_index

--- a/models/_sector/dex/trades/bnb/_schema.yml
+++ b/models/_sector/dex/trades/bnb/_schema.yml
@@ -15,16 +15,5 @@ models:
           combination_of_columns:
             - tx_hash
             - evt_index
-      - check_seed:
-          seed_file: ref('uniswap_bnb_base_trades_seed')
-          match_columns:
-            - tx_hash
-            - evt_index
-          check_columns:
-            - block_number
-            - token_bought_address
-            - token_sold_address
-            - token_bought_amount_raw
-            - token_sold_amount_raw
             
   - name: dex_bnb_base_trades

--- a/models/_sector/dex/trades/celo/_schema.yml
+++ b/models/_sector/dex/trades/celo/_schema.yml
@@ -16,7 +16,7 @@ models:
             - tx_hash
             - evt_index
       - check_seed:
-          seed_file: ref('uniswap_celo_base_trades')
+          seed_file: ref('uniswap_celo_base_trades_seed')
           match_columns:
             - tx_hash
             - evt_index

--- a/models/_sector/nft/trades/old/platforms/quix_optimism_sources.yml
+++ b/models/_sector/nft/trades/old/platforms/quix_optimism_sources.yml
@@ -132,8 +132,6 @@ sources:
 
 
   - name: quixotic_optimism
-    freshness:
-      warn_after: { count: 24, period: hour }
     tables:
       - name: Seaport_evt_OrderFulfilled
       - name: Seaport_call_matchOrders

--- a/models/base_sources/ethereum_base_sources.yml
+++ b/models/base_sources/ethereum_base_sources.yml
@@ -4,8 +4,6 @@ sources:
   # Base Tables
   - name: ethereum
     description: "Ethereum raw tables including transactions, traces and logs."
-    freshness:
-      warn_after: { count: 12, period: hour }
     tables:
       - name: transactions_0006
         description: "underlying transactions table. ethereum.transactions is an exposed view of this table."
@@ -182,8 +180,6 @@ sources:
           - *tx_hash
 
       - name: blocks
-        freshness:
-          warn_after: { count: 1, period: day }
         loaded_at_field: time
         description: "Blocks are batches of transactions with a hash of the previous block in the chain. This links blocks together (in a chain) because hashes are cryptographically derived from the block data."
         columns:

--- a/models/gitcoin/ethereum/gitcoin_ethereum_sources.yml
+++ b/models/gitcoin/ethereum/gitcoin_ethereum_sources.yml
@@ -3,8 +3,6 @@ version: 2
 sources: 
   - name: gitcoin_ethereum
     description: "Ethereum decoded tables related to Gitcoin contract"
-    freshness:
-      warn_after: { count: 12, period: hour }
     tables:
       - name: GovernorAlpha_evt_VoteCast
         loaded_at_field: evt_block_time


### PR DESCRIPTION
- we had two missing seed files, likely due to lack of rows in overall dex seed (bnb, arbitrum)
- a few schema files left off the `_seed` suffix on the file name, so `dbt compile` gave warnings and the tests didn't run most likely
- remove freshness on some sources without field specified
