### PR TITLE
Update balancer_bpt_prices_macro

### DIFF
--- a/macros/models/_project/balancer/balancer_bpt_prices_macro.sql
+++ b/macros/models/_project/balancer/balancer_bpt_prices_macro.sql
@@ -372,6 +372,8 @@ WITH pool_labels AS (
         l.pool_address AS contract_address,
         CASE WHEN pl.pool_type = 'LP' AND median_price IS NOT NULL
         THEN p.median_price
+        WHEN l.liquidity = 0 AND median_price IS NOT NULL 
+        THEN p.median_price
         ELSE l.liquidity / s.supply 
         END AS bpt_price
     FROM tvl l


### PR DESCRIPTION
This PR updates the bpt_prices macro by adding another case on it's final statement:
`      WHEN l.liquidity = 0 AND median_price IS NOT NULL
        THEN p.median_price`

The idea is to account for a few pools that can't have it's bpt price calculated via it's liquidity, since none of their tokens are priced on prices.usd. One example is https://app.balancer.fi/#/arbitrum/pool/0x451b0afd69ace11ec0ac339033d54d2543b088a80000000000000000000004d5