### PR TITLE
fix: trx has 6 decimals

### DIFF
--- a/models/prices/bnb/prices_bnb_tokens.sql
+++ b/models/prices/bnb/prices_bnb_tokens.sql
@@ -167,7 +167,7 @@ FROM
     ('sfo-starfish-os' ,'bnb' ,'SFO' ,0xc544d8ab2b5ed395b96e3ec87462801eca579ae1 ,18),
     ('baby-babyswap' ,'bnb' ,'BABY' ,0x53e562b9b7e5e94b81f10e96ee70ad06df3d2657 ,18),
     ('sol-solana' ,'bnb' ,'SOL' ,0x570a5d26f7765ecb712c0924e4de545b89fd43df ,18),
-    ('trx-tron' ,'bnb' ,'TRX' ,0xce7de646e7208a4ef112cb6ed5038fa6cc6b12e3 ,18),
+    ('trx-tron' ,'bnb' ,'TRX' ,0xce7de646e7208a4ef112cb6ed5038fa6cc6b12e3 ,6),
     ('sss-starsharks' ,'bnb' ,'SSS' ,0xc3028fbc1742a16a5d69de1b334cbce28f5d7eb3 ,18)    ,
     ('sfp-safepal-token', 'bnb' ,'SFP' ,0xd41fdb03ba84762dd66a0af1a6c8540ff1ba5dfb ,18),
     ('ssg-surviving-soldiers','bnb' ,'SSG' ,0xa0c8c80ed6b7f09f885e826386440b2349f0da7e ,18),


### PR DESCRIPTION
TRX has 6 decimals 
<img width="885" alt="Screenshot 2024-03-11 at 10 55 47 PM" src="https://github.com/duneanalytics/spellbook/assets/7258308/bd613b17-0652-4847-a522-e68c180484f8">

# Thank you for contributing to Spellbook!

Thank you for taking the time to submit code in Spellbook. A few things to consider:

- If you are a first-time contributor, please sign the CLA by copy & pasting **_exactly_** what the bot mentions in PR comment
- Refer to [docs](#spellbook-contribution-docs) section below to answer questions
- Dune team will review submitted PRs as soon as possible

## Best practices
### To speed up your development process in PRs, keep these tips in mind:

- Each commit to your feature branch will rerun CI tests ([see example](https://github.com/duneanalytics/spellbook/actions/runs/8202519819/job/22433451880?pr=5519))
    - This includes *all* modified models on your branch
    - This includes *all* history of the data
- Two tips for faster development iteration:
    - Ensure dbt is installed locally (refer to main `readme`) and run `dbt compile`
        - This will output raw SQL in `target/` directory to copy/paste and run on Dune directly for initial query testing
    - Hardcode a `WHERE` filter for only ~7 days of history on large source tables, i.e. `ethereum.transactions`
        - This will speed up the CI tests and output results quicker -- whether that's an error or fully successful run
        - Once comfortable with small timeframe, remove filter and let full history run

### Incremental model setup
- Make sure your unique key columns are *exactly* the same in the model config block, schema yml file, and seed match columns (where applicable)
- There cannot be nulls in the unique key columns
    - Be sure to double check key columns are correct or `COALESCE()` as needed on key column(s), otherwise the tests may fail on duplicates

### 🪄 Use the built CI tables for testing 🪄

Once CI completes, you can query the CI tables and errors in dune when it finishes running.
- For example:
    - In the `run initial models` and `test initial models`, there will be a schema that looks like this: `test_schema.git_dunesql_4da8bae_sudoswap_v2_base_pool_creations`
    - This can be temporarily queried in Dune for ~24 hours

Leverage these tables to perform QA testing on Dune query editor -- or even full test dashboards!

## Spellbook contribution docs

The [docs](docs) directory has been implemented to answer as many questions as possible. Please take the time to reference each `.md` file within this directory to understand how to efficiently contribute & why the repo is designed as it is 🪄

Example questions to be answered:

- What does each property in the [model config block](/docs/models/model_config_block.md) mean?
- What is the [CI test](/docs/ci_test/ci_test_overview.md) attached to PRs and how can I best utilize it?
- What are the Spellbook [best practices](/docs/general/best_practices.md)?

Please navigate through the [docs](/docs) directory to find as much info as you can.

**Note**: happy to take PRs to improve the docs, let us know 🤝
