### PR TITLE
Changes to balancer.liquidity and balancer.protocol_fee

### DIFF
--- a/macros/models/_project/balancer/balancer_liquidity_macro.sql
+++ b/macros/models/_project/balancer/balancer_liquidity_macro.sql
@@ -32,18 +32,26 @@ WITH pool_labels AS (
             sum(sample_size) AS sample_size
         FROM {{ ref('dex_prices') }}
         GROUP BY 1, 2
-        HAVING sum(sample_size) > 9
+        HAVING sum(sample_size) > 3
     ),
+
+    dex_prices_2 AS(
+        SELECT 
+            day,
+            token,
+            price,
+            lag(price) OVER(PARTITION BY token ORDER BY day) AS previous_price
+        FROM dex_prices_1
+    ),    
 
     dex_prices AS (
         SELECT
-            *,
-            LEAD(DAY, 1, NOW()) OVER (
-                PARTITION BY token
-                ORDER BY
-                    DAY
-            ) AS day_of_next_change
-        FROM dex_prices_1
+            day,
+            token,
+            price,
+            LEAD(DAY, 1, NOW()) OVER (PARTITION BY token ORDER BY DAY) AS day_of_next_change
+        FROM dex_prices_2
+        WHERE (price < previous_price * 1e4 AND price > previous_price / 1e4)
     ),
 
     bpt_prices AS(


### PR DESCRIPTION
This PR introduces a small change in how the `dex.prices `spell is queried on `balancer.liquidity` and `balancer.protocol_fee`.
It basically allows us to lower the minimum `sample_size` required while protecting us from outliers with a simple filter 
`WHERE (price < previous_price * 1e4 AND price > previous_price / 1e4)`.
A clear example of an outlier that was skewing our data is for the [MIMO](https://coinpaprika.com/coin/mimo-mimo-governance/) token, as shown on this [query](https://dune.com/queries/3475121), while thie [query](https://dune.com/queries/3472661/5836489) show the fixed data.