### PR TITLE
exclude pharaoh on avalanche_c due to missing sources

### DIFF
--- a/models/_sector/dex/trades/avalanche_c/platforms/pharaoh_avalanche_c_base_trades.sql
+++ b/models/_sector/dex/trades/avalanche_c/platforms/pharaoh_avalanche_c_base_trades.sql
@@ -1,5 +1,6 @@
 {{ config(
-    schema = 'pharaoh_avalanche_c'
+    tags = ['prod_exclude']
+    , schema = 'pharaoh_avalanche_c'
     , alias = 'base_trades'
     , materialized = 'incremental'
     , file_format = 'delta'

--- a/models/pharaoh/pharaoh_avalanche_c_trades.sql
+++ b/models/pharaoh/pharaoh_avalanche_c_trades.sql
@@ -1,5 +1,6 @@
 {{ config(
-    schema = 'pharaoh_avalanche_c'
+    tags = ['prod_exclude']
+    , schema = 'pharaoh_avalanche_c'
     , alias = 'trades'
     , partition_by = ['block_month']
     , materialized = 'incremental'


### PR DESCRIPTION
fyi @discochuck @Hosuke 
these are failing in prod due to missing source (likely a decoded table renamed)

please open a new PR with a fix and we can re-enable in prod. update the source yaml file and the source itself in the model.