### PR TITLE
Refactor OP chains table

### DIFF
--- a/models/evms/evms_info.sql
+++ b/models/evms/evms_info.sql
@@ -33,5 +33,4 @@ FROM (VALUES
         , (420, 'optimism_goerli', 'Optimism Goerli', 'Testnet', 'Optimistic Rollup', 'GTH', 0x4200000000000000000000000000000000000006, 'https://optimism-goerli.blockscout.com/', timestamp '2022-06-09 16:55', 'OP Stack', 'goerli')
         , (1313161554, 'aurora', 'Aurora', 'Layer 2', NULL, 'ETH', 0xC9BdeEd33CD01541e1eeD10f90519d2C06Fe3feB, 'https://explorer.aurora.dev/', timestamp '2020-07-21 21:50:11', NULL, NULL)
         , (8217, 'klaytn', 'Klaytn', 'Layer 1', NULL, 'KLAY', 0xe4f05a66ec68b54a58b17c22107b02e0232cc817, 'https://scope.klaytn.com/', timestamp '2019-06-25 13:41:14', NULL, NULL)
-
         ) AS temp_table (chain_id, blockchain, name, chain_type, rollup_type, native_token_symbol, wrapped_native_token_address, explorer_link, first_block_time, codebase, data_availability)

--- a/models/evms/evms_info.sql
+++ b/models/evms/evms_info.sql
@@ -34,8 +34,4 @@ FROM (VALUES
         , (1313161554, 'aurora', 'Aurora', 'Layer 2', NULL, 'ETH', 0xC9BdeEd33CD01541e1eeD10f90519d2C06Fe3feB, 'https://explorer.aurora.dev/', timestamp '2020-07-21 21:50:11', NULL, NULL)
         , (8217, 'klaytn', 'Klaytn', 'Layer 1', NULL, 'KLAY', 0xe4f05a66ec68b54a58b17c22107b02e0232cc817, 'https://scope.klaytn.com/', timestamp '2019-06-25 13:41:14', NULL, NULL)
 
-        , (34443, 'mode', 'Mode', 'Layer 2', 'Optimistic Rollup', 'ETH', 0x4200000000000000000000000000000000000006, 'https://explorer.mode.network/', timestamp '2023-11-16 20:46:23', 'OP Stack', 'ethereum')
-        , (291, 'orderly', 'Orderly Mainnet', 'Layer 2', 'Optimistic Rollup', 'ETH', 0x4200000000000000000000000000000000000006, 'https://explorer.orderly.network/', timestamp '2023-10-06 16:03:49', 'OP Stack', 'ethereum')
-        , (957, 'lyra', 'Lyra', 'Layer 2', 'Optimistic Rollup', 'ETH', 0x4200000000000000000000000000000000000006, 'https://explorer.lyra.finance/', timestamp NULL, 'OP Stack', 'ethereum')
-
         ) AS temp_table (chain_id, blockchain, name, chain_type, rollup_type, native_token_symbol, wrapped_native_token_address, explorer_link, first_block_time, codebase, data_availability)

--- a/models/evms/evms_info.sql
+++ b/models/evms/evms_info.sql
@@ -33,4 +33,9 @@ FROM (VALUES
         , (420, 'optimism_goerli', 'Optimism Goerli', 'Testnet', 'Optimistic Rollup', 'GTH', 0x4200000000000000000000000000000000000006, 'https://optimism-goerli.blockscout.com/', timestamp '2022-06-09 16:55', 'OP Stack', 'goerli')
         , (1313161554, 'aurora', 'Aurora', 'Layer 2', NULL, 'ETH', 0xC9BdeEd33CD01541e1eeD10f90519d2C06Fe3feB, 'https://explorer.aurora.dev/', timestamp '2020-07-21 21:50:11', NULL, NULL)
         , (8217, 'klaytn', 'Klaytn', 'Layer 1', NULL, 'KLAY', 0xe4f05a66ec68b54a58b17c22107b02e0232cc817, 'https://scope.klaytn.com/', timestamp '2019-06-25 13:41:14', NULL, NULL)
+
+        , (34443, 'mode', 'Mode', 'Layer 2', 'Optimistic Rollup', 'ETH', 0x4200000000000000000000000000000000000006, 'https://explorer.mode.network/', timestamp '2023-11-16 20:46:23', 'OP Stack', 'ethereum')
+        , (291, 'orderly', 'Orderly Mainnet', 'Layer 2', 'Optimistic Rollup', 'ETH', 0x4200000000000000000000000000000000000006, 'https://explorer.orderly.network/', timestamp '2023-10-06 16:03:49', 'OP Stack', 'ethereum')
+        , (957, 'lyra', 'Lyra', 'Layer 2', 'Optimistic Rollup', 'ETH', 0x4200000000000000000000000000000000000006, 'https://explorer.lyra.finance/', timestamp NULL, 'OP Stack', 'ethereum')
+
         ) AS temp_table (chain_id, blockchain, name, chain_type, rollup_type, native_token_symbol, wrapped_native_token_address, explorer_link, first_block_time, codebase, data_availability)

--- a/models/op/op_chains/op_chains_optimism_chain_list.sql
+++ b/models/op/op_chains/op_chains_optimism_chain_list.sql
@@ -2,23 +2,31 @@
      schema = 'op_chains'
         , alias = 'chain_list'
         , unique_key = ['blockchain', 'chain_id']
-        , post_hook='{{ expose_spells(\'["optimism"]\',
+        , post_hook='{{ expose_spells(\'["optimism","base","zora"]\',
                                   "project",
                                   "op_chains",
                                   \'["msilb7"]\') }}'
   )
 }}
 
+{% set op_chains = all_op_chains() %} --macro: all_op_chains.sql
+
+WITH chain_names AS (
+        {% for chain in op_chains %}
+                SELECT chain AS chain_dune_name -- name of the chain's dune database
+        {% if not loop.last %}
+                UNION ALL
+        {% endif %}
+        {% endfor %}
+)
+
 SELECT 
-        lower(blockchain) AS blockchain,
-        blockchain_name,
+        blockchain,
+        name as blockchain_name,
         chain_id,
-        cast(start_date AS date) AS start_date,
-        is_superchain
+        cast(first_block_time AS date) AS start_date,
+        1 as is_superchain
 
-FROM(values
-
-         ('optimism',   'Optimism Mainnet', 10, '2021-06-23',   1)
-        ,('base',       'Base Mainnet',     NULL,   NULL,       1)
-
-) op (blockchain, blockchain_name, chain_id, start_date, is_superchain)
+FROM chain_names c
+        LEFT JOIN {{ ref('evms_info') }} i 
+                ON i.blockchain = c.chain_dune_name

--- a/models/op/op_chains/op_chains_optimism_chain_list.sql
+++ b/models/op/op_chains/op_chains_optimism_chain_list.sql
@@ -14,7 +14,7 @@
 WITH chain_names AS (
         {% for chain in op_chains %}
                 SELECT
-                        chain AS chain_dune_name -- name of the chain's dune database
+                        '{{chain}}' AS chain_dune_name -- name of the chain's dune database
                         , 1 as is_superchain --op chains macro should only contain superchain chains (forks would be a different macro)
         {% if not loop.last %}
                 UNION ALL

--- a/models/op/op_chains/op_chains_optimism_chain_list.sql
+++ b/models/op/op_chains/op_chains_optimism_chain_list.sql
@@ -23,9 +23,9 @@ WITH chain_names AS (
 )
 
 SELECT 
-        i.blockchain,
-        i.name as blockchain_name,
-        i.chain_id,
+        c.chain_dune_name as blockchain,
+        cast(i.name as varchar) as blockchain_name,
+        cast(i.chain_id as int) AS chain_id,
         cast(i.first_block_time AS date) AS start_date,
         c.is_superchain
 

--- a/models/op/op_chains/op_chains_optimism_chain_list.sql
+++ b/models/op/op_chains/op_chains_optimism_chain_list.sql
@@ -13,7 +13,9 @@
 
 WITH chain_names AS (
         {% for chain in op_chains %}
-                SELECT chain AS chain_dune_name -- name of the chain's dune database
+                SELECT
+                        chain AS chain_dune_name -- name of the chain's dune database
+                        , 1 as is_superchain --op chains macro should only contain superchain chains (forks would be a different macro)
         {% if not loop.last %}
                 UNION ALL
         {% endif %}
@@ -21,11 +23,11 @@ WITH chain_names AS (
 )
 
 SELECT 
-        blockchain,
-        name as blockchain_name,
-        chain_id,
-        cast(first_block_time AS date) AS start_date,
-        1 as is_superchain
+        i.blockchain,
+        i.name as blockchain_name,
+        i.chain_id,
+        cast(i.first_block_time AS date) AS start_date,
+        c.is_superchain
 
 FROM chain_names c
         LEFT JOIN {{ ref('evms_info') }} i 


### PR DESCRIPTION
Refactors the OP Chains table to read from the `op_chains` macro and `evms.info` tables, so that we don't have to duplicate metadata in multiple places.