### PR TITLE
Fix apeswap.trades blockchains

### DIFF
--- a/models/apeswap/apeswap_trades.sql
+++ b/models/apeswap/apeswap_trades.sql
@@ -1,7 +1,7 @@
 {{ config(
         
         alias = 'trades',
-        post_hook='{{ expose_spells(\'["bnb, ethereum, polygon"]\',
+        post_hook='{{ expose_spells(\'["bnb", "ethereum", "polygon"]\',
                         "project",
                         "apeswap",
                         \'["codingsh"]\') }}'


### PR DESCRIPTION
Running the command 

```
dbt compile && jq . target/manifest.json | rg --context 65 '"model.spellbook.apeswap.trades": \{'
```

Before:
```
"sql": "{{ expose_spells('[\"bnb, ethereum, polygon\"]
```

After:

```
 "sql": "{{ expose_spells('[\"bnb\", \"ethereum\", \"polygon\"]
```

Towards PRO-708.