### PR TITLE
PRO-140 Rename the view from reservoir.tokens_beta to reservoir.tokens

### DIFF
--- a/models/datasets/reservoir/ethereum/tokens.sql
+++ b/models/datasets/reservoir/ethereum/tokens.sql
@@ -1,6 +1,6 @@
 {{ config(    
     schema = 'reservoir',
-    alias = 'tokens_beta',
+    alias = 'tokens',
     post_hook = '{{ expose_dataset(\'["ethereum"]\',
                 \'[""]\') }}'
     )


### PR DESCRIPTION
The view `reservoir.tokens` already exists and has a different definition. The definition is defined in the tablelog. We need to override the view using the definition in the spellbook. I will remove the definition in tablelog once this PR is merged.

Is it ok to rename the view from `reservoir.tokens_beta` to `reservoir.tokens`, given that `reservoir.tokens` already exists ?? cc @jeff-dude 