### PR TITLE
`labels.infrastructure` remove duplicates

### DIFF
--- a/models/labels/addresses/infrastructure/labels_infrastructure.sql
+++ b/models/labels/addresses/infrastructure/labels_infrastructure.sql
@@ -8,18 +8,20 @@
                                 \'["ilemi", "hildobby"]\') }}')
 }}
 
+--exclude due to duplicates:
+ --ref('labels_eth_stakers') 
+
 {% set infrastructure_models = [
- ref('labels_eth_stakers')
- , ref('labels_miners')
- , ref('labels_system_addresses')
- , ref('labels_validators')
- , ref('labels_flashbots_ethereum')
- , ref('labels_mev_ethereum')
- , ref('labels_contract_deployers')
- , ref('labels_stablecoins')
- , ref('labels_cex_tokens')
- , ref('labels_burn_addresses')
- , ref('labels_flashloans_ethereum')
+    ref('labels_miners')
+    , ref('labels_system_addresses')
+    , ref('labels_validators')
+    , ref('labels_flashbots_ethereum')
+    , ref('labels_mev_ethereum')
+    , ref('labels_contract_deployers')
+    , ref('labels_stablecoins')
+    , ref('labels_cex_tokens')
+    , ref('labels_burn_addresses')
+    , ref('labels_flashloans_ethereum')
 ] %}
 
 SELECT *


### PR DESCRIPTION
fyi @hildobby 
have to remove the eth stakers in labels due to duplicates. we should add a unique combo of columns test to the model when fixing. the test is on `labels.addresses` now, which is where this got caught (in another PR #4937)
```
with
  model as (
    WITH
      identified_stakers AS (
        SELECT
          'ethereum' AS blockchain,
          depositor_address as address,
          entity AS name,
          'infrastructure' AS category,
          'hildobby' AS contributor,
          'query' AS source,
          TIMESTAMP '2023-01-18' AS created_at,
          NOW() AS updated_at,
          'eth_stakers' AS model_name,
          'identifier' as label_type
        FROM
          staking_ethereum.entities
      ),
      unidentified_stakers AS (
        SELECT
          'ethereum' AS blockchain,
          et."from" AS address,
          'Unidentified ETH staker' AS name,
          'infrastructure' AS category,
          'hildobby' AS contributor,
          'query' AS source,
          TIMESTAMP '2023-01-18' AS created_at,
          NOW() AS updated_at,
          'eth_stakers' AS model_name,
          'identifier' as label_type
        FROM
          "ethereum"."traces" et
          LEFT JOIN identified_stakers idst ON et."from" = idst.address
        WHERE
          et.to = 0x00000000219ab540356cbb839cbe05303d7705fa
          AND idst.address IS NULL
          AND et.success
          AND CAST(et.value AS double) > 0
        GROUP BY
          et."from"
      )
    SELECT
      *
    FROM
      identified_stakers
    UNION ALL
    SELECT
      *
    FROM
      unidentified_stakers
  )
select
  address,
  name,
  category,
  model_name,
  blockchain,
  count(1)
from
  model
group by
  address,
  name,
  category,
  model_name,
  blockchain
having
  count(1) > 1
```