### PR TITLE
Use right join for transfers due to prices performance

### DIFF
--- a/macros/models/_sector/tokens/transfers_enrich.sql
+++ b/macros/models/_sector/tokens/transfers_enrich.sql
@@ -33,7 +33,7 @@ FROM {{ source('prices', 'usd') }} prices
 RIGHT JOIN {{transfers_base}} t ON (
     CASE
         WHEN t.token_standard = 'erc20' THEN prices.contract_address = t.contract_address and prices.blockchain = '{{ blockchain }}'
-        WHEN t.token_standard = 'native' THEN p.contract_address = (SELECT wrapped_native_token_address FROM {{ ref('evms_info') }} WHERE blockchain='{{blockchain}}')
+        WHEN t.token_standard = 'native' THEN prices.contract_address = (SELECT wrapped_native_token_address FROM {{ ref('evms_info') }} WHERE blockchain='{{blockchain}}')
         ELSE false
     END)
     AND prices.minute = date_trunc('minute', t.block_time)

--- a/macros/models/_sector/tokens/transfers_enrich.sql
+++ b/macros/models/_sector/tokens/transfers_enrich.sql
@@ -32,8 +32,8 @@ FROM {{ source('prices', 'usd') }} prices
 -- Right join due to performance reasons
 RIGHT JOIN {{transfers_base}} t ON (
     CASE
-        WHEN type = 'erc20' THEN prices.contract_address = balances.contract_address and prices.blockchain = '{{ blockchain }}'
-        WHEN type = 'native' THEN contract_address = (SELECT wrapped_native_token_address FROM {{ ref('evms_info') }} WHERE blockchain='{{blockchain}}')
+        WHEN token_standard = 'erc20' THEN prices.contract_address = balances.contract_address and prices.blockchain = '{{ blockchain }}'
+        WHEN token_standard = 'native' THEN contract_address = (SELECT wrapped_native_token_address FROM {{ ref('evms_info') }} WHERE blockchain='{{blockchain}}')
         ELSE false
     END)
     AND prices.minute = date_trunc('minute', t.block_time)

--- a/macros/models/_sector/tokens/transfers_enrich.sql
+++ b/macros/models/_sector/tokens/transfers_enrich.sql
@@ -28,12 +28,13 @@ SELECT t.blockchain
 , {{case_when_token_standard('(t.amount_raw / power(10, 18)) * prices.price',
     '(t.amount_raw / power(10, tokens_erc20.decimals)) * prices.price',
     'NULL')}} AS usd_amount
-FROM {{transfers_base}} t
-LEFT JOIN {{ref('tokens_erc20')}} tokens_erc20 on tokens_erc20.blockchain = '{{blockchain}}' AND tokens_erc20.contract_address = t.contract_address
-LEFT JOIN {{ source('prices', 'usd') }} prices ON prices.blockchain = '{{blockchain}}'
+FROM {{ source('prices', 'usd') }} prices
+-- Right join due to performance reasons
+RIGHT JOIN JOIN FROM {{transfers_base}} t  ON prices.blockchain = '{{blockchain}}'
     AND (
             prices.contract_address=t.contract_address
             OR t.contract_address IS NULL AND prices.contract_address=(SELECT wrapped_native_token_address FROM {{ ref('evms_info') }} WHERE blockchain='{{blockchain}}')
         )
     AND prices.minute = date_trunc('minute', t.block_time)
+LEFT JOIN {{ref('tokens_erc20')}} tokens_erc20 on tokens_erc20.blockchain = '{{blockchain}}' AND tokens_erc20.contract_address = t.contract_address
 {%- endmacro %}

--- a/macros/models/_sector/tokens/transfers_enrich.sql
+++ b/macros/models/_sector/tokens/transfers_enrich.sql
@@ -30,7 +30,7 @@ SELECT t.blockchain
     'NULL')}} AS usd_amount
 FROM {{ source('prices', 'usd') }} prices
 -- Right join due to performance reasons
-RIGHT JOIN JOIN FROM {{transfers_base}} t  ON prices.blockchain = '{{blockchain}}'
+RIGHT JOIN {{transfers_base}} t ON prices.blockchain = '{{blockchain}}'
     AND (
             prices.contract_address=t.contract_address
             OR t.contract_address IS NULL AND prices.contract_address=(SELECT wrapped_native_token_address FROM {{ ref('evms_info') }} WHERE blockchain='{{blockchain}}')

--- a/macros/models/_sector/tokens/transfers_enrich.sql
+++ b/macros/models/_sector/tokens/transfers_enrich.sql
@@ -30,7 +30,7 @@ SELECT t.blockchain
     'NULL')}} AS usd_amount
 FROM {{ source('prices', 'usd') }} prices
 -- Right join due to performance reasons
-RIGHT JOIN {{transfers_base}} t ON on (
+RIGHT JOIN {{transfers_base}} t ON (
     CASE
         WHEN type = 'erc20' THEN prices.contract_address = balances.contract_address and prices.blockchain = '{{ blockchain }}'
         WHEN type = 'native' THEN contract_address = (SELECT wrapped_native_token_address FROM {{ ref('evms_info') }} WHERE blockchain='{{blockchain}}')

--- a/macros/models/_sector/tokens/transfers_enrich.sql
+++ b/macros/models/_sector/tokens/transfers_enrich.sql
@@ -32,8 +32,8 @@ FROM {{ source('prices', 'usd') }} prices
 -- Right join due to performance reasons
 RIGHT JOIN {{transfers_base}} t ON (
     CASE
-        WHEN token_standard = 'erc20' THEN prices.contract_address = balances.contract_address and prices.blockchain = '{{ blockchain }}'
-        WHEN token_standard = 'native' THEN contract_address = (SELECT wrapped_native_token_address FROM {{ ref('evms_info') }} WHERE blockchain='{{blockchain}}')
+        WHEN t.token_standard = 'erc20' THEN prices.contract_address = t.contract_address and prices.blockchain = '{{ blockchain }}'
+        WHEN t.token_standard = 'native' THEN p.contract_address = (SELECT wrapped_native_token_address FROM {{ ref('evms_info') }} WHERE blockchain='{{blockchain}}')
         ELSE false
     END)
     AND prices.minute = date_trunc('minute', t.block_time)


### PR DESCRIPTION
Follow up on https://github.com/duneanalytics/spellbook/pull/5198 where @jeff-dude discovered that transfers are slow.

This can (hopefully) be fixed by selecting from the prices and right joining the transfers table instead.