### PR TITLE
`mummy_finance_optimism` fix to handle denormalized decoded tables

### DIFF
--- a/models/mummy_finance/optimism/mummy_finance_optimism_perpetual_trades.sql
+++ b/models/mummy_finance/optimism/mummy_finance_optimism_perpetual_trades.sql
@@ -5,7 +5,7 @@
 }}
 
 {% set mummy_finance_optimism_perpetual_trade_models = [
- ref('mummy_finance_v1_optimism_perpetual_trades')
+ 	ref('mummy_finance_v1_optimism_perpetual_trades')
 ] %}
 
 

--- a/models/mummy_finance/optimism/mummy_finance_v1_optimism_perpetual_trades.sql
+++ b/models/mummy_finance/optimism/mummy_finance_v1_optimism_perpetual_trades.sql
@@ -5,7 +5,8 @@
 	materialized = 'incremental',
 	file_format = 'delta',
 	incremental_strategy = 'merge',
-	unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index']
+	unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
 	)
 }}
 
@@ -13,72 +14,119 @@
 {% set project_start_date = '2023-03-03' %}
 
 WITH all_executed_positions AS (
-SELECT *,
-       'Open' AS trade_type
-FROM {{ source('mummy_finance_optimism', 'Vault_evt_IncreasePosition') }}
-WHERE evt_tx_hash IN ( SELECT evt_tx_hash FROM {{ source('mummy_finance_optimism', 'PositionRouter_evt_ExecuteIncreasePosition') }} )
-    {% if not is_incremental() %}
-  AND evt_block_time >= DATE '{{project_start_date}}'
-    {% else %}
-  AND {{ incremental_predicate('evt_block_time') }}
-    {% endif %}
+    SELECT
+        account,
+        collateralDelta,
+        collateralToken,
+        contract_address,
+        fee,
+        indexToken,
+        isLong,
+        key,
+        price,
+        sizeDelta,
+        evt_block_number,
+        evt_block_time,
+        evt_index,
+        evt_tx_hash,
+        evt_tx_from,
+        evt_tx_to,
+        'Open' AS trade_type
+    FROM {{ source('mummy_finance_optimism', 'Vault_evt_IncreasePosition') }}
+    WHERE evt_tx_hash IN ( SELECT evt_tx_hash FROM {{ source('mummy_finance_optimism', 'PositionRouter_evt_ExecuteIncreasePosition') }} )
+        {% if not is_incremental() %}
+        AND evt_block_time >= DATE '{{project_start_date}}'
+        {% else %}
+        AND {{ incremental_predicate('evt_block_time') }}
+        {% endif %}
 
-UNION ALL
+    UNION ALL
 
-SELECT *, 
-    'Close' AS trade_type
-FROM {{ source('mummy_finance_optimism', 'Vault_evt_DecreasePosition') }}
-WHERE evt_tx_hash IN ( SELECT evt_tx_hash FROM {{ source('mummy_finance_optimism', 'PositionRouter_evt_ExecuteDecreasePosition') }} )
-    {% if not is_incremental() %}
-  AND evt_block_time >= DATE '{{project_start_date}}'
-    {% else %}
-  AND {{ incremental_predicate('evt_block_time') }}
-    {% endif %}
+    SELECT
+        account,
+        collateralDelta,
+        collateralToken,
+        contract_address,
+        fee,
+        indexToken,
+        isLong,
+        key,
+        price,
+        sizeDelta,
+        evt_block_number,
+        evt_block_time,
+        evt_index,
+        evt_tx_hash,
+        evt_tx_from,
+        evt_tx_to,
+        'Close' AS trade_type
+    FROM {{ source('mummy_finance_optimism', 'Vault_evt_DecreasePosition') }}
+    WHERE evt_tx_hash IN ( SELECT evt_tx_hash FROM {{ source('mummy_finance_optimism', 'PositionRouter_evt_ExecuteDecreasePosition') }} )
+        {% if not is_incremental() %}
+        AND evt_block_time >= DATE '{{project_start_date}}'
+        {% else %}
+        AND {{ incremental_predicate('evt_block_time') }}
+        {% endif %}
 ),
 
 margin_fees_info AS (
-SELECT *,
-       LEAD(evt_index, 1, 1000000) OVER (PARTITION BY evt_tx_hash ORDER BY evt_index) AS next_evt_index
-FROM {{ source('mummy_finance_optimism', 'Vault_evt_CollectMarginFees') }}
+    SELECT
+        *
+        , LEAD(evt_index, 1, 1000000) OVER (PARTITION BY evt_tx_hash ORDER BY evt_index) AS next_evt_index
+    FROM {{ source('mummy_finance_optimism', 'Vault_evt_CollectMarginFees') }}
     {% if not is_incremental() %}
-WHERE evt_block_time >= DATE '{{project_start_date}}'
+    WHERE evt_block_time >= DATE '{{project_start_date}}'
     {% else %}
-WHERE {{ incremental_predicate('evt_block_time') }}
+    WHERE {{ incremental_predicate('evt_block_time') }}
     {% endif %}
 ),
 
 complete_perp_tx AS (
-SELECT *, index_token || '/USD' AS market
-FROM (SELECT event.*,
-             tokens1.symbol AS underlying_asset,
-             (CASE
-                  WHEN tokens.symbol = 'WETH' THEN 'ETH'
-                  WHEN tokens.symbol = 'WBTC' THEN 'BTC'
-                  ELSE tokens.symbol
-                 END
-                 )          AS index_token,
-             trx."from",
-             trx.to,
-             fee.feeUsd     AS margin_fee
-      FROM all_executed_positions event
-      INNER JOIN {{ source('optimism', 'transactions') }} trx
-      ON event.evt_tx_hash = trx.hash
-          {% if not is_incremental() %}
-          AND event.evt_block_time >= DATE '{{project_start_date}}'
-          {% else %}
-          AND {{ incremental_predicate('event.evt_block_time') }}
-          {% endif %}
-      INNER JOIN margin_fees_info fee
-          ON event.evt_tx_hash = fee.evt_tx_hash
-          AND event.evt_index > fee.evt_index
-          AND event.evt_index < fee.next_evt_index
-      INNER JOIN {{ ref('tokens_erc20') }} tokens
-          ON event.indexToken = tokens.contract_address
-          AND tokens.blockchain = 'optimism'
-      INNER JOIN {{ ref('tokens_erc20') }} tokens1
-          ON event.collateralToken = tokens1.contract_address
-          AND tokens1.blockchain = 'optimism'
-      GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)
+    SELECT
+        *
+        , index_token || '/USD' AS market
+    FROM
+    (
+        SELECT
+            event.account,
+            event.collateralDelta,
+            event.collateralToken,
+            event.contract_address,
+            event.fee,
+            event.indexToken,
+            event.isLong,
+            event.key,
+            event.price,
+            event.sizeDelta,
+            event.evt_block_number,
+            event.evt_block_time,
+            event.evt_index,
+            event.evt_tx_hash,
+            event.evt_tx_from,
+            event.evt_tx_to,
+            event.trade_type,
+            tokens1.symbol AS underlying_asset,
+            (
+                CASE
+                    WHEN tokens.symbol = 'WETH' THEN 'ETH'
+                    WHEN tokens.symbol = 'WBTC' THEN 'BTC'
+                    ELSE tokens.symbol
+                END
+            ) AS index_token,
+            fee.feeUsd     AS margin_fee
+        FROM all_executed_positions as event
+        INNER JOIN margin_fees_info fee
+            ON event.evt_tx_hash = fee.evt_tx_hash
+            AND event.evt_index > fee.evt_index
+            AND event.evt_index < fee.next_evt_index
+        INNER JOIN {{ ref('tokens_erc20') }} tokens
+            ON event.indexToken = tokens.contract_address
+            AND tokens.blockchain = 'optimism'
+        INNER JOIN {{ ref('tokens_erc20') }} tokens1
+            ON event.collateralToken = tokens1.contract_address
+            AND tokens1.blockchain = 'optimism'
+        GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+    )
 )
 
 SELECT
@@ -106,7 +154,7 @@ SELECT
 	,account AS trader
 	,sizeDelta AS volume_raw
 	,evt_tx_hash AS tx_hash
-	,"from" AS tx_from
-	,to AS tx_to
+	,evt_tx_from AS tx_from
+	,evt_tx_to AS tx_to
 	,evt_index
 FROM complete_perp_tx

--- a/models/perpetual/perpetual_trades.sql
+++ b/models/perpetual/perpetual_trades.sql
@@ -6,6 +6,7 @@
         file_format = 'delta',
         incremental_strategy = 'merge',
 	      unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         post_hook='{{ expose_spells(\'["optimism","avalanche_c","arbitrum", "polygon","celo"]\',
                                 "sector",
                                 "perpetual",
@@ -14,20 +15,20 @@
 }}
 
 {% set perpetual_trade_models = [
- ref('perpetual_protocol_perpetual_trades')
-,ref('pika_perpetual_trades')
-,ref('synthetix_perpetual_trades')
-,ref('emdx_avalanche_c_perpetual_trades')
-,ref('hubble_exchange_avalanche_c_perpetual_trades')
-,ref('gmx_perpetual_trades')
-,ref('tigris_perpetual_trades')
-,ref('mummy_finance_optimism_perpetual_trades')
-,ref('fxdx_optimism_perpetual_trades')
-,ref('opx_finance_optimism_perpetual_trades')
-,ref('nex_optimism_perpetual_trades')
-,ref('avt_optimism_perpetual_trades')
-,ref('minerva_money_optimism_perpetual_trades')
-,ref('immortalx_perpetual_trades')
+  ref('perpetual_protocol_perpetual_trades')
+  ,ref('pika_perpetual_trades')
+  ,ref('synthetix_perpetual_trades')
+  ,ref('emdx_avalanche_c_perpetual_trades')
+  ,ref('hubble_exchange_avalanche_c_perpetual_trades')
+  ,ref('gmx_perpetual_trades')
+  ,ref('tigris_perpetual_trades')
+  ,ref('mummy_finance_optimism_perpetual_trades')
+  ,ref('fxdx_optimism_perpetual_trades')
+  ,ref('opx_finance_optimism_perpetual_trades')
+  ,ref('nex_optimism_perpetual_trades')
+  ,ref('avt_optimism_perpetual_trades')
+  ,ref('minerva_money_optimism_perpetual_trades')
+  ,ref('immortalx_perpetual_trades')
 ] %}
 
 SELECT *
@@ -58,7 +59,7 @@ FROM
     ,evt_index
   FROM {{ perpetual_model }}
   {% if is_incremental() %}
-  WHERE block_time >= date_trunc('day', now() - interval '7' Day)
+  WHERE {{ incremental_predicate('block_time') }}
   {% endif %}
   {% if not loop.last %}
   UNION ALL


### PR DESCRIPTION
- when using a `group by`, ensure no `select *` but explicitly pull columns
- remove join to base table, since decoded has columns now
- update incremental logic
- force changes downstream to see lineage run