### PR TITLE
Contract Updates - Remove 'Drop Table' and Simplify Min Block Time

### DIFF
--- a/macros/models/_sector/contracts/contracts_base_iterated_creators.sql
+++ b/macros/models/_sector/contracts/contracts_base_iterated_creators.sql
@@ -21,7 +21,7 @@ WITH check_date AS (
   {% if is_incremental() %}
     MAX(created_time) AS base_time FROM {{this}}
   {% else %}
-    MIN(block_time) AS base_time FROM {{ source( chain , 'blocks') }}
+    MIN(time) AS base_time FROM {{ source( chain , 'blocks') }}
   {% endif %}
 )
 

--- a/macros/models/_sector/contracts/contracts_base_iterated_creators.sql
+++ b/macros/models/_sector/contracts/contracts_base_iterated_creators.sql
@@ -21,7 +21,7 @@ WITH check_date AS (
   {% if is_incremental() %}
     MAX(created_time) AS base_time FROM {{this}}
   {% else %}
-    MIN(block_time) AS base_time FROM {{ source( chain , 'transactions') }}
+    MIN(block_time) AS base_time FROM {{ source( chain , 'blocks') }}
   {% endif %}
 )
 

--- a/macros/models/_sector/contracts/contracts_base_starting_level.sql
+++ b/macros/models/_sector/contracts/contracts_base_starting_level.sql
@@ -6,7 +6,7 @@ WITH check_date AS (
   {% if is_incremental() %}
     MAX(created_time) AS base_time FROM {{this}}
   {% else %}
-    MIN(block_time) AS base_time FROM {{ source( chain , 'transactions') }}
+    MIN(block_time) AS base_time FROM {{ source( chain , 'blocks') }}
   {% endif %}
 )
 

--- a/macros/models/_sector/contracts/contracts_base_starting_level.sql
+++ b/macros/models/_sector/contracts/contracts_base_starting_level.sql
@@ -6,7 +6,7 @@ WITH check_date AS (
   {% if is_incremental() %}
     MAX(created_time) AS base_time FROM {{this}}
   {% else %}
-    MIN(block_time) AS base_time FROM {{ source( chain , 'blocks') }}
+    MIN(time) AS base_time FROM {{ source( chain , 'blocks') }}
   {% endif %}
 )
 

--- a/models/_sector/contracts/arbitrum/contracts_arbitrum_contract_mapping.sql
+++ b/models/_sector/contracts/arbitrum/contracts_arbitrum_contract_mapping.sql
@@ -3,7 +3,6 @@
         schema = 'contracts_arbitrum',
         alias = 'contract_mapping',
         materialized ='table',
-        on_table_exists = 'drop',
         partition_by =['created_month']
   )
 }}

--- a/models/_sector/contracts/base/contracts_base_contract_mapping.sql
+++ b/models/_sector/contracts/base/contracts_base_contract_mapping.sql
@@ -3,7 +3,6 @@
         schema = 'contracts_base',
         alias = 'contract_mapping',
         materialized ='table',
-        on_table_exists = 'drop',
         partition_by =['created_month']
   )
 }}

--- a/models/_sector/contracts/bnb/contracts_bnb_contract_mapping_dynamic.sql
+++ b/models/_sector/contracts/bnb/contracts_bnb_contract_mapping_dynamic.sql
@@ -3,7 +3,6 @@
         schema = 'contracts_bnb',
         alias = 'contract_mapping_dynamic',
         materialized ='table',
-        on_table_exists = 'drop',
         partition_by =['created_month']
   )
 }}

--- a/models/_sector/contracts/celo/contracts_celo_contract_mapping.sql
+++ b/models/_sector/contracts/celo/contracts_celo_contract_mapping.sql
@@ -3,7 +3,6 @@
         schema = 'contracts_celo',
         alias = 'contract_mapping',
         materialized ='table',
-        on_table_exists = 'drop',
         partition_by =['created_month']
     )
 }}

--- a/models/_sector/contracts/contracts_system_predeploys.sql
+++ b/models/_sector/contracts/contracts_system_predeploys.sql
@@ -12,7 +12,7 @@
 
 {% set op_chains = all_op_chains() %} --macro: all_op_chains.sql
 
--- https://github.com/ethereum-optimism/optimism/blob/c93958755b4f6ab7f95cc0b2459f39ca95c06684/specs/predeploys.md?plain=1#L48
+-- https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md
 WITH op_stack_predeploys AS (
 	SELECT contract_project, contract_name, contract_address
 	FROM (values
@@ -34,6 +34,7 @@ WITH op_stack_predeploys AS (
 		,('OVM',	'ProxyAdmin',					0x4200000000000000000000000000000000000018)
 		,('OVM',	'BaseFeeVault',				0x4200000000000000000000000000000000000019)
 		,('OVM',	'L1FeeVault',					0x420000000000000000000000000000000000001a)
+		,('OVM',	'create2Deployer',	0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2)
 		---
 		,('EAS',	'EAS',					0x4200000000000000000000000000000000000021)
 		,('EAS',	'SchemaRegistry',				0x4200000000000000000000000000000000000020)

--- a/models/_sector/contracts/ethereum/contracts_ethereum_contract_mapping.sql
+++ b/models/_sector/contracts/ethereum/contracts_ethereum_contract_mapping.sql
@@ -3,7 +3,6 @@
         schema = 'contracts_ethereum',
         alias = 'contract_mapping',
         materialized ='table',
-        on_table_exists = 'drop',
         partition_by =['created_month']
   )
 }}

--- a/models/_sector/contracts/optimism/contracts_optimism_contract_mapping.sql
+++ b/models/_sector/contracts/optimism/contracts_optimism_contract_mapping.sql
@@ -3,7 +3,6 @@
         schema = 'contracts_optimism',
         alias = 'contract_creator_project_mapping',
         materialized ='table',
-        on_table_exists = 'drop',
         partition_by =['created_month']
   )
 }}

--- a/models/_sector/contracts/polygon/contracts_polygon_contract_mapping.sql
+++ b/models/_sector/contracts/polygon/contracts_polygon_contract_mapping.sql
@@ -3,7 +3,6 @@
         schema = 'contracts_polygon',
         alias = 'contract_mapping',
         materialized ='table',
-        on_table_exists = 'drop',
         partition_by =['created_month']
   )
 }}

--- a/models/_sector/contracts/zora/contracts_zora_contract_mapping.sql
+++ b/models/_sector/contracts/zora/contracts_zora_contract_mapping.sql
@@ -3,7 +3,6 @@
         schema = 'contracts_zora',
         alias = 'contract_mapping',
         materialized ='table',
-        on_table_exists = 'drop',
         partition_by =['created_month']
   )
 }}


### PR DESCRIPTION
1. Removes 'Drop table' from configs, since we have already overwritten the views -> Tables
2. When we do initial builds, and look for the first block time, do this via the smaller "blocks" table instead of transactions.