### PR TITLE
evm.creation_traces materialization edit

### DIFF
--- a/models/evms/evms_creation_traces.sql
+++ b/models/evms/evms_creation_traces.sql
@@ -1,6 +1,7 @@
 {{ config(
         
         alias = 'creation_traces',
+        materialized = 'table',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
         post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "celo", "base", "goerli", "zksync", "zora"]\',
                                     "sector",

--- a/models/evms/evms_creation_traces.sql
+++ b/models/evms/evms_creation_traces.sql
@@ -1,7 +1,6 @@
 {{ config(
-        
+
         alias = 'creation_traces',
-        materialized = 'table',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
         post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "celo", "base", "goerli", "zksync", "zora"]\',
                                     "sector",

--- a/models/evms/evms_creation_traces.sql
+++ b/models/evms/evms_creation_traces.sql
@@ -40,11 +40,11 @@ FROM (
         --, tx_from
         --, tx_to
         FROM {{ creation_traces_model[1] }}
-        {% if not loop.last %}
-        {% if is_incremental() %}
+    {% if not loop.last or is_incremental() %}
         WHERE {{incremental_predicate('block_time')}}
-        {% endif %}
+    {% endif %}
+    {% if not loop.last %}
         UNION ALL
-        {% endif %}
-        {% endfor %}
-        );
+    {% endif %}
+    {% endfor %}
+);

--- a/models/evms/evms_creation_traces.sql
+++ b/models/evms/evms_creation_traces.sql
@@ -1,6 +1,7 @@
 {{ config(
 
         alias = 'creation_traces',
+        materialized = 'incremental',
         unique_key=['blockchain', 'tx_hash', 'evt_index'],
         post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "celo", "base", "goerli", "zksync", "zora"]\',
                                     "sector",
@@ -40,6 +41,9 @@ FROM (
         --, tx_to
         FROM {{ creation_traces_model[1] }}
         {% if not loop.last %}
+        {% if is_incremental() %}
+        WHERE {{incremental_predicate('block_time')}}
+        {% endif %}
         UNION ALL
         {% endif %}
         {% endfor %}


### PR DESCRIPTION
Querying evm.creation_traces is a requirement of an internal project and queries are taking ~2 min. I'd like to see if it's possible to materialize this as a table. fwiw, I think this is going to need to be incremental because it's 1,075,547,999 rows atm but I wanted to at least verify table was out of the question before making it incremental. 