### PR TITLE
`contracts_ethereum_base_iterated_creators` add exclude tag in prod

### DIFF
--- a/models/_sector/contracts/ethereum/contracts_ethereum_base_iterated_creators.sql
+++ b/models/_sector/contracts/ethereum/contracts_ethereum_base_iterated_creators.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_ethereum',
         alias = 'base_iterated_creators',
         materialized ='incremental',


### PR DESCRIPTION
this model is failing due to duplicates.
- run `dbt compile` to build query
- put query into dune app
- wrap in CTE
- write group by / having on unique keys to find dupes
- fix logic and submit PR to remove tag / fixes

fyi @MSilb7