### PR TITLE
Add zkSync to Contracts Mapping

### DIFF
--- a/models/_sector/contracts/contracts_contract_mapping.sql
+++ b/models/_sector/contracts/contracts_contract_mapping.sql
@@ -2,7 +2,7 @@
   config(     
         schema = 'contracts',
         alias = 'contract_mapping',
-        post_hook='{{ expose_spells(\'["ethereum", "base", "optimism", "zora", "arbitrum", "celo", "polygon", "bnb", "avalanche_c", "fantom", "gnosis", "goerli"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "base", "optimism", "zora", "arbitrum", "celo", "polygon", "bnb", "avalanche_c", "fantom", "gnosis", "goerli","zksync"]\',
                                     "sector",
                                     "contracts",
                                     \'["msilb7", "chuxin", "tomfutago"]\') }}'
@@ -23,6 +23,7 @@
  , ref('contracts_fantom_contract_mapping_dynamic')
  , ref('contracts_gnosis_contract_mapping')
  , ref('contracts_goerli_contract_mapping')
+ , ref('contracts_zksync_contract_mapping')
 ] %}
 -- todo: add chains for all EVMs in Dune
 

--- a/models/_sector/contracts/zksync/_schema.yml
+++ b/models/_sector/contracts/zksync/_schema.yml
@@ -1,0 +1,229 @@
+version: 2
+
+models:
+
+  - name: contracts_zksync_contract_mapping
+    meta:
+      blockchain: zksync
+      sector: contracts
+      contributors: chuxin, msilb7
+    config:
+      tags: ['evm', 'zksync', 'contracts', 'addresses']
+    description: "Mapping of contracts to its creators and names on zksync."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - contract_address
+            
+    columns:
+      - &created_month
+        name: created_month
+        description: "Monthly partition, when the contract was created"
+      - &blockchain
+        name: blockchain
+        description: "Name of chain in Dune database"
+      - &trace_creator_address
+        name: trace_creator_address
+        description: "Address creating the contract in the transaction trace"
+      - &contract_address
+        name: contract_address
+        description: "Address of the contract"
+      - &contract_project
+        name: contract_project
+        description: "Project name of the contract"
+      - &token_symbol
+        name: token_symbol
+        description: "Token symbol of the contract, if any"
+      - &contract_name
+        name: contract_name
+        description: "Contract name"
+      - &creator_address
+        name: creator_address
+        description: "Highest-level contract creator address (i.e. which address deployed the factory which deployed contracts), or the tx_from when the contract creator address is non-deterministic."
+      - &trace_deployer_address
+        name: trace_deployer_address
+        description: "Attribution to the mapped deployer address at the creation trace, handles for ~most deterministic deployers and smart wallet creations."
+      - &created_time
+        name: created_time
+        description: "contract creation time"
+      - &is_self_destruct
+        name: is_self_destruct
+        description: "Flag if it is a self destruct contract"
+      - &created_tx_hash
+        name: created_tx_hash
+        description: "Contract creation transaction hash"
+      - &created_block_number
+        name: created_block_number
+        description: "Contract creation block number"
+      - &created_tx_from
+        name: created_tx_from
+        description: "Contract creation transaction from address"
+      - &created_tx_to
+        name: created_tx_to
+        description: "Contract creation transaction to address"
+      - &created_tx_method_id
+        name: created_tx_method_id
+        description: "Method ID of the transaction. This is useful for determining how a contract was deployed (i.e Safe transaction vs traditional deployment)"
+      - &created_tx_index
+        name: created_tx_index
+        description: "Index of the contract creation transaction within its block"
+      - &top_level_time
+        name: top_level_time
+        description: "Top-Level contract creation transaction block time"
+      - &top_level_tx_hash
+        name: top_level_tx_hash
+        description: "Top-Level contract creation transaction hash"
+      - &top_level_block_number
+        name: top_level_block_number
+        description: "Top-Level contract creation transaction block number"
+      - &top_level_tx_from
+        name: top_level_tx_from
+        description: "Top-Level contract creation transaction from address"
+      - &top_level_tx_to
+        name: top_level_tx_to
+        description: "Top-Level contract creation transaction to address"
+      - &top_level_tx_method_id
+        name: top_level_tx_method_id
+        description: "Method ID of the top-level transaction. This is useful for determining how the top-level contract was deployed (i.e Safe transaction vs traditional deployment)"
+      
+      - &code_bytelength
+        name: code_bytelength
+        description: "Length of the deployed code, measured in bytes. This is used for spam filtering"
+      - &token_standard
+        name: token_standard
+        description: "What token standard the contract is. For non-tokens, this field will be null."
+        
+      - &code
+        name: code
+        description: "Runtime bytecode of the contract"
+
+      - &code_deploy_rank_by_chain
+        name: code_deploy_rank_by_chain
+        description: "Was this the 1st, 2rd, 3rd, etc time the same exact bytecode was deployed by chain? (1 = 1st). This can be used for spam filtering."
+      - &is_eoa_deployed
+        name: is_eoa_deployed
+        description: "Was the contract deployed by an EOA (test if the trace creator = the transaction sender)"
+      - &is_smart_wallet_deployed
+        name: is_smart_wallet_deployed
+        description: "Was the contract deployed by a smart wallet (i.e. Gnosis Safe, ERC4337 wallet)"
+      - &is_deterministic_deployer_deployed
+        name: is_deterministic_deployer_deployed
+        description: "Was the contract deployed by a deterministic deployer factory (i.e. create2)"
+
+  - name: contracts_zksync_find_self_destruct_contracts
+    meta:
+      blockchain: zksync
+      sector: contracts
+      contributors: chuxin, msilb7
+    config:
+      tags: ['evm', 'contracts', 'addresses']
+    description: "A list of contracts that are self-destruct, with the time that they were most recently self-destructed."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - contract_address
+
+    columns:
+      - *blockchain
+      - *created_time
+      - *created_block_number
+      - *created_tx_hash
+      - *contract_address
+      - &destructed_time
+        name: destructed_time
+        description: "Block Time when contract was destructed"
+      - &destructed_block_number
+        name: destructed_block_number
+        description: "Block Number when contract was destructed"
+      - &destructed_tx_hash
+        name: destructed_tx_hash
+        description: "Tx Hash where contract was destructed"
+
+  - name: contracts_zksync_base_starting_level
+    meta:
+      blockchain: zksync
+      sector: contracts
+      contributors: chuxin, msilb7
+    config:
+      tags: ['evm', 'zksync', 'contracts', 'addresses']
+    description: "Base Level for mapping of contracts to its creators and names on zksync."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - contract_address
+            
+    columns:
+      - *blockchain
+      - *trace_creator_address
+      - *contract_address
+        
+      - *created_time
+      - *created_month
+      - *created_block_number
+      - *created_tx_hash
+      - *created_tx_from
+      - *created_tx_to
+      - *created_tx_method_id
+      - *created_tx_index
+      - *top_level_time
+      - *top_level_block_number
+      - *top_level_tx_hash
+      - *top_level_tx_from
+      - *top_level_tx_to
+      - *top_level_tx_method_id
+      - *code_bytelength
+      - *code
+      - &reinitialize_rank
+        name: reinitialize_rank
+        description: "Rank of the same contract being deployed in descending order - used to only ensure we get the most recent contract instance (allowlist & self-destructs can cause duplicates)."
+
+  - name: contracts_zksync_base_iterated_creators
+    meta:
+      blockchain: zksync
+      sector: contracts
+      contributors: chuxin, msilb7
+    config:
+      tags: ['evm', 'zksync', 'contracts', 'addresses']
+    description: "Iterated creators for mapping of contracts to its creators and names on zksync."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - contract_address
+            
+    columns:
+      - *blockchain
+      - *trace_creator_address
+      - *creator_address
+      - *trace_deployer_address
+      - *contract_address
+      - *created_time
+      - *created_month
+      - *top_level_time
+      - *created_tx_hash
+      - *created_block_number
+      - *top_level_tx_hash
+      - *top_level_block_number
+      - *top_level_tx_from
+      - *top_level_tx_to
+      - *top_level_tx_method_id
+      - *created_tx_from
+      - *created_tx_to
+      - *created_tx_method_id
+      - *created_tx_index
+      - *code_bytelength
+      - *code_deploy_rank_by_chain
+      - *code
+      - *is_self_destruct
+      - &creator_address_lineage
+        name: creator_address_lineage
+        description: "array of the lineage of creator addresses until the top-level creator"
+      - &tx_method_id_lineage
+        name: tx_method_id_lineage
+        description: "array of the lineage of tx method ids until the top-level creator"
+      - &token_standard_erc20
+        name: token_standard_erc20
+        description: "Token Standard ERC20 Only"

--- a/models/_sector/contracts/zksync/_sources.yml
+++ b/models/_sector/contracts/zksync/_sources.yml
@@ -1,0 +1,33 @@
+version: 2
+
+sources:
+  # Base Tables
+  - name: zksync_era_zksync
+    description: "zkSync contracts on zkSyns."
+    freshness:
+      warn_after: { count: 12, period: hour }
+    tables:
+      - name: ContractDeployer_evt_ContractDeployed
+        loaded_at_field: evt_block_time
+        description: "zkSync contract deployed events."
+        columns:
+        - &bytecodeHash
+            name: bytecodeHash
+        - &contractAddress
+            name: contractAddress
+        - &contract_address
+            name: contract_address
+        - &deployerAddress
+            name: deployerAddress
+        - &evt_block_number
+            name: evt_block_number
+        - &evt_block_time
+            name: evt_block_time
+        - &evt_index
+            name: evt_index
+        - &evt_tx_from
+            name: evt_tx_from
+        - &evt_tx_hash
+            name: evt_tx_hash
+        - &evt_tx_to
+            name: evt_tx_to

--- a/models/_sector/contracts/zksync/contracts_zksync_base_iterated_creators.sql
+++ b/models/_sector/contracts/zksync/contracts_zksync_base_iterated_creators.sql
@@ -1,0 +1,15 @@
+ {{
+  config(
+        schema = 'contracts_zksync',
+        alias = 'base_iterated_creators',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key = ['blockchain', 'contract_address'],
+        partition_by = ['created_month']
+  )
+}}
+
+{{contracts_base_iterated_creators(
+    chain='zksync', days_forward=183
+)}}

--- a/models/_sector/contracts/zksync/contracts_zksync_base_starting_level.sql
+++ b/models/_sector/contracts/zksync/contracts_zksync_base_starting_level.sql
@@ -1,0 +1,16 @@
+ {{
+  config(
+        schema = 'contracts_zksync',
+        alias = 'base_starting_level',
+        materialized ='incremental',
+        file_format ='delta',
+        incremental_strategy='merge',
+        unique_key = ['blockchain', 'contract_address'],
+        partition_by = ['created_month']
+  )
+}}
+-- depends_on: {{ ref('contracts_deterministic_contract_creators') }}
+
+{{contracts_base_starting_level(
+    chain='zksync', days_forward=183
+)}}

--- a/models/_sector/contracts/zksync/contracts_zksync_contract_mapping.sql
+++ b/models/_sector/contracts/zksync/contracts_zksync_contract_mapping.sql
@@ -1,0 +1,12 @@
+ {{
+  config(     
+        schema = 'contracts_zksync',
+        alias = 'contract_mapping',
+        materialized ='table',
+        partition_by =['created_month']
+  )
+}}
+
+{{contracts_contract_mapping(
+    chain='zksync'
+)}}

--- a/models/_sector/contracts/zksync/contracts_zksync_find_self_destruct_contracts.sql
+++ b/models/_sector/contracts/zksync/contracts_zksync_find_self_destruct_contracts.sql
@@ -1,0 +1,14 @@
+ {{
+  config(
+        schema = 'contracts_zksync',
+        alias = 'find_self_destruct_contracts',
+        materialized ='incremental',
+        file_format ='delta',
+        unique_key = ['blockchain', 'contract_address'],
+        incremental_strategy='merge'
+  )
+}}
+
+{{find_self_destruct_contracts(
+    chain='zksync', days_forward=183
+)}}


### PR DESCRIPTION
Adds logic to pull extra zkSync contracts (where creation data is in events).

ref: https://github.com/duneanalytics/spellbook/pull/4788
cc @lgingerich for sanity checking

edit: my local dbt is throwing beethovenx schema errors, so testing compiling here.