### PR TITLE
Update to Balancer Protocol Fees Spell

### DIFF
--- a/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
+++ b/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
@@ -68,8 +68,8 @@ WITH pool_labels AS (
         SELECT 
             l.day,
             s.token_address AS token,
-            SUM(protocol_liquidity_usd / supply) AS price,
             18 AS decimals
+            SUM(protocol_liquidity_usd / supply) AS price
         FROM {{ ref('balancer_liquidity') }} l
         LEFT JOIN {{ ref('balancer_bpt_supply') }} s ON s.token_address = l.pool_address 
         AND l.blockchain = s.blockchain AND s.day = l.day
@@ -79,7 +79,7 @@ WITH pool_labels AS (
         {% if is_incremental() %}
         AND {{ incremental_predicate('l.day') }}
         {% endif %}
-        GROUP BY 1, 2, 3, 4
+        GROUP BY 1, 2, 3
     ),
 
     daily_protocol_fee_collected AS (

--- a/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
+++ b/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
@@ -64,17 +64,20 @@ WITH pool_labels AS (
         WHERE (price < previous_price * 1e4 AND price > previous_price / 1e4)
     ),
 
-    bpt_prices AS(
+    bpt_prices AS( --special calculation for this spell, in order to achieve completeness without relying on prices.usd
         SELECT 
-            day,
-            contract_address AS token,
-            bpt_price AS price,
-            decimals
-        FROM {{ ref('balancer_bpt_prices') }}
-        WHERE blockchain = '{{blockchain}}'
-        AND version = '{{version}}'
+            l.day,
+            s.token_address AS token,
+            SUM(protocol_liquidity_usd / supply) AS price,
+            18 AS decimals
+        FROM {{ ref('balancer_liquidity') }} l
+        LEFT JOIN {{ ref('balancer_bpt_supply') }} s ON s.token_address = l.pool_address 
+        AND l.blockchain = s.blockchain AND s.day = l.day
+        WHERE l.blockchain = '{{blockchain}}'
+        AND l.version = '{{version}}'
+        AND s.supply > 0
         {% if is_incremental() %}
-        AND {{ incremental_predicate('day') }}
+        AND {{ incremental_predicate('l.day') }}
         {% endif %}
         GROUP BY 1, 2, 3, 4
     ),

--- a/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
+++ b/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
@@ -68,7 +68,7 @@ WITH pool_labels AS (
         SELECT 
             l.day,
             s.token_address AS token,
-            18 AS decimals
+            18 AS decimals,
             SUM(protocol_liquidity_usd / supply) AS price
         FROM {{ ref('balancer_liquidity') }} l
         LEFT JOIN {{ ref('balancer_bpt_supply') }} s ON s.token_address = l.pool_address 


### PR DESCRIPTION
This PR makes a small change on the bpt_prices CTE for the protocol_fee macro.
The reason for it is that Balancer has been rapidly growing on fees collected in LST and LRT pools and many of these tokens (some examples are ggAVAX, rswETH and svETH) are still not available on coinpaprika and, therefore, on prices.usd, which leads to some BPTs being undervalued on the bpt_prices spell and will likely require a more complex solution (we can't use dex.prices on it due to circular references). 
So, in the meantime, this PR is a simple solution for the protocol_fee spell only.

@mendesfabio 