### PR TITLE
Create macro for `nft.mints` and add `nft_base_native_mints`

### DIFF
--- a/macros/models/_sector/nft/nft_mints.sql
+++ b/macros/models/_sector/nft/nft_mints.sql
@@ -167,9 +167,9 @@ FROM
         WHERE 1=1
         {% endif %}
         AND nft_mints."from"= 0x0000000000000000000000000000000000000000
-        {% if blockchain == 'ethereum' %}
+        {%- if blockchain == 'ethereum' %}
         AND nft_mints.contract_address NOT IN (SELECT address FROM {{ ref('addresses_ethereum_defi') }})
-        {% endif %}
+        {%- endif -%}
         AND nft_mints.blockchain = '{{blockchain}}'
         {% if is_incremental() %}
         {{incremental_predicate('nft_mints.block_time')}}

--- a/macros/models/_sector/nft/nft_mints.sql
+++ b/macros/models/_sector/nft/nft_mints.sql
@@ -117,7 +117,7 @@ FROM
         , nft_mints.evt_index
         FROM {{ ref('nft_transfers') }} nft_mints
         LEFT JOIN nfts_per_tx nft_count ON nft_count.tx_hash=nft_mints.tx_hash
-        LEFT JOIN{{ base_traces }} et ON et.block_time=nft_mints.block_time
+        LEFT JOIN {{ base_traces }} et ON et.block_time=nft_mints.block_time
             AND et.tx_hash=nft_mints.tx_hash
             AND et."from"=nft_mints.to
             AND (et.call_type NOT IN ('delegatecall', 'callcode', 'staticcall') OR et.call_type IS NULL)
@@ -170,7 +170,7 @@ FROM
         {%- if blockchain == 'ethereum' %}
         AND nft_mints.contract_address NOT IN (SELECT address FROM {{ ref('addresses_ethereum_defi') }})
         {%- endif -%}
-        AND nft_mints.blockchain = '{{blockchain}}'
+         AND nft_mints.blockchain = '{{blockchain}}'
         {% if is_incremental() %}
         {{incremental_predicate('nft_mints.block_time')}}
         {% endif %}

--- a/macros/models/_sector/nft/nft_mints.sql
+++ b/macros/models/_sector/nft/nft_mints.sql
@@ -1,0 +1,185 @@
+{% macro nft_mints(blockchain, base_contracts, base_traces, erc20_transfer, base_transactions ) %}
+
+WITH namespaces AS (
+    SELECT 
+        address
+        , min_by(namespace, created_at) AS namespace
+	FROM {{ base_contracts }}
+	GROUP BY address
+	)
+
+, nfts_per_tx_tmp AS (
+    SELECT 
+        tx_hash
+        , sum(amount) AS nfts_minted_in_tx
+    FROM {{ ref('nft_transfers') }}
+    WHERE 
+        blockchain = '{{blockchain}}'
+        {% if is_incremental() %}
+        AND {{incremental_predicate('block_time')}}
+        {% endif %}
+    GROUP BY tx_hash
+    )
+
+, nfts_per_tx as (
+    SELECT
+        tx_hash
+        , case when nfts_minted_in_tx = UINT256 '0' THEN UINT256 '1' ELSE nfts_minted_in_tx END as nfts_minted_in_tx
+    FROM nfts_per_tx_tmp
+)
+SELECT
+    blockchain
+    , project
+    , version
+    , block_time
+    , block_date
+    , block_month
+    , block_number
+    , token_id
+    , collection
+    , token_standard
+    , trade_type
+    , number_of_items
+    , trade_category
+    , evt_type
+    , seller
+    , buyer
+    , amount_raw
+    , amount_original
+    , amount_usd
+    , currency_symbol
+    , currency_contract
+    , nft_contract_address
+    , project_contract_address
+    , aggregator_name
+    , aggregator_address
+    , tx_hash
+    , tx_from
+    , tx_to
+    , platform_fee_amount_raw
+    , platform_fee_amount
+    , platform_fee_amount_usd
+    , platform_fee_percentage
+    , royalty_fee_receive_address
+    , royalty_fee_currency_symbol
+    , royalty_fee_amount_raw
+    , royalty_fee_amount
+    , royalty_fee_amount_usd
+    , royalty_fee_percentage
+    , evt_index
+FROM
+(
+SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY tx_hash, evt_index, token_id, number_of_items ORDER BY amount_usd DESC NULLS LAST) as rank_index
+FROM
+    (
+        SELECT distinct '{{blockchain}}' AS blockchain
+        , COALESCE(ec.namespace, 'Unknown') AS project
+        , '' AS version
+        , nft_mints.block_time AS block_time
+        , CAST(date_trunc('day', nft_mints.block_time) as date) AS block_date
+        , CAST(date_trunc('month', nft_mints.block_time) as date) AS block_month
+        , nft_mints.block_number AS block_number
+        , nft_mints.token_id AS token_id
+        , tok.name AS collection
+        , nft_mints.token_standard
+        , CASE WHEN nft_mints.amount= UINT256 '1' THEN 'Single Item Mint'
+            ELSE 'Bundle Mint'
+            END AS trade_type
+        , nft_mints.amount AS number_of_items
+        , 'Mint' AS trade_category
+        , 'Mint' AS evt_type
+        , nft_mints."from" AS seller
+        , nft_mints.to AS buyer
+        , CAST(COALESCE(SUM(CAST(et.value as DOUBLE)), SUM(CAST(erc20s.value as DOUBLE)), 0)*(nft_mints.amount/nft_count.nfts_minted_in_tx) AS UINT256) AS amount_raw
+        , COALESCE(SUM(CAST(et.value as DOUBLE))/POWER(10, 18), SUM(CAST(erc20s.value as DOUBLE))/POWER(10, pu_erc20s.decimals))*(nft_mints.amount/nft_count.nfts_minted_in_tx) AS amount_original
+        , COALESCE(pu_eth.price*SUM(CAST(et.value as DOUBLE))/POWER(10, 18), pu_erc20s.price*SUM(CAST(erc20s.value as DOUBLE))/POWER(10, pu_erc20s.decimals))*(nft_mints.amount/nft_count.nfts_minted_in_tx) AS amount_usd
+        , CASE WHEN et.success THEN 'ETH' ELSE pu_erc20s.symbol END AS currency_symbol
+        , CASE WHEN et.success THEN 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 ELSE erc20s.contract_address END AS currency_contract
+        , nft_mints.contract_address AS nft_contract_address
+        , etxs.to AS project_contract_address
+        , agg.name AS aggregator_name
+        , agg.contract_address AS aggregator_address
+        , nft_mints.tx_hash AS tx_hash
+        , etxs."from" AS tx_from
+        , etxs.to AS tx_to
+        , UINT256 '0' AS platform_fee_amount_raw
+        , DOUBLE '0' AS platform_fee_amount
+        , DOUBLE '0' AS platform_fee_amount_usd
+        , DOUBLE '0' AS platform_fee_percentage
+        , CAST(NULL as VARBINARY) AS royalty_fee_receive_address
+        , '0' AS royalty_fee_currency_symbol
+        , UINT256 '0' AS royalty_fee_amount_raw
+        , DOUBLE '0' AS royalty_fee_amount
+        , DOUBLE '0' AS royalty_fee_amount_usd
+        , DOUBLE '0' AS royalty_fee_percentage
+        , nft_mints.evt_index
+        FROM {{ ref('nft_transfers') }} nft_mints
+        LEFT JOIN nfts_per_tx nft_count ON nft_count.tx_hash=nft_mints.tx_hash
+        LEFT JOIN{{ base_traces }} et ON et.block_time=nft_mints.block_time
+            AND et.tx_hash=nft_mints.tx_hash
+            AND et."from"=nft_mints.to
+            AND (et.call_type NOT IN ('delegatecall', 'callcode', 'staticcall') OR et.call_type IS NULL)
+            AND et.success
+            AND CAST(et.value as DOUBLE) > 0
+            {% if is_incremental() %}
+            AND {{incremental_predicate('et.block_time')}}
+            {% endif %}
+        LEFT JOIN {{ source('prices','usd') }} pu_eth 
+            ON pu_eth.blockchain IS NULL
+            AND pu_eth.minute=date_trunc('minute', et.block_time)
+            AND pu_eth.symbol = 'ETH'
+            {% if is_incremental() %}
+            AND {{incremental_predicate('pu_eth.minute')}}
+            {% endif %}
+        LEFT JOIN {{ erc20_transfer }} erc20s ON erc20s.evt_block_time=nft_mints.block_time
+            AND erc20s."from"=nft_mints.to
+            AND erc20s.evt_tx_hash = nft_mints.tx_hash
+            AND (et.value IS NULL OR CAST(et.value as double) = 0)
+            {% if is_incremental() %}
+            AND {{incremental_predicate('erc20s.evt_block_time')}}
+            {% endif %}
+        LEFT JOIN {{ source('prices','usd') }} pu_erc20s ON pu_erc20s.blockchain='{{blockchain}}'
+            AND pu_erc20s.minute=date_trunc('minute', erc20s.evt_block_time)
+            AND erc20s.contract_address=pu_erc20s.contract_address
+            {% if is_incremental() %}
+            AND {{incremental_predicate('pu_erc20s.minute')}}
+            {% endif %}
+        LEFT JOIN {{ base_transactions }} etxs ON etxs.block_time=nft_mints.block_time
+            AND etxs.hash=nft_mints.tx_hash
+            {% if is_incremental() %}
+            AND {{incremental_predicate('etxs.block_time')}}
+            {% endif %}
+        LEFT JOIN {{ ref('nft_aggregators') }} agg 
+            ON etxs.to=agg.contract_address
+            AND agg.blockchain = '{{blockchain}}'
+        LEFT JOIN {{ ref('tokens_nft') }} tok 
+            ON tok.contract_address=nft_mints.contract_address
+            and tok.blockchain = '{{blockchain}}'
+        LEFT JOIN namespaces ec ON etxs.to=ec.address
+        {% if is_incremental() %}
+        LEFT JOIN {{this}} anti_txs 
+            ON anti_txs.block_time=nft_mints.block_time
+            AND anti_txs.tx_hash=nft_mints.tx_hash
+        WHERE anti_txs.tx_hash IS NULL
+        {% else %}
+        WHERE 1=1
+        {% endif %}
+        AND nft_mints."from"= 0x0000000000000000000000000000000000000000
+        {% if blockchain == 'ethereum' %}
+        AND nft_mints.contract_address NOT IN (SELECT address FROM {{ ref('addresses_ethereum_defi') }})
+        {% endif %}
+        AND nft_mints.blockchain = '{{blockchain}}'
+        {% if is_incremental() %}
+        {{incremental_predicate('nft_mints.block_time')}}
+        {% endif %}
+        GROUP BY nft_mints.block_time, nft_mints.block_number, nft_mints.token_id, nft_mints.token_standard
+        , nft_mints.amount, nft_mints."from", nft_mints.to, nft_mints.contract_address, etxs.to, nft_mints.evt_index
+        , nft_mints.tx_hash, etxs."from", ec.namespace, tok.name, pu_erc20s.decimals, pu_eth.price, pu_erc20s.price
+        , agg.name, agg.contract_address, nft_count.nfts_minted_in_tx, pu_erc20s.symbol, erc20s.contract_address, et.success
+    ) tmp
+) tmp_2
+WHERE rank_index = 1
+
+{% endmacro %}

--- a/macros/models/_sector/nft/nft_mints.sql
+++ b/macros/models/_sector/nft/nft_mints.sql
@@ -167,10 +167,10 @@ FROM
         WHERE 1=1
         {% endif %}
         AND nft_mints."from"= 0x0000000000000000000000000000000000000000
+        AND nft_mints.blockchain = '{{blockchain}}'
         {%- if blockchain == 'ethereum' %}
         AND nft_mints.contract_address NOT IN (SELECT address FROM {{ ref('addresses_ethereum_defi') }})
         {%- endif -%}
-         AND nft_mints.blockchain = '{{blockchain}}'
         {% if is_incremental() %}
         {{incremental_predicate('nft_mints.block_time')}}
         {% endif %}

--- a/models/_sector/nft/mints/native/_schema.yml
+++ b/models/_sector/nft/mints/native/_schema.yml
@@ -52,7 +52,30 @@ models:
       sector: nft
       contributors: chuxin
     config:
-      tags: [ 'nft','ethereum' ]
+      tags: [ 'nft','optimism' ]
+    description: >
+      NFT native (i.e., non-platform) mints
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - evt_index
+            - token_id
+            - number_of_items
+    columns:
+      - *tx_hash
+      - *evt_index
+      - *token_id
+      - *number_of_items
+      - *amount_usd
+      
+  - name: nft_base_native_mints
+    meta:
+      blockchain: base
+      sector: nft
+      contributors: chuxin
+    config:
+      tags: [ 'nft','base' ]
     description: >
       NFT native (i.e., non-platform) mints
     tests:

--- a/models/_sector/nft/mints/native/nft_base_native_mints.sql
+++ b/models/_sector/nft/mints/native/nft_base_native_mints.sql
@@ -1,0 +1,20 @@
+{{ config(
+        
+        schema = 'nft_base',
+        alias = 'native_mints',
+        partition_by = ['block_month'],
+		file_format = 'delta',
+		incremental_strategy = 'merge',
+        unique_key = ['tx_hash','evt_index','token_id','number_of_items']
+        )
+}}
+
+{% macro nft_mints(blockchain, base_contracts, base_traces, eth_address, erc20_transfer, base_transactions ) %}
+
+{{nft_mints(
+    blockchain='base'
+    , base_contracts = source('base','contracts')
+    , base_traces = source('base','traces')
+    , erc20_transfer = source('erc20_base','evt_Transfer')
+    , base_transactions = source('base','transactions')
+)}}

--- a/models/_sector/nft/mints/native/nft_base_native_mints.sql
+++ b/models/_sector/nft/mints/native/nft_base_native_mints.sql
@@ -13,6 +13,6 @@
     blockchain='base'
     , base_contracts = source('base','contracts')
     , base_traces = source('base','traces')
-    , erc20_transfer = source('erc20_base','evt_Transfer')
+    , erc20_transfer = source('erc20_base','evt_transfer')
     , base_transactions = source('base','transactions')
 )}}

--- a/models/_sector/nft/mints/native/nft_base_native_mints.sql
+++ b/models/_sector/nft/mints/native/nft_base_native_mints.sql
@@ -9,8 +9,6 @@
         )
 }}
 
-{% macro nft_mints(blockchain, base_contracts, base_traces, eth_address, erc20_transfer, base_transactions ) %}
-
 {{nft_mints(
     blockchain='base'
     , base_contracts = source('base','contracts')

--- a/models/_sector/nft/mints/nft_mints.sql
+++ b/models/_sector/nft/mints/nft_mints.sql
@@ -17,6 +17,7 @@
 {% set native_mints = [
  ref('nft_ethereum_native_mints')
 ,ref('nft_optimism_native_mints')
+,ref('nft_base_native_mints')
 ] %}
 
 


### PR DESCRIPTION
## Description
Create a macro for `nft.mints`, specifically `nft_native_mints` (let me know if we should change the macro name to `nft_native_mints` instead.

Would like to get this one PR reviewed and merged before touching existing queries for `nft_native_mints`