### PR TITLE
Fix odos source

### DIFF
--- a/sources/odos/optimism/odos_optimism_sources.yml
+++ b/sources/odos/optimism/odos_optimism_sources.yml
@@ -17,3 +17,4 @@ sources:
       Decoded event table for swaps on odos_v2
     tables:
       - name: OdosRouterV2_evt_Swap
+        loaded_at_field: evt_block_time


### PR DESCRIPTION
Adding `loaded_at_field` to fix this warning:
https://github.com/duneanalytics/spellbook/actions/runs/7905960218/job/21579741079?pr=5336#step:8:13
