### PR TITLE
bnb transfers: break out wrapped into own model

### DIFF
--- a/models/_sector/tokens/bnb/_schema.yml
+++ b/models/_sector/tokens/bnb/_schema.yml
@@ -47,6 +47,52 @@ models:
       - name: amount_raw
         description: "The raw amount of the transfer"
 
+  - name: tokens_bnb_base_wrapped_transfers
+    meta:
+      blockchain: bnb
+      sector: tokens
+      contributors: aalan3, jeff-dude
+    config:
+      tags: ['tokens','transfers', 'bnb', 'wrapped']
+    description: >
+      Wrapped token transfers
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_number
+            - tx_index
+            - evt_index
+            - trace_address
+    columns:
+      - name: blockchain
+        description: "The blockchain of the transfers"
+      - name: block_datetime
+        description: "The date of the block"
+      - name: block_number
+        description: "The block number"
+      - name: tx_hash
+        description: "The transaction hash"
+      - name: tx_index
+        description: "The transaction index"
+      - name: tx_from
+        description: "The transaction sender"
+      - name: tx_to
+        description: "The transaction receiver"
+      - name: evt_index
+        description: "The log event index of the transfer if any"
+      - name: trace_address
+        description: "The trace address of the transfer if any"
+      - name: token_standard
+        description: "The token standard of the transfer"
+      - name: contract_address
+        description: "The contract address of the transfer"
+      - name: to
+        description: "The receiver of the transfer"
+      - name: from
+        description: "The sender of the transfer"
+      - name: amount_raw
+        description: "The raw amount of the transfer"
+
   - name: tokens_bnb_transfers
     meta:
       blockchain: bnb

--- a/models/_sector/tokens/bnb/tokens_bnb_base_wrapped_transfers.sql
+++ b/models/_sector/tokens/bnb/tokens_bnb_base_wrapped_transfers.sql
@@ -1,7 +1,7 @@
 {{config(
     tags = ['base_transfers_macro'],
     schema = 'tokens_bnb',
-    alias = 'base_transfers',
+    alias = 'base_wrapped_transfers',
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
@@ -11,11 +11,14 @@
 )
 }}
 
-{{transfers_base(
-    blockchain='bnb',
-    traces = source('bnb','traces'),
-    transactions = source('bnb','transactions'),
-    erc20_transfers = source('erc20_bnb','evt_transfer'),
-    native_contract_address = null
+SELECT *
+FROM
+(
+    {{transfers_base_wrapped_token(
+        blockchain='bnb',
+        transactions = source('bnb','transactions'),
+        wrapped_token_deposit = source('bnb_bnb', 'WBNB_evt_Deposit'),
+        wrapped_token_withdrawal = source('bnb_bnb', 'WBNB_evt_Withdrawal')
+    )
+    }}
 )
-}}


### PR DESCRIPTION
bnb won't run as-is on current prod cluster.
first attempt, try to break out wrapped into it's own model.