### PR TITLE
`dex_raw_pool_creations` remove bnb due to duplicates

### DIFF
--- a/models/dex/dex_raw_pool_creations.sql
+++ b/models/dex/dex_raw_pool_creations.sql
@@ -55,7 +55,6 @@
     set blockchains = [
         "ethereum",
         "polygon",
-        "bnb",
         "avalanche_c",
         "gnosis",
         "fantom",


### PR DESCRIPTION
fyi @grkhr @max-morrow 
similar to #5308 -- remove blockchain which is causing duplicates and prod to fail
the same query from previous PR can be used:
https://dune.com/queries/3412754