### PR TITLE
Contracts - Make contract_mapping build on incremental refresh

### DIFF
--- a/models/_sector/contracts/arbitrum/contracts_arbitrum_contract_mapping.sql
+++ b/models/_sector/contracts/arbitrum/contracts_arbitrum_contract_mapping.sql
@@ -2,7 +2,10 @@
   config(     
         schema = 'contracts_arbitrum',
         alias = 'contract_mapping',
-        materialized ='table',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key = ['blockchain', 'contract_address'],
         on_table_exists = 'drop',
         partition_by =['created_month']
   )

--- a/models/_sector/contracts/base/contracts_base_contract_mapping.sql
+++ b/models/_sector/contracts/base/contracts_base_contract_mapping.sql
@@ -2,7 +2,10 @@
   config(     
         schema = 'contracts_base',
         alias = 'contract_mapping',
-        materialized ='table',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key = ['blockchain', 'contract_address'],
         on_table_exists = 'drop',
         partition_by =['created_month']
   )

--- a/models/_sector/contracts/bnb/contracts_bnb_contract_mapping_dynamic.sql
+++ b/models/_sector/contracts/bnb/contracts_bnb_contract_mapping_dynamic.sql
@@ -2,7 +2,10 @@
   config(     
         schema = 'contracts_bnb',
         alias = 'contract_mapping_dynamic',
-        materialized ='table',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key = ['blockchain', 'contract_address'],
         on_table_exists = 'drop',
         partition_by =['created_month']
   )

--- a/models/_sector/contracts/celo/contracts_celo_contract_mapping.sql
+++ b/models/_sector/contracts/celo/contracts_celo_contract_mapping.sql
@@ -2,7 +2,10 @@
     config(     
         schema = 'contracts_celo',
         alias = 'contract_mapping',
-        materialized ='table',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key = ['blockchain', 'contract_address'],
         on_table_exists = 'drop',
         partition_by =['created_month']
     )

--- a/models/_sector/contracts/ethereum/contracts_ethereum_contract_mapping.sql
+++ b/models/_sector/contracts/ethereum/contracts_ethereum_contract_mapping.sql
@@ -2,7 +2,10 @@
   config(     
         schema = 'contracts_ethereum',
         alias = 'contract_mapping',
-        materialized ='table',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key = ['blockchain', 'contract_address'],
         on_table_exists = 'drop',
         partition_by =['created_month']
   )

--- a/models/_sector/contracts/optimism/contracts_optimism_contract_mapping.sql
+++ b/models/_sector/contracts/optimism/contracts_optimism_contract_mapping.sql
@@ -2,7 +2,10 @@
   config(     
         schema = 'contracts_optimism',
         alias = 'contract_creator_project_mapping',
-        materialized ='table',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key = ['blockchain', 'contract_address'],
         on_table_exists = 'drop',
         partition_by =['created_month']
   )

--- a/models/_sector/contracts/polygon/contracts_polygon_contract_mapping.sql
+++ b/models/_sector/contracts/polygon/contracts_polygon_contract_mapping.sql
@@ -2,7 +2,10 @@
   config(     
         schema = 'contracts_polygon',
         alias = 'contract_mapping',
-        materialized ='table',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key = ['blockchain', 'contract_address'],
         on_table_exists = 'drop',
         partition_by =['created_month']
   )

--- a/models/_sector/contracts/zora/contracts_zora_contract_mapping.sql
+++ b/models/_sector/contracts/zora/contracts_zora_contract_mapping.sql
@@ -2,7 +2,10 @@
   config(     
         schema = 'contracts_zora',
         alias = 'contract_mapping',
-        materialized ='table',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key = ['blockchain', 'contract_address'],
         on_table_exists = 'drop',
         partition_by =['created_month']
   )


### PR DESCRIPTION
In https://github.com/duneanalytics/spellbook/pull/5023 the contract_mapping tables were changed from views to materialized tables, since the views were slow to run at the Dune.com query stage (required ~5 mins).

---

Since then, the contract_mapping tables for each chain only build once, and do not refresh on incremental runs. This is an attempt at making these tables rebuild on incremental runs.

cc @jeff-dude on the ideal solution, but putting this up as a starting point.