### PR TITLE
Update OP Block Explorer Link

### DIFF
--- a/macros/public/get_chain_explorer.sql
+++ b/macros/public/get_chain_explorer.sql
@@ -5,7 +5,7 @@
    SELECT
       case 
          when 'ethereum' = chain_ then 'https://etherscan.io'
-         when 'optimism' = chain_ then 'https://optimistic.etherscan.io'
+         when 'optimism' = chain_ then 'https://explorer.optimism.io'
          when 'polygon' = chain_ then 'https://polygonscan.com'
          when 'arbitrum' = chain_ then 'https://arbiscan.io'
          when 'avalanche_c' = chain_ then 'https://snowtrace.io'

--- a/macros/public/get_chain_explorer_address.sql
+++ b/macros/public/get_chain_explorer_address.sql
@@ -5,7 +5,7 @@
    SELECT
       case 
          when 'ethereum' = chain_ then 'https://etherscan.io/address/' || CAST(column_ AS VARCHAR)
-         when 'optimism' = chain_ then 'https://optimistic.etherscan.io/address/' || CAST(column_ AS VARCHAR)
+         when 'optimism' = chain_ then 'https://explorer.optimism.io/address/' || CAST(column_ AS VARCHAR)
          when 'polygon' = chain_ then 'https://polygonscan.com/address/' || CAST(column_ AS VARCHAR)
          when 'arbitrum' = chain_ then 'https://arbiscan.io/address/' || CAST(column_ AS VARCHAR)
          when 'avalanche_c' = chain_ then 'https://snowtrace.io/address/' || CAST(column_ AS VARCHAR)

--- a/macros/public/get_chain_explorer_tx_hash.sql
+++ b/macros/public/get_chain_explorer_tx_hash.sql
@@ -5,7 +5,7 @@
    SELECT
       case 
          when 'ethereum' = chain_ then 'https://etherscan.io/tx/' || CAST(hash_ AS VARCHAR)
-         when 'optimism' = chain_ then 'https://optimistic.etherscan.io/tx/' || CAST(hash_ AS VARCHAR)
+         when 'optimism' = chain_ then 'https://explorer.optimism.io/tx/' || CAST(hash_ AS VARCHAR)
          when 'polygon' = chain_ then 'https://polygonscan.com/tx/' || CAST(hash_ AS VARCHAR)
          when 'arbitrum' = chain_ then 'https://arbiscan.io/tx/' || CAST(hash_ AS VARCHAR)
          when 'avalanche_c' = chain_ then 'https://snowtrace.io/tx/' || CAST(hash_ AS VARCHAR)

--- a/models/evms/evms_info.sql
+++ b/models/evms/evms_info.sql
@@ -12,7 +12,7 @@ FROM (VALUES
         (1, 'ethereum', 'Ethereum', 'Layer 1', NULL, 'ETH', 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, 'https://etherscan.io/', timestamp '2015-07-30 15:26', NULL, NULL)
         , (43114, 'avalanche_c', 'Avalanche C-Chain', 'Layer 1', NULL, 'AVAX', 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7, 'https://snowtrace.io/', timestamp '2020-09-23 11:02', NULL, NULL)
         , (42161, 'arbitrum', 'Arbitrum One', 'Layer 2', 'Optimistic Rollup', 'ETH', 0x82af49447d8a07e3bd95bd0d56f35241523fbab1, 'https://arbiscan.io/', timestamp '2021-05-29 00:35', 'Arbitrum', 'ethereum')
-        , (10, 'optimism', 'OP Mainnet', 'Layer 2', 'Optimistic Rollup', 'ETH', 0x4200000000000000000000000000000000000006, 'https://optimistic.etherscan.io/', timestamp '2021-11-11 21:16', 'OP Stack', 'ethereum')
+        , (10, 'optimism', 'OP Mainnet', 'Layer 2', 'Optimistic Rollup', 'ETH', 0x4200000000000000000000000000000000000006, 'https://explorer.optimism.io/', timestamp '2021-11-11 21:16', 'OP Stack', 'ethereum')
         , (100, 'gnosis', 'Gnosis', 'Layer 1', NULL, 'xDAI', 0xe91d153e0b41518a2ce8dd3d7944fa863463a97d, 'https://gnosisscan.io/', timestamp '2018-10-08 18:43', NULL, NULL)
         , (137, 'polygon', 'Polygon PoS', 'Layer 1', NULL, 'MATIC', 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270, 'https://polygonscan.com/', timestamp '2020-05-30 16:30', NULL, NULL)
         , (250, 'fantom', 'Fantom', 'Layer 1', NULL, 'FTM', 0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83, 'https://ftmscan.com/', timestamp '2019-12-27 03:56', NULL, NULL)


### PR DESCRIPTION
Updates the OP Mainnet Block Explorer link to be "future proof." explorer.optimism.io redirects to the "best" current block explorer.

The macros could read from evms.info as well, to reduce how many places where info lives.