### PR TITLE
Add ggAVAX to tokens.erc20.sql

### DIFF
--- a/tokens/models/tokens/avalanche_c/tokens_avalanche_c_erc20.sql
+++ b/tokens/models/tokens/avalanche_c/tokens_avalanche_c_erc20.sql
@@ -237,4 +237,6 @@ FROM (VALUES
         ,(0xefd6aa06eb95e0ab23de9ac0977d870888b89a71, 'MICRO', 18)
         ,(0x913c61ec3573e5e4ee6488552535fb1be84ff2ac, 'XAV', 18)
         ,(0x609268b9c47c7be0a8d77ae93c31d2bf6859d175, 'LONG', 18)
+        ,(0xa25eaf2906fa1a3a13edac9b9657108af7b703e3, 'ggAVAX', 18)
+        ,(0xf7d9281e8e363584973f946201b82ba72c965d27, 'yyAVAX', 18)        
     ) AS temp_table (contract_address, symbol, decimals)

--- a/tokens/models/tokens/avalanche_c/tokens_avalanche_c_erc20.sql
+++ b/tokens/models/tokens/avalanche_c/tokens_avalanche_c_erc20.sql
@@ -237,6 +237,5 @@ FROM (VALUES
         ,(0xefd6aa06eb95e0ab23de9ac0977d870888b89a71, 'MICRO', 18)
         ,(0x913c61ec3573e5e4ee6488552535fb1be84ff2ac, 'XAV', 18)
         ,(0x609268b9c47c7be0a8d77ae93c31d2bf6859d175, 'LONG', 18)
-        ,(0xa25eaf2906fa1a3a13edac9b9657108af7b703e3, 'ggAVAX', 18)
-        ,(0xf7d9281e8e363584973f946201b82ba72c965d27, 'yyAVAX', 18)        
+        ,(0xa25eaf2906fa1a3a13edac9b9657108af7b703e3, 'ggAVAX', 18)    
     ) AS temp_table (contract_address, symbol, decimals)


### PR DESCRIPTION
This PR adds a missing token on `tokens.erc20` for the avalanche-c chain.
[ggAVAX](https://snowtrace.io/address/0xa25eaf2906fa1a3a13edac9b9657108af7b703e3)