### PR TITLE
Disable opensea_v4_ethereum

### DIFF
--- a/models/opensea/ethereum/opensea_v4_ethereum_events.sql
+++ b/models/opensea/ethereum/opensea_v4_ethereum_events.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'opensea_v4_ethereum',
     alias = 'events',
-    
+    tags=['prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',


### PR DESCRIPTION
This model is failing on merge duplicates.
Disabling should unblock the rest of `nft.trades`, I'll investigate and fix on monday. 