### PR TITLE
Fix for balancer_v1_ethereum_liquidity.sql

### DIFF
--- a/models/balancer/ethereum/balancer_v1_ethereum_liquidity.sql
+++ b/models/balancer/ethereum/balancer_v1_ethereum_liquidity.sql
@@ -33,7 +33,7 @@ prices AS (
         AND minute >= date_trunc('day', now() - interval '7' day)
         {% endif %}
         GROUP BY 1, 2, 3
-    )
+    ),
 
     cumulative_balance AS (
         SELECT


### PR DESCRIPTION
This PR removes dex.prices from the calculation of liquidity for balancer V1 pools on Ethereum.
This change is necessary because dex.prices was causing distortions, as shown in this [query](https://dune.com/queries/3234538) and removing it has a minimal impact on TVL calculations.
@mendesfabio @thetroyharris 