### PR TITLE
Fixed ICP name in prices_native_tokens spell

### DIFF
--- a/models/prices/prices_native_tokens.sql
+++ b/models/prices/prices_native_tokens.sql
@@ -35,7 +35,7 @@ FROM
     ('eth-ethereum', null, 'ETH', null, null),
     ('ftm-fantom', null, 'FTM', null, null),
     ('hbar-hedera-hashgraph', null, 'HBAR', null, null),
-    ('icp-internet-protocol', null, 'ICP', null, null),
+    ('icp-internet-computer', null, 'ICP', null, null),
     ('icx-icon', null, 'ICX', null, null),
     ('kava-kava', null, 'KAVA', null, null),
     ('kuji-kujira', null, 'KUJI', null, null),


### PR DESCRIPTION
# Thank you for contributing to Spellbook!
Please refer to the top of the `readme` in the root of Spellbook to learn how to contribute to Spellbook on DuneSQL.

It seems I had made a mistake while adding the ICP name to prices_native_tokens spell few days ago. Prices for all other 9 assets added on my PR #5051 are now available on Dune, except ICP. It turns out the token_id for ICP should be "icp-internet-computer" and not "icp-internet-protocol" as I had written.

Coinpaprika also gives "icp-internet-computer" as API ID.
https://coinpaprika.com/coin/icp-internet-computer/