### PR TITLE
Add missing tokens on tokens_erc20

### DIFF
--- a/tokens/models/tokens/arbitrum/tokens_arbitrum_erc20.sql
+++ b/tokens/models/tokens/arbitrum/tokens_arbitrum_erc20.sql
@@ -220,5 +220,4 @@ FROM (VALUES
         ,(0xe3b3FE7bcA19cA77Ad877A5Bebab186bEcfAD906, 'sFRAX', 18)   
         ,(0x641441c631e2F909700d2f41FD87F0aA6A6b4EDb, 'USX', 18)   
         ,(0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51, 'plsRDNT', 18)   
-    
      ) AS temp_table (contract_address, symbol, decimals)

--- a/tokens/models/tokens/arbitrum/tokens_arbitrum_erc20.sql
+++ b/tokens/models/tokens/arbitrum/tokens_arbitrum_erc20.sql
@@ -215,4 +215,10 @@ FROM (VALUES
         ,(0xA98c94d67D9dF259Bee2E7b519dF75aB00E3E2A8, 'bwAJNA', 18)
         ,(0x95ab45875cffdba1e5f451b950bc2e42c0053f39, 'sfrxETH', 18)   
         ,(0xe05a08226c49b636acf99c40da8dc6af83ce5bb3, 'ankrETH', 18)   
+        ,(0x6A7661795C374c0bFC635934efAddFf3A7Ee23b6, 'DOLA', 18)   
+        ,(0x1509706a6c66CA549ff0cB464de88231DDBe213B, 'AURA', 18)   
+        ,(0xe3b3FE7bcA19cA77Ad877A5Bebab186bEcfAD906, 'sFRAX', 18)   
+        ,(0x641441c631e2F909700d2f41FD87F0aA6A6b4EDb, 'USX', 18)   
+        ,(0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51, 'plsRDNT', 18)   
+    
      ) AS temp_table (contract_address, symbol, decimals)

--- a/tokens/models/tokens/gnosis/tokens_gnosis_erc20.sql
+++ b/tokens/models/tokens/gnosis/tokens_gnosis_erc20.sql
@@ -8994,4 +8994,5 @@ FROM (VALUES (0x3f9463bdb502ec2079bf39da6c924d4022ff9f4c, 'biubiu.tools', 18),
             ,(0x35915abb3505dffc115b79b090dde438ebe311f1, 'CRC', 18)
             ,(0x4b1e2c2762667331bc91648052f646d1b0d35984, 'agEUR', 18)
             ,(0x7fE440bC581DA8fF0173a588D3f7603814393763, 'bwAJNA', 18)
+            ,(0xaf204776c7245bf4147c2612bf6e5972ee483701, 'sDAI', 18)
      ) AS temp_table (contract_address, symbol, decimals)

--- a/tokens/models/tokens/gnosis/tokens_gnosis_erc20.sql
+++ b/tokens/models/tokens/gnosis/tokens_gnosis_erc20.sql
@@ -8995,4 +8995,5 @@ FROM (VALUES (0x3f9463bdb502ec2079bf39da6c924d4022ff9f4c, 'biubiu.tools', 18),
             ,(0x4b1e2c2762667331bc91648052f646d1b0d35984, 'agEUR', 18)
             ,(0x7fE440bC581DA8fF0173a588D3f7603814393763, 'bwAJNA', 18)
             ,(0xaf204776c7245bf4147c2612bf6e5972ee483701, 'sDAI', 18)
+            ,(0xce11e14225575945b8e6dc0d4f2dd4c570f79d9f, 'OLAS', 18)
      ) AS temp_table (contract_address, symbol, decimals)


### PR DESCRIPTION
This PR adds [sDAI](https://gnosisscan.io/token/0xaf204776c7245bf4147c2612bf6e5972ee483701) and [OLAS](https://gnosisscan.io/token/0xce11e14225575945b8e6dc0d4f2dd4c570f79d9f) on gnosis and [DOLA](https://arbiscan.io/token/0x6a7661795c374c0bfc635934efaddff3a7ee23b6), [AURA](https://arbiscan.io/token/0x1509706a6c66ca549ff0cb464de88231ddbe213b), [sFRAX](https://arbiscan.io/token/0xe3b3fe7bca19ca77ad877a5bebab186becfad906), [USX](https://arbiscan.io/token/0x641441c631e2f909700d2f41fd87f0aa6a6b4edb) and [plsRDNT](https://arbiscan.io/token/0x6dbf2155b0636cb3fd5359fccefb8a2c02b6cb51) on Arbitrum to the tokens_erc20 table