### PR TITLE
Fix broken link in contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Welcome to [Spellbook](https://youtu.be/o7p0BNt7NHs). Cast a magical incantation
 - Don't know where to start? The docs below will guide you, but as a summary:
   - Want to make an incremental improvement to one of our spells? (add a new project, fix a bug you found), simply open a PR with your changes. 
     - Follow the guide for [Submitting a PR](), [Setting up your dev environment]() and [Using dbt to write spells]() if you find yourself lost.
-    - Not sure how to start? Follow the walkthrough [here](https://dune.com/docs/data-tables/spellbook/contributing/).
+    - Not sure how to start? Follow the walkthrough [here](https://dune.com/docs/spellbook/).
     - Make sure to open a draft PR if you will work on your spell for longer than a few days, to avoid duplicated work
   - Do you want to get started building spells and you don't know what to build? Check [Issues]() to see what the community needs.
   - Check the Discussions section to see what problems the community is trying to solve (i.e. non-incremental changes) or propose your own!


### PR DESCRIPTION
Hello,

### Description
This change is made to ensure that contributors can access the correct documentation.

### Changes Made
This pull request fixes a broken link in the Dune documentation's contribution guide.

### Why
Current link(404 - Not found):
https://dune.com/docs/data-tables/spellbook/contributing/#7-steps-to-adding-a-spell

Correct link:
[Spellbook Contribution Guide](https://dune.com/docs/spellbook/)

### Testing Done
Manually reviewed the documentation and verified the correct link.

Thank you.



# Thank you for contributing to Spellbook!
Please refer to the top of the `readme` in the root of Spellbook to learn how to contribute to Spellbook on DuneSQL.