### PR TITLE
feat: add bonkbot trades spellbook

### DIFF
--- a/models/bonkbot/solana/bonkbot_solana_schema.yml
+++ b/models/bonkbot/solana/bonkbot_solana_schema.yml
@@ -1,0 +1,95 @@
+version: 2
+
+models:
+  - name: bonkbot_solana_trades
+    meta:
+      blockchain: solana
+      sector: dex
+      project: bonkbot
+      contributors: whale_hunter
+    config:
+      tags: ["solana", "dex", "bonkbot", "trades"]
+    description: >
+      Bonkbot trades on Solana
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - tx_id
+            - tx_index
+            - outer_instruction_index
+            - inner_instruction_index
+
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain where the trade occured"
+      - &block_time
+        name: block_time
+        description: "UTC event block time of each DEX trade"
+      - &amount_usd
+        name: amount_usd
+        description: "USD value of the trade at time of execution"
+      - &type
+        name: type
+        description: "Wether the trade is a buy or sell"
+      - &token_bought_amount
+        name: token_bought_amount
+        description: "Value of the token bought at time of execution in the original currency"
+      - &token_bought_symbol
+        name: token_bought_symbol
+        description: "Token symbol for token bought in the trade"
+      - &token_bought_address
+        name: token_bought_address
+        description: "Contract address of the token bought"
+      - &token_sold_amount
+        name: token_sold_amount
+        description: "Value of the token sold at time of execution in the original currency"
+      - &token_sold_symbol
+        name: token_sold_symbol
+        description: "Token symbol for token sold in the trade"
+      - &token_sold_address
+        name: token_sold_address
+        description: "Contract address of the token sold"
+      - &fee_usd
+        name: fee_usd
+        description: "USD value of the fee at time of execution"
+      - &fee_token_amount
+        name: fee_token_amount
+        description: "Value of the fee paid at time of execution in the original currency"
+      - &fee_token_symbol
+        name: fee_token_symbol
+        description: "Token symbol for fee token"
+      - &fee_token_address
+        name: fee_token_address
+        description: "Contract address of the fee token"
+      - &project
+        name: project
+        description: "Project name of the DEX"
+      - &version
+        name: version
+        description: "Version of the contract built and deployed by the DEX project"
+      - &token_pair
+        name: token_pair
+        description: "Token symbol pair for each token involved in the trade"
+      - &project_contract_address
+        name: project_contract_address
+        description: "Project contract address which executed the trade on the blockchain"
+      - &user
+        name: user
+        description: "Address which initiated the trade"
+      - &tx_id
+        name: tx_id
+        description: "Unique transaction hash value tied to each transaction on the DEX"
+      - &tx_index
+        name: tx_index
+        description: "Index of the corresponding transaction in the block"
+      - &outer_instruction_index
+        name: outer_instruction_index
+        description: "Outer instruction index of the corresponding trade event in the transaction"
+      - &inner_instruction_index
+        name: inner_instruction_index
+        description: "Inner instruction index of the corresponding trade event in the transaction"
+      - &is_last_trade_in_transaction
+        name: is_last_trade_in_transaction
+        description: "Wether the trade is the last hop of the trade transaction, in case of a multi-hop trade"

--- a/models/bonkbot/solana/bonkbot_solana_trades.sql
+++ b/models/bonkbot/solana/bonkbot_solana_trades.sql
@@ -1,0 +1,141 @@
+{{ config(
+    alias = 'trades',
+    schema = 'bonkbot_solana',
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['blockchain', 'tx_id', 'tx_index', 'outer_instruction_index', 'inner_instruction_index'],
+    post_hook='{{ expose_spells(\'["solana"]\',
+                                "sector",
+                                "dex",
+                                \'["whale_hunter"]\') }}'
+    )
+}}
+
+{% set project_start_date = '2023-08-17' %}
+{% set fee_receiver = 'ZG98FUCjb8mJ824Gbs6RsgVmr1FhXb2oNiJHa2dwmPd' %}
+{% set wsol_token = 'So11111111111111111111111111111111111111112' %}
+
+WITH
+  allFeePayments AS (
+    SELECT
+      tx_id,
+      IF(balance_change > 0, 'SOL', 'SPL') AS feeTokenType,
+      IF(
+        balance_change > 0,
+        balance_change / 1e9,
+        token_balance_change
+      ) AS fee_token_amount,
+      IF(
+        balance_change > 0,
+        '{{wsol_token}}',
+        token_mint_address
+      ) AS fee_token_mint_address
+    FROM
+      solana.account_activity
+    WHERE
+      block_time >= TIMESTAMP '{{project_start_date}}'
+      AND tx_success
+      AND (
+        (
+          address = '{{fee_receiver}}'
+          AND balance_change > 0 -- SOL fee payments
+        )
+        OR (
+          token_balance_owner = '{{fee_receiver}}'
+          AND token_balance_change > 0 -- SPL fee payments
+        )
+      )
+  ),
+  botTrades AS (
+    SELECT
+      block_time,
+      amount_usd,
+      IF(
+        token_sold_mint_address = '{{wsol_token}}',
+        'Buy',
+        'Sell'
+      ) AS type,
+      token_bought_amount,
+      token_bought_symbol,
+      token_bought_mint_address AS token_bought_address,
+      token_sold_amount,
+      token_sold_symbol,
+      token_sold_mint_address AS token_sold_address,
+      fee_token_amount * price AS fee_usd,
+      fee_token_amount,
+      IF(feeTokenType = 'SOL', 'SOL', symbol) AS fee_token_symbol,
+      fee_token_mint_address AS fee_token_address,
+      project,
+      version,
+      token_pair,
+      project_program_id AS project_contract_address,
+      trader_id AS user,
+      trades.tx_id,
+      tx_index,
+      outer_instruction_index,
+      inner_instruction_index
+    FROM
+      dex_solana.trades AS trades
+      JOIN allFeePayments AS feePayments ON trades.tx_id = feePayments.tx_id
+      LEFT JOIN prices.usd AS feeTokenPrices ON (
+        feeTokenPrices.blockchain = 'solana'
+        AND fee_token_mint_address = toBase58 (feeTokenPrices.contract_address)
+        AND date_trunc('minute', block_time) = minute
+        AND minute >= TIMESTAMP '{{project_start_date}}'
+      )
+    WHERE
+      trades.block_time >= TIMESTAMP '{{project_start_date}}'
+      AND trades.trader_id != '{{fee_receiver}}' -- Exclude trades signed by FeeWallet
+  ),
+  highestInnerInstructionIndexForEachTrade AS (
+    SELECT
+      tx_id,
+      outer_instruction_index,
+      MAX(inner_instruction_index) AS highestInnerInstructionIndex
+    FROM
+      botTrades
+    GROUP BY
+      tx_id,
+      outer_instruction_index
+  )
+SELECT
+  block_time,
+  amount_usd,
+  type,
+  token_bought_amount,
+  token_bought_symbol,
+  token_bought_address,
+  token_sold_amount,
+  token_sold_symbol,
+  token_sold_address,
+  fee_usd,
+  fee_token_amount,
+  fee_token_symbol,
+  fee_token_address,
+  project,
+  version,
+  token_pair,
+  project_contract_address,
+  user,
+  botTrades.tx_id,
+  tx_index,
+  botTrades.outer_instruction_index,
+  inner_instruction_index,
+  IF(
+    inner_instruction_index = highestInnerInstructionIndex,
+    true,
+    false
+  ) AS is_last_trade_in_transaction
+FROM
+  botTrades
+  JOIN highestInnerInstructionIndexForEachTrade ON (
+    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
+    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
+  )
+ORDER BY
+  block_time DESC,
+  tx_index DESC,
+  outer_instruction_index DESC,
+  inner_instruction_index DESC


### PR DESCRIPTION
This PR adds a dedicated spellbook for Bonkbots Solana DEX trades, since the data got too big to execute on the query engine itself.

Let me know if there are any changes/adjustments to be made!