### PR TITLE
fix dbt compile and exclude failing model `safe_bnb_safes`

### DIFF
--- a/models/governance/optimism/governance_optimism_sources.yml
+++ b/models/governance/optimism/governance_optimism_sources.yml
@@ -2,8 +2,6 @@ version: 2
 
 sources: 
   - name: snapshot
-    freshness:
-          warn_after: { count: 12, period: hour }
     description: >
       Decoded table for proposals and their voting on Snapshot platform
     tables:
@@ -11,8 +9,6 @@ sources:
       - name: votes
   
   - name: optimism_governor_optimism
-    freshness:
-          warn_after: { count: 12, period: hour }
     description: >
       Decoded table for proposals and their voting on Agora platform
     tables:

--- a/models/safe/bnb/safe_bnb_safes.sql
+++ b/models/safe/bnb/safe_bnb_safes.sql
@@ -1,13 +1,14 @@
 {{ 
     config(
-        materialized='incremental',
-        
+        schema = 'safe_bnb',
         alias = 'safes',
+        tags = ['prod_exclude'],
         partition_by = ['block_month'],
-        unique_key = ['block_date', 'address'],
         on_schema_change='fail',
+        materialized='incremental',
         file_format ='delta',
         incremental_strategy='merge',
+        unique_key = ['block_date', 'address'],
         post_hook='{{ expose_spells(\'["bnb"]\',
                                     "project",
                                     "safe",


### PR DESCRIPTION
`safe_bnb_safes` started failing every run in prod on january 24th.
added `prod_exclude` tag to disable in prod until fixed in spellbook.

query investigation:
```
with
  src as (
    select
      'bnb' as blockchain,
      et."from" as address,
      case
        when et.to = 0x8942595a2dc5181df0465af0d7be08c8f23c93af then '0.1.0'
        when et.to = 0xb6029ea3b2c51d09a50b53ca8012feeb05bda35a then '1.0.0'
        when et.to = 0xae32496491b53841efb51829d6f886387708f99b then '1.1.0'
        when et.to = 0x34cfac646f301356faa8b21e94227e3583fe3f5f then '1.1.1'
        when et.to = 0x6851d6fdfafd08c0295c392436245e5bc78b0185 then '1.2.0'
        when et.to = 0x2bb001433cf04c1f7d71e3c40fed66b2b563065e then '1.2.0Binance'
        when et.to = 0xd9db270c1b5e3bd161e8c8503c55ceabee709552 then '1.3.0'
        when et.to = 0x69f4d1788e39c87893c980c06edf4b7f686e2938 then '1.3.0' -- for chains with EIP-155
        when et.to = 0x3e5c63644e683549055b9be8653de26e0b4cd36e then '1.3.0L2'
        when et.to = 0xfb1bffc9d739b8d520daf37df666da4c687191ea then '1.3.0L2' -- for chains with EIP-155
        else 'unknown'
      end as creation_version,
      try_cast(date_trunc('day', et.block_time) as date) as block_date,
      CAST(date_trunc('month', et.block_time) as DATE) as block_month,
      et.block_time as creation_time,
      et.tx_hash
    from
      "delta_prod"."bnb"."traces" et
      join safe_bnb.singletons s on et.to = s.address
    where
      et.success = true
      and et.call_type = 'delegatecall' -- delegatecall to singleton is Safe (proxy) address
      and bytearray_substring (et.input, 1, 4) in (
        0x0ec78d9e, -- setup method v0.1.0
        0xa97ab18a, -- setup method v1.0.0
        0xb63e800d -- setup method v1.1.0, v1.1.1, v1.2.0, v1.3.0, v1.3.0L2
      )
      and et.gas_used > 10000 -- to ensure the setup call was successful. excludes e.g. setup calls with missing params that fallback
      and et.block_time > date_trunc('day', now() - interval '7' day)
  ),
  find_dupes as (
    select
      block_date,
      address,
      count(1)
    from
      src
    group by
      block_date,
      address
    having
      count(1) > 1
  ),
  dupe_detail as (
    select
      *
    from
      src
    where
      block_date = date('2024-01-24')
      and address in (
        0x7926917669911ecc2cad01baab8b618875df4d31,
        0x798fa0a2cadb2e4efc8787bb5e45a3ae0d5b1900,
        0xf2f0829018452a00435edb9cf6fd5158d2e92bf5
      )
  )
select
  *
from
  dupe_detail
order by
  address
```

results of dupes:
![image](https://github.com/duneanalytics/spellbook/assets/102681548/90608e1e-edfb-4d75-bb93-f0cf3aa98c65)
