### PR TITLE
Migrate cex_ethereum.flows to a sector spell with macros to easily add new chains

### DIFF
--- a/macros/models/_sector/cex/cex_flows.sql
+++ b/macros/models/_sector/cex/cex_flows.sql
@@ -1,14 +1,6 @@
-{{config(
-        schema = 'cex_ethereum',
-        alias = 'flows',
-        partition_by = ['block_month'],
-        materialized = 'incremental',
-        file_format = 'delta',
-        incremental_strategy = 'merge',
-        unique_key = ['flow_type', 'unique_key']
-        )}}
+{% macro cex_flows(blockchain, transfers, addresses) %}
 
-SELECT t.blockchain
+SELECT '{{blockchain}}' AS blockchain
 , CAST(date_trunc('month', block_time) AS date) AS block_month
 , block_time
 , block_number
@@ -29,8 +21,10 @@ SELECT t.blockchain
 , t.tx_hash
 , t.evt_index
 , t.unique_key
-FROM {{ ref('tokens_ethereum_transfers')}} t
-INNER JOIN {{ ref('cex_ethereum_addresses')}} a ON a.address IN (t."from", t.to)
+FROM {{transfers}} t
+INNER JOIN {{addresses}} a ON a.address IN (t."from", t.to)
 {% if is_incremental() %}
 WHERE {{incremental_predicate('block_time')}}
 {% endif %}
+
+{% endmacro %}

--- a/macros/models/_sector/cex/cex_flows.sql
+++ b/macros/models/_sector/cex/cex_flows.sql
@@ -22,7 +22,7 @@ SELECT '{{blockchain}}' AS blockchain
 , t.evt_index
 , t.unique_key
 FROM {{transfers}} t
-INNER JOIN {{addresses}} a ON a.address IN (t."from", t.to)
+INNER JOIN {{addresses}} a ON a.address = t."from" OR a.address = t.to
 {% if is_incremental() %}
 WHERE {{incremental_predicate('block_time')}}
 {% endif %}

--- a/models/_sector/cex/flows/_schema.yml
+++ b/models/_sector/cex/flows/_schema.yml
@@ -1,35 +1,6 @@
 version: 2
 
 models:
-  - name: cex_ethereum_addresses
-    meta:
-      blockchain: ethereum
-      sector: cex
-      contributors: hildobby
-    config:
-      tags: ['cex','addresses', 'deposits', 'withdrawals', 'ethereum']
-    description: "All CEX-tied addresses identified on Ethereum"
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - blockchain
-            - address
-    columns:
-      - name: blockchain
-        description: "Blockchain"
-      - name: address
-        description: "Address"
-      - name: cex_name
-        description: "Name of centralised exchange"
-      - name: distinct_name
-        description: "Distinct name of centralised exchange address"
-        tests:
-          - unique
-      - name: added_by
-        description: "Who added the address"
-      - name: added_date
-        description: "Date the address was added on"
-
   - name: cex_ethereum_flows
     meta:
       blockchain: ethereum

--- a/models/_sector/cex/flows/cex_ethereum_flows.sql
+++ b/models/_sector/cex/flows/cex_ethereum_flows.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'ethereum' %}
+
+{{ config(
+        
+        schema = 'cex_' + blockchain,
+        alias = 'flows',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['flow_type', 'unique_key']
+)
+}}
+
+{{cex_flows(
+        blockchain = blockchain
+        , transfers = ref('tokens_ethereum_transfers')
+        , addresses = ref('cex_ethereum_addresses')
+)}}


### PR DESCRIPTION
Goal here is to create this macro so i can easily add cex_{chain}.flows for all other evm chains afterwards @jeff-dude 