### PR TITLE
exclude crosschain transfers until prod cluster is ready

### DIFF
--- a/models/_sector/tokens/tokens_base_transfers.sql
+++ b/models/_sector/tokens/tokens_base_transfers.sql
@@ -1,4 +1,5 @@
 {{config(
+    tags = ['prod_exclude'],
     schema = 'tokens',
     alias = 'base_transfers',
     partition_by = ['blockchain', 'block_date'],


### PR DESCRIPTION
- bnb base transfers needs full refresh, cluster crashes
- cross chain crashes even without bnb included
- exclude for now to resume hourly job