### PR TITLE
Balances enrich performance fix

### DIFF
--- a/macros/models/_sector/tokens/balances_enrich.sql
+++ b/macros/models/_sector/tokens/balances_enrich.sql
@@ -24,7 +24,7 @@ from   {{ source('prices', 'usd') }} prices
 right join {{ balances_base }} balances on (
     CASE
         WHEN type = 'erc20' THEN prices.contract_address = balances.contract_address and prices.blockchain = '{{ blockchain }}'
-        WHEN type = 'native' THEN prices.contract_address is null and prices.symbol = 'ETH' and prices.blockchain is false
+        WHEN type = 'native' THEN prices.contract_address is null and prices.symbol = 'ETH' and prices.blockchain is null
         ELSE false
     END)
     and prices.minute = date_trunc('minute', balances.block_time)

--- a/macros/models/_sector/tokens/balances_enrich.sql
+++ b/macros/models/_sector/tokens/balances_enrich.sql
@@ -34,13 +34,13 @@ left join {{ ref('tokens_erc20') }} erc20_tokens on
         WHEN type = 'erc20' THEN erc20_tokens.contract_address = balances.contract_address
         -- TODO: should not be hardcoded
         WHEN type = 'native' THEN erc20_tokens.contract_address = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-        ELSE null
+        ELSE false
     END)
 left join {{ ref('tokens_nft') }} nft_tokens on (
    nft_tokens.blockchain = '{{ blockchain }}' AND (
    CASE
         WHEN (type = 'erc721' OR type = 'erc1155') THEN nft_tokens.contract_address = balances.contract_address
-        ELSE null
+        ELSE false
     END
     )
 )


### PR DESCRIPTION
Prices is a tricky one to join on. It very easily results in a full scan on the table, which is not huge in bytes but becomes billions of rows. To make performance better we can select on prices and right join on balances.

Right join balances
<img width="569" alt="Screenshot 2024-01-11 at 13 45 59" src="https://github.com/duneanalytics/spellbook/assets/1659079/bf7c4893-bd74-4a4a-addf-5b68f48daad1">

Left join prices
<img width="574" alt="Screenshot 2024-01-11 at 13 42 39" src="https://github.com/duneanalytics/spellbook/assets/1659079/609ddfe5-cb45-41aa-976a-ba5526260dfc">


Also changed `null` in the case conditionals to be `false` because it's a bit more readable and less confusing that `null = false`.