### PR TITLE
Contracts - Fix Incremental Predicate

### DIFF
--- a/macros/models/_sector/contracts/contracts_base_iterated_creators.sql
+++ b/macros/models/_sector/contracts/contracts_base_iterated_creators.sql
@@ -88,7 +88,6 @@ WITH deterministic_deployers AS (
           1=1
           {% if is_incremental() %}
           AND {{ incremental_predicate('s.created_time') }}
-          AND {{ incremental_predicate('s.created_month') }}
           {% endif %}
     )
 


### PR DESCRIPTION
The incremental predicate in `base_iterated_creators` applied to `created_month` which caused all contracts (unless added on the first of the month) to not be added in the incremental build.

This removes that, and only applied the incremental predicate to `created_time`.