### PR TITLE
CI workflow: clean up dbt compile warnings and apply forced error

### DIFF
--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Activate DuneSQL Cluster
         run: "./scripts/ensure_cluster.sh"
 
-      - name: dbt compile to create manifest to compare to, fail on warnings to help clean prior to merge
+      - name: dbt compile to create manifest to compare to
         run: "dbt --warn-error compile $PROFILE"
 
       - name: check schemas

--- a/.github/workflows/dbt_slim_ci.yml
+++ b/.github/workflows/dbt_slim_ci.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Activate DuneSQL Cluster
         run: "./scripts/ensure_cluster.sh"
 
-      - name: dbt compile to create manifest to compare to
-        run: "dbt compile $PROFILE"
+      - name: dbt compile to create manifest to compare to, fail on warnings to help clean prior to merge
+        run: "dbt --warn-error compile $PROFILE"
 
       - name: check schemas
         run: |

--- a/models/_sector/dex/trades/_schema.yml
+++ b/models/_sector/dex/trades/_schema.yml
@@ -1,7 +1,7 @@
 version: 2
 
 models:
-  - name: dex_trades_beta_
+  - name: dex_trades_beta
     meta:
       blockchain: arbitrum, base, bnb, celo, ethereum, optimism, polygon
       sector: dex

--- a/models/_sector/dex/trades/_schema.yml
+++ b/models/_sector/dex/trades/_schema.yml
@@ -1,7 +1,7 @@
 version: 2
 
 models:
-  - name: dex_trades_beta
+  - name: dex_trades_beta_
     meta:
       blockchain: arbitrum, base, bnb, celo, ethereum, optimism, polygon
       sector: dex

--- a/models/addresses/ethereum/addresses_ethereum_schema.yml
+++ b/models/addresses/ethereum/addresses_ethereum_schema.yml
@@ -1,23 +1,6 @@
 version: 2
 
 models:
-  - name: addresses_ethereum_bridges
-    meta:
-      blockchain: ethereum
-      sector: bridges
-      project: addresses
-      contributors: hildobby
-    config:
-      tags: ['table', 'bridges', 'addresses', 'ethereum']
-    description: "Known bridge addresses"
-    columns:
-      - name: address
-        description: "Address of known Bridges"
-      - name: bridge_name
-        description: "Name of protocol behind the bridge"
-      - name: description
-        description: "Description of the bridge"
-
   - name: addresses_ethereum_ofac_sanctioned
     meta:
       blockchain: ethereum

--- a/models/base_sources/ethereum_base_sources.yml
+++ b/models/base_sources/ethereum_base_sources.yml
@@ -7,10 +7,16 @@ sources:
     tables:
       - name: transactions_0006
         description: "underlying transactions table. ethereum.transactions is an exposed view of this table."
+        freshness:
+          warn_after: { count: 12, period: hour }
+          error_after: { count: 24, period: hour }
         loaded_at_field: block_time
       - name: transactions
-        loaded_at_field: block_time
         description: "An Ethereum transaction refers to an action initiated by an externally-owned account (i.e., an account managed by a human, not a contract)."
+        freshness:
+          warn_after: { count: 12, period: hour }
+          error_after: { count: 24, period: hour }
+        loaded_at_field: block_time
         columns:
           - &block_date
             name: block_date
@@ -65,8 +71,11 @@ sources:
             description: "Specifies a list of addresses and storage keys"
 
       - name: traces
-        loaded_at_field: block_time
         description: "An Ethereum trace is a small atomic action that modify the internal state of the Ethereum Virtual Machine. The three main trace types are call, create, and suicide."
+        freshness:
+          warn_after: { count: 12, period: hour }
+          error_after: { count: 24, period: hour }
+        loaded_at_field: block_time
         columns:
           - *block_date
           - *block_time
@@ -113,8 +122,11 @@ sources:
             description: "Refund Address"
 
       - name: traces_decoded
-        loaded_at_field: block_time
         description: "An Ethereum trace is a small atomic action that modify the internal state of the Ethereum Virtual Machine. The three main trace types are call, create, and suicide. Decoded traces include additional information based on submitted smart contracts and their ABI"
+        freshness:
+          warn_after: { count: 12, period: hour }
+          error_after: { count: 24, period: hour }
+        loaded_at_field: block_time
         columns:
           - *block_date
           - *block_time
@@ -134,8 +146,11 @@ sources:
           - *tx_hash
 
       - name: logs
-        loaded_at_field: block_time
         description: "An Ethereum log can be used to describe an event within a smart contract, like a token transfer or a change of ownership."
+        freshness:
+          warn_after: { count: 12, period: hour }
+          error_after: { count: 24, period: hour }
+        loaded_at_field: block_time
         columns:
           - *block_date
           - *block_time
@@ -159,8 +174,11 @@ sources:
           - *tx_index
 
       - name: logs_decoded
-        loaded_at_field: block_time
         description: "An Ethereum log can be used to describe an event within a smart contract, like a token transfer or a change of ownership. Those logs are decoded based on submitted smart contracts to make them human readable."
+        freshness:
+          warn_after: { count: 12, period: hour }
+          error_after: { count: 24, period: hour }
+        loaded_at_field: block_time
         columns:
           - *block_date
           - *block_time
@@ -180,8 +198,11 @@ sources:
           - *tx_hash
 
       - name: blocks
-        loaded_at_field: time
         description: "Blocks are batches of transactions with a hash of the previous block in the chain. This links blocks together (in a chain) because hashes are cryptographically derived from the block data."
+        freshness:
+          warn_after: { count: 12, period: hour }
+          error_after: { count: 24, period: hour }
+        loaded_at_field: block_time
         columns:
           - name: base_fee_per_gas
           - name: difficulty
@@ -197,11 +218,11 @@ sources:
           - name: total_difficulty
 
       - name: contracts
-        freshness:
-          warn_after: { count: 1, period: day }
-          error_after: { count: 3, period: day }
-        loaded_at_field: created_at
         description: "A view keeping track of what contracts are decoded on Dune on Ethereum; contains information associated with the decoded contract such as namespace, name, address, ABI."
+        freshness:
+          warn_after: { count: 12, period: hour }
+          error_after: { count: 24, period: hour }
+        loaded_at_field: block_time
         columns:
           - name: abi
             description: "ABI of the decoded contract"
@@ -230,8 +251,11 @@ sources:
             description: "Timestamp for contract creation"
           
       - name: creation_traces
-        loaded_at_field: block_time
         description: "Ethereum creation traces"
+        freshness:
+          warn_after: { count: 12, period: hour }
+          error_after: { count: 24, period: hour }
+        loaded_at_field: block_time
         columns:
           - *block_time
           - *block_number
@@ -242,6 +266,13 @@ sources:
             description: "Contract creator address"
           - name: code
             description: "Contract code"
+
+      - name: withdrawals
+        description: "Ethereum withdrawals"
+        freshness:
+          warn_after: { count: 12, period: hour }
+          error_after: { count: 24, period: hour }
+        loaded_at_field: block_time
 
   # ERC Transfer Tables
   - name: erc20_ethereum

--- a/models/lido/accounting/ethereum/lido_accounting_ethereum_sources.yml
+++ b/models/lido/accounting/ethereum/lido_accounting_ethereum_sources.yml
@@ -22,10 +22,4 @@ sources:
       - name: steth_evt_ELRewardsReceived
       - name: steth_evt_WithdrawalsReceived
       - name: WithdrawalQueueERC721_evt_WithdrawalsFinalized
-  - name: ethereum
-    freshness: # default freshness
-      warn_after: { count: 1, period: day }
-      error_after: { count: 7, period: day }
-    tables:
-      - name: withdrawals   
       


### PR DESCRIPTION
since we've upgraded dbt version, we've seen more warnings during `dbt compile`. they are easy to overlook in CI workflow, then appear in prod / local setups after merge into main branch. we then have to retroactively clean up those warnings. this change is intended to force failure in gh workflow, so users are aware to fix prior to merge.