### PR TITLE
Remove incremental settings from Balancer Pools Labels

### DIFF
--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_arbitrum.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_arbitrum.sql
@@ -1,10 +1,5 @@
 {{config(
   alias = 'balancer_v2_pools_arbitrum',
-  materialized = 'incremental',
-  
-  file_format = 'delta',
-  incremental_strategy = 'merge',
-  unique_key = ['address'],
   post_hook = '{{ expose_spells(\'["arbitrum"]\',
                                "sector",
                                "labels",
@@ -32,10 +27,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -60,10 +51,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -88,10 +75,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -116,10 +99,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -144,10 +123,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -163,10 +138,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -181,10 +152,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -199,10 +166,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -217,10 +180,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -235,10 +194,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -253,10 +208,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(ARRAY[cc.mainToken, cc.wrappedToken]) AS t (element)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -271,10 +222,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(ARRAY[cc.mainToken, cc.wrappedToken]) AS t (element)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -289,10 +236,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 ),
 
 settings AS (

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_avalanche_c.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_avalanche_c.sql
@@ -1,10 +1,5 @@
 {{config(
   alias = 'balancer_v2_pools_avalanche_c',
-  materialized = 'incremental',
-  
-  file_format = 'delta',
-  incremental_strategy = 'merge',
-  unique_key = ['address'],
   post_hook = '{{ expose_spells(\'["avalanche_c"]\',
                                "sector",
                                "labels",
@@ -32,10 +27,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -51,10 +42,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
   
   UNION ALL
 
@@ -69,10 +56,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -87,10 +70,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(ARRAY[cc.mainToken, cc.wrappedToken]) AS t (element)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -105,10 +84,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(ARRAY[cc.mainToken, cc.wrappedToken]) AS t (element)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 ),
 
 settings AS (

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_base.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_base.sql
@@ -1,10 +1,5 @@
 {{config(
   alias = 'balancer_v2_pools_base',
-  materialized = 'incremental',
-  
-  file_format = 'delta',
-  incremental_strategy = 'merge',
-  unique_key = ['address'],
   post_hook = '{{ expose_spells(\'["base"]\',
                                "sector",
                                "labels",
@@ -32,10 +27,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -51,10 +42,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
   
   UNION ALL
 
@@ -69,10 +56,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -87,10 +70,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(ARRAY[cc.mainToken, cc.wrappedToken]) AS t (element)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -105,10 +84,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(ARRAY[cc.mainToken, cc.wrappedToken]) AS t (element)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 ),
 
 settings AS (

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_ethereum.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_ethereum.sql
@@ -1,10 +1,5 @@
 {{config(
   alias = 'balancer_v2_pools_ethereum',
-  materialized = 'incremental',
-  
-  file_format = 'delta',
-  incremental_strategy = 'merge',
-  unique_key = ['address'],
   post_hook = '{{ expose_spells(\'["ethereum"]\',
                                "sector",
                                "labels",
@@ -32,10 +27,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -60,10 +51,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -88,10 +75,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -116,10 +99,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -144,10 +123,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
 
@@ -165,10 +140,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -183,10 +154,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -201,10 +168,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -219,10 +182,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -237,10 +196,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -255,10 +210,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -273,10 +224,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(ARRAY[cc.mainToken, cc.wrappedToken]) AS t (element)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -291,10 +238,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 ),
 
 settings AS (

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_gnosis.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_gnosis.sql
@@ -1,10 +1,5 @@
 {{config(
   alias = 'balancer_v2_pools_gnosis',
-  materialized = 'incremental',
-  
-  file_format = 'delta',
-  incremental_strategy = 'merge',
-  unique_key = ['address'],
   post_hook = '{{ expose_spells(\'["gnosis"]\',
                                "sector",
                                "labels",
@@ -32,10 +27,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -60,10 +51,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -79,10 +66,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -97,10 +80,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -115,10 +94,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -133,10 +108,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(ARRAY[cc.mainToken, cc.wrappedToken]) AS t (element)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -151,10 +122,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(ARRAY[cc.mainToken, cc.wrappedToken]) AS t (element)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -169,10 +136,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 ),
 
 settings AS (

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_optimism.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_optimism.sql
@@ -1,10 +1,5 @@
 {{config(
   alias = 'balancer_v2_pools_optimism',
-  materialized = 'incremental',
-  
-  file_format = 'delta',
-  incremental_strategy = 'merge',
-  unique_key = ['address'],
   post_hook = '{{ expose_spells(\'["optimism"]\',
                                "sector",
                                "labels",
@@ -32,10 +27,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -60,10 +51,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -88,10 +75,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -107,10 +90,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -125,10 +104,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -143,10 +118,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -161,10 +132,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -179,10 +146,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(ARRAY[cc.mainToken, cc.wrappedToken]) AS t (element)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -197,10 +160,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 ),
 
 settings AS (

--- a/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_polygon.sql
+++ b/models/labels/addresses/__single_category_labels__/balancer_v2/labels_balancer_v2_pools_polygon.sql
@@ -1,10 +1,5 @@
 {{config(
   alias = 'balancer_v2_pools_polygon',
-  materialized = 'incremental',
-  
-  file_format = 'delta',
-  incremental_strategy = 'merge',
-  unique_key = ['address'],
   post_hook = '{{ expose_spells(\'["polygon"]\',
                                "sector",
                                "labels",
@@ -32,10 +27,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -60,10 +51,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -88,10 +75,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.normalizedWeights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -116,10 +99,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -144,10 +123,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -163,10 +138,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -181,10 +152,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -199,10 +166,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -217,10 +180,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -235,10 +194,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -253,10 +208,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -271,10 +222,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(ARRAY[cc.mainToken, cc.wrappedToken]) AS t (element)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -289,10 +236,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 ),
 
 settings AS (

--- a/models/labels/addresses/__single_category_labels__/beethoven_x/labels_beethoven_x_pools_fantom.sql
+++ b/models/labels/addresses/__single_category_labels__/beethoven_x/labels_beethoven_x_pools_fantom.sql
@@ -1,9 +1,5 @@
 {{config(
   alias = 'beethoven_x_pools_fantom',
-  materialized = 'incremental',
-  file_format = 'delta',
-  incremental_strategy = 'merge',
-  unique_key = ['address'],
   post_hook = '{{ expose_spells(\'["fantom"]\',
                                "sector",
                                "labels",
@@ -31,10 +27,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -59,10 +51,6 @@ WITH pools AS (
     CROSS JOIN UNNEST(cc.tokens) WITH ORDINALITY t(tokens, pos)
     CROSS JOIN UNNEST(cc.weights) WITH ORDINALITY w(weights, pos)
     WHERE t.pos = w.pos
-    {% if is_incremental() %}
-      AND c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-      AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-    {% endif %}
   ) zip
 
   UNION ALL
@@ -78,10 +66,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -96,10 +80,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -114,10 +94,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 
   UNION ALL
 
@@ -132,11 +108,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
-
 
   UNION ALL
 
@@ -151,10 +122,6 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(ARRAY[cc.mainToken, cc.wrappedToken]) AS t (element)
-  {% if is_incremental() %}
-  WHERE c.evt_block_time >= date_trunc('day', now() - interval '7' day)
-    AND cc.call_block_time >= date_trunc('day', now() - interval '7' day)
-  {% endif %}
 ),
 
 settings AS (


### PR DESCRIPTION
Following discussions on Telegram, this PR removes the incremental models from the balancer and beethoven X pools labels spells