### PR TITLE
Switch BPT Supply spell to table

### DIFF
--- a/models/balancer/arbitrum/balancer_v2_arbitrum_bpt_supply.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_bpt_supply.sql
@@ -3,11 +3,8 @@
 {{ config(
         schema='balancer_v2_' + blockchain,
         alias = 'bpt_supply',
-        materialized = 'incremental',
-        file_format = 'delta',
-        incremental_strategy = 'merge',
-        unique_key = ['day', 'token_address'],
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
+        materialized = 'table',
+        file_format = 'delta'
     )
 }}
 

--- a/models/balancer/avalanche_c/balancer_v2_avalanche_c_bpt_supply.sql
+++ b/models/balancer/avalanche_c/balancer_v2_avalanche_c_bpt_supply.sql
@@ -4,11 +4,8 @@
     config(
         schema='balancer_v2_' + blockchain,
         alias = 'bpt_supply',
-        materialized = 'incremental',
-        file_format = 'delta',
-        incremental_strategy = 'merge',
-        unique_key = ['day', 'token_address'],
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
+        materialized = 'table',
+        file_format = 'delta'
 
     )
 }}

--- a/models/balancer/base/balancer_v2_base_bpt_supply.sql
+++ b/models/balancer/base/balancer_v2_base_bpt_supply.sql
@@ -4,11 +4,8 @@
     config(
         schema='balancer_v2_' + blockchain,
         alias = 'bpt_supply',
-        materialized = 'incremental',
-        file_format = 'delta',
-        incremental_strategy = 'merge',
-        unique_key = ['day', 'token_address'],
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
+        materialized = 'table',
+        file_format = 'delta'
 
     )
 }}

--- a/models/balancer/ethereum/balancer_v2_ethereum_bpt_supply.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_bpt_supply.sql
@@ -4,11 +4,8 @@
     config(
         schema='balancer_v2_' + blockchain,
         alias = 'bpt_supply',
-        materialized = 'incremental',
-        file_format = 'delta',
-        incremental_strategy = 'merge',
-        unique_key = ['day', 'token_address'],
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
+        materialized = 'table',
+        file_format = 'delta'
 
     )
 }}

--- a/models/balancer/gnosis/balancer_v2_gnosis_bpt_supply.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_bpt_supply.sql
@@ -4,11 +4,8 @@
     config(
         schema='balancer_v2_' + blockchain,
         alias = 'bpt_supply',
-        materialized = 'incremental',
-        file_format = 'delta',
-        incremental_strategy = 'merge',
-        unique_key = ['day', 'token_address'],
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
+        materialized = 'table',
+        file_format = 'delta'
     )
 }}
 

--- a/models/balancer/optimism/balancer_v2_optimism_bpt_supply.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_bpt_supply.sql
@@ -4,11 +4,8 @@
     config(
         schema='balancer_v2_' + blockchain,
         alias = 'bpt_supply',
-        materialized = 'incremental',
-        file_format = 'delta',
-        incremental_strategy = 'merge',
-        unique_key = ['day', 'token_address'],
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
+        materialized = 'table',
+        file_format = 'delta'
     )
 }}
 

--- a/models/balancer/polygon/balancer_v2_polygon_bpt_supply.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_bpt_supply.sql
@@ -4,11 +4,8 @@
     config(
         schema='balancer_v2_' + blockchain,
         alias = 'bpt_supply',
-        materialized = 'incremental',
-        file_format = 'delta',
-        incremental_strategy = 'merge',
-        unique_key = ['day', 'token_address'],
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
+        materialized = 'table',
+        file_format = 'delta'
     )
 }}
 


### PR DESCRIPTION
As shown in this [query](https://dune.com/queries/3382117), the new BPT supply spell has the proper data until 2024-01-22. I believe what may have caused this issue was the fact that the spell was incremental. In this PR, I switch it to the same settings as the `balancer.liquidity` spell, which should fix is, as this [query](https://dune.com/queries/3382142) shows.

@mendesfabio 