### PR TITLE
add v2 automation nodes

### DIFF
--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_meta.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_meta.sql
@@ -1,6 +1,5 @@
 {{
   config(
-    
     alias='automation_meta',
     materialized = 'view'
   )
@@ -9,6 +8,7 @@
 {% set _01node = '01node' %}
 {% set alphachain = 'alphachain' %}
 {% set blockdaemon = 'blockdaemon' %}
+{% set chainlayer = 'chainlayer' %}
 {% set dextrac = 'dextrac' %}
 {% set fiews = 'fiews' %}
 {% set inotel = 'inotel' %}
@@ -16,6 +16,7 @@
 {% set linkforest = 'linkforest' %}
 {% set linkpool = 'linkpool' %}
 {% set linkriver = 'linkriver' %}
+{% set piertwo = 'piertwo' %}
 {% set simplyvc = 'simplyvc' %}
 {% set validationcapital = 'validationcapital' %}
 
@@ -27,13 +28,22 @@ FROM (VALUES
   ('{{_01node}}', 0xe0b4fb0822d1f71977B33109F9F84948d4c31e4A),
   ('{{alphachain}}', 0xcB3Ef22D906a3518EF3FB318DFaf94C039ee683c),
   ('{{blockdaemon}}', 0xA18cE786F361a00CB830E87F3B1179c5ac89484E),
+  ('{{chainlayer}}', 0xCD55352E94264D35F1C7792b0d78a9Df7DEe9bE4),
   ('{{dextrac}}', 0xCf3C657abF393D4425d938d7DC35AF774fa31410),
   ('{{fiews}}', 0x23C3B573aec3D978082F8F4DfAe1B9b57c658Fb9),
+  ('{{fiews}}', 0x4dD8ED7943AaAAF2f637620c20eb703b8BABB842),
   ('{{inotel}}', 0x3965BCE1B6F4B872d0C6e3A2EfC5ecF39ec2c883),
+  ('{{inotel}}', 0x9db12f20287385224bB54a98BA1e217e636A14e6),
   ('{{lexisnexis}}', 0xA7542d863e6bcCF9DFa4db11fD5823dd56022f34),
   ('{{linkforest}}', 0x762A9C7c6EC4b80ef01ac89D72A0eB5731Dd3447),
+  ('{{linkforest}}', 0xD7B588602C3eba9545D2f07FD203bF70ceB8db32),
+  ('{{linkforest}}', 0x70eF4887667C7FA839B75dE14CAEF587439aD29d),
   ('{{linkpool}}', 0xF12930fE0d73957Bac81C4A44000891A69219157),
+  ('{{linkpool}}', 0x3C7f1112FB3Dc51CD9b680a04ba7D08f32673E6c),
   ('{{linkriver}}', 0x5F5fc989ea771E07dc01db04BeE543b9bab2D5E1),
+  ('{{linkriver}}', 0xbc47E2923FAE161AcC6f9C58Bc5e171b9229748C),
+  ('{{piertwo}}', 0x99A21e78eb13b6ACEE09dF60842557a9E6C73dB2),
   ('{{simplyvc}}', 0x648715137b75f40c9F8DC17701d0BEd43958771f),
+  ('{{simplyvc}}', 0xefFA312e7287F4a66301032d413286821fe822A4),
   ('{{validationcapital}}', 0xDb1e4d2378B20E8bc933b134395279b0ddB8e682)
 ) a (operator_name, keeper_address)

--- a/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_upkeep_performed_logs.sql
+++ b/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_upkeep_performed_logs.sql
@@ -29,3 +29,5 @@ FROM
   {{ source('avalanche_c', 'logs') }} logs
 WHERE
   topic0 = 0xcaacad83e47cc45c280d487ec84184eee2fa3b54ebaa393bda7549f13da228f6 -- UpkeepPerformed
+OR
+  topic0 = 0xad8cc9579b21dfe2c2f6ea35ba15b656e46b4f5b0cb424f52739b8ce5cac9c5b -- UpkeepPerformedV2

--- a/models/chainlink/bnb/chainlink_bnb_automation_meta.sql
+++ b/models/chainlink/bnb/chainlink_bnb_automation_meta.sql
@@ -1,6 +1,5 @@
 {{
   config(
-    
     alias='automation_meta',
     materialized = 'view'
   )
@@ -8,10 +7,14 @@
 
 {% set _01node = '01node' %}
 {% set alphachain = 'alphachain' %}
+{% set chainlayer = 'chainlayer' %}
+{% set dextrac = 'dextrac' %}
 {% set easy2stake = 'easy2stake' %}
 {% set fiews = 'fiews' %}
 {% set inotel = 'inotel' %}
 {% set linkforest = 'linkforest' %}
+{% set linkpool = 'linkpool' %}
+{% set linkriver = 'linkriver' %}
 {% set piertwo = 'piertwo' %}
 {% set simplyvc = 'simplyvc' %}
 
@@ -22,18 +25,27 @@ SELECT
 FROM (VALUES
   ('{{_01node}}', 0xd0C77d2E37d87E14922B07C48D448251ea3A6141),
   ('{{_01node}}', 0x43028Ea36A0db9BaBe5D0Bd9DA00d010aC135c37),
-  ('{{alphachain}}', 0x7828bD0D31aaE91193676139d96d2572942cC489),
   ('{{alphachain}}', 0x22901bdd0ACC34F435F57CAD1F0A9C5957136F8C),
-  ('{{easy2stake}}', 0x3c2a32898f6504BC35e8e3689d13A8E9A114B7b5),
+  ('{{alphachain}}', 0x7828bD0D31aaE91193676139d96d2572942cC489),
+  ('{{chainlayer}}', 0x228aB6d3e8bEbd6FA30B50E478D87A510617AA0f),
+  ('{{dextrac}}', 0x24753929D0848988f2CF3d779CFe3211CD43b379),
   ('{{easy2stake}}', 0xA4e2864F6541721dFa36F96e8D868E0AdBD94881),
-  ('{{fiews}}', 0x2c86d590177554E1A99343cb18f095D5e099c4D7),
+  ('{{easy2stake}}', 0x3c2a32898f6504BC35e8e3689d13A8E9A114B7b5),
   ('{{fiews}}', 0x765e469537F580f16B8C4bCF5BD4D823761678ad),
-  ('{{inotel}}', 0x4922449C17Cee53b262191834FFf6fbc82A80f9C),
+  ('{{fiews}}', 0x2c86d590177554E1A99343cb18f095D5e099c4D7),
+  ('{{fiews}}', 0xA13fDb8Dda2196091E993498C7F2A3183A3ED58a),
   ('{{inotel}}', 0xdd381028cfa5241284D23CE73ef7F0E3042d80F8),
-  ('{{linkforest}}', 0x604410B182CDe4eCEB191Cfa2E0FD33224024c83),
+  ('{{inotel}}', 0x7D23dd26E2F0465150625667d224BBD3B35E2b17),
+  ('{{inotel}}', 0x4922449C17Cee53b262191834FFf6fbc82A80f9C),
   ('{{linkforest}}', 0x80C0EB96c401a441DF6D19ECd8e562b18C4E4E24),
-  ('{{piertwo}}', 0xDed3787602432bc12271C467Bb02138b0Ee79923),
+  ('{{linkforest}}', 0x604410B182CDe4eCEB191Cfa2E0FD33224024c83),
+  ('{{linkforest}}', 0xa7d2C71Eaa52DdD12eB4C48C52318eaa82C5bb37),
+  ('{{linkpool}}', 0xB9a93AADAB82a903eC43967F4C9FEf9297116D90),
+  ('{{linkriver}}', 0x017B3bc89c1EA9b7F02f1F01B8E667290e9c1ff4),
   ('{{piertwo}}', 0x60a764804dC2FaA78e06C1f09C1fc7236a3A7B9E),
+  ('{{piertwo}}', 0xDed3787602432bc12271C467Bb02138b0Ee79923),
+  ('{{piertwo}}', 0x8b4b6886dFAfD77Bd8d8ddF84Ad3a0F2d1Cad936),
+  ('{{simplyvc}}', 0x07ACeD52eeBbd1642799fb48bBEaD5Bc64616341),
   ('{{simplyvc}}', 0xBa61a9E217306315C239E73597d410e1bd469420),
-  ('{{simplyvc}}', 0x07ACeD52eeBbd1642799fb48bBEaD5Bc64616341)
+  ('{{simplyvc}}', 0x2CCADCa3Dc99a6d55E2588e4255215b90Cff3320)
 ) a (operator_name, keeper_address)

--- a/models/chainlink/bnb/chainlink_bnb_automation_upkeep_performed_logs.sql
+++ b/models/chainlink/bnb/chainlink_bnb_automation_upkeep_performed_logs.sql
@@ -29,3 +29,5 @@ FROM
   {{ source('bnb', 'logs') }} logs
 WHERE
   topic0 = 0xcaacad83e47cc45c280d487ec84184eee2fa3b54ebaa393bda7549f13da228f6 -- UpkeepPerformed
+OR
+  topic0 = 0xad8cc9579b21dfe2c2f6ea35ba15b656e46b4f5b0cb424f52739b8ce5cac9c5b -- UpkeepPerformedV2

--- a/models/chainlink/ethereum/chainlink_ethereum_automation_meta.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_automation_meta.sql
@@ -1,6 +1,5 @@
 {{
   config(
-    
     alias='automation_meta',
     materialized = 'view'
   )
@@ -17,6 +16,7 @@
 {% set linkforest = 'linkforest' %}
 {% set linkpool = 'linkpool' %}
 {% set linkriver = 'linkriver' %}
+{% set piertwo = 'piertwo' %}
 {% set simplyvc = 'simplyvc' %}
 {% set snzpool = 'snzpool' %}
 {% set syncnode = 'syncnode' %}
@@ -28,30 +28,38 @@ SELECT
 FROM (VALUES
   ('{{_01node}}', 0x5428D5Ef94E5998d39613ADCf2f523Cee6f6fb45),
   ('{{_01node}}', 0x4b247AFfe9c4CE6bF05e4A3204ea261288bB4156),
-  ('{{alphachain}}', 0xB9B28c3341A88005E421612996BD69A86550909d),
   ('{{alphachain}}', 0x18cBe724E7C248cdA2803F48D1EA6d019623b5cC),
-  ('{{anyblock}}', 0x0CE0d98B1FFC1E670e4A68a4B809733884C43174),
+  ('{{alphachain}}', 0xB9B28c3341A88005E421612996BD69A86550909d),
   ('{{anyblock}}', 0xa7b2Cf222d287D568E24085E514d4b197759394f),
-  ('{{chainlayer}}', 0xaEDcB41619D651dcB0ACF7652127Fc1C66776136),
+  ('{{anyblock}}', 0x0CE0d98B1FFC1E670e4A68a4B809733884C43174),
   ('{{chainlayer}}', 0x72855d64b7EB20379cbd9AB826c0a35DCE33f375),
-  ('{{cryptomanufaktur}}', 0x7cb9ff1Ad03DB9D6CCBF99c2A1da872218467612),
+  ('{{chainlayer}}', 0xaEDcB41619D651dcB0ACF7652127Fc1C66776136),
+  ('{{chainlayer}}', 0xA6723Be6bbf6991c8b2dd56e38b82fe2a945aadc),
   ('{{cryptomanufaktur}}', 0x3824b7a9C6d4Ea93456DF9B07df4fFDB37FFBcbf),
-  ('{{dextrac}}', 0x79A4e2666554bF0d47854df60dEaA2636c3E7423),
+  ('{{cryptomanufaktur}}', 0x7cb9ff1Ad03DB9D6CCBF99c2A1da872218467612),
   ('{{dextrac}}', 0x33512418380F170e5752Fc233F1326f3e805eA62),
-  ('{{fiews}}', 0x354B6380aD551B805d4910FF1827FC71102dDBCd),
+  ('{{dextrac}}', 0x79A4e2666554bF0d47854df60dEaA2636c3E7423),
   ('{{fiews}}', 0x98924befaA16b607b3E168b6C57C9528AF5CC076),
-  ('{{inotel}}', 0x8Ad2f5C3e80db1B1e60c13F1D68Fb71807E665DA),
+  ('{{fiews}}', 0x354B6380aD551B805d4910FF1827FC71102dDBCd),
+  ('{{fiews}}', 0x4ef3c3dC7fBd1eda22e6F85241Bd22f2C2013721),
   ('{{inotel}}', 0x083b4cC0DB892160DC5928066D294ba8D4220830),
-  ('{{linkforest}}', 0x6E0BD9b8AD35fDc17a6DEf7CF81B5067B7FaA72f),
+  ('{{inotel}}', 0x8Ad2f5C3e80db1B1e60c13F1D68Fb71807E665DA),
+  ('{{inotel}}', 0x476e1Cd47944E6EC43B1Fdae606C312544C79569),
   ('{{linkforest}}', 0x5C581b8c0961F93543112bf1Ffa27C1cA166e0e5),
-  ('{{linkpool}}', 0xFc79eB954321f2e63E29AcbCd46e0e63374923ff),
+  ('{{linkforest}}', 0x6E0BD9b8AD35fDc17a6DEf7CF81B5067B7FaA72f),
+  ('{{linkforest}}', 0x9ae266Da46F55b48bD85B18B441FEC15ca07Eb8b),
   ('{{linkpool}}', 0x836cDB9041b442c11c85442A4E5a87aB3dcc0a5F),
-  ('{{linkriver}}', 0xd835f40d4719d96E7a000003276786f8Ab50a4A7),
+  ('{{linkpool}}', 0xFc79eB954321f2e63E29AcbCd46e0e63374923ff),
+  ('{{linkpool}}', 0x72B8fD3eb0c08275b8B60F96aAb0C8a50Cb80EcA),
   ('{{linkriver}}', 0xE48f40fBc76cbA315F99Fd5Ba08AfA2f00B8E074),
-  ('{{simplyvc}}', 0x77d189d2fD02053978B2E0dc959A6A5536084813),
+  ('{{linkriver}}', 0xd835f40d4719d96E7a000003276786f8Ab50a4A7),
+  ('{{linkriver}}', 0x31DB4c2360d0fE6881c9015b11a93f4E7e78a3b0),
+  ('{{piertwo}}', 0x5Cc9b29c498cE52D6aFEFE1AAB7dEbf54A71E754),
   ('{{simplyvc}}', 0xF12571de5A310008F1B7490F1aAf52de11325cC8),
-  ('{{snzpool}}', 0xaD221f4A2D705CDe03c594beab517CecBDA6727d),
+  ('{{simplyvc}}', 0x77d189d2fD02053978B2E0dc959A6A5536084813),
+  ('{{simplyvc}}', 0xf8AF3C8D4CEaf3c5a94Fa1a9384a0ef197FD50e5),
   ('{{snzpool}}', 0x0Fd40853B3B8c7805158b862B76B35A2a27B596A),
-  ('{{syncnode}}', 0xA6dBdafa187eDDc4D7A9D8E6B9A2D3F46ee30d24),
-  ('{{syncnode}}', 0x86C5d9efB1377DbA0535Cf944Bd6F5736c4290cB)
+  ('{{snzpool}}', 0xaD221f4A2D705CDe03c594beab517CecBDA6727d),
+  ('{{syncnode}}', 0x86C5d9efB1377DbA0535Cf944Bd6F5736c4290cB),
+  ('{{syncnode}}', 0xA6dBdafa187eDDc4D7A9D8E6B9A2D3F46ee30d24)
 ) a (operator_name, keeper_address)

--- a/models/chainlink/ethereum/chainlink_ethereum_automation_upkeep_performed_logs.sql
+++ b/models/chainlink/ethereum/chainlink_ethereum_automation_upkeep_performed_logs.sql
@@ -25,3 +25,5 @@ FROM
   {{ source('ethereum', 'logs') }} logs
 WHERE
   topic0 = 0xcaacad83e47cc45c280d487ec84184eee2fa3b54ebaa393bda7549f13da228f6 -- UpkeepPerformed
+OR
+  topic0 = 0xad8cc9579b21dfe2c2f6ea35ba15b656e46b4f5b0cb424f52739b8ce5cac9c5b -- UpkeepPerformedV2

--- a/models/chainlink/fantom/chainlink_fantom_automation_meta.sql
+++ b/models/chainlink/fantom/chainlink_fantom_automation_meta.sql
@@ -1,6 +1,5 @@
 {{
   config(
-    
     alias='automation_meta',
     materialized = 'view'
   )

--- a/models/chainlink/fantom/chainlink_fantom_automation_upkeep_performed_logs.sql
+++ b/models/chainlink/fantom/chainlink_fantom_automation_upkeep_performed_logs.sql
@@ -30,3 +30,5 @@ FROM
 LEFT JOIN {{ source('fantom', 'transactions') }} fantom_tx ON fantom_tx.hash = logs.tx_hash
 WHERE
   topic0 = 0xcaacad83e47cc45c280d487ec84184eee2fa3b54ebaa393bda7549f13da228f6 -- UpkeepPerformed
+OR
+  topic0 = 0xad8cc9579b21dfe2c2f6ea35ba15b656e46b4f5b0cb424f52739b8ce5cac9c5b -- UpkeepPerformedV2

--- a/models/chainlink/polygon/chainlink_polygon_automation_meta.sql
+++ b/models/chainlink/polygon/chainlink_polygon_automation_meta.sql
@@ -1,16 +1,18 @@
 {{
   config(
-    
     alias='automation_meta',
     materialized = 'view'
   )
 }}
 
 {% set _01node = '01node' %}
+{% set chainlayer = 'chainlayer' %}
 {% set cryptomanufaktur = 'cryptomanufaktur' %}
+{% set dextrac = 'dextrac' %}
 {% set fiews = 'fiews' %}
 {% set inotel = 'inotel' %}
 {% set linkforest = 'linkforest' %}
+{% set linkpool = 'linkpool' %}
 {% set linkriver = 'linkriver' %}
 {% set piertwo = 'piertwo' %}
 {% set simplyvc = 'simplyvc' %}
@@ -23,20 +25,29 @@ SELECT
 FROM (VALUES
   ('{{_01node}}', 0xA7d87D93Fc879c5ec959EbdC4a058bC906be42EC),
   ('{{_01node}}', 0x8B544FcE2177A84FFDb42800e947747A6277f5Ab),
-  ('{{cryptomanufaktur}}', 0x27c143A6B7CfADB4686c1d06e45EaB79B53f82B6),
+  ('{{chainlayer}}', 0xD2cEBc57ADc65d03Af829ccB53517a9b90e3219C),
   ('{{cryptomanufaktur}}', 0xd9a31dc8347284a6BEa9598d49d8DAcbFD5774F1),
-  ('{{fiews}}', 0x0c904E705943c4C1D8e56ba5062Fa005343F4bfd),
+  ('{{cryptomanufaktur}}', 0x27c143A6B7CfADB4686c1d06e45EaB79B53f82B6),
+  ('{{dextrac}}', 0x9cB11Bb6568082502e46A43cE4fC48d6e07c567A),
   ('{{fiews}}', 0x4ED89b6E3eBE0FB4a97cb9Fa5C4FAB64b1045B39),
-  ('{{inotel}}', 0x858A480e5b92A8d9D8864785cbF11B4C5dD56Dfe),
+  ('{{fiews}}', 0x0c904E705943c4C1D8e56ba5062Fa005343F4bfd),
+  ('{{fiews}}', 0xdDb52466E31F80E3269885BD161C08087b54B287),
   ('{{inotel}}', 0x71DD101432FD1041DfD7b718b1c0adeb1cE13d60),
-  ('{{linkforest}}', 0x5175d113eaC843Da5bff4a577C64789328AEbb4f),
+  ('{{inotel}}', 0x858A480e5b92A8d9D8864785cbF11B4C5dD56Dfe),
+  ('{{inotel}}', 0x99Fd8F54f0FD6AE073De12Ae7efe554B9A8b76C0),
   ('{{linkforest}}', 0x18542E08F4267C8ddCFEF6E6E692CeF8eF3A8365),
-  ('{{linkriver}}', 0xe58B9a01f01f444cd45fF47C41529d400adE9A52),
+  ('{{linkforest}}', 0x5175d113eaC843Da5bff4a577C64789328AEbb4f),
+  ('{{linkforest}}', 0x80aC52aC017f8cEbE579F40f2fFC5C3A7968De10),
+  ('{{linkpool}}', 0xCe08a02e0f6858DDc0e31110972e8139Cf0a146d),
   ('{{linkriver}}', 0x8ABe586e96745D4acA358bAe11e71F5A59434f47),
-  ('{{piertwo}}', 0x93fa1481BF95C47a9c6F26B8e70a81C7A607934b),
+  ('{{linkriver}}', 0xe58B9a01f01f444cd45fF47C41529d400adE9A52),
+  ('{{linkriver}}', 0xA53e021Be83d0251eD58452Dd3FC1623186a6ad0),
   ('{{piertwo}}', 0x7a80bEaCcA09e2F3d8DDb7ABFdc975e1efB194d7),
-  ('{{simplyvc}}', 0x6c995b2abCbd72a4A35D80F9c5476f496Ee97bD1),
+  ('{{piertwo}}', 0x93fa1481BF95C47a9c6F26B8e70a81C7A607934b),
+  ('{{piertwo}}', 0x3036fc59b1c457ab5336059d828518e6fDb54cfD),
   ('{{simplyvc}}', 0x953731C84798d6F64c795da8973f565761A8964C),
-  ('{{stakingfacilities}}', 0x19c67363742a485a7BE3DF520a889E5E3a73337A),
-  ('{{stakingfacilities}}', 0xd1Be7FcE9C87F22E3715d257FCE92F7595018B67)
+  ('{{simplyvc}}', 0x6c995b2abCbd72a4A35D80F9c5476f496Ee97bD1),
+  ('{{simplyvc}}', 0x09DafcF34369842EB7E7a5662Bb6793171127Ed1),
+  ('{{stakingfacilities}}', 0xd1Be7FcE9C87F22E3715d257FCE92F7595018B67),
+  ('{{stakingfacilities}}', 0x19c67363742a485a7BE3DF520a889E5E3a73337A)
 ) a (operator_name, keeper_address)

--- a/models/chainlink/polygon/chainlink_polygon_automation_upkeep_performed_logs.sql
+++ b/models/chainlink/polygon/chainlink_polygon_automation_upkeep_performed_logs.sql
@@ -29,3 +29,5 @@ FROM
   {{ source('polygon', 'logs') }} logs
 WHERE
   topic0 = 0xcaacad83e47cc45c280d487ec84184eee2fa3b54ebaa393bda7549f13da228f6 -- UpkeepPerformed
+OR
+  topic0 = 0xad8cc9579b21dfe2c2f6ea35ba15b656e46b4f5b0cb424f52739b8ce5cac9c5b -- UpkeepPerformedV2


### PR DESCRIPTION
Chainlink Automation V2 update.
- Add node operator meta for V2 nodes
- Add new event to `upkeepPerformed` logs