### PR TITLE
Attempt to add Base & Zora to Seaport Trades

### DIFF
--- a/models/seaport/base/seaport_base_base_pairs.sql
+++ b/models/seaport/base/seaport_base_base_pairs.sql
@@ -1,0 +1,195 @@
+{{ config(
+    
+    alias = 'base_pairs',
+    partition_by = ['block_date'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'tx_hash', 'evt_index', 'sub_type', 'sub_idx'],
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                            "project",
+                            "seaport",
+                            \'["sohwak"]\') }}'
+    )
+}}
+
+{% set c_seaport_first_date = '2022-06-01' %}
+
+with iv_offer_consideration as (
+    select evt_block_time as block_time
+            ,evt_block_number as block_number
+            ,evt_tx_hash as tx_hash
+            ,evt_index
+            ,'offer' as sub_type
+            ,offer_idx as sub_idx
+            ,case json_extract_scalar(element_at(offer,1),'$.itemType')
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc'
+            end as offer_first_item_type
+            ,case json_extract_scalar(element_at(consideration,1),'$.itemType')
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc'
+            end as consideration_first_item_type       
+            ,offerer as sender
+            ,recipient as receiver
+            ,zone
+            ,from_hex(json_extract_scalar(offer_item,'$.token')) as token_contract_address
+            ,cast(json_extract_scalar(offer_item,'$.amount') as uint256) as original_amount
+            ,case json_extract_scalar(offer_item,'$.itemType')
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc'
+            end as item_type
+            ,cast(json_extract_scalar(offer_item,'$.identifier') as uint256) as token_id
+            ,contract_address as platform_contract_address
+            ,cardinality(offer) as offer_cnt
+            ,cardinality(consideration) as consideration_cnt
+            ,case when recipient = 0x0000000000000000000000000000000000000000 then true
+                else false
+            end as is_private
+    from
+    (
+        select consideration
+            , contract_address
+            , evt_block_number
+            , evt_block_time
+            , evt_index
+            , evt_tx_hash
+            , offer
+            , offerer
+            -- , orderHash
+            , recipient
+            , zone
+            , offer_idx
+            , offer_item
+        from {{ source('opensea_optimism', 'Seaport_evt_OrderFulfilled') }}
+        cross join unnest(offer) with ordinality as foo(offer_item, offer_idx)
+        {% if not is_incremental() %}
+        where evt_block_time >= TIMESTAMP '{{c_seaport_first_date}}'  -- seaport first txn
+        {% endif %}
+        {% if is_incremental() %}
+        where evt_block_time >= date_trunc('day', now() - interval '7' day)
+        {% endif %}
+    )
+    union all
+    select evt_block_time as block_time
+            ,evt_block_number as block_number
+            ,evt_tx_hash as tx_hash
+            ,evt_index
+            ,'consideration' as sub_type
+            ,consideration_idx as sub_idx
+            ,case json_extract_scalar(element_at(offer,1),'$.itemType')
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc'
+            end as offer_first_item_type
+            ,case json_extract_scalar(element_at(consideration,1),'$.itemType')
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc'
+            end as consideration_first_item_type        
+            ,recipient as sender
+            ,from_hex(json_extract_scalar(consideration_item,'$.recipient')) as receiver
+            ,zone
+            ,from_hex(json_extract_scalar(consideration_item,'$.token')) as token_contract_address
+            ,cast(json_extract_scalar(consideration_item,'$.amount') as uint256) as original_amount
+            ,case json_extract_scalar(consideration_item,'$.itemType')
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc' -- actually not exists
+            end as item_type
+            ,cast(json_extract_scalar(consideration_item,'$.identifier') as uint256) as token_id
+            ,contract_address as platform_contract_address
+            ,cardinality(offer) as offer_cnt
+            ,cardinality(consideration) as consideration_cnt
+            ,case when recipient = 0x0000000000000000000000000000000000000000 then true
+                else false
+            end as is_private
+    from
+    (
+        select consideration
+            , contract_address
+            , evt_block_number
+            , evt_block_time
+            , evt_index
+            , evt_tx_hash
+            , offer
+            , recipient
+            , zone
+            , consideration_item
+            , consideration_idx
+        from {{ source('opensea_optimism','Seaport_evt_OrderFulfilled') }}
+        cross join unnest(consideration) with ordinality as foo(consideration_item,consideration_idx)
+        {% if not is_incremental() %}
+        where evt_block_time >= TIMESTAMP '{{c_seaport_first_date}}'  -- seaport first txn
+        {% endif %}
+        {% if is_incremental() %}
+        where evt_block_time >= date_trunc('day', now() - interval '7' day)
+        {% endif %}
+    )
+)
+,iv_base_pairs as (
+    select a.*
+            ,try_cast(date_trunc('day', a.block_time) as date) as block_date
+            ,case when offer_first_item_type = 'erc20' then 'offer accepted'
+                when offer_first_item_type in ('erc721','erc1155') then 'buy'
+                else 'etc' -- some txns has no nfts
+            end as order_type
+            ,case when offer_first_item_type = 'erc20' and sub_type = 'offer' and item_type = 'erc20' then true
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and item_type in ('native','erc20') then true
+                else false
+            end is_price
+            ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and eth_erc_idx = 0 then true  -- offer accepted has no price at all. it has to be calculated.
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and eth_erc_idx = 1 then true
+                else false
+            end is_netprice
+            ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and eth_erc_idx = 1 then true
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and eth_erc_idx = 2 then true
+                else false
+            end is_platform_fee
+            ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and eth_erc_idx > 1 then true
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and eth_erc_idx > 2 then true
+                else false
+            end is_creator_fee
+            ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and eth_erc_idx > 1 then eth_erc_idx - 1
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and eth_erc_idx > 2 then eth_erc_idx - 2
+            end creator_fee_idx
+            ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and item_type in ('erc721','erc1155') then true
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'offer' and item_type in ('erc721','erc1155') then true
+                else false
+            end is_traded_nft
+            ,case when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and item_type in ('erc721','erc1155') then true
+                else false
+            end is_moved_nft
+    from
+    (
+        select a.*
+            ,case when item_type in ('native','erc20') then sum(case when item_type in ('native','erc20') then 1 end) over (partition by tx_hash, evt_index, sub_type order by sub_idx) end as eth_erc_idx
+            ,sum(case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and item_type in ('erc721','erc1155') then 1
+                        when offer_first_item_type in ('erc721','erc1155') and sub_type = 'offer' and item_type in ('erc721','erc1155') then 1
+                end) over (partition by tx_hash, evt_index) as nft_cnt
+            ,sum(case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and item_type in ('erc721') then 1
+                        when offer_first_item_type in ('erc721','erc1155') and sub_type = 'offer' and item_type in ('erc721') then 1
+                end) over (partition by tx_hash, evt_index) as erc721_cnt
+            ,sum(case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and item_type in ('erc1155') then 1
+                        when offer_first_item_type in ('erc721','erc1155') and sub_type = 'offer' and item_type in ('erc1155') then 1
+                end) over (partition by tx_hash, evt_index) as erc1155_cnt
+        from iv_offer_consideration a
+    ) a
+)
+select *
+from iv_base_pairs

--- a/models/seaport/base/seaport_base_trades.sql
+++ b/models/seaport/base/seaport_base_trades.sql
@@ -1,0 +1,326 @@
+{{ config(
+    
+    alias = 'trades',
+    partition_by = ['block_date'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'tx_hash', 'evt_index', 'nft_contract_address', 'token_id', 'sub_type', 'sub_idx'],
+    post_hook='{{ expose_spells(\'["base"]\',
+                            "project",
+                            "seaport",
+                            \'["sohwak"]\') }}'
+    )
+}}
+
+{% set c_native_token_address = '0x0000000000000000000000000000000000000000' %}
+{% set c_alternative_token_address = "0x4200000000000000000000000000000000000006" %}  -- WETH
+{% set c_native_symbol = 'ETH' %}
+{% set c_seaport_first_date = '2022-06-01' %}
+
+with source_base_transactions as (
+    select *
+    from {{ source('base','transactions') }}
+    {% if not is_incremental() %}
+    where block_time >= TIMESTAMP '{{c_seaport_first_date}}'  -- seaport first txn
+    {% endif %}
+    {% if is_incremental() %}
+    where block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+)
+,ref_seaport_base_base_pairs as (
+      select *
+      from {{ ref('seaport_base_base_pairs') }}
+      where 1=1
+      {% if is_incremental() %}
+            and block_time >= date_trunc('day', now() - interval '7' day)
+      {% endif %}
+)
+,ref_tokens_nft as (
+    select *
+    from {{ ref('tokens_nft') }}
+    where blockchain = 'base'
+)
+,ref_tokens_erc20 as (
+    select *
+    from {{ source('tokens', 'erc20') }}
+    where blockchain = 'base'
+)
+,ref_nft_aggregators as (
+    select *
+    from {{ ref('nft_aggregators') }}
+    where blockchain = 'base'
+)
+,source_prices_usd as (
+    select *
+    from {{ source('prices', 'usd') }}
+    where blockchain = 'base'
+    {% if not is_incremental() %}
+      and minute >= TIMESTAMP '{{c_seaport_first_date}}'  -- seaport first txn
+    {% endif %}
+    {% if is_incremental() %}
+      and minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+)
+,iv_base_pairs_priv as (
+  select a.block_date
+        ,a.block_time
+        ,a.block_number
+        ,a.tx_hash
+        ,a.evt_index
+        ,a.sub_type
+        ,a.sub_idx
+        ,a.offer_first_item_type
+        ,a.consideration_first_item_type
+        ,a.sender
+        ,a.receiver
+        ,a.zone
+        ,a.token_contract_address
+        ,a.original_amount
+        ,a.item_type
+        ,a.token_id
+        ,a.platform_contract_address
+        ,a.offer_cnt
+        ,a.consideration_cnt
+        ,a.is_private
+        ,a.eth_erc_idx
+        ,a.nft_cnt
+        ,a.erc721_cnt
+        ,a.erc1155_cnt
+        ,a.order_type
+        ,a.is_price
+        ,a.is_netprice
+        ,a.is_platform_fee
+        ,a.is_creator_fee
+        ,a.creator_fee_idx
+        ,a.is_traded_nft
+        ,a.is_moved_nft
+  from ref_seaport_base_base_pairs a
+  where 1=1
+    and not a.is_private
+  union all
+  select a.block_date
+        ,a.block_time
+        ,a.block_number
+        ,a.tx_hash
+        ,a.evt_index
+        ,a.sub_type
+        ,a.sub_idx
+        ,a.offer_first_item_type
+        ,a.consideration_first_item_type
+        ,a.sender
+        ,case when b.tx_hash is not null then b.receiver
+              else a.receiver
+          end as receiver
+        ,a.zone
+        ,a.token_contract_address
+        ,a.original_amount
+        ,a.item_type
+        ,a.token_id
+        ,a.platform_contract_address
+        ,a.offer_cnt
+        ,a.consideration_cnt
+        ,a.is_private
+        ,a.eth_erc_idx
+        ,a.nft_cnt
+        ,a.erc721_cnt
+        ,a.erc1155_cnt
+        ,a.order_type
+        ,a.is_price
+        ,a.is_netprice
+        ,a.is_platform_fee
+        ,a.is_creator_fee
+        ,a.creator_fee_idx
+        ,a.is_traded_nft
+        ,a.is_moved_nft
+  from ref_seaport_base_base_pairs a
+  left join ref_seaport_base_base_pairs b on b.tx_hash = a.tx_hash
+    and b.evt_index = a.evt_index
+    and b.block_date = a.block_date -- for performance
+    and b.token_contract_address = a.token_contract_address
+    and b.token_id = a.token_id
+    and b.original_amount = a.original_amount
+    and b.is_moved_nft
+  where 1=1
+    and a.is_private
+    and not a.is_moved_nft
+    and a.consideration_cnt > 0
+)
+,iv_volume as (
+  select block_date
+        ,block_time
+        ,tx_hash
+        ,evt_index
+        ,max(token_contract_address) as token_contract_address
+        ,sum(case when is_price then original_amount end) as price_amount_raw
+        ,sum(case when is_platform_fee then original_amount end) as platform_fee_amount_raw
+        ,max(case when is_platform_fee then receiver end) as platform_fee_receiver
+        ,sum(case when is_creator_fee then original_amount end) as creator_fee_amount_raw
+        ,sum(case when is_creator_fee and creator_fee_idx = 1 then original_amount end) as creator_fee_amount_raw_1
+        ,sum(case when is_creator_fee and creator_fee_idx = 2 then original_amount end) as creator_fee_amount_raw_2
+        ,sum(case when is_creator_fee and creator_fee_idx = 3 then original_amount end) as creator_fee_amount_raw_3
+        ,sum(case when is_creator_fee and creator_fee_idx = 4 then original_amount end) as creator_fee_amount_raw_4
+        ,max(case when is_creator_fee and creator_fee_idx = 1 then receiver end) as creator_fee_receiver_1
+        ,max(case when is_creator_fee and creator_fee_idx = 2 then receiver end) as creator_fee_receiver_2
+        ,max(case when is_creator_fee and creator_fee_idx = 3 then receiver end) as creator_fee_receiver_3
+        ,max(case when is_creator_fee and creator_fee_idx = 4 then receiver end) as creator_fee_receiver_4
+  from iv_base_pairs_priv a
+  where 1=1
+    and eth_erc_idx > 0
+  group by 1,2,3,4
+)
+,iv_nfts as (
+  select a.block_date
+        ,a.block_time
+        ,a.tx_hash
+        ,a.evt_index
+        ,a.block_number
+        ,a.sender as seller
+        ,a.receiver as buyer
+        ,case when nft_cnt > 1 then 'bundle trade'
+              else 'single item trade'
+          end as trade_type
+        ,a.order_type
+        ,a.token_contract_address as nft_contract_address
+        ,a.original_amount as nft_token_amount
+        ,a.token_id as nft_token_id
+        ,a.item_type as nft_token_standard
+        ,a.zone
+        ,a.platform_contract_address
+        ,b.token_contract_address
+        ,CAST(price_amount_raw / nft_cnt as uint256) as price_amount_raw  -- to truncate the odd number of decimal places
+        ,cast(platform_fee_amount_raw / nft_cnt as uint256) as platform_fee_amount_raw
+        ,platform_fee_receiver
+        ,cast(creator_fee_amount_raw / nft_cnt as uint256) as creator_fee_amount_raw
+        ,creator_fee_amount_raw_1 / nft_cnt as creator_fee_amount_raw_1
+        ,creator_fee_amount_raw_2 / nft_cnt as creator_fee_amount_raw_2
+        ,creator_fee_amount_raw_3 / nft_cnt as creator_fee_amount_raw_3
+        ,creator_fee_amount_raw_4 / nft_cnt as creator_fee_amount_raw_4
+        ,creator_fee_receiver_1
+        ,creator_fee_receiver_2
+        ,creator_fee_receiver_3
+        ,creator_fee_receiver_4
+        ,case when nft_cnt > 1 then true
+              else false
+          end as estimated_price
+        ,is_private
+        ,sub_type
+        ,sub_idx
+  from iv_base_pairs_priv a
+  left join iv_volume b on b.block_date = a.block_date  -- tx_hash and evt_index is PK, but for performance, block_time is included
+    and b.tx_hash = a.tx_hash
+    and b.evt_index = a.evt_index
+  where 1=1
+    and a.is_traded_nft
+)
+,iv_trades as (
+  select a.*
+          ,n.name AS nft_token_name
+          ,t."from" as tx_from
+          ,t.to as tx_to
+          ,bytearray_reverse(bytearray_substring(bytearray_reverse(t.data),1,4)) as right_hash
+          ,case when a.token_contract_address = {{c_native_token_address}} then '{{c_native_symbol}}'
+                else e.symbol
+           end as token_symbol
+          ,case when a.token_contract_address = {{c_native_token_address}} then {{c_alternative_token_address}}
+                else a.token_contract_address
+           end as token_alternative_symbol
+          ,e.decimals as price_token_decimals
+          ,a.price_amount_raw / power(10, e.decimals) as price_amount
+          ,a.price_amount_raw / power(10, e.decimals) * p.price as price_amount_usd
+          ,a.platform_fee_amount_raw / power(10, e.decimals) as platform_fee_amount
+          ,a.platform_fee_amount_raw / power(10, e.decimals) * p.price as platform_fee_amount_usd
+          ,a.creator_fee_amount_raw / power(10, e.decimals) as creator_fee_amount
+          ,a.creator_fee_amount_raw / power(10, e.decimals) * p.price as creator_fee_amount_usd
+          ,agg.name as aggregator_name
+          ,agg.contract_address AS aggregator_address
+  from iv_nfts a
+  inner join source_base_transactions t on t.hash = a.tx_hash
+  left join ref_tokens_nft n on n.contract_address = nft_contract_address
+  left join ref_tokens_erc20 e on e.contract_address = case when a.token_contract_address = {{c_native_token_address}} then {{c_alternative_token_address}}
+                                                            else a.token_contract_address
+                                                      end
+  left join source_prices_usd p on p.contract_address = case when a.token_contract_address = {{c_native_token_address}} then {{c_alternative_token_address}}
+                                                            else a.token_contract_address
+                                                        end
+    and p.minute = date_trunc('minute', a.block_time)
+  left join ref_nft_aggregators agg on agg.contract_address = t.to
+)
+,iv_columns as (
+  -- Rename column to align other *.trades tables
+  -- But the columns ordering is according to convenience.
+  -- initcap the code value if needed
+  select
+    -- basic info
+    'base' as blockchain
+    ,'seaport' as project
+    ,'v1' as version
+
+    -- order info
+    ,block_date
+    ,block_time
+    ,seller
+    ,buyer
+    ,initcap(trade_type) as trade_type
+    ,initcap(order_type) as trade_category -- Buy / Offer Accepted
+    ,'Trade' as evt_type
+
+    -- nft token info
+    ,nft_contract_address
+    ,nft_token_name as collection
+    ,nft_token_id as token_id
+    ,nft_token_amount as number_of_items
+    ,nft_token_standard as token_standard
+
+    -- price info
+    ,price_amount as amount_original
+    ,price_amount_raw as amount_raw
+    ,price_amount_usd as amount_usd
+    ,token_symbol as currency_symbol
+    ,token_alternative_symbol as currency_contract
+    ,token_contract_address as original_currency_contract
+    ,price_token_decimals as currency_decimals   -- in case calculating royalty1~4
+
+    -- project info (platform or exchange)
+    ,platform_contract_address as project_contract_address
+    ,platform_fee_receiver as platform_fee_receive_address
+    ,platform_fee_amount_raw
+    ,platform_fee_amount
+    ,platform_fee_amount_usd
+
+    -- royalty info
+    ,creator_fee_receiver_1 as royalty_fee_receive_address
+    ,creator_fee_amount_raw as royalty_fee_amount_raw
+    ,creator_fee_amount as royalty_fee_amount
+    ,creator_fee_amount_usd as royalty_fee_amount_usd
+    ,creator_fee_receiver_1 as royalty_fee_receive_address_1
+    ,creator_fee_receiver_2 as royalty_fee_receive_address_2
+    ,creator_fee_receiver_3 as royalty_fee_receive_address_3
+    ,creator_fee_receiver_4 as royalty_fee_receive_address_4
+    ,creator_fee_amount_raw_1 as royalty_fee_amount_raw_1
+    ,creator_fee_amount_raw_2 as royalty_fee_amount_raw_2
+    ,creator_fee_amount_raw_3 as royalty_fee_amount_raw_3
+    ,creator_fee_amount_raw_4 as royalty_fee_amount_raw_4
+
+    -- aggregator
+    ,aggregator_name
+    ,aggregator_address
+
+    -- tx
+    ,block_number
+    ,tx_hash
+    ,evt_index
+    ,tx_from
+    ,tx_to
+    ,right_hash
+
+    -- seaport etc
+    ,zone as zone_address
+    ,estimated_price
+    ,is_private
+    ,sub_idx
+    ,sub_type
+  from iv_trades
+)
+select  *
+from iv_columns

--- a/models/seaport/chains/seaport_zora_traces.sql
+++ b/models/seaport/chains/seaport_zora_traces.sql
@@ -1,0 +1,12 @@
+{{ config(
+        
+        schema = 'seaport_zora',
+        alias ='traces',
+        unique_key = ['block_number', 'tx_hash', 'evt_index', 'order_hash', 'trace_side', 'trace_index']
+        )
+}}
+
+{{seaport_traces(
+    blockchain='zora'
+    , seaport_events = source('seaport_zora', 'Seaport_evt_OrderFulfilled')
+)}}

--- a/models/seaport/seaport_tagging.sql
+++ b/models/seaport/seaport_tagging.sql
@@ -2,7 +2,7 @@
         tags = [ 'static'],
         alias = 'tagging',
         unique_key = ['blockchain', 'tagging_method', 'identifier'],
-        post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "base", "bnb", "ethereum", "optimism", "polygon"]\',
+        post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "base", "bnb", "ethereum", "optimism", "polygon", "zora"]\',
                                     "project",
                                     "seaport",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@ ref('seaport_arbitrum_tagging')
 , ref('seaport_ethereum_tagging')
 , ref('seaport_optimism_tagging')
 , ref('seaport_polygon_tagging')
+, ref('seaport_zora_tagging')
 ] %}
 
 SELECT *

--- a/models/seaport/seaport_traces.sql
+++ b/models/seaport/seaport_traces.sql
@@ -2,7 +2,7 @@
         
         alias = 'traces',
         unique_key = ['blockchain', 'block_number', 'tx_hash', 'evt_index', 'order_hash', 'trace_side', 'trace_index'],
-        post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "base", "bnb", "ethereum", "optimism", "polygon"]\',
+        post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "base", "bnb", "ethereum", "optimism", "polygon", "zora"]\',
                                     "project",
                                     "seaport",
                                     \'["hildobby"]\') }}'
@@ -17,6 +17,7 @@ ref('seaport_arbitrum_traces')
 , ref('seaport_ethereum_traces')
 , ref('seaport_optimism_traces')
 , ref('seaport_polygon_traces')
+, ref('seaport_zora_traces')
 ] %}
 
 SELECT *

--- a/models/seaport/zora/seaport_zora_base_pairs.sql
+++ b/models/seaport/zora/seaport_zora_base_pairs.sql
@@ -1,0 +1,195 @@
+{{ config(
+    
+    alias = 'base_pairs',
+    partition_by = ['block_date'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'tx_hash', 'evt_index', 'sub_type', 'sub_idx'],
+    post_hook='{{ expose_spells(\'["zora"]\',
+                            "project",
+                            "seaport",
+                            \'["sohwak"]\') }}'
+    )
+}}
+
+{% set c_seaport_first_date = '2022-06-01' %}
+
+with iv_offer_consideration as (
+    select evt_block_time as block_time
+            ,evt_block_number as block_number
+            ,evt_tx_hash as tx_hash
+            ,evt_index
+            ,'offer' as sub_type
+            ,offer_idx as sub_idx
+            ,case json_extract_scalar(element_at(offer,1),'$.itemType')
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc'
+            end as offer_first_item_type
+            ,case json_extract_scalar(element_at(consideration,1),'$.itemType')
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc'
+            end as consideration_first_item_type       
+            ,offerer as sender
+            ,recipient as receiver
+            ,zone
+            ,from_hex(json_extract_scalar(offer_item,'$.token')) as token_contract_address
+            ,cast(json_extract_scalar(offer_item,'$.amount') as uint256) as original_amount
+            ,case json_extract_scalar(offer_item,'$.itemType')
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc'
+            end as item_type
+            ,cast(json_extract_scalar(offer_item,'$.identifier') as uint256) as token_id
+            ,contract_address as platform_contract_address
+            ,cardinality(offer) as offer_cnt
+            ,cardinality(consideration) as consideration_cnt
+            ,case when recipient = 0x0000000000000000000000000000000000000000 then true
+                else false
+            end as is_private
+    from
+    (
+        select consideration
+            , contract_address
+            , evt_block_number
+            , evt_block_time
+            , evt_index
+            , evt_tx_hash
+            , offer
+            , offerer
+            -- , orderHash
+            , recipient
+            , zone
+            , offer_idx
+            , offer_item
+        from {{ source('opensea_zora', 'Seaport_evt_OrderFulfilled') }}
+        cross join unnest(offer) with ordinality as foo(offer_item, offer_idx)
+        {% if not is_incremental() %}
+        where evt_block_time >= TIMESTAMP '{{c_seaport_first_date}}'  -- seaport first txn
+        {% endif %}
+        {% if is_incremental() %}
+        where evt_block_time >= date_trunc('day', now() - interval '7' day)
+        {% endif %}
+    )
+    union all
+    select evt_block_time as block_time
+            ,evt_block_number as block_number
+            ,evt_tx_hash as tx_hash
+            ,evt_index
+            ,'consideration' as sub_type
+            ,consideration_idx as sub_idx
+            ,case json_extract_scalar(element_at(offer,1),'$.itemType')
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc'
+            end as offer_first_item_type
+            ,case json_extract_scalar(element_at(consideration,1),'$.itemType')
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc'
+            end as consideration_first_item_type        
+            ,recipient as sender
+            ,from_hex(json_extract_scalar(consideration_item,'$.recipient')) as receiver
+            ,zone
+            ,from_hex(json_extract_scalar(consideration_item,'$.token')) as token_contract_address
+            ,cast(json_extract_scalar(consideration_item,'$.amount') as uint256) as original_amount
+            ,case json_extract_scalar(consideration_item,'$.itemType')
+                when '0' then 'native'
+                when '1' then 'erc20'
+                when '2' then 'erc721'
+                when '3' then 'erc1155'
+                else 'etc' -- actually not exists
+            end as item_type
+            ,cast(json_extract_scalar(consideration_item,'$.identifier') as uint256) as token_id
+            ,contract_address as platform_contract_address
+            ,cardinality(offer) as offer_cnt
+            ,cardinality(consideration) as consideration_cnt
+            ,case when recipient = 0x0000000000000000000000000000000000000000 then true
+                else false
+            end as is_private
+    from
+    (
+        select consideration
+            , contract_address
+            , evt_block_number
+            , evt_block_time
+            , evt_index
+            , evt_tx_hash
+            , offer
+            , recipient
+            , zone
+            , consideration_item
+            , consideration_idx
+        from {{ source('opensea_zora','Seaport_evt_OrderFulfilled') }}
+        cross join unnest(consideration) with ordinality as foo(consideration_item,consideration_idx)
+        {% if not is_incremental() %}
+        where evt_block_time >= TIMESTAMP '{{c_seaport_first_date}}'  -- seaport first txn
+        {% endif %}
+        {% if is_incremental() %}
+        where evt_block_time >= date_trunc('day', now() - interval '7' day)
+        {% endif %}
+    )
+)
+,iv_base_pairs as (
+    select a.*
+            ,try_cast(date_trunc('day', a.block_time) as date) as block_date
+            ,case when offer_first_item_type = 'erc20' then 'offer accepted'
+                when offer_first_item_type in ('erc721','erc1155') then 'buy'
+                else 'etc' -- some txns has no nfts
+            end as order_type
+            ,case when offer_first_item_type = 'erc20' and sub_type = 'offer' and item_type = 'erc20' then true
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and item_type in ('native','erc20') then true
+                else false
+            end is_price
+            ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and eth_erc_idx = 0 then true  -- offer accepted has no price at all. it has to be calculated.
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and eth_erc_idx = 1 then true
+                else false
+            end is_netprice
+            ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and eth_erc_idx = 1 then true
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and eth_erc_idx = 2 then true
+                else false
+            end is_platform_fee
+            ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and eth_erc_idx > 1 then true
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and eth_erc_idx > 2 then true
+                else false
+            end is_creator_fee
+            ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and eth_erc_idx > 1 then eth_erc_idx - 1
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and eth_erc_idx > 2 then eth_erc_idx - 2
+            end creator_fee_idx
+            ,case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and item_type in ('erc721','erc1155') then true
+                when offer_first_item_type in ('erc721','erc1155') and sub_type = 'offer' and item_type in ('erc721','erc1155') then true
+                else false
+            end is_traded_nft
+            ,case when offer_first_item_type in ('erc721','erc1155') and sub_type = 'consideration' and item_type in ('erc721','erc1155') then true
+                else false
+            end is_moved_nft
+    from
+    (
+        select a.*
+            ,case when item_type in ('native','erc20') then sum(case when item_type in ('native','erc20') then 1 end) over (partition by tx_hash, evt_index, sub_type order by sub_idx) end as eth_erc_idx
+            ,sum(case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and item_type in ('erc721','erc1155') then 1
+                        when offer_first_item_type in ('erc721','erc1155') and sub_type = 'offer' and item_type in ('erc721','erc1155') then 1
+                end) over (partition by tx_hash, evt_index) as nft_cnt
+            ,sum(case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and item_type in ('erc721') then 1
+                        when offer_first_item_type in ('erc721','erc1155') and sub_type = 'offer' and item_type in ('erc721') then 1
+                end) over (partition by tx_hash, evt_index) as erc721_cnt
+            ,sum(case when offer_first_item_type = 'erc20' and sub_type = 'consideration' and item_type in ('erc1155') then 1
+                        when offer_first_item_type in ('erc721','erc1155') and sub_type = 'offer' and item_type in ('erc1155') then 1
+                end) over (partition by tx_hash, evt_index) as erc1155_cnt
+        from iv_offer_consideration a
+    ) a
+)
+select *
+from iv_base_pairs

--- a/models/seaport/zora/seaport_zora_schema.yml
+++ b/models/seaport/zora/seaport_zora_schema.yml
@@ -1,105 +1,13 @@
 version: 2
 
 models:
-  - name: seaport_base_traces
+  - name: seaport_zora_base_pairs
     meta:
-      blockchain: base
-      project: seaport
-      contributors: hildobby
-    config:
-      tags: ['seaport', 'base', 'traces']
-    description: >
-        Seaport emitted event traces on Base
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - block_number
-            - tx_hash
-            - evt_index
-            - order_hash
-            - trace_side
-            - trace_index
-    columns:
-      - name: blockchain
-        description: "Blockchain"
-      - name: block_date
-        description: "UTC event block date"
-      - name: block_time
-        description: "UTC event block time"
-      - name: block_number
-        description: "Block number in which the transaction was executed"
-      - name: trace_side
-        tests:
-          - accepted_values:
-              values: ['consideration', 'offer']
-        description: "Side of the trace"
-      - name: order_hash
-        description: "Unique trade identifier hash"
-      - name: tx_hash
-        description: "Transaction hash"
-      - name: token_standard
-        tests:
-          - accepted_values:
-              values: ['native', 'erc20', 'erc721', 'erc1155']
-        description: "Token standard"
-      - name: trace_index
-        description: "Index of the trace"
-      - name: seaport_contract_address
-        description: "Seaport contract address"
-      - name: seaport_version
-        description: "Seaport version"
-      - name: token_address
-        description: "Token address"
-      - name: amount
-        description: "Amount"
-      - name: identifier
-        description: "Token identified"
-      - name: recipient
-        description: "Recipient"
-      - name: offerer
-        description: "Offerer"
-      - name: zone
-        description: "Seaport zone"
-      - name: evt_index
-        description: "Event index"
-
-  - name: seaport_base_tagging
-    meta:
-      blockchain: base
-      project: seaport
-      contributors: hildobby
-    config:
-      tags: ['seaport', 'base', 'tagging']
-    description: >
-        Seaport tagging to identify the different protocols using Seaport on Base 
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - blockchain
-            - tagging_method
-            - identifier
-    columns:
-      - name: blockchain
-        description: "Blockchain"
-      - name: tagging_method
-        description: "Identification method"
-        tests:
-          - accepted_values:
-              values: ['zone', 'fee_recipient', 'tx_data_salt']
-      - name: identifier
-        description: "Identifier hash"
-      - name: protocol
-        description: "Protocol"
-      - name: protocol_type
-        description: "Type of Protocol"
-
-  - name: seaport_base_base_pairs
-    meta:
-      blockchain: base
+      blockchain: zora
       project: seaport
       contributors: sohwak
     config:
-      tags: ['base','seaport','base_pairs','sohwak']
+      tags: ['zora','seaport','base_pairs','sohwak']
     description: >
         Exploded table from Seaport trade events with `offer` and `consideration` array columns
     tests:
@@ -208,15 +116,15 @@ models:
         name: is_moved_nft
         description: "Transferred NFT if `true`, because it is traded or just transferred."
 
-  - name: seaport_base_trades
+  - name: seaport_zora_trades
     meta:
-      blockchain: base
+      blockchain: zora
       project: seaport
       contributors: sohwak
     config:
-      tags: ['base','seaport','base_pairs','sohwak']
+      tags: ['zora','seaport','base_pairs','sohwak']
     description: >
-        Seaport trades on base
+        Seaport trades on zora
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -227,6 +135,10 @@ models:
             - token_id
             - sub_type
             - sub_idx
+      - check_seaport_seed:
+          blockchain: zora
+          project: seaport
+          version: v1
     columns:
       - &blockchain
         name: blockchain
@@ -358,3 +270,95 @@ models:
         name: estimated_price
         description: "True if it is bundle trade and dividened price"
       - *is_private
+
+  - name: seaport_zora_traces
+    meta:
+      blockchain: zora
+      project: seaport
+      contributors: hildobby
+    config:
+      tags: ['seaport', 'zora', 'traces']
+    description: >
+        Seaport emitted event traces on zora
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_number
+            - tx_hash
+            - evt_index
+            - order_hash
+            - trace_side
+            - trace_index
+    columns:
+      - name: blockchain
+        description: "Blockchain"
+      - name: block_date
+        description: "UTC event block date"
+      - name: block_time
+        description: "UTC event block time"
+      - name: block_number
+        description: "Block number in which the transaction was executed"
+      - name: trace_side
+        tests:
+          - accepted_values:
+              values: ['consideration', 'offer']
+        description: "Side of the trace"
+      - name: order_hash
+        description: "Unique trade identifier hash"
+      - name: tx_hash
+        description: "Transaction hash"
+      - name: token_standard
+        tests:
+          - accepted_values:
+              values: ['native', 'erc20', 'erc721', 'erc1155']
+        description: "Token standard"
+      - name: trace_index
+        description: "Index of the trace"
+      - name: seaport_contract_address
+        description: "Seaport contract address"
+      - name: seaport_version
+        description: "Seaport version"
+      - name: token_address
+        description: "Token address"
+      - name: amount
+        description: "Amount"
+      - name: identifier
+        description: "Token identified"
+      - name: recipient
+        description: "Recipient"
+      - name: offerer
+        description: "Offerer"
+      - name: zone
+        description: "Seaport zone"
+      - name: evt_index
+        description: "Event index"
+
+  - name: seaport_zora_tagging
+    meta:
+      blockchain: zora
+      project: seaport
+      contributors: hildobby
+    config:
+      tags: ['seaport', 'zora', 'tagging']
+    description: >
+        Seaport tagging to identify the different protocols using Seaport on zora 
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - tagging_method
+            - identifier
+    columns:
+      - name: blockchain
+        description: "Blockchain"
+      - name: tagging_method
+        description: "Identification method"
+        tests:
+          - accepted_values:
+              values: ['zone', 'fee_recipient', 'tx_data_salt']
+      - name: identifier
+        description: "Identifier hash"
+      - name: protocol
+        description: "Protocol"
+      - name: protocol_type
+        description: "Type of Protocol"

--- a/models/seaport/zora/seaport_zora_tagging.sql
+++ b/models/seaport/zora/seaport_zora_tagging.sql
@@ -1,0 +1,14 @@
+{{ config(
+    alias = 'tagging',
+    tags = [ 'static'],
+    unique_key = ['blockchain', 'tagging_method', 'identifier'])
+}}
+
+SELECT blockchain, tagging_method, identifier, protocol, protocol_type
+FROM
+(VALUES
+('zora', 'zone', 0x000000e7ec00e7b300774b00001314b8610022b8, 'OpenSea', 'Marketplace')
+    , ('zora', 'zone', 0x110b2b128a9ed1be5ef3232d8e4e41640df5c2cd, 'OpenSea', 'Marketplace')
+    , ('zora', 'tx_data_salt', 0x360c6ebe, 'OpenSea', 'Marketplace')
+    ) 
+    x (blockchain, tagging_method, identifier, protocol, protocol_type)

--- a/models/seaport/zora/seaport_zora_trades.sql
+++ b/models/seaport/zora/seaport_zora_trades.sql
@@ -1,0 +1,326 @@
+{{ config(
+    
+    alias = 'trades',
+    partition_by = ['block_date'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'tx_hash', 'evt_index', 'nft_contract_address', 'token_id', 'sub_type', 'sub_idx'],
+    post_hook='{{ expose_spells(\'["zora"]\',
+                            "project",
+                            "seaport",
+                            \'["sohwak"]\') }}'
+    )
+}}
+
+{% set c_native_token_address = '0x0000000000000000000000000000000000000000' %}
+{% set c_alternative_token_address = "0x4200000000000000000000000000000000000006" %}  -- WETH
+{% set c_native_symbol = 'ETH' %}
+{% set c_seaport_first_date = '2022-06-01' %}
+
+with source_zora_transactions as (
+    select *
+    from {{ source('zora','transactions') }}
+    {% if not is_incremental() %}
+    where block_time >= TIMESTAMP '{{c_seaport_first_date}}'  -- seaport first txn
+    {% endif %}
+    {% if is_incremental() %}
+    where block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+)
+,ref_seaport_zora_base_pairs as (
+      select *
+      from {{ ref('seaport_zora_base_pairs') }}
+      where 1=1
+      {% if is_incremental() %}
+            and block_time >= date_trunc('day', now() - interval '7' day)
+      {% endif %}
+)
+,ref_tokens_nft as (
+    select *
+    from {{ ref('tokens_nft') }}
+    where blockchain = 'zora'
+)
+,ref_tokens_erc20 as (
+    select *
+    from {{ source('tokens', 'erc20') }}
+    where blockchain = 'zora'
+)
+,ref_nft_aggregators as (
+    select *
+    from {{ ref('nft_aggregators') }}
+    where blockchain = 'zora'
+)
+,source_prices_usd as (
+    select *
+    from {{ source('prices', 'usd') }}
+    where blockchain = 'zora'
+    {% if not is_incremental() %}
+      and minute >= TIMESTAMP '{{c_seaport_first_date}}'  -- seaport first txn
+    {% endif %}
+    {% if is_incremental() %}
+      and minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+)
+,iv_base_pairs_priv as (
+  select a.block_date
+        ,a.block_time
+        ,a.block_number
+        ,a.tx_hash
+        ,a.evt_index
+        ,a.sub_type
+        ,a.sub_idx
+        ,a.offer_first_item_type
+        ,a.consideration_first_item_type
+        ,a.sender
+        ,a.receiver
+        ,a.zone
+        ,a.token_contract_address
+        ,a.original_amount
+        ,a.item_type
+        ,a.token_id
+        ,a.platform_contract_address
+        ,a.offer_cnt
+        ,a.consideration_cnt
+        ,a.is_private
+        ,a.eth_erc_idx
+        ,a.nft_cnt
+        ,a.erc721_cnt
+        ,a.erc1155_cnt
+        ,a.order_type
+        ,a.is_price
+        ,a.is_netprice
+        ,a.is_platform_fee
+        ,a.is_creator_fee
+        ,a.creator_fee_idx
+        ,a.is_traded_nft
+        ,a.is_moved_nft
+  from ref_seaport_zora_base_pairs a
+  where 1=1
+    and not a.is_private
+  union all
+  select a.block_date
+        ,a.block_time
+        ,a.block_number
+        ,a.tx_hash
+        ,a.evt_index
+        ,a.sub_type
+        ,a.sub_idx
+        ,a.offer_first_item_type
+        ,a.consideration_first_item_type
+        ,a.sender
+        ,case when b.tx_hash is not null then b.receiver
+              else a.receiver
+          end as receiver
+        ,a.zone
+        ,a.token_contract_address
+        ,a.original_amount
+        ,a.item_type
+        ,a.token_id
+        ,a.platform_contract_address
+        ,a.offer_cnt
+        ,a.consideration_cnt
+        ,a.is_private
+        ,a.eth_erc_idx
+        ,a.nft_cnt
+        ,a.erc721_cnt
+        ,a.erc1155_cnt
+        ,a.order_type
+        ,a.is_price
+        ,a.is_netprice
+        ,a.is_platform_fee
+        ,a.is_creator_fee
+        ,a.creator_fee_idx
+        ,a.is_traded_nft
+        ,a.is_moved_nft
+  from ref_seaport_zora_base_pairs a
+  left join ref_seaport_zora_base_pairs b on b.tx_hash = a.tx_hash
+    and b.evt_index = a.evt_index
+    and b.block_date = a.block_date -- for performance
+    and b.token_contract_address = a.token_contract_address
+    and b.token_id = a.token_id
+    and b.original_amount = a.original_amount
+    and b.is_moved_nft
+  where 1=1
+    and a.is_private
+    and not a.is_moved_nft
+    and a.consideration_cnt > 0
+)
+,iv_volume as (
+  select block_date
+        ,block_time
+        ,tx_hash
+        ,evt_index
+        ,max(token_contract_address) as token_contract_address
+        ,sum(case when is_price then original_amount end) as price_amount_raw
+        ,sum(case when is_platform_fee then original_amount end) as platform_fee_amount_raw
+        ,max(case when is_platform_fee then receiver end) as platform_fee_receiver
+        ,sum(case when is_creator_fee then original_amount end) as creator_fee_amount_raw
+        ,sum(case when is_creator_fee and creator_fee_idx = 1 then original_amount end) as creator_fee_amount_raw_1
+        ,sum(case when is_creator_fee and creator_fee_idx = 2 then original_amount end) as creator_fee_amount_raw_2
+        ,sum(case when is_creator_fee and creator_fee_idx = 3 then original_amount end) as creator_fee_amount_raw_3
+        ,sum(case when is_creator_fee and creator_fee_idx = 4 then original_amount end) as creator_fee_amount_raw_4
+        ,max(case when is_creator_fee and creator_fee_idx = 1 then receiver end) as creator_fee_receiver_1
+        ,max(case when is_creator_fee and creator_fee_idx = 2 then receiver end) as creator_fee_receiver_2
+        ,max(case when is_creator_fee and creator_fee_idx = 3 then receiver end) as creator_fee_receiver_3
+        ,max(case when is_creator_fee and creator_fee_idx = 4 then receiver end) as creator_fee_receiver_4
+  from iv_base_pairs_priv a
+  where 1=1
+    and eth_erc_idx > 0
+  group by 1,2,3,4
+)
+,iv_nfts as (
+  select a.block_date
+        ,a.block_time
+        ,a.tx_hash
+        ,a.evt_index
+        ,a.block_number
+        ,a.sender as seller
+        ,a.receiver as buyer
+        ,case when nft_cnt > 1 then 'bundle trade'
+              else 'single item trade'
+          end as trade_type
+        ,a.order_type
+        ,a.token_contract_address as nft_contract_address
+        ,a.original_amount as nft_token_amount
+        ,a.token_id as nft_token_id
+        ,a.item_type as nft_token_standard
+        ,a.zone
+        ,a.platform_contract_address
+        ,b.token_contract_address
+        ,CAST(price_amount_raw / nft_cnt as uint256) as price_amount_raw  -- to truncate the odd number of decimal places
+        ,cast(platform_fee_amount_raw / nft_cnt as uint256) as platform_fee_amount_raw
+        ,platform_fee_receiver
+        ,cast(creator_fee_amount_raw / nft_cnt as uint256) as creator_fee_amount_raw
+        ,creator_fee_amount_raw_1 / nft_cnt as creator_fee_amount_raw_1
+        ,creator_fee_amount_raw_2 / nft_cnt as creator_fee_amount_raw_2
+        ,creator_fee_amount_raw_3 / nft_cnt as creator_fee_amount_raw_3
+        ,creator_fee_amount_raw_4 / nft_cnt as creator_fee_amount_raw_4
+        ,creator_fee_receiver_1
+        ,creator_fee_receiver_2
+        ,creator_fee_receiver_3
+        ,creator_fee_receiver_4
+        ,case when nft_cnt > 1 then true
+              else false
+          end as estimated_price
+        ,is_private
+        ,sub_type
+        ,sub_idx
+  from iv_base_pairs_priv a
+  left join iv_volume b on b.block_date = a.block_date  -- tx_hash and evt_index is PK, but for performance, block_time is included
+    and b.tx_hash = a.tx_hash
+    and b.evt_index = a.evt_index
+  where 1=1
+    and a.is_traded_nft
+)
+,iv_trades as (
+  select a.*
+          ,n.name AS nft_token_name
+          ,t."from" as tx_from
+          ,t.to as tx_to
+          ,bytearray_reverse(bytearray_substring(bytearray_reverse(t.data),1,4)) as right_hash
+          ,case when a.token_contract_address = {{c_native_token_address}} then '{{c_native_symbol}}'
+                else e.symbol
+           end as token_symbol
+          ,case when a.token_contract_address = {{c_native_token_address}} then {{c_alternative_token_address}}
+                else a.token_contract_address
+           end as token_alternative_symbol
+          ,e.decimals as price_token_decimals
+          ,a.price_amount_raw / power(10, e.decimals) as price_amount
+          ,a.price_amount_raw / power(10, e.decimals) * p.price as price_amount_usd
+          ,a.platform_fee_amount_raw / power(10, e.decimals) as platform_fee_amount
+          ,a.platform_fee_amount_raw / power(10, e.decimals) * p.price as platform_fee_amount_usd
+          ,a.creator_fee_amount_raw / power(10, e.decimals) as creator_fee_amount
+          ,a.creator_fee_amount_raw / power(10, e.decimals) * p.price as creator_fee_amount_usd
+          ,agg.name as aggregator_name
+          ,agg.contract_address AS aggregator_address
+  from iv_nfts a
+  inner join source_zora_transactions t on t.hash = a.tx_hash
+  left join ref_tokens_nft n on n.contract_address = nft_contract_address
+  left join ref_tokens_erc20 e on e.contract_address = case when a.token_contract_address = {{c_native_token_address}} then {{c_alternative_token_address}}
+                                                            else a.token_contract_address
+                                                      end
+  left join source_prices_usd p on p.contract_address = case when a.token_contract_address = {{c_native_token_address}} then {{c_alternative_token_address}}
+                                                            else a.token_contract_address
+                                                        end
+    and p.minute = date_trunc('minute', a.block_time)
+  left join ref_nft_aggregators agg on agg.contract_address = t.to
+)
+,iv_columns as (
+  -- Rename column to align other *.trades tables
+  -- But the columns ordering is according to convenience.
+  -- initcap the code value if needed
+  select
+    -- basic info
+    'zora' as blockchain
+    ,'seaport' as project
+    ,'v1' as version
+
+    -- order info
+    ,block_date
+    ,block_time
+    ,seller
+    ,buyer
+    ,initcap(trade_type) as trade_type
+    ,initcap(order_type) as trade_category -- Buy / Offer Accepted
+    ,'Trade' as evt_type
+
+    -- nft token info
+    ,nft_contract_address
+    ,nft_token_name as collection
+    ,nft_token_id as token_id
+    ,nft_token_amount as number_of_items
+    ,nft_token_standard as token_standard
+
+    -- price info
+    ,price_amount as amount_original
+    ,price_amount_raw as amount_raw
+    ,price_amount_usd as amount_usd
+    ,token_symbol as currency_symbol
+    ,token_alternative_symbol as currency_contract
+    ,token_contract_address as original_currency_contract
+    ,price_token_decimals as currency_decimals   -- in case calculating royalty1~4
+
+    -- project info (platform or exchange)
+    ,platform_contract_address as project_contract_address
+    ,platform_fee_receiver as platform_fee_receive_address
+    ,platform_fee_amount_raw
+    ,platform_fee_amount
+    ,platform_fee_amount_usd
+
+    -- royalty info
+    ,creator_fee_receiver_1 as royalty_fee_receive_address
+    ,creator_fee_amount_raw as royalty_fee_amount_raw
+    ,creator_fee_amount as royalty_fee_amount
+    ,creator_fee_amount_usd as royalty_fee_amount_usd
+    ,creator_fee_receiver_1 as royalty_fee_receive_address_1
+    ,creator_fee_receiver_2 as royalty_fee_receive_address_2
+    ,creator_fee_receiver_3 as royalty_fee_receive_address_3
+    ,creator_fee_receiver_4 as royalty_fee_receive_address_4
+    ,creator_fee_amount_raw_1 as royalty_fee_amount_raw_1
+    ,creator_fee_amount_raw_2 as royalty_fee_amount_raw_2
+    ,creator_fee_amount_raw_3 as royalty_fee_amount_raw_3
+    ,creator_fee_amount_raw_4 as royalty_fee_amount_raw_4
+
+    -- aggregator
+    ,aggregator_name
+    ,aggregator_address
+
+    -- tx
+    ,block_number
+    ,tx_hash
+    ,evt_index
+    ,tx_from
+    ,tx_to
+    ,right_hash
+
+    -- seaport etc
+    ,zone as zone_address
+    ,estimated_price
+    ,is_private
+    ,sub_idx
+    ,sub_type
+  from iv_trades
+)
+select  *
+from iv_columns


### PR DESCRIPTION
Hard to follow the spells, but made attempts here to add Base & Zora to nft trades (been a consistent request from app teams).

1. Hard to see where the seaport spells flow through to nft trades
2. I've found seaport trades on OP Mainnet that do not appear in the spell (`matchAdvancedOrders` event?)

Not sure what the sufficient approach is, but starting this so others can edit / comment.