### PR TITLE
fix: Broken contributing link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Spellbook is built for and by the community, you are welcome to close any gaps t
 - **Propose** changes to spellbook - [Discussions](https://github.com/duneanalytics/spellbook/discussions) are where we bring up, challenge and develop ideas to continue building spellbook. If you want to make a major change to a spell (e.g. major overhaul to a sector, launching a new sector, designing a new organic volume filter, etc.).
 
 ### Submitting a PR
-Want to get right to work? Follow the guide [here](https://dune.com/docs/data-tables/spellbook/contributing/#7-steps-to-adding-a-spell) to get started.
+Want to get right to work? Follow the guide [here](https://dune.com/docs/spellbook/?h=7+steps+adding+a+spell) to get started.
 
 ### Testing your spell
 You don't need a complex local setup to test spells against Dune's engine. Once you send a PR, our CI pipeline will run and test it, and, if the job finishes successfully, you'll be able to query the data your PR created directly from dune.com.


### PR DESCRIPTION
I was trying to figure out how to contribute to spellbook and came across a broken link.

I replaced the link https://dune.com/docs/data-tables/spellbook/contributing/#7-steps-to-adding-a-spell with https://dune.com/docs/spellbook/?h=7+steps+adding+a+spell