### PR TITLE
Element ex macro update | `nft.trades` | `EASY`

### DIFF
--- a/macros/models/_sector/nft/platforms/element_v1_base_trades.sql
+++ b/macros/models/_sector/nft/platforms/element_v1_base_trades.sql
@@ -19,6 +19,7 @@ SELECT
   maker AS seller,
   cast(erc20TokenAmount AS UINT256) AS price_raw,
   CASE
+    WHEN erc20Token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee AND '{{blockchain}}' = 'zksync' THEN 0x000000000000000000000000000000000000800a
     WHEN erc20Token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee THEN 0x0000000000000000000000000000000000000000
     ELSE erc20Token
   END AS currency_contract,
@@ -53,6 +54,7 @@ SELECT
   taker AS seller,
   cast(erc20TokenAmount AS UINT256) AS price_raw,
   CASE
+    WHEN erc20Token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee AND '{{blockchain}}' = 'zksync' THEN 0x000000000000000000000000000000000000800a
     WHEN erc20Token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee THEN 0x0000000000000000000000000000000000000000
     ELSE erc20Token
   END AS currency_contract,
@@ -87,6 +89,7 @@ SELECT
   maker AS seller,
   cast(erc20FillAmount AS UINT256) AS price_raw,
   CASE
+    WHEN erc20Token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee AND '{{blockchain}}' = 'zksync' THEN 0x000000000000000000000000000000000000800a
     WHEN erc20Token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee THEN 0x0000000000000000000000000000000000000000
     ELSE erc20Token
   END AS currency_contract,
@@ -121,6 +124,7 @@ SELECT
   taker AS seller,
   cast(erc20FillAmount AS UINT256) AS price_raw,
   CASE
+    WHEN erc20Token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee AND '{{blockchain}}' = 'zksync' THEN 0x000000000000000000000000000000000000800a
     WHEN erc20Token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee THEN 0x0000000000000000000000000000000000000000
     ELSE erc20Token
   END AS currency_contract,

--- a/models/_sector/nft/trades/chains/zksync/platforms/_schema.yml
+++ b/models/_sector/nft/trades/chains/zksync/platforms/_schema.yml
@@ -81,7 +81,7 @@ models:
    meta:
      blockchain: zksync
      project: element
-     contributors: thetroyharris
+     contributors: ['0xRob', 'thetroyharris']
    config:
      tags: [ 'zksync','element','base_trades' ]
    description: >


### PR DESCRIPTION
Change the CASE statement so we can get a USD price of the Element Ex trades on zksync.

My apologies @0xRobin for not adding you in as a contributor to this spell originally. This was merely an oversight and was in no way malicious. Thank you for making the spell and macro!