### PR TITLE
[EASY] Update balancer_protocol_fee_macro.sql

### DIFF
--- a/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
+++ b/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
@@ -76,9 +76,6 @@ WITH pool_labels AS (
         WHERE l.blockchain = '{{blockchain}}'
         AND l.version = '{{version}}'
         AND s.supply > 0
-        {% if is_incremental() %}
-        AND {{ incremental_predicate('l.day') }}
-        {% endif %}
         GROUP BY 1, 2, 3
     ),
 


### PR DESCRIPTION
This PR removes the incremental filter for the bpt_prices CTE on the protocol_fee macro, as it was causing an underreporting of fees collected in BPTs since the last PR was merged.