### PR TITLE
Add HoldStation token - zksync

### DIFF
--- a/models/prices/zksync/prices_zksync_tokens.sql
+++ b/models/prices/zksync/prices_zksync_tokens.sql
@@ -25,5 +25,6 @@ FROM
     ('usdc-usd-coin', 'zksync', 'USDC.e', 0x3355df6d4c9c3035724fd0e3914de96a5a83aaf4, 6),
     ('usdt-tether', 'zksync', 'USDT.e', 0x493257fd37edb34451f62edf8d2a0c418852ba4c, 6),
     ('wbtc-wrapped-bitcoin', 'zksync', 'WBTC', 0xbbeb516fb02a01611cbbe0453fe3c580d7281011, 8),
-    ('weth-weth', 'zksync', 'WETH', 0x5aea5775959fbc2557cc8789bc1bf90a239d9a91, 18)
+    ('weth-weth', 'zksync', 'WETH', 0x5aea5775959fbc2557cc8789bc1bf90a239d9a91, 18),
+    ('hold-holdstation', 'zksync', 'HOLD', 0xed4040fd47629e7c8fbb7da76bb50b3e7695f0f2, 18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)


### PR DESCRIPTION
- Add holdstation's token on zksync.


- What is Holdstation? Holdstation solves the problem of secure and decentralized cryptocurrency management by providing a user-friendly Web3 Wallet and in-app perp DEX on zkSync. Users can securely store and manage their digital assets across multiple EVM-compatible networks, including Ethereum.

