### PR TITLE
Adds missing contract to labels_balancer_v2_pools_gnosis.sql

### DIFF
--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_gnosis.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_gnosis.sql
@@ -40,6 +40,27 @@ WITH pools AS (
 
   UNION ALL
 
+    SELECT
+      c.poolId AS pool_id,
+      t.tokens,
+      w.weights,
+      cc.symbol,
+      'WP' AS pool_type
+    FROM {{ source('balancer_v2_gnosis', 'Vault_evt_PoolRegistered') }} c
+    INNER JOIN {{ source('balancer_v2_gnosis', 'WeightedPoolV4Factory_call_create') }} cc
+      ON c.evt_tx_hash = cc.call_tx_hash
+      AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
+    CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
+    CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
+    WHERE t.pos = w.pos
+    {% if is_incremental() %}
+      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
+      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+  ) zip
+
+  UNION ALL
+
   SELECT
     c.poolId AS pool_id,
     t.tokens,


### PR DESCRIPTION
This PR adds the WeightedPoolv4Factory contract to balancer pools on gnosis.

@mendesfabio @thetroyharris 

# Thank you for contributing to Spellbook!
Please refer to the top of the `readme` in the root of Spellbook to learn how to contribute to Spellbook on DuneSQL.