### PR TITLE
Add missing tokens to prices and tokens.erc20

### DIFF
--- a/models/prices/arbitrum/prices_arbitrum_tokens.sql
+++ b/models/prices/arbitrum/prices_arbitrum_tokens.sql
@@ -127,5 +127,6 @@ FROM
     ('vela-vela-token','arbitrum','VELA',0x088cd8f5ef3652623c22d48b1605dcfe860cd704,18),
     ('choke-artichoke','arbitrum','CHOKE',0x6fc2680d8ad8e8312191441b4eca9eff8d06b45a,18),
     ('cbeth-coinbase-wrapped-staked-eth','arbitrum','CBETH',0x1debd73e752beaf79865fd6446b0c970eae7732f, 18),        
-    ('aeth-ankreth','arbitrum','AETH',0xe05a08226c49b636acf99c40da8dc6af83ce5bb3, 18)        
+    ('aeth-ankreth','arbitrum','AETH',0xe05a08226c49b636acf99c40da8dc6af83ce5bb3, 18),       
+    ('y2k-y2k','arbitrum','Y2K',0x65c936f008bc34fe819bce9fa5afd9dc2d49977f, 18)         
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/models/prices/polygon/prices_polygon_tokens.sql
+++ b/models/prices/polygon/prices_polygon_tokens.sql
@@ -89,6 +89,6 @@ FROM
     ('gmt-stepn', 'polygon', 'GMT', 0x714db550b574b3e927af3d93e26127d15721d4c2,8),
     ('tel-telcoin', 'polygon', 'TEL', 0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32,2),
     ('mana-decentraland', 'polygon', 'MANA', 0xa1c57f48f0deb89f569dfbe6e2b7f46d33606fd4,18),
-    ('ata-automata', 'polygon', 'ATA', 0x0df0f72EE0e5c9B7ca761ECec42754992B2Da5BF, 18)
+    ('ata-automata', 'polygon', 'ATA', 0x0df0f72EE0e5c9B7ca761ECec42754992B2Da5BF, 18),
     ('egx-enegra', 'polygon', 'EGX', 0x8db0a6d1b06950b4e81c4f67d1289fc7b9359c7f, 6)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/models/prices/polygon/prices_polygon_tokens.sql
+++ b/models/prices/polygon/prices_polygon_tokens.sql
@@ -90,4 +90,5 @@ FROM
     ('tel-telcoin', 'polygon', 'TEL', 0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32,2),
     ('mana-decentraland', 'polygon', 'MANA', 0xa1c57f48f0deb89f569dfbe6e2b7f46d33606fd4,18),
     ('ata-automata', 'polygon', 'ATA', 0x0df0f72EE0e5c9B7ca761ECec42754992B2Da5BF, 18)
+    ('egx-enegra', 'polygon', 'EGX', 0x8db0a6d1b06950b4e81c4f67d1289fc7b9359c7f, 6)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/tokens/models/tokens/ethereum/tokens_ethereum_erc20.sql
+++ b/tokens/models/tokens/ethereum/tokens_ethereum_erc20.sql
@@ -39383,4 +39383,5 @@ FROM (VALUES
         ,(0xCe6E54DaA1ea95fb3530859d69D4bdb978dd821b, 'ORBK', 18)
         ,(0x8C282C35B5E1088bb208991c151182A782637699, 'MONAI', 18)
         ,(0x857FfC55B1Aa61A7fF847C82072790cAE73cd883, 'EEFI', 18)
+        ,(0x51fa2efd62ee56a493f24ae963eace7d0051929e, 'psdnOCEAN', 18)        
      ) AS temp_table (contract_address, symbol, decimals)

--- a/tokens/models/tokens/gnosis/tokens_gnosis_erc20.sql
+++ b/tokens/models/tokens/gnosis/tokens_gnosis_erc20.sql
@@ -8996,5 +8996,6 @@ FROM (VALUES (0x3f9463bdb502ec2079bf39da6c924d4022ff9f4c, 'biubiu.tools', 18),
             ,(0x7fE440bC581DA8fF0173a588D3f7603814393763, 'bwAJNA', 18)
             ,(0xaf204776c7245bf4147c2612bf6e5972ee483701, 'sDAI', 18)
             ,(0xce11e14225575945b8e6dc0d4f2dd4c570f79d9f, 'OLAS', 18)
-            ,(0x004626A008B1aCdC4c74ab51644093b155e59A23, 'stEUR', 18)                 
+            ,(0x004626A008B1aCdC4c74ab51644093b155e59A23, 'stEUR', 18)             
+            ,(0x1509706a6c66CA549ff0cB464de88231DDBe213B, 'AURA', 18)                      
      ) AS temp_table (contract_address, symbol, decimals)

--- a/tokens/models/tokens/optimism/tokens_optimism_erc20_curated.sql
+++ b/tokens/models/tokens/optimism/tokens_optimism_erc20_curated.sql
@@ -429,7 +429,11 @@ WITH raw_token_list AS (
     ,(0x20279b6d57Ba6D3eF852f34800e43e39d46d6487, 'MERK', 18, 'underlying')
     ,(0x9cfB13E6c11054ac9fcB92BA89644F30775436e4, 'axl-wstETH', 18, 'underlying')
     ,(0xc55E93C62874D8100dBd2DfE307EDc1036ad5434, 'mooBIFI', 18, 'receipt')
-
+    ,(0x3ee6107d9c93955acbb3f39871d32b02f82b78ab, 'stERN', 18, 'underlying')
+    ,(0x2dd1b4d4548accea497050619965f91f78b3b532, 'sFRAX', 18, 'underlying')
+    ,(0x3b08fcd15280e7b5a6e404c4abb87f7c774d1b2e, 'OVN', 18, 'underlying')
+    ,(0xe05a08226c49b636acf99c40da8dc6af83ce5bb3, 'ankrETH', 18, 'underlying')
+    ,(0x00e1724885473b63bce08a9f0a52f35b0979e35a, 'OATH', 18, 'receipt')
     ) AS temp_table (contract_address, symbol, decimals, token_type)
 )
 SELECT contract_address, symbol, decimals, token_type, 'manual' AS token_mapping_source

--- a/tokens/models/tokens/optimism/tokens_optimism_erc20_curated.sql
+++ b/tokens/models/tokens/optimism/tokens_optimism_erc20_curated.sql
@@ -433,7 +433,7 @@ WITH raw_token_list AS (
     ,(0x2dd1b4d4548accea497050619965f91f78b3b532, 'sFRAX', 18, 'underlying')
     ,(0x3b08fcd15280e7b5a6e404c4abb87f7c774d1b2e, 'OVN', 18, 'underlying')
     ,(0xe05a08226c49b636acf99c40da8dc6af83ce5bb3, 'ankrETH', 18, 'underlying')
-    ,(0x00e1724885473b63bce08a9f0a52f35b0979e35a, 'OATH', 18, 'receipt')
+    ,(0x00e1724885473b63bce08a9f0a52f35b0979e35a, 'OATH', 18, 'underlying')
     ) AS temp_table (contract_address, symbol, decimals, token_type)
 )
 SELECT contract_address, symbol, decimals, token_type, 'manual' AS token_mapping_source

--- a/tokens/models/tokens/polygon/tokens_polygon_erc20.sql
+++ b/tokens/models/tokens/polygon/tokens_polygon_erc20.sql
@@ -530,4 +530,7 @@ SELECT contract_address, symbol, decimals
 ,(0xf33687811f3ad0cd6b48dd4b39f9f977bd7165a2, 'truMATIC', 18)
 ,(0xfcbb00df1d663eee58123946a30ab2138bf9eb2a, 'csMATIC', 18)
 ,(0x2934b36ca9a4b31e633c5be670c8c8b28b6aa015, 'THX', 18)   
+,(0x8db0a6d1b06950b4e81c4f67d1289fc7b9359c7f, 'EGX', 6)
+,(0x2aeb3acbeb4c604451c560d89d88d95d54c2c2cc, 'MTLSTR', 6)
+,(0xf07a8cc2d26a87d6bbcf6e578d7f5202f3ed9642, 'MSGLD', 6)   
 ) AS temp_table (contract_address, symbol, decimals)


### PR DESCRIPTION
This PR adds a few more tokens across multiple chains to the tokens.erc20 table and also adds [EGX](https://coinpaprika.com/coin/egx-enegra/) on polygon to prices.usd.

I'm sorry for breaking this down in multiple PRs over the last few days, but it's been the possible  approach in order to find these missing tokens and tying-out our numbers. Thanks for your work on that!