### PR TITLE
Paraswap v6

### DIFF
--- a/macros/models/_project/paraswap/v6/paraswap_v6_balancer_v2_method.sql
+++ b/macros/models/_project/paraswap/v6/paraswap_v6_balancer_v2_method.sql
@@ -28,7 +28,10 @@ WITH
                                   substr(try_cast(data as varchar), 11), --dbl ch -eck if need
                                   regexp_extract_all(substr(try_cast(data as varchar), 11), '.{64}') as sData
                                 FROM
-                                  {{ srcTable }}
+                                  {{ srcTable }} 
+                                  {% if is_incremental() %}
+                                    WHERE call_block_time >= date_trunc('day', now() - interval '7' day)
+                                  {% endif %}
                               ) AS s1
                           ) as s2
                       )
@@ -97,5 +100,5 @@ select
                           '{{ method }}' as method{% if inOrOut == 'out' %},
                           output_spentAmount as spentAmount{% endif %}
             from
-              {{tableOuter}}
+              {{tableOuter}}              
 {% endmacro %}

--- a/macros/models/_project/paraswap/v6/paraswap_v6_balancer_v2_method.sql
+++ b/macros/models/_project/paraswap/v6/paraswap_v6_balancer_v2_method.sql
@@ -1,0 +1,101 @@
+{% macro paraswap_v6_balancer_v2_method(tableOuter, tableInner, srcTable, inOrOut, method ) %}
+WITH
+                  {{ tableOuter }} as (
+                    WITH
+                      {{tableInner}} AS (
+                        SELECT
+                          *,
+                          try_cast(
+                            varbinary_to_uint256 (from_hex(s2.sData[s2.assetsOffset])) as integer
+                          ) as assetsSize,
+                          try_cast(
+                            varbinary_to_uint256 (from_hex(s2.sData[s2.limitOffset])) as integer
+                          ) as limitSize
+                        FROM
+                          (
+                            SELECT
+                              *,
+                              try_cast(
+                                varbinary_to_uint256 (from_hex(s1.sData[3])) as integer
+                              ) / 32 + 1 as assetsOffset,
+                              try_cast(
+                                varbinary_to_uint256 (from_hex(s1.sData[8])) as integer
+                              ) / 32 + 1 as limitOffset
+                            FROM
+                              (
+                                SELECT
+                                  *,
+                                  substr(try_cast(data as varchar), 11), --dbl ch -eck if need
+                                  regexp_extract_all(substr(try_cast(data as varchar), 11), '.{64}') as sData
+                                FROM
+                                  {{ srcTable }}
+                              ) AS s1
+                          ) as s2
+                      )
+                    SELECT
+                      *,{% if inOrOut == 'in' %}
+                      sData[assetsOffset + 1] as srcToken,
+                      sData[assetsOffset + assetsSize] as destToken,
+                      varbinary_to_uint256 (from_hex(sData[limitOffset + 1])) as fromAmount,
+                      try_cast(
+                        - varbinary_to_int256 (from_hex(sData[limitOffset + limitSize])) as uint256
+                      ) as toAmount,{% elif inOrOut == 'out' %}
+                      sData[assetsOffset + assetsSize] as srcToken,
+                      sData[assetsOffset + 1] as destToken,
+                      try_cast(
+                        varbinary_to_int256 (from_hex(sData[limitOffset + limitSize])) as uint256
+                      ) as fromAmount,
+                      try_cast(
+                        (
+                          - varbinary_to_int256 (from_hex(sData[limitOffset + 1]))
+                        ) as uint256
+                      ) as toAmount,{% endif %}                                              
+                      to_hex(
+                        try_cast(
+                          bitwise_and(
+                            try_cast(
+                              JSON_EXTRACT_SCALAR(balancerData, '$.beneficiaryAndApproveFlag') AS UINT256
+                            ),
+                            varbinary_to_uint256 (0xffffffffffffffffffffffffffffffffffffffff)
+                          ) as VARBINARY
+                        )
+                      ) as beneficiary
+                    FROM
+                      {{ tableInner }}
+                  )
+select
+              call_block_time,
+                          call_block_number,
+                          call_tx_hash,
+                          contract_address as project_contract_address,
+                          call_trace_address,
+                          case
+                            when try_cast(srcToken as uint256) = uint256 '0' then '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+                            else try_cast(
+                              from_hex(regexp_replace(srcToken, '(00){12}')) as varchar
+                            ) -- shrink address to to bytes20
+                          end as srcToken,
+                          case
+                            when try_cast(destToken as uint256) = uint256 '0' then '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+                            else try_cast(
+                              from_hex(regexp_replace(destToken, '(00){12}')) as varchar
+                            ) -- shrink address to to bytes20
+                          end as destToken,
+                          fromAmount,
+                          toAmount,
+                          try_cast(
+                            JSON_EXTRACT_SCALAR(balancerData, '$.quotedAmount') as uint256
+                          ) AS quotedAmount,
+                          output_receivedAmount,
+                          JSON_EXTRACT_SCALAR(balancerData, '$.metadata') AS metadata,
+                          try_cast(
+                            from_hex(regexp_replace(beneficiary, '(00){12}')) as varchar
+                          ) as beneficiary,
+                          partnerAndFee,
+                          output_partnerShare,
+                          output_paraswapShare,
+                          '{{ method }}' as method{% if inOrOut == 'out' %},
+                          output_spentAmount as spentAmount{% endif %}
+            from
+              {{tableOuter}}
+{% endmacro %}

--- a/macros/models/_project/paraswap/v6/paraswap_v6_trades_master.sql
+++ b/macros/models/_project/paraswap/v6/paraswap_v6_trades_master.sql
@@ -1,0 +1,142 @@
+{% macro paraswap_v6_trades_master(blockchain, project, contract_name) %}with
+  v6_trades as (
+    with
+      sell_trades as (
+            with
+            swapExactAmountIn as ({{ paraswap_v6_uniswaplike_method( source(project + '_' + blockchain, contract_name + '_call_swapExactAmountIn'), 'swapExactAmountIn', 'swapData') }}),
+          swapExactAmountInOnUniswapV2 as ({{ paraswap_v6_uniswaplike_method( source(project + '_' + blockchain, contract_name + '_call_swapExactAmountInOnUniswapV2'), 'swapExactAmountInOnUniswapV2', 'uniData') }}),
+          swapExactAmountInOnUniswapV3 as ({{ paraswap_v6_uniswaplike_method( source(project + '_' + blockchain, contract_name + '_call_swapExactAmountInOnUniswapV3'), 'swapExactAmountInOnUniswapV3', 'uniData') }}),
+          swapExactAmountInOnCurveV1 as ({{ paraswap_v6_uniswaplike_method( source(project + '_' + blockchain, contract_name + '_call_swapExactAmountInOnCurveV1'), 'swapExactAmountInOnCurveV1', 'curveV1Data') }}),
+          swapExactAmountInOnCurveV2 as ({{ paraswap_v6_uniswaplike_method( source(project + '_' + blockchain, contract_name + '_call_swapExactAmountInOnCurveV2'), 'swapExactAmountInOnCurveV2', 'curveV2Data') }}),
+          swapExactAmountInOnBalancerV2 as ({{ paraswap_v6_balancer_v2_method('swapExactAmountInOnBalancerV2_decoded', 'swapExactAmountInOnBalancerV2_raw', source(project + '_' + blockchain, contract_name + '_call_swapExactAmountInOnBalancerV2'), 'in', 'swapExactAmountInOnBalancerV2') }})
+select
+  *,
+  fromAmount as spentAmount,
+  'sell' as side
+from
+          (
+            select
+              *
+            from
+              swapExactAmountIn
+            union
+            select
+              *
+            from
+              swapExactAmountInOnUniswapV2
+            union
+            select
+              *
+            from
+              swapExactAmountInOnUniswapV3
+            union
+            select
+              *
+            from
+              swapExactAmountInOnCurveV1
+            union
+            select
+              *
+            from
+              swapExactAmountInOnCurveV2
+            union
+            select
+              *
+            from
+              swapExactAmountInOnBalancerV2
+          )
+      ),
+      buy_trades as (
+            with            
+              swapExactAmountOut as ({{ paraswap_v6_uniswaplike_method( source(project + '_' + blockchain, contract_name + '_call_swapExactAmountOut'), 'swapExactAmountOut', 'swapData', 'output_spentAmount as spentAmount') }}),
+              swapExactAmountOutOnUniswapV2 as ({{ paraswap_v6_uniswaplike_method( source(project + '_' + blockchain, contract_name + '_call_swapExactAmountOutOnUniswapV2'), 'swapExactAmountOutOnUniswapV2', 'uniData', 'output_spentAmount as spentAmount' ) }}),
+              swapExactAmountOutOnUniswapV3 as ({{ paraswap_v6_uniswaplike_method( source(project + '_' + blockchain, contract_name + '_call_swapExactAmountOutOnUniswapV3'), 'swapExactAmountOutOnUniswapV3', 'uniData', 'output_spentAmount as spentAmount') }}),
+              swapExactAmountOutOnBalancerV2 as ({{ paraswap_v6_balancer_v2_method('swapexactAmountOutOnBalancerV2_decoded', 'swapexactAmountOutOnBalancerV2_raw', source(project + '_' + blockchain, contract_name + '_call_swapExactAmountOutOnBalancerV2'), 'out', 'swapExactAmountOutOnBalancerV2')}} )              
+            select
+              *,
+              'buy' as side
+        from
+          (
+            select
+              *
+            from
+              swapExactAmountOut
+            union
+            select
+              *
+            from
+              swapExactAmountOutOnUniswapV2
+            union
+            select
+              *
+            from
+              swapExactAmountOutOnUniswapV3
+            union
+            select
+              *
+            from
+              swapExactAmountOutOnBalancerV2
+          )
+      )
+    select
+      *
+    from
+      (
+        select
+          *
+        from
+          sell_trades
+        union
+        select
+          *
+        from
+          buy_trades
+      )
+  )
+select
+  '{{ blockchain }}' as blockchain,
+  cast(date_trunc('day', call_block_time) as date) as block_date,
+  cast(date_trunc('month', call_block_time) as date) as block_month,
+  'paraswap' AS project,
+  '6' as version,
+  call_block_time as blockTime,
+  call_block_number as blockNumber,
+  call_tx_hash as txHash,
+  project_contract_address as projectContractAddress,
+  call_trace_address as callTraceAddress,
+  srcToken,
+  destToken,
+  fromAmount,
+  spentAmount,
+  toAmount,
+  quotedAmount,
+  output_receivedAmount as receivedAmount,
+  metadata,
+  beneficiary,
+  method,
+  side,
+  partnerAndFee as feeCode,
+  output_partnerShare as partnerShare,
+  output_paraswapShare as paraswapShare,
+  '0x' || regexp_replace(
+                try_cast(
+                  TRY_CAST(
+                    BITWISE_RIGHT_SHIFT(partnerAndFee, 96) AS VARBINARY
+                  ) as VARCHAR
+                ),
+                '0x(00){12}'
+              ) AS partnerAddress,
+              BITWISE_AND(
+                try_cast(partnerAndFee as UINT256),
+                varbinary_to_uint256 (0x3FFF)
+              ) as feeBps,              
+              BITWISE_AND(
+                try_cast(partnerAndFee as uint256),
+                bitwise_left_shift(TRY_CAST(1 as uint256), 94)
+              ) <> 0 AS isReferral,
+              BITWISE_AND(
+                try_cast(partnerAndFee as uint256),
+                bitwise_left_shift(TRY_CAST(1 as uint256), 95)
+              ) <> 0 AS isTakeSurplus
+  from 
+    v6_trades{% endmacro %}

--- a/macros/models/_project/paraswap/v6/paraswap_v6_uniswaplike_method.sql
+++ b/macros/models/_project/paraswap/v6/paraswap_v6_uniswaplike_method.sql
@@ -25,7 +25,10 @@
                   '{{ method_name }}' as method{% if extra_field %},
                   {{ extra_field }}{% endif %}                  
                 FROM
-                  {{ table_name }}
+                  {{ table_name }}                  
                 WHERE
                   call_success = TRUE
+                  {% if is_incremental() %}
+                    AND call_block_time >= date_trunc('day', now() - interval '7' day)
+                  {% endif %}
 {% endmacro %}

--- a/macros/models/_project/paraswap/v6/paraswap_v6_uniswaplike_method.sql
+++ b/macros/models/_project/paraswap/v6/paraswap_v6_uniswaplike_method.sql
@@ -1,0 +1,31 @@
+{% macro paraswap_v6_uniswaplike_method(table_name, method_name, data_field, extra_field=None) %}
+                SELECT                
+                  call_block_time,
+                  call_block_number,
+                  call_tx_hash,                  
+                  contract_address as project_contract_address,
+                  call_trace_address,
+                  JSON_EXTRACT_SCALAR({{ data_field }}, '$.srcToken') AS srcToken,
+                  JSON_EXTRACT_SCALAR({{ data_field }}, '$.destToken') AS destToken,
+                  try_cast(
+                    JSON_EXTRACT_SCALAR({{ data_field }}, '$.fromAmount') as uint256
+                  ) AS fromAmount,
+                  try_cast(
+                    JSON_EXTRACT_SCALAR({{ data_field }}, '$.toAmount') as uint256
+                  ) AS toAmount,
+                  try_cast(
+                    JSON_EXTRACT_SCALAR({{ data_field }}, '$.quotedAmount') as uint256
+                  ) AS quotedAmount,
+                  output_receivedAmount,
+                  JSON_EXTRACT_SCALAR({{ data_field }}, '$.metadata') AS metadata,
+                  JSON_EXTRACT_SCALAR({{ data_field }}, '$.beneficiary') AS beneficiary,
+                  partnerAndFee,
+                  output_partnerShare,
+                  output_paraswapShare,
+                  '{{ method_name }}' as method{% if extra_field %},
+                  {{ extra_field }}{% endif %}                  
+                FROM
+                  {{ table_name }}
+                WHERE
+                  call_success = TRUE
+{% endmacro %}

--- a/models/paraswap/arbitrum/paraswap_arbitrum_schema.yml
+++ b/models/paraswap/arbitrum/paraswap_arbitrum_schema.yml
@@ -96,6 +96,60 @@ models:
         name: evt_index
         description: ""
 
+  - name: paraswap_v6_arbitrum_trades
+    meta:
+      blockchain: arbitrum
+      sector: dex
+      project: paraswap_v6
+      contributors: eptighte, mwamedacen
+    config:
+      tags: ['arbitrum','paraswap_v6','trades', 'paraswap','dex']
+    description: >
+        Paraswap V6 contract aggregator trades on arbitrum
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - tx_hash
+            - method
+            - trace_address            
+
+      - check_dex_aggregator_seed:
+         blockchain: arbitrum
+         project: paraswap
+         version: 6
+    columns:
+      - *blockchain
+      - *project
+      - *version  
+      - *block_date
+      - *block_time
+      - *token_bought_symbol
+      - *token_sold_symbol
+      - *token_pair
+      - *token_bought_amount
+      - *token_sold_amount
+      - *token_bought_amount_raw
+      - *token_sold_amount_raw
+      - *amount_usd
+      - *token_bought_address
+      - *token_sold_address
+      - *taker
+      - *maker
+      - *project_contract_address
+      - *tx_hash
+      - *tx_from
+      - *tx_to
+      - *trace_address
+      - *evt_index       
+      - &method
+        name: method
+        description: "Method"   
+
+
   - name: paraswap_arbitrum_trades
     meta:
       blockchain: arbitrum
@@ -130,3 +184,65 @@ models:
       - *tx_to
       - *trace_address
       - *evt_index
+
+
+  - name: paraswap_v6_arbitrum_trades_decoded
+    description: "Paraswap V6 trades decoded"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - txHash
+            - method
+            - callTraceAddress                        
+    columns:
+      - name: blockTime
+        description: "Block time"        
+      - name: blockNumber
+        description: "Block number"        
+      - name: txHash
+        description: "Transaction hash"        
+      - name: projectContractAddress
+        description: "Project contract address"        
+      - name: callTraceAddress
+        description: "Call trace address"        
+      - name: srcToken
+        description: "Source token"        
+      - name: destToken
+        description: "Destination token"        
+      - name: fromAmount
+        description: "From amount"        
+      - name: spentAmount
+        description: "Spent amount"        
+      - name: toAmount
+        description: "To amount"        
+      - name: quotedAmount
+        description: "Quoted amount"        
+      - name: receivedAmount
+        description: "Received amount"        
+      - name: metadata
+        description: "Metadata"        
+      - name: beneficiary
+        description: "Beneficiary"
+      - name: method
+        description: "Method"
+      - name: side
+        description: "Side"        
+      - name: feeCode
+        description: "Fee code"
+      - name: partnerShare
+        description: "Partner share"
+      - name: paraswapShare
+        description: "Paraswap share"
+      - name: partnerAddress
+        description: "Partner address"
+      - name: feeBps
+        description: "Fee in basis points"
+      - name: isReferral
+        description: "Is referral"
+      - name: isTakeSurplus
+        description: "Is take surplus"
+

--- a/models/paraswap/arbitrum/paraswap_arbitrum_trades.sql
+++ b/models/paraswap/arbitrum/paraswap_arbitrum_trades.sql
@@ -6,6 +6,7 @@
 
 {% set paraswap_models = [
 ref('paraswap_v5_arbitrum_trades')
+,ref('paraswap_v6_arbitrum_trades')
 ] %}
 
 

--- a/models/paraswap/arbitrum/paraswap_v6_arbitrum_trades.sql
+++ b/models/paraswap/arbitrum/paraswap_v6_arbitrum_trades.sql
@@ -1,0 +1,111 @@
+{{ config(
+    schema = 'paraswap_v6_arbitrum',
+    alias = 'trades',
+    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["springzh"]\') }}'
+    )
+}}
+
+{% set project_start_date = '2024-03-01' %}
+
+with dexs AS (
+        SELECT 
+            blockTime AS block_time,
+            blockNumber AS block_number,
+            from_hex(beneficiary) AS taker, 
+            null AS maker,  -- TODO: can parse from traces
+            receivedAmount AS token_bought_amount_raw,
+            fromAmount AS token_sold_amount_raw,
+            CAST(NULL AS double) AS amount_usd,  
+            method,              
+            CASE 
+                WHEN from_hex(destToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                THEN 0x82af49447d8a07e3bd95bd0d56f35241523fbab1 -- WETH 
+                ELSE from_hex(destToken)
+            END AS token_bought_address,
+            CASE 
+                WHEN from_hex(srcToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                THEN 0x82af49447d8a07e3bd95bd0d56f35241523fbab1 -- WETH 
+                ELSE from_hex(srcToken)
+            END AS token_sold_address,
+            projectContractAddress as project_contract_address,
+            txHash AS tx_hash, 
+            callTraceAddress AS trace_address,
+            CAST(-1 as integer) AS evt_index
+        FROM {{ ref('paraswap_v6_arbitrum_trades_decoded') }}     
+        {% if is_incremental() %}
+        WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+        {% endif %}        
+)
+
+SELECT 'arbitrum' AS blockchain,
+    'paraswap' AS project,
+    '6' AS version,
+    cast(date_trunc('day', d.block_time) as date) as block_date,
+    cast(date_trunc('month', d.block_time) as date) as block_month,
+    d.block_time,
+method,
+    e1.symbol AS token_bought_symbol,
+    e2.symbol AS token_sold_symbol,
+    CASE
+        WHEN lower(e1.symbol) > lower(e2.symbol) THEN concat(e2.symbol, '-', e1.symbol)
+        ELSE concat(e1.symbol, '-', e2.symbol)
+    END AS token_pair,
+    d.token_bought_amount_raw / power(10, e1.decimals) AS token_bought_amount,
+    d.token_sold_amount_raw / power(10, e2.decimals) AS token_sold_amount,
+    d.token_bought_amount_raw,
+    d.token_sold_amount_raw,
+    coalesce(
+        d.amount_usd
+        ,(d.token_bought_amount_raw / power(10, p1.decimals)) * p1.price
+        ,(d.token_sold_amount_raw / power(10, p2.decimals)) * p2.price
+    ) AS amount_usd,
+    d.token_bought_address,
+    d.token_sold_address,
+    coalesce(d.taker, tx."from") AS taker,
+    coalesce(d.maker, tx."from") as maker,
+    d.project_contract_address,
+    d.tx_hash,
+    tx."from" AS tx_from,
+    tx.to AS tx_to,
+    d.trace_address,
+    d.evt_index
+FROM dexs d
+INNER JOIN {{ source('arbitrum', 'transactions') }} tx ON d.tx_hash = tx.hash
+    AND d.block_number = tx.block_number
+    {% if not is_incremental() %}
+    AND tx.block_time >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND tx.block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('tokens', 'erc20') }} e1 ON e1.contract_address = d.token_bought_address
+    AND e1.blockchain = 'arbitrum'
+LEFT JOIN {{ source('tokens', 'erc20') }} e2 on e2.contract_address = d.token_sold_address
+    AND e2.blockchain = 'arbitrum'
+LEFT JOIN {{ source('prices', 'usd') }} p1 ON p1.minute = date_trunc('minute', d.block_time)
+    AND p1.contract_address = d.token_bought_address
+    AND p1.blockchain = 'arbitrum'
+    {% if not is_incremental() %}
+    AND p1.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p1.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('prices', 'usd') }} p2 ON p2.minute = date_trunc('minute', d.block_time)
+    AND p2.contract_address = d.token_sold_address
+    AND p2.blockchain = 'arbitrum'
+    {% if not is_incremental() %}
+    AND p2.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p2.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}

--- a/models/paraswap/arbitrum/paraswap_v6_arbitrum_trades.sql
+++ b/models/paraswap/arbitrum/paraswap_v6_arbitrum_trades.sql
@@ -42,7 +42,7 @@ with dexs AS (
             CAST(-1 as integer) AS evt_index
         FROM {{ ref('paraswap_v6_arbitrum_trades_decoded') }}     
         {% if is_incremental() %}
-        WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+        WHERE blockTime >= date_trunc('day', now() - interval '7' day)
         {% endif %}        
 )
 

--- a/models/paraswap/arbitrum/paraswap_v6_arbitrum_trades_decoded.sql
+++ b/models/paraswap/arbitrum/paraswap_v6_arbitrum_trades_decoded.sql
@@ -5,11 +5,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
-    post_hook='{{ expose_spells(\'["arbitrum"]\',
-                                "project",
-                                "paraswap_v6",
-                                \'["eptighte", "mwamedacen"]\') }}'
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress']    
     )
 }}
 

--- a/models/paraswap/arbitrum/paraswap_v6_arbitrum_trades_decoded.sql
+++ b/models/paraswap/arbitrum/paraswap_v6_arbitrum_trades_decoded.sql
@@ -1,0 +1,16 @@
+{{ config(
+    schema = 'paraswap_v6_arbitrum',
+    alias = 'trades_decoded',    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
+    post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{{ paraswap_v6_trades_master('arbitrum', 'paraswap', 'AugustusV6') }}

--- a/models/paraswap/avalanche_c/paraswap_avalanche_c_schema.yml
+++ b/models/paraswap/avalanche_c/paraswap_avalanche_c_schema.yml
@@ -96,6 +96,59 @@ models:
         name: evt_index
         description: ""
 
+  - name: paraswap_v6_avalanche_c_trades
+    meta:
+      blockchain: avalanche_c
+      sector: dex
+      project: paraswap_v6
+      contributors: eptighte, mwamedacen
+    config:
+      tags: ['avalanche_c','paraswap_v6','trades', 'paraswap','dex']
+    description: >
+        Paraswap V6 contract aggregator trades on avalanche_c
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - tx_hash
+            - method
+            - trace_address            
+
+      - check_dex_aggregator_seed:
+         blockchain: avalanche_c
+         project: paraswap
+         version: 6
+    columns:
+      - *blockchain
+      - *project
+      - *version  
+      - *block_date
+      - *block_time
+      - *token_bought_symbol
+      - *token_sold_symbol
+      - *token_pair
+      - *token_bought_amount
+      - *token_sold_amount
+      - *token_bought_amount_raw
+      - *token_sold_amount_raw
+      - *amount_usd
+      - *token_bought_address
+      - *token_sold_address
+      - *taker
+      - *maker
+      - *project_contract_address
+      - *tx_hash
+      - *tx_from
+      - *tx_to
+      - *trace_address
+      - *evt_index       
+      - &method
+        name: method
+        description: "Method"   
+
   - name: paraswap_avalanche_c_trades
     meta:
       blockchain: avalanche_c
@@ -130,3 +183,64 @@ models:
       - *tx_to
       - *trace_address
       - *evt_index
+
+  - name: paraswap_v6_avalanche_c_trades_decoded
+    description: "Paraswap V6 trades decoded"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - txHash
+            - method
+            - callTraceAddress                        
+    columns:
+      - name: blockTime
+        description: "Block time"        
+      - name: blockNumber
+        description: "Block number"        
+      - name: txHash
+        description: "Transaction hash"        
+      - name: projectContractAddress
+        description: "Project contract address"        
+      - name: callTraceAddress
+        description: "Call trace address"        
+      - name: srcToken
+        description: "Source token"        
+      - name: destToken
+        description: "Destination token"        
+      - name: fromAmount
+        description: "From amount"        
+      - name: spentAmount
+        description: "Spent amount"        
+      - name: toAmount
+        description: "To amount"        
+      - name: quotedAmount
+        description: "Quoted amount"        
+      - name: receivedAmount
+        description: "Received amount"        
+      - name: metadata
+        description: "Metadata"        
+      - name: beneficiary
+        description: "Beneficiary"
+      - name: method
+        description: "Method"
+      - name: side
+        description: "Side"        
+      - name: feeCode
+        description: "Fee code"
+      - name: partnerShare
+        description: "Partner share"
+      - name: paraswapShare
+        description: "Paraswap share"
+      - name: partnerAddress
+        description: "Partner address"
+      - name: feeBps
+        description: "Fee in basis points"
+      - name: isReferral
+        description: "Is referral"
+      - name: isTakeSurplus
+        description: "Is take surplus"
+

--- a/models/paraswap/avalanche_c/paraswap_avalanche_c_trades.sql
+++ b/models/paraswap/avalanche_c/paraswap_avalanche_c_trades.sql
@@ -6,6 +6,7 @@
 
 {% set paraswap_models = [
 ref('paraswap_v5_avalanche_c_trades')
+,ref('paraswap_v6_avalanche_c_trades')
 ] %}
 
 

--- a/models/paraswap/avalanche_c/paraswap_v6_avalanche_c_trades.sql
+++ b/models/paraswap/avalanche_c/paraswap_v6_avalanche_c_trades.sql
@@ -1,0 +1,170 @@
+{{ config(
+    schema = 'paraswap_v6_avalanche_c',
+    alias = 'trades',    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'method', 'trace_address'],
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{% set project_start_date = '2024-03-01' %}
+
+with dexs AS (
+    SELECT 
+        blockTime AS block_time,
+        blockNumber AS block_number,
+        from_hex(beneficiary) AS taker, 
+        null AS maker,  -- TODO: can parse from traces
+        receivedAmount AS token_bought_amount_raw,
+        fromAmount AS token_sold_amount_raw,
+        CAST(NULL AS double) AS amount_usd,  
+        method,              
+        CASE 
+            WHEN from_hex(destToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+            THEN 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- wavax 
+            ELSE from_hex(destToken)
+        END AS token_bought_address,        
+        CASE 
+            WHEN from_hex(srcToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+            THEN 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- wavax 
+            ELSE from_hex(srcToken)
+        END AS token_sold_address,
+        projectContractAddress as project_contract_address,
+        txHash AS tx_hash, 
+        callTraceAddress AS trace_address,
+        CAST(-1 as integer) AS evt_index
+    FROM {{ ref('paraswap_v6_avalanche_c_trades_decoded') }}     
+    {% if is_incremental() %}
+    WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+),
+
+-- USDC.e AND USDT.e price are missing before 2022-10
+price_missed_previous AS (
+    WITH usdc_price AS (
+        SELECT minute, contract_address, decimals, symbol, price
+        FROM {{ source('prices', 'usd') }}
+        WHERE contract_address = 0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664 -- USDC.e
+        ORDER BY minute
+        LIMIT 1
+    ),
+
+     usdt_price AS (
+        SELECT minute, contract_address, decimals, symbol, price
+        FROM {{ source('prices', 'usd') }}
+        WHERE contract_address = 0xc7198437980c041c805a1edcba50c1ce5db95118 -- USDT.e
+        ORDER BY minute
+        LIMIT 1
+    )
+
+    SELECT minute, contract_address, decimals, symbol, price
+    FROM usdc_price
+        UNION ALL
+
+    SELECT minute, contract_address, decimals, symbol, price
+    FROM usdt_price
+),
+--  USDC.e AND USDT.e price may be missed for latest swaps
+price_missed_next AS (
+    WITH usdc_price AS (
+        SELECT minute, contract_address, decimals, symbol, price
+        FROM {{ source('prices', 'usd') }}
+        WHERE contract_address = 0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664 -- USDC.e
+        ORDER BY minute DESC
+        LIMIT 1
+    ),
+
+    usdt_price AS (
+    SELECT minute, contract_address, decimals, symbol, price
+    FROM {{ source('prices', 'usd') }}
+    WHERE contract_address = 0xc7198437980c041c805a1edcba50c1ce5db95118 -- USDT.e
+    ORDER BY minute DESC
+    LIMIT 1
+)
+
+    SELECT minute, contract_address, decimals, symbol, price
+    FROM usdc_price
+
+    UNION ALL
+    
+    SELECT minute, contract_address, decimals, symbol, price
+    FROM usdt_price
+)
+
+SELECT 'avalanche_c' AS blockchain,
+    'paraswap' AS project,
+    '6' AS version,
+    cast(date_trunc('day', d.block_time) as date) as block_date,
+    cast(date_trunc('month', d.block_time) as date) as block_month,    
+    d.block_time,
+    method,
+    e1.symbol AS token_bought_symbol,
+    e2.symbol AS token_sold_symbol,
+    CASE
+        WHEN lower(e1.symbol) > lower(e2.symbol) THEN concat(e2.symbol, '-', e1.symbol)
+        ELSE concat(e1.symbol, '-', e2.symbol)
+    END AS token_pair,
+    d.token_bought_amount_raw / power(10, e1.decimals) AS token_bought_amount,
+    d.token_sold_amount_raw / power(10, e2.decimals) AS token_sold_amount,
+    d.token_bought_amount_raw,
+    d.token_sold_amount_raw,    
+    coalesce(
+        d.amount_usd
+        ,(d.token_bought_amount_raw / power(10, e1.decimals)) * coalesce(p1.price, p_prev1.price, p_next1.price)
+        ,(d.token_sold_amount_raw / power(10, e2.decimals)) * coalesce(p2.price, p_prev2.price, p_next2.price)
+    ) AS amount_usd,
+    d.token_bought_address,    
+    d.token_sold_address,    
+    coalesce(d.taker, tx."from") AS taker,
+    coalesce(d.maker, tx."from") as maker,
+    d.project_contract_address,
+    d.tx_hash,
+    tx."from" AS tx_from,
+    tx.to AS tx_to,
+    d.trace_address,
+    d.evt_index
+FROM dexs d
+INNER JOIN {{ source('avalanche_c', 'transactions') }} tx ON d.tx_hash = tx.hash
+    AND d.block_number = tx.block_number
+    {% if not is_incremental() %}
+    AND tx.block_time >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND tx.block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('tokens', 'erc20') }} e1 ON e1.contract_address = d.token_bought_address
+    AND e1.blockchain = 'avalanche_c'
+LEFT JOIN {{ source('tokens', 'erc20') }} e2 on e2.contract_address = d.token_sold_address
+    AND e2.blockchain = 'avalanche_c'
+LEFT JOIN {{ source('prices', 'usd') }} p1 ON p1.minute = date_trunc('minute', d.block_time)
+    AND p1.contract_address = d.token_bought_address
+    AND p1.blockchain = 'avalanche_c'
+    {% if not is_incremental() %}
+    AND p1.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p1.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN price_missed_previous p_prev1 ON d.token_bought_address = p_prev1.contract_address
+    AND d.block_time < p_prev1.minute -- Swap before first price record time
+LEFT JOIN price_missed_next p_next1 ON d.token_bought_address = p_next1.contract_address
+    AND d.block_time > p_next1.minute -- Swap after last price record time
+LEFT JOIN {{ source('prices', 'usd') }} p2 ON p2.minute = date_trunc('minute', d.block_time)
+    AND p2.contract_address = d.token_sold_address
+    AND p2.blockchain = 'avalanche_c'
+    {% if not is_incremental() %}
+    AND p2.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p2.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN price_missed_previous p_prev2 ON d.token_sold_address = p_prev2.contract_address
+    AND d.block_time < p_prev2.minute -- Swap before first price record time
+LEFT JOIN price_missed_next p_next2 ON d.token_sold_address = p_next2.contract_address
+    AND d.block_time > p_next2.minute -- Swap after last price record time

--- a/models/paraswap/avalanche_c/paraswap_v6_avalanche_c_trades.sql
+++ b/models/paraswap/avalanche_c/paraswap_v6_avalanche_c_trades.sql
@@ -41,7 +41,7 @@ with dexs AS (
         CAST(-1 as integer) AS evt_index
     FROM {{ ref('paraswap_v6_avalanche_c_trades_decoded') }}     
     {% if is_incremental() %}
-    WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+    WHERE blockTime >= date_trunc('day', now() - interval '7' day)
     {% endif %}
 ),
 

--- a/models/paraswap/avalanche_c/paraswap_v6_avalanche_c_trades_decoded.sql
+++ b/models/paraswap/avalanche_c/paraswap_v6_avalanche_c_trades_decoded.sql
@@ -5,11 +5,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
-    post_hook='{{ expose_spells(\'["avalanche_c"]\',
-                                "project",
-                                "paraswap_v6",
-                                \'["eptighte", "mwamedacen"]\') }}'
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress']    
     )
 }}
 

--- a/models/paraswap/avalanche_c/paraswap_v6_avalanche_c_trades_decoded.sql
+++ b/models/paraswap/avalanche_c/paraswap_v6_avalanche_c_trades_decoded.sql
@@ -1,0 +1,16 @@
+{{ config(
+    schema = 'paraswap_v6_avalanche_c',
+    alias = 'trades_decoded',    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
+    post_hook='{{ expose_spells(\'["avalanche_c"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{{ paraswap_v6_trades_master('avalanche_c', 'paraswap', 'AugustusV6') }}

--- a/models/paraswap/base/paraswap_base_schema.yml
+++ b/models/paraswap/base/paraswap_base_schema.yml
@@ -155,8 +155,7 @@ models:
           blockchain: base
           project: paraswap
           version: 6
-    columns:
-      -
+    columns:      
       - *blockchain
       - *project
       - *version
@@ -184,41 +183,6 @@ models:
         name: method
         description: "Method"
 
-  # notmally there would follow this definition but it conflicts with main query?
-  # - name: paraswap_base_c_trades
-  #   meta:
-  #     blockchain: base
-  #     sector: dex
-  #     project: paraswap
-  #     contributors: Henrystats
-  #   config:
-  #     tags: ['base','dex','trades', 'paraswap']
-  #   description: >
-  #       paraswap aggregator trades on base across all contracts and versions. This table will load dex trades downstream.
-  #   columns:
-  #     - *blockchain
-  #     - *project
-  #     - *version
-  #     - *block_date
-  #     - *block_time
-  #     - *token_bought_symbol
-  #     - *token_sold_symbol
-  #     - *token_pair
-  #     - *token_bought_amount
-  #     - *token_sold_amount
-  #     - *token_bought_amount_raw
-  #     - *token_sold_amount_raw
-  #     - *amount_usd
-  #     - *token_bought_address
-  #     - *token_sold_address
-  #     - *taker
-  #     - *maker
-  #     - *project_contract_address
-  #     - *tx_hash
-  #     - *tx_from
-  #     - *tx_to
-  #     - *trace_address
-  #     - *evt_index
 
   - name: paraswap_v6_base_trades_decoded
     description: "Paraswap V6 trades decoded"

--- a/models/paraswap/base/paraswap_base_schema.yml
+++ b/models/paraswap/base/paraswap_base_schema.yml
@@ -8,9 +8,9 @@ models:
       project: paraswap_v5
       contributors: Henrystats
     config:
-      tags: ['base','paraswap_v5','trades', 'paraswap','dex']
+      tags: ["base", "paraswap_v5", "trades", "paraswap", "dex"]
     description: >
-        Paraswap V5 contract aggregator trades on base
+      Paraswap V5 contract aggregator trades on base
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -22,16 +22,16 @@ models:
             - evt_index
             - trace_address
       - check_dex_aggregator_seed:
-         blockchain: base
-         project: paraswap
-         version: 5
+          blockchain: base
+          project: paraswap
+          version: 5
     columns:
       - &blockchain
         name: blockchain
         description: "Blockchain which the DEX is deployed"
-      - &project 
+      - &project
         name: project
-        description: "Project name of the DEX"  
+        description: "Project name of the DEX"
       - &version
         name: version
         description: "Version of the contract built and deployed by the DEX project"
@@ -103,13 +103,13 @@ models:
       project: paraswap
       contributors: Henrystats
     config:
-      tags: ['base','dex','trades', 'paraswap']
+      tags: ["base", "dex", "trades", "paraswap"]
     description: >
-        paraswap aggregator trades on base across all contracts and versions. This table will load dex trades downstream.
+      paraswap aggregator trades on base across all contracts and versions. This table will load dex trades downstream.
     columns:
       - *blockchain
       - *project
-      - *version  
+      - *version
       - *block_date
       - *block_time
       - *token_bought_symbol
@@ -130,3 +130,152 @@ models:
       - *tx_to
       - *trace_address
       - *evt_index
+
+  - name: paraswap_v6_base_trades
+    meta:
+      blockchain: base
+      sector: dex
+      project: paraswap_v6
+      contributors: eptighte
+    config:
+      tags: ["eptighte", "paraswap_v6", "trades", "paraswap", "dex"]
+    description: >
+      Paraswap V6 contract aggregator trades on eptighte
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - tx_hash
+            - method
+            - trace_address
+      - check_dex_aggregator_seed:
+          blockchain: base
+          project: paraswap
+          version: 6
+    columns:
+      -
+      - *blockchain
+      - *project
+      - *version
+      - *block_date
+      - *block_time
+      - *token_bought_symbol
+      - *token_sold_symbol
+      - *token_pair
+      - *token_bought_amount
+      - *token_sold_amount
+      - *token_bought_amount_raw
+      - *token_sold_amount_raw
+      - *amount_usd
+      - *token_bought_address
+      - *token_sold_address
+      - *taker
+      - *maker
+      - *project_contract_address
+      - *tx_hash
+      - *tx_from
+      - *tx_to
+      - *trace_address
+      - *evt_index
+      - &method
+        name: method
+        description: "Method"
+
+  # notmally there would follow this definition but it conflicts with main query?
+  # - name: paraswap_base_c_trades
+  #   meta:
+  #     blockchain: base
+  #     sector: dex
+  #     project: paraswap
+  #     contributors: Henrystats
+  #   config:
+  #     tags: ['base','dex','trades', 'paraswap']
+  #   description: >
+  #       paraswap aggregator trades on base across all contracts and versions. This table will load dex trades downstream.
+  #   columns:
+  #     - *blockchain
+  #     - *project
+  #     - *version
+  #     - *block_date
+  #     - *block_time
+  #     - *token_bought_symbol
+  #     - *token_sold_symbol
+  #     - *token_pair
+  #     - *token_bought_amount
+  #     - *token_sold_amount
+  #     - *token_bought_amount_raw
+  #     - *token_sold_amount_raw
+  #     - *amount_usd
+  #     - *token_bought_address
+  #     - *token_sold_address
+  #     - *taker
+  #     - *maker
+  #     - *project_contract_address
+  #     - *tx_hash
+  #     - *tx_from
+  #     - *tx_to
+  #     - *trace_address
+  #     - *evt_index
+
+  - name: paraswap_v6_base_trades_decoded
+    description: "Paraswap V6 trades decoded"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - txHash
+            - method
+            - callTraceAddress
+    columns:
+      - name: blockTime
+        description: "Block time"
+      - name: blockNumber
+        description: "Block number"
+      - name: txHash
+        description: "Transaction hash"
+      - name: projectContractAddress
+        description: "Project contract address"
+      - name: callTraceAddress
+        description: "Call trace address"
+      - name: srcToken
+        description: "Source token"
+      - name: destToken
+        description: "Destination token"
+      - name: fromAmount
+        description: "From amount"
+      - name: spentAmount
+        description: "Spent amount"
+      - name: toAmount
+        description: "To amount"
+      - name: quotedAmount
+        description: "Quoted amount"
+      - name: receivedAmount
+        description: "Received amount"
+      - name: metadata
+        description: "Metadata"
+      - name: beneficiary
+        description: "Beneficiary"
+      - name: method
+        description: "Method"
+      - name: side
+        description: "Side"
+      - name: feeCode
+        description: "Fee code"
+      - name: partnerShare
+        description: "Partner share"
+      - name: paraswapShare
+        description: "Paraswap share"
+      - name: partnerAddress
+        description: "Partner address"
+      - name: feeBps
+        description: "Fee in basis points"
+      - name: isReferral
+        description: "Is referral"
+      - name: isTakeSurplus
+        description: "Is take surplus"

--- a/models/paraswap/base/paraswap_base_schema.yml
+++ b/models/paraswap/base/paraswap_base_schema.yml
@@ -8,9 +8,9 @@ models:
       project: paraswap_v5
       contributors: Henrystats
     config:
-      tags: ["base", "paraswap_v5", "trades", "paraswap", "dex"]
+      tags: ['base','paraswap_v5','trades', 'paraswap','dex']
     description: >
-      Paraswap V5 contract aggregator trades on base
+        Paraswap V5 contract aggregator trades on base
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -22,16 +22,16 @@ models:
             - evt_index
             - trace_address
       - check_dex_aggregator_seed:
-          blockchain: base
-          project: paraswap
-          version: 5
+         blockchain: base
+         project: paraswap
+         version: 5
     columns:
       - &blockchain
         name: blockchain
         description: "Blockchain which the DEX is deployed"
-      - &project
+      - &project 
         name: project
-        description: "Project name of the DEX"
+        description: "Project name of the DEX"  
       - &version
         name: version
         description: "Version of the contract built and deployed by the DEX project"
@@ -103,13 +103,13 @@ models:
       project: paraswap
       contributors: Henrystats
     config:
-      tags: ["base", "dex", "trades", "paraswap"]
+      tags: ['base','dex','trades', 'paraswap']
     description: >
-      paraswap aggregator trades on base across all contracts and versions. This table will load dex trades downstream.
+        paraswap aggregator trades on base across all contracts and versions. This table will load dex trades downstream.
     columns:
       - *blockchain
       - *project
-      - *version
+      - *version  
       - *block_date
       - *block_time
       - *token_bought_symbol

--- a/models/paraswap/base/paraswap_base_trades.sql
+++ b/models/paraswap/base/paraswap_base_trades.sql
@@ -1,17 +1,19 @@
-{ { config(
+{{ config(
     alias = 'trades',
     schema = 'paraswap_base'
-) } } { %
-set
-    paraswap_models = [
- ref('paraswap_v5_base_trades')
- ,ref('paraswap_v6_base_trades')
-] % }
-SELECT
-    *
-FROM
-    (
-        { % for dex_model in paraswap_models % }
+
+)
+}}
+
+{% set paraswap_models = [
+ref('paraswap_v5_base_trades')
+,ref('paraswap_v6_base_trades')
+ ] %}
+
+
+SELECT *
+FROM (
+        {% for dex_model in paraswap_models %}
         SELECT
             blockchain,
             project,
@@ -37,8 +39,10 @@ FROM
             tx_to,
             trace_address,
             evt_index
-        FROM
-            { { dex_model } } { % if not loop.last % }
-        UNION
-        ALL { % endif % } { % endfor % }
-    );
+        FROM {{ dex_model }}
+    {% if not loop.last %}
+        UNION ALL
+    {% endif %}
+    {% endfor %}
+    )
+;

--- a/models/paraswap/base/paraswap_base_trades.sql
+++ b/models/paraswap/base/paraswap_base_trades.sql
@@ -1,47 +1,44 @@
-{{ config(
-        alias = 'trades',
-        schema = 'paraswap_base'
-        
-        )
-}}
-
-{% set paraswap_models = [
-ref('paraswap_v5_base_trades')
-] %}
-
-
-SELECT *
-FROM (
-    {% for dex_model in paraswap_models %}
-    SELECT
-        blockchain,
-        project,
-        version,
-        block_month,
-        block_date,
-        block_time,
-        token_bought_symbol,
-        token_sold_symbol,
-        token_pair,
-        token_bought_amount,
-        token_sold_amount,
-        token_bought_amount_raw,
-        token_sold_amount_raw,
-        amount_usd,
-        token_bought_address,
-        token_sold_address,
-        taker,
-        maker,
-        project_contract_address,
-        tx_hash,
-        tx_from,
-        tx_to,
-        trace_address,
-        evt_index
-    FROM {{ dex_model }}
-    {% if not loop.last %}
-    UNION ALL
-    {% endif %}
-    {% endfor %}
-)
-;
+{ { config(
+    alias = 'trades',
+    schema = 'paraswap_base'
+) } } { %
+set
+    paraswap_models = [
+ ref('paraswap_v5_base_trades')
+ ,ref('paraswap_v6_base_trades')
+] % }
+SELECT
+    *
+FROM
+    (
+        { % for dex_model in paraswap_models % }
+        SELECT
+            blockchain,
+            project,
+            version,
+            block_month,
+            block_date,
+            block_time,
+            token_bought_symbol,
+            token_sold_symbol,
+            token_pair,
+            token_bought_amount,
+            token_sold_amount,
+            token_bought_amount_raw,
+            token_sold_amount_raw,
+            amount_usd,
+            token_bought_address,
+            token_sold_address,
+            taker,
+            maker,
+            project_contract_address,
+            tx_hash,
+            tx_from,
+            tx_to,
+            trace_address,
+            evt_index
+        FROM
+            { { dex_model } } { % if not loop.last % }
+        UNION
+        ALL { % endif % } { % endfor % }
+    );

--- a/models/paraswap/base/paraswap_v6_base_trades.sql
+++ b/models/paraswap/base/paraswap_v6_base_trades.sql
@@ -1,0 +1,111 @@
+{{ config(
+    schema = 'paraswap_v6_base',
+    alias = 'trades',
+    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'method', 'trace_address'],
+    post_hook='{{ expose_spells(\'["base"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{% set project_start_date = '2024-03-01' %}
+
+with dexs AS (
+        SELECT 
+            blockTime AS block_time,
+            blockNumber AS block_number,
+            from_hex(beneficiary) AS taker, 
+            null AS maker,  -- TODO: can parse from traces 
+            receivedAmount AS token_bought_amount_raw,
+            fromAmount AS token_sold_amount_raw,
+            CAST(NULL AS double) AS amount_usd,
+            method,       
+            CASE 
+                WHEN from_hex(destToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                THEN 0x4200000000000000000000000000000000000006 -- WETH 
+                ELSE from_hex(destToken)
+            END AS token_bought_address,
+            CASE 
+                WHEN from_hex(srcToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                THEN 0x4200000000000000000000000000000000000006 -- WETH 
+                ELSE from_hex(srcToken)
+            END AS token_sold_address,
+            projectContractAddress as project_contract_address,
+            txHash AS tx_hash, 
+            callTraceAddress AS trace_address,
+            CAST(-1 as integer) AS evt_index
+        FROM {{ ref('paraswap_v6_base_trades_decoded') }}    
+        {% if is_incremental() %}
+        WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+        {% endif %}      
+)
+
+SELECT 'base' AS blockchain,
+    'paraswap' AS project,
+    '6' AS version,
+    cast(date_trunc('day', d.block_time) as date) as block_date,
+    cast(date_trunc('month', d.block_time) as date) as block_month,
+    d.block_time,
+method,
+    e1.symbol AS token_bought_symbol,
+    e2.symbol AS token_sold_symbol,
+    CASE
+        WHEN lower(e1.symbol) > lower(e2.symbol) THEN concat(e2.symbol, '-', e1.symbol)
+        ELSE concat(e1.symbol, '-', e2.symbol)
+    END AS token_pair,
+    d.token_bought_amount_raw / power(10, e1.decimals) AS token_bought_amount,
+    d.token_sold_amount_raw / power(10, e2.decimals) AS token_sold_amount,
+    d.token_bought_amount_raw,
+    d.token_sold_amount_raw,
+    coalesce(
+        d.amount_usd
+        ,(d.token_bought_amount_raw / power(10, p1.decimals)) * p1.price
+        ,(d.token_sold_amount_raw / power(10, p2.decimals)) * p2.price
+    ) AS amount_usd,
+    d.token_bought_address,
+    d.token_sold_address,
+    coalesce(d.taker, tx."from") AS taker,
+    coalesce(d.maker, tx."from") as maker,
+    d.project_contract_address,
+    d.tx_hash,
+    tx."from" AS tx_from,
+    tx.to AS tx_to,
+    d.trace_address,
+    d.evt_index
+FROM dexs d
+INNER JOIN {{ source('base', 'transactions') }} tx ON d.tx_hash = tx.hash
+    AND d.block_number = tx.block_number
+    {% if not is_incremental() %}
+    AND tx.block_time >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND tx.block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('tokens', 'erc20') }} e1 ON e1.contract_address = d.token_bought_address
+    AND e1.blockchain = 'base'
+LEFT JOIN {{ source('tokens', 'erc20') }} e2 on e2.contract_address = d.token_sold_address
+    AND e2.blockchain = 'base'
+LEFT JOIN {{ source('prices', 'usd') }} p1 ON p1.minute = date_trunc('minute', d.block_time)
+    AND p1.contract_address = d.token_bought_address
+    AND p1.blockchain = 'base'
+    {% if not is_incremental() %}
+    AND p1.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p1.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('prices', 'usd') }} p2 ON p2.minute = date_trunc('minute', d.block_time)
+    AND p2.contract_address = d.token_sold_address
+    AND p2.blockchain = 'base'
+    {% if not is_incremental() %}
+    AND p2.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p2.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}

--- a/models/paraswap/base/paraswap_v6_base_trades.sql
+++ b/models/paraswap/base/paraswap_v6_base_trades.sql
@@ -42,7 +42,7 @@ with dexs AS (
             CAST(-1 as integer) AS evt_index
         FROM {{ ref('paraswap_v6_base_trades_decoded') }}    
         {% if is_incremental() %}
-        WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+        WHERE blockTime >= date_trunc('day', now() - interval '7' day)
         {% endif %}      
 )
 

--- a/models/paraswap/base/paraswap_v6_base_trades_decoded.sql
+++ b/models/paraswap/base/paraswap_v6_base_trades_decoded.sql
@@ -5,11 +5,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
-    post_hook='{{ expose_spells(\'["base"]\',
-                                "project",
-                                "paraswap_v6",
-                                \'["eptighte", "mwamedacen"]\') }}'
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress']    
     )
 }}
 

--- a/models/paraswap/base/paraswap_v6_base_trades_decoded.sql
+++ b/models/paraswap/base/paraswap_v6_base_trades_decoded.sql
@@ -1,0 +1,16 @@
+{{ config(
+    schema = 'paraswap_v6_base',
+    alias = 'trades_decoded',    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
+    post_hook='{{ expose_spells(\'["base"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{{ paraswap_v6_trades_master('base', 'paraswap', 'AugustusV6') }}

--- a/models/paraswap/bnb/paraswap_bnb_schema.yml
+++ b/models/paraswap/bnb/paraswap_bnb_schema.yml
@@ -145,6 +145,59 @@ models:
       - *trace_address
       - *evt_index
 
+  - name: paraswap_v6_bnb_trades
+    meta:
+      blockchain: bnb
+      sector: dex
+      project: paraswap_v6
+      contributors: eptighte, mwamedacen
+    config:
+      tags: ['bnb','paraswap_v6','trades', 'paraswap','dex']
+    description: >
+        Paraswap V6 contract aggregator trades on bnb
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - tx_hash
+            - method
+            - trace_address            
+
+      - check_dex_aggregator_seed:
+         blockchain: bnb
+         project: paraswap
+         version: 6
+    columns:
+      - *blockchain
+      - *project
+      - *version  
+      - *block_date
+      - *block_time
+      - *token_bought_symbol
+      - *token_sold_symbol
+      - *token_pair
+      - *token_bought_amount
+      - *token_sold_amount
+      - *token_bought_amount_raw
+      - *token_sold_amount_raw
+      - *amount_usd
+      - *token_bought_address
+      - *token_sold_address
+      - *taker
+      - *maker
+      - *project_contract_address
+      - *tx_hash
+      - *tx_from
+      - *tx_to
+      - *trace_address
+      - *evt_index       
+      - &method
+        name: method
+        description: "Method"   
+
   - name: paraswap_bnb_trades
     meta:
       blockchain: bnb
@@ -179,3 +232,64 @@ models:
       - *tx_to
       - *trace_address
       - *evt_index
+
+  - name: paraswap_v6_bnb_trades_decoded
+    description: "Paraswap V6 trades decoded"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - txHash
+            - method
+            - callTraceAddress                        
+    columns:
+      - name: blockTime
+        description: "Block time"        
+      - name: blockNumber
+        description: "Block number"        
+      - name: txHash
+        description: "Transaction hash"        
+      - name: projectContractAddress
+        description: "Project contract address"        
+      - name: callTraceAddress
+        description: "Call trace address"        
+      - name: srcToken
+        description: "Source token"        
+      - name: destToken
+        description: "Destination token"        
+      - name: fromAmount
+        description: "From amount"        
+      - name: spentAmount
+        description: "Spent amount"        
+      - name: toAmount
+        description: "To amount"        
+      - name: quotedAmount
+        description: "Quoted amount"        
+      - name: receivedAmount
+        description: "Received amount"        
+      - name: metadata
+        description: "Metadata"        
+      - name: beneficiary
+        description: "Beneficiary"
+      - name: method
+        description: "Method"
+      - name: side
+        description: "Side"        
+      - name: feeCode
+        description: "Fee code"
+      - name: partnerShare
+        description: "Partner share"
+      - name: paraswapShare
+        description: "Paraswap share"
+      - name: partnerAddress
+        description: "Partner address"
+      - name: feeBps
+        description: "Fee in basis points"
+      - name: isReferral
+        description: "Is referral"
+      - name: isTakeSurplus
+        description: "Is take surplus"
+

--- a/models/paraswap/bnb/paraswap_bnb_trades.sql
+++ b/models/paraswap/bnb/paraswap_bnb_trades.sql
@@ -7,6 +7,7 @@
 {% set paraswap_models = [
     ref('paraswap_v4_bnb_trades')
     ,ref('paraswap_v5_bnb_trades')
+    ,ref('paraswap_v6_bnb_trades')
 ] %}
 
 

--- a/models/paraswap/bnb/paraswap_v6_bnb_trades.sql
+++ b/models/paraswap/bnb/paraswap_v6_bnb_trades.sql
@@ -28,12 +28,12 @@ with dexs AS (
             method,       
             CASE 
                 WHEN from_hex(destToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-                THEN 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- wavax 
+                THEN 0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c -- WBNB 
                 ELSE from_hex(destToken)
             END AS token_bought_address,
             CASE 
                 WHEN from_hex(srcToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-                THEN 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- wavax 
+                THEN 0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c -- WBNB 
                 ELSE from_hex(srcToken)
             END AS token_sold_address,
             projectContractAddress as project_contract_address,

--- a/models/paraswap/bnb/paraswap_v6_bnb_trades.sql
+++ b/models/paraswap/bnb/paraswap_v6_bnb_trades.sql
@@ -1,0 +1,111 @@
+{{ config(
+    schema = 'paraswap_v6_bnb',
+    alias = 'trades',
+    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'method', 'trace_address'],
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{% set project_start_date = '2024-03-01' %}
+
+with dexs AS (
+        SELECT 
+            blockTime AS block_time,
+            blockNumber AS block_number,
+            from_hex(beneficiary) AS taker, 
+            null AS maker,  -- TODO: can parse from traces 
+            receivedAmount AS token_bought_amount_raw,
+            fromAmount AS token_sold_amount_raw,
+            CAST(NULL AS double) AS amount_usd,
+            method,       
+            CASE 
+                WHEN from_hex(destToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                THEN 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- wavax 
+                ELSE from_hex(destToken)
+            END AS token_bought_address,
+            CASE 
+                WHEN from_hex(srcToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                THEN 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- wavax 
+                ELSE from_hex(srcToken)
+            END AS token_sold_address,
+            projectContractAddress as project_contract_address,
+            txHash AS tx_hash, 
+            callTraceAddress AS trace_address,
+            CAST(-1 as integer) AS evt_index
+        FROM {{ ref('paraswap_v6_bnb_trades_decoded') }}     
+        {% if is_incremental() %}
+        WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+        {% endif %}      
+)
+
+SELECT 'bnb' AS blockchain,
+    'paraswap' AS project,
+    '6' AS version,
+    cast(date_trunc('day', d.block_time) as date) as block_date,
+    cast(date_trunc('month', d.block_time) as date) as block_month,
+    d.block_time,
+method,
+    e1.symbol AS token_bought_symbol,
+    e2.symbol AS token_sold_symbol,
+    CASE
+        WHEN lower(e1.symbol) > lower(e2.symbol) THEN concat(e2.symbol, '-', e1.symbol)
+        ELSE concat(e1.symbol, '-', e2.symbol)
+    END AS token_pair,
+    d.token_bought_amount_raw / power(10, e1.decimals) AS token_bought_amount,
+    d.token_sold_amount_raw / power(10, e2.decimals) AS token_sold_amount,
+    d.token_bought_amount_raw,
+    d.token_sold_amount_raw,
+    coalesce(
+        d.amount_usd
+        ,(d.token_bought_amount_raw / power(10, p1.decimals)) * p1.price
+        ,(d.token_sold_amount_raw / power(10, p2.decimals)) * p2.price
+    ) AS amount_usd,
+    d.token_bought_address,
+    d.token_sold_address,
+    coalesce(d.taker, tx."from") AS taker,
+    coalesce(d.maker, tx."from") as maker,
+    d.project_contract_address,
+    d.tx_hash,
+    tx."from" AS tx_from,
+    tx.to AS tx_to,
+    d.trace_address,
+    d.evt_index
+FROM dexs d
+INNER JOIN {{ source('bnb', 'transactions') }} tx ON d.tx_hash = tx.hash
+    AND d.block_number = tx.block_number
+    {% if not is_incremental() %}
+    AND tx.block_time >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND tx.block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('tokens', 'erc20') }} e1 ON e1.contract_address = d.token_bought_address
+    AND e1.blockchain = 'bnb'
+LEFT JOIN {{ source('tokens', 'erc20') }} e2 on e2.contract_address = d.token_sold_address
+    AND e2.blockchain = 'bnb'
+LEFT JOIN {{ source('prices', 'usd') }} p1 ON p1.minute = date_trunc('minute', d.block_time)
+    AND p1.contract_address = d.token_bought_address
+    AND p1.blockchain = 'bnb'
+    {% if not is_incremental() %}
+    AND p1.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p1.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('prices', 'usd') }} p2 ON p2.minute = date_trunc('minute', d.block_time)
+    AND p2.contract_address = d.token_sold_address
+    AND p2.blockchain = 'bnb'
+    {% if not is_incremental() %}
+    AND p2.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p2.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}

--- a/models/paraswap/bnb/paraswap_v6_bnb_trades.sql
+++ b/models/paraswap/bnb/paraswap_v6_bnb_trades.sql
@@ -42,7 +42,7 @@ with dexs AS (
             CAST(-1 as integer) AS evt_index
         FROM {{ ref('paraswap_v6_bnb_trades_decoded') }}     
         {% if is_incremental() %}
-        WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+        WHERE blockTime >= date_trunc('day', now() - interval '7' day)
         {% endif %}      
 )
 

--- a/models/paraswap/bnb/paraswap_v6_bnb_trades_decoded.sql
+++ b/models/paraswap/bnb/paraswap_v6_bnb_trades_decoded.sql
@@ -5,11 +5,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
-    post_hook='{{ expose_spells(\'["bnb"]\',
-                                "project",
-                                "paraswap_v6",
-                                \'["eptighte", "mwamedacen"]\') }}'
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress']
     )
 }}
 

--- a/models/paraswap/bnb/paraswap_v6_bnb_trades_decoded.sql
+++ b/models/paraswap/bnb/paraswap_v6_bnb_trades_decoded.sql
@@ -1,0 +1,16 @@
+{{ config(
+    schema = 'paraswap_v6_bnb',
+    alias = 'trades_decoded',    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
+    post_hook='{{ expose_spells(\'["bnb"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{{ paraswap_v6_trades_master('bnb', 'paraswap', 'AugustusV6') }}

--- a/models/paraswap/ethereum/paraswap_ethereum_schema.yml
+++ b/models/paraswap/ethereum/paraswap_ethereum_schema.yml
@@ -195,6 +195,60 @@ models:
       - *trace_address
       - *evt_index
 
+  - name: paraswap_v6_ethereum_trades
+    meta:
+      blockchain: ethereum
+      sector: dex
+      project: paraswap_v6
+      contributors: eptighte, mwamedacen
+    config:
+      tags: ['ethereum','paraswap_v6','trades', 'paraswap','dex']
+    description: >
+        Paraswap V6 contract aggregator trades on ethereum
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - tx_hash
+            - method
+            - trace_address            
+
+      - check_dex_aggregator_seed:
+         blockchain: ethereum
+         project: paraswap
+         version: 6
+    columns:
+      - *blockchain
+      - *project
+      - *version  
+      - *block_date
+      - *block_time
+      - *token_bought_symbol
+      - *token_sold_symbol
+      - *token_pair
+      - *token_bought_amount
+      - *token_sold_amount
+      - *token_bought_amount_raw
+      - *token_sold_amount_raw
+      - *amount_usd
+      - *token_bought_address
+      - *token_sold_address
+      - *taker
+      - *maker
+      - *project_contract_address
+      - *tx_hash
+      - *tx_from
+      - *tx_to
+      - *trace_address
+      - *evt_index       
+      - &method
+        name: method
+        description: "Method"   
+
+
   - name: paraswap_ethereum_trades
     meta:
       blockchain: ethereum
@@ -229,3 +283,65 @@ models:
       - *tx_to
       - *trace_address
       - *evt_index
+
+
+  - name: paraswap_v6_ethereum_trades_decoded
+    description: "Paraswap V6 trades decoded"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - txHash
+            - method
+            - callTraceAddress                        
+    columns:
+      - name: blockTime
+        description: "Block time"        
+      - name: blockNumber
+        description: "Block number"        
+      - name: txHash
+        description: "Transaction hash"        
+      - name: projectContractAddress
+        description: "Project contract address"        
+      - name: callTraceAddress
+        description: "Call trace address"        
+      - name: srcToken
+        description: "Source token"        
+      - name: destToken
+        description: "Destination token"        
+      - name: fromAmount
+        description: "From amount"        
+      - name: spentAmount
+        description: "Spent amount"        
+      - name: toAmount
+        description: "To amount"        
+      - name: quotedAmount
+        description: "Quoted amount"        
+      - name: receivedAmount
+        description: "Received amount"        
+      - name: metadata
+        description: "Metadata"        
+      - name: beneficiary
+        description: "Beneficiary"
+      - name: method
+        description: "Method"
+      - name: side
+        description: "Side"        
+      - name: feeCode
+        description: "Fee code"
+      - name: partnerShare
+        description: "Partner share"
+      - name: paraswapShare
+        description: "Paraswap share"
+      - name: partnerAddress
+        description: "Partner address"
+      - name: feeBps
+        description: "Fee in basis points"
+      - name: isReferral
+        description: "Is referral"
+      - name: isTakeSurplus
+        description: "Is take surplus"
+

--- a/models/paraswap/ethereum/paraswap_ethereum_trades.sql
+++ b/models/paraswap/ethereum/paraswap_ethereum_trades.sql
@@ -7,7 +7,7 @@
 {% set paraswap_models = [
     ref('paraswap_v4_ethereum_trades')
     ,ref('paraswap_v5_ethereum_trades')
-,ref('paraswap_v6_ethereum_trades')
+    ,ref('paraswap_v6_ethereum_trades')
 ] %}
 
 

--- a/models/paraswap/ethereum/paraswap_ethereum_trades.sql
+++ b/models/paraswap/ethereum/paraswap_ethereum_trades.sql
@@ -7,6 +7,7 @@
 {% set paraswap_models = [
     ref('paraswap_v4_ethereum_trades')
     ,ref('paraswap_v5_ethereum_trades')
+,ref('paraswap_v6_ethereum_trades')
 ] %}
 
 

--- a/models/paraswap/ethereum/paraswap_v6_ethereum_trades.sql
+++ b/models/paraswap/ethereum/paraswap_v6_ethereum_trades.sql
@@ -1,0 +1,110 @@
+{{ config(
+    schema = 'paraswap_v6_ethereum',
+    alias = 'trades',
+    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'method', 'trace_address'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{% set project_start_date = '2024-03-01' %}
+
+with dexs AS (
+        SELECT 
+            blockTime AS block_time,
+            blockNumber AS block_number,
+            from_hex(beneficiary) AS taker, 
+            null AS maker,  -- TODO: can parse from traces 
+            receivedAmount AS token_bought_amount_raw,
+            fromAmount AS token_sold_amount_raw,
+            CAST(NULL AS double) AS amount_usd,
+            method,       
+            CASE 
+                WHEN from_hex(destToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                THEN 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- wavax 
+                ELSE from_hex(destToken)
+            END AS token_bought_address,
+            CASE 
+                WHEN from_hex(srcToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                THEN 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- wavax 
+                ELSE from_hex(srcToken)
+            END AS token_sold_address,
+            projectContractAddress as project_contract_address,
+            txHash AS tx_hash, 
+            callTraceAddress AS trace_address,
+            CAST(-1 as integer) AS evt_index
+        FROM {{ ref('paraswap_v6_ethereum_trades_decoded') }}     
+        {% if is_incremental() %}
+        WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+        {% endif %}  
+)
+SELECT 'ethereum' AS blockchain,
+    'paraswap' AS project,
+    '6' AS version,
+    cast(date_trunc('day', d.block_time) as date) as block_date,
+    cast(date_trunc('month', d.block_time) as date) as block_month,
+    d.block_time,
+method,
+    e1.symbol AS token_bought_symbol,
+    e2.symbol AS token_sold_symbol,
+    CASE
+        WHEN lower(e1.symbol) > lower(e2.symbol) THEN concat(e2.symbol, '-', e1.symbol)
+        ELSE concat(e1.symbol, '-', e2.symbol)
+    END AS token_pair,
+    d.token_bought_amount_raw / power(10, e1.decimals) AS token_bought_amount,
+    d.token_sold_amount_raw / power(10, e2.decimals) AS token_sold_amount,
+    d.token_bought_amount_raw,
+    d.token_sold_amount_raw,
+    coalesce(
+        d.amount_usd
+        ,(d.token_bought_amount_raw / power(10, p1.decimals)) * p1.price
+        ,(d.token_sold_amount_raw / power(10, p2.decimals)) * p2.price
+    ) AS amount_usd,
+    d.token_bought_address,
+    d.token_sold_address,
+    coalesce(d.taker, tx."from") AS taker,
+    coalesce(d.maker, tx."from") as maker,
+    d.project_contract_address,
+    d.tx_hash,
+    tx."from" AS tx_from,
+    tx.to AS tx_to,
+    d.trace_address,
+    d.evt_index
+FROM dexs d
+INNER JOIN {{ source('ethereum', 'transactions') }} tx ON d.tx_hash = tx.hash
+    AND d.block_number = tx.block_number
+    {% if not is_incremental() %}
+    AND tx.block_time >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND tx.block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('tokens', 'erc20') }} e1 ON e1.contract_address = d.token_bought_address
+    AND e1.blockchain = 'ethereum'
+LEFT JOIN {{ source('tokens', 'erc20') }} e2 ON e2.contract_address = d.token_sold_address
+    AND e2.blockchain = 'ethereum'
+LEFT JOIN {{ source('prices', 'usd') }} p1 ON p1.minute = date_trunc('minute', d.block_time)
+    AND p1.contract_address = d.token_bought_address
+    AND p1.blockchain = 'ethereum'
+    {% if not is_incremental() %}
+    AND p1.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p1.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('prices', 'usd') }} p2 ON p2.minute = date_trunc('minute', d.block_time)
+    AND p2.contract_address = d.token_sold_address
+    AND p2.blockchain = 'ethereum'
+    {% if not is_incremental() %}
+    AND p2.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p2.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}

--- a/models/paraswap/ethereum/paraswap_v6_ethereum_trades.sql
+++ b/models/paraswap/ethereum/paraswap_v6_ethereum_trades.sql
@@ -28,12 +28,12 @@ with dexs AS (
             method,       
             CASE 
                 WHEN from_hex(destToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-                THEN 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- wavax 
+                THEN 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 -- WETH 
                 ELSE from_hex(destToken)
             END AS token_bought_address,
             CASE 
                 WHEN from_hex(srcToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-                THEN 0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7 -- wavax 
+                THEN 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 -- WETH 
                 ELSE from_hex(srcToken)
             END AS token_sold_address,
             projectContractAddress as project_contract_address,

--- a/models/paraswap/ethereum/paraswap_v6_ethereum_trades.sql
+++ b/models/paraswap/ethereum/paraswap_v6_ethereum_trades.sql
@@ -42,7 +42,7 @@ with dexs AS (
             CAST(-1 as integer) AS evt_index
         FROM {{ ref('paraswap_v6_ethereum_trades_decoded') }}     
         {% if is_incremental() %}
-        WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+        WHERE blockTime >= date_trunc('day', now() - interval '7' day)
         {% endif %}  
 )
 SELECT 'ethereum' AS blockchain,

--- a/models/paraswap/ethereum/paraswap_v6_ethereum_trades_decoded.sql
+++ b/models/paraswap/ethereum/paraswap_v6_ethereum_trades_decoded.sql
@@ -1,0 +1,16 @@
+{{ config(
+    schema = 'paraswap_v6_ethereum',
+    alias = 'trades_decoded',    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
+    post_hook='{{ expose_spells(\'["ethereum"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{{ paraswap_v6_trades_master('ethereum', 'paraswap', 'AugustusV6') }}

--- a/models/paraswap/ethereum/paraswap_v6_ethereum_trades_decoded.sql
+++ b/models/paraswap/ethereum/paraswap_v6_ethereum_trades_decoded.sql
@@ -5,11 +5,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
-    post_hook='{{ expose_spells(\'["ethereum"]\',
-                                "project",
-                                "paraswap_v6",
-                                \'["eptighte", "mwamedacen"]\') }}'
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress']
     )
 }}
 

--- a/models/paraswap/fantom/paraswap_fantom_schema.yml
+++ b/models/paraswap/fantom/paraswap_fantom_schema.yml
@@ -95,6 +95,58 @@ models:
       - &evt_index
         name: evt_index
         description: ""
+  - name: paraswap_v6_fantom_trades
+    meta:
+      blockchain: fantom
+      sector: dex
+      project: paraswap_v6
+      contributors: eptighte, mwamedacen
+    config:
+      tags: ['fantom','paraswap_v6','trades', 'paraswap','dex']
+    description: >
+        Paraswap V6 contract aggregator trades on fantom
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - tx_hash
+            - method
+            - trace_address            
+
+      - check_dex_aggregator_seed:
+         blockchain: fantom
+         project: paraswap
+         version: 6
+    columns:
+      - *blockchain
+      - *project
+      - *version  
+      - *block_date
+      - *block_time
+      - *token_bought_symbol
+      - *token_sold_symbol
+      - *token_pair
+      - *token_bought_amount
+      - *token_sold_amount
+      - *token_bought_amount_raw
+      - *token_sold_amount_raw
+      - *amount_usd
+      - *token_bought_address
+      - *token_sold_address
+      - *taker
+      - *maker
+      - *project_contract_address
+      - *tx_hash
+      - *tx_from
+      - *tx_to
+      - *trace_address
+      - *evt_index       
+      - &method
+        name: method
+        description: "Method"   
 
   - name: paraswap_fantom_trades
     meta:
@@ -130,3 +182,64 @@ models:
       - *tx_to
       - *trace_address
       - *evt_index
+
+  - name: paraswap_v6_fantom_trades_decoded
+    description: "Paraswap V6 trades decoded"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - txHash
+            - method
+            - callTraceAddress                        
+    columns:
+      - name: blockTime
+        description: "Block time"        
+      - name: blockNumber
+        description: "Block number"        
+      - name: txHash
+        description: "Transaction hash"        
+      - name: projectContractAddress
+        description: "Project contract address"        
+      - name: callTraceAddress
+        description: "Call trace address"        
+      - name: srcToken
+        description: "Source token"        
+      - name: destToken
+        description: "Destination token"        
+      - name: fromAmount
+        description: "From amount"        
+      - name: spentAmount
+        description: "Spent amount"        
+      - name: toAmount
+        description: "To amount"        
+      - name: quotedAmount
+        description: "Quoted amount"        
+      - name: receivedAmount
+        description: "Received amount"        
+      - name: metadata
+        description: "Metadata"        
+      - name: beneficiary
+        description: "Beneficiary"
+      - name: method
+        description: "Method"
+      - name: side
+        description: "Side"        
+      - name: feeCode
+        description: "Fee code"
+      - name: partnerShare
+        description: "Partner share"
+      - name: paraswapShare
+        description: "Paraswap share"
+      - name: partnerAddress
+        description: "Partner address"
+      - name: feeBps
+        description: "Fee in basis points"
+      - name: isReferral
+        description: "Is referral"
+      - name: isTakeSurplus
+        description: "Is take surplus"
+

--- a/models/paraswap/fantom/paraswap_fantom_trades.sql
+++ b/models/paraswap/fantom/paraswap_fantom_trades.sql
@@ -6,6 +6,7 @@
 
 {% set paraswap_models = [
 ref('paraswap_v5_fantom_trades')
+,ref('paraswap_v6_fantom_trades')
 ] %}
 
 

--- a/models/paraswap/fantom/paraswap_v6_fantom_trades.sql
+++ b/models/paraswap/fantom/paraswap_v6_fantom_trades.sql
@@ -42,7 +42,7 @@ with dexs AS (
             CAST(-1 as integer) AS evt_index
         FROM {{ ref('paraswap_v6_fantom_trades_decoded') }}     
         {% if is_incremental() %}
-        WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+        WHERE blockTime >= date_trunc('day', now() - interval '7' day)
         {% endif %}      
 )
 

--- a/models/paraswap/fantom/paraswap_v6_fantom_trades.sql
+++ b/models/paraswap/fantom/paraswap_v6_fantom_trades.sql
@@ -1,0 +1,111 @@
+{{ config(
+    schema = 'paraswap_v6_fantom',
+    alias = 'trades',
+    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'method', 'trace_address'],
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{% set project_start_date = '2024-03-01' %}
+
+with dexs AS (
+        SELECT 
+            blockTime AS block_time,
+            blockNumber AS block_number,
+            from_hex(beneficiary) AS taker, 
+            null AS maker,  -- TODO: can parse from traces 
+            receivedAmount AS token_bought_amount_raw,
+            fromAmount AS token_sold_amount_raw,
+            CAST(NULL AS double) AS amount_usd,
+            method,       
+            CASE 
+                WHEN from_hex(destToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                THEN 0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83 -- wftm 
+                ELSE from_hex(destToken)
+            END AS token_bought_address,
+            CASE 
+                WHEN from_hex(srcToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                THEN 0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83 -- wftm 
+                ELSE from_hex(srcToken)
+            END AS token_sold_address,
+            projectContractAddress as project_contract_address,
+            txHash AS tx_hash, 
+            callTraceAddress AS trace_address,
+            CAST(-1 as integer) AS evt_index
+        FROM {{ ref('paraswap_v6_fantom_trades_decoded') }}     
+        {% if is_incremental() %}
+        WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+        {% endif %}      
+)
+
+SELECT 'fantom' AS blockchain,
+    'paraswap' AS project,
+    '6' AS version,
+    cast(date_trunc('day', d.block_time) as date) as block_date,
+    cast(date_trunc('month', d.block_time) as date) as block_month,
+    d.block_time,
+method,
+    e1.symbol AS token_bought_symbol,
+    e2.symbol AS token_sold_symbol,
+    CASE
+        WHEN lower(e1.symbol) > lower(e2.symbol) THEN concat(e2.symbol, '-', e1.symbol)
+        ELSE concat(e1.symbol, '-', e2.symbol)
+    END AS token_pair,
+    d.token_bought_amount_raw / power(10, e1.decimals) AS token_bought_amount,
+    d.token_sold_amount_raw / power(10, e2.decimals) AS token_sold_amount,
+    d.token_bought_amount_raw,
+    d.token_sold_amount_raw,
+    coalesce(
+        d.amount_usd
+        ,(d.token_bought_amount_raw / power(10, p1.decimals)) * p1.price
+        ,(d.token_sold_amount_raw / power(10, p2.decimals)) * p2.price
+    ) AS amount_usd,
+    d.token_bought_address,
+    d.token_sold_address,
+    coalesce(d.taker, tx."from") AS taker,
+    coalesce(d.maker, tx."from") as maker,
+    d.project_contract_address,
+    d.tx_hash,
+    tx."from" AS tx_from,
+    tx.to AS tx_to,
+    d.trace_address,
+    d.evt_index
+FROM dexs d
+INNER JOIN {{ source('fantom', 'transactions') }} tx ON d.tx_hash = tx.hash
+    AND d.block_number = tx.block_number
+    {% if not is_incremental() %}
+    AND tx.block_time >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND tx.block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('tokens', 'erc20') }} e1 ON e1.contract_address = d.token_bought_address
+    AND e1.blockchain = 'fantom'
+LEFT JOIN {{ source('tokens', 'erc20') }} e2 on e2.contract_address = d.token_sold_address
+    AND e2.blockchain = 'fantom'
+LEFT JOIN {{ source('prices', 'usd') }} p1 ON p1.minute = date_trunc('minute', d.block_time)
+    AND p1.contract_address = d.token_bought_address
+    AND p1.blockchain = 'fantom'
+    {% if not is_incremental() %}
+    AND p1.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p1.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('prices', 'usd') }} p2 ON p2.minute = date_trunc('minute', d.block_time)
+    AND p2.contract_address = d.token_sold_address
+    AND p2.blockchain = 'fantom'
+    {% if not is_incremental() %}
+    AND p2.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p2.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}

--- a/models/paraswap/fantom/paraswap_v6_fantom_trades_decoded.sql
+++ b/models/paraswap/fantom/paraswap_v6_fantom_trades_decoded.sql
@@ -1,0 +1,16 @@
+{{ config(
+    schema = 'paraswap_v6_fantom',
+    alias = 'trades_decoded',    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
+    post_hook='{{ expose_spells(\'["fantom"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{{ paraswap_v6_trades_master('fantom', 'paraswap', 'AugustusV6') }}

--- a/models/paraswap/fantom/paraswap_v6_fantom_trades_decoded.sql
+++ b/models/paraswap/fantom/paraswap_v6_fantom_trades_decoded.sql
@@ -5,11 +5,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
-    post_hook='{{ expose_spells(\'["fantom"]\',
-                                "project",
-                                "paraswap_v6",
-                                \'["eptighte", "mwamedacen"]\') }}'
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress']
     )
 }}
 

--- a/models/paraswap/optimism/paraswap_optimism_schema.yml
+++ b/models/paraswap/optimism/paraswap_optimism_schema.yml
@@ -95,6 +95,58 @@ models:
       - &evt_index
         name: evt_index
         description: ""
+  - name: paraswap_v6_optimism_trades
+    meta:
+      blockchain: optimism
+      sector: dex
+      project: paraswap_v6
+      contributors: eptighte, mwamedacen
+    config:
+      tags: ['optimism','paraswap_v6','trades', 'paraswap','dex']
+    description: >
+        Paraswap V6 contract aggregator trades on optimism
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - tx_hash
+            - method
+            - trace_address            
+
+      - check_dex_aggregator_seed:
+         blockchain: optimism
+         project: paraswap
+         version: 6
+    columns:
+      - *blockchain
+      - *project
+      - *version  
+      - *block_date
+      - *block_time
+      - *token_bought_symbol
+      - *token_sold_symbol
+      - *token_pair
+      - *token_bought_amount
+      - *token_sold_amount
+      - *token_bought_amount_raw
+      - *token_sold_amount_raw
+      - *amount_usd
+      - *token_bought_address
+      - *token_sold_address
+      - *taker
+      - *maker
+      - *project_contract_address
+      - *tx_hash
+      - *tx_from
+      - *tx_to
+      - *trace_address
+      - *evt_index       
+      - &method
+        name: method
+        description: "Method"   
 
   - name: paraswap_optimism_trades
     meta:
@@ -130,3 +182,64 @@ models:
       - *tx_to
       - *trace_address
       - *evt_index
+
+  - name: paraswap_v6_optimism_trades_decoded
+    description: "Paraswap V6 trades decoded"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - txHash
+            - method
+            - callTraceAddress                        
+    columns:
+      - name: blockTime
+        description: "Block time"        
+      - name: blockNumber
+        description: "Block number"        
+      - name: txHash
+        description: "Transaction hash"        
+      - name: projectContractAddress
+        description: "Project contract address"        
+      - name: callTraceAddress
+        description: "Call trace address"        
+      - name: srcToken
+        description: "Source token"        
+      - name: destToken
+        description: "Destination token"        
+      - name: fromAmount
+        description: "From amount"        
+      - name: spentAmount
+        description: "Spent amount"        
+      - name: toAmount
+        description: "To amount"        
+      - name: quotedAmount
+        description: "Quoted amount"        
+      - name: receivedAmount
+        description: "Received amount"        
+      - name: metadata
+        description: "Metadata"        
+      - name: beneficiary
+        description: "Beneficiary"
+      - name: method
+        description: "Method"
+      - name: side
+        description: "Side"        
+      - name: feeCode
+        description: "Fee code"
+      - name: partnerShare
+        description: "Partner share"
+      - name: paraswapShare
+        description: "Paraswap share"
+      - name: partnerAddress
+        description: "Partner address"
+      - name: feeBps
+        description: "Fee in basis points"
+      - name: isReferral
+        description: "Is referral"
+      - name: isTakeSurplus
+        description: "Is take surplus"
+

--- a/models/paraswap/optimism/paraswap_optimism_trades.sql
+++ b/models/paraswap/optimism/paraswap_optimism_trades.sql
@@ -6,6 +6,7 @@
 
 {% set paraswap_models = [
 ref('paraswap_v5_optimism_trades')
+,ref('paraswap_v5_optimism_trades')
 ] %}
 
 

--- a/models/paraswap/optimism/paraswap_v6_optimism_trades.sql
+++ b/models/paraswap/optimism/paraswap_v6_optimism_trades.sql
@@ -1,0 +1,111 @@
+{{ config(
+    schema = 'paraswap_v6_optimism',
+    alias = 'trades',
+    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'method', 'trace_address'],
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{% set project_start_date = '2024-03-01' %}
+
+with dexs AS (
+        SELECT 
+            blockTime AS block_time,
+            blockNumber AS block_number,
+            from_hex(beneficiary) AS taker, 
+            null AS maker,  -- TODO: can parse from traces 
+            receivedAmount AS token_bought_amount_raw,
+            fromAmount AS token_sold_amount_raw,
+            CAST(NULL AS double) AS amount_usd,
+            method,       
+            CASE 
+                WHEN from_hex(destToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                THEN 0x4200000000000000000000000000000000000006 -- WETH 
+                ELSE from_hex(destToken)
+            END AS token_bought_address,
+            CASE 
+                WHEN from_hex(srcToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                THEN 0x4200000000000000000000000000000000000006 -- WETH 
+                ELSE from_hex(srcToken)
+            END AS token_sold_address,
+            projectContractAddress as project_contract_address,
+            txHash AS tx_hash, 
+            callTraceAddress AS trace_address,
+            CAST(-1 as integer) AS evt_index
+        FROM {{ ref('paraswap_v6_optimism_trades_decoded') }}     
+        {% if is_incremental() %}
+        WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+        {% endif %}      
+)
+
+SELECT 'optimism' AS blockchain,
+    'paraswap' AS project,
+    '6' AS version,
+    cast(date_trunc('day', d.block_time) as date) as block_date,
+    cast(date_trunc('month', d.block_time) as date) as block_month,
+    d.block_time,
+    method,
+    e1.symbol AS token_bought_symbol,
+    e2.symbol AS token_sold_symbol,
+    CASE
+        WHEN lower(e1.symbol) > lower(e2.symbol) THEN concat(e2.symbol, '-', e1.symbol)
+        ELSE concat(e1.symbol, '-', e2.symbol)
+    END AS token_pair,
+    d.token_bought_amount_raw / power(10, e1.decimals) AS token_bought_amount,
+    d.token_sold_amount_raw / power(10, e2.decimals) AS token_sold_amount,
+    d.token_bought_amount_raw,
+    d.token_sold_amount_raw,
+    coalesce(
+        d.amount_usd
+        ,(d.token_bought_amount_raw / power(10, p1.decimals)) * p1.price
+        ,(d.token_sold_amount_raw / power(10, p2.decimals)) * p2.price
+    ) AS amount_usd,
+    d.token_bought_address,
+    d.token_sold_address,
+    coalesce(d.taker, tx."from") AS taker,
+    coalesce(d.maker, tx."from") as maker,
+    d.project_contract_address,
+    d.tx_hash,
+    tx."from" AS tx_from,
+    tx.to AS tx_to,
+    d.trace_address,
+    d.evt_index
+FROM dexs d
+INNER JOIN {{ source('optimism', 'transactions') }} tx ON d.tx_hash = tx.hash
+    AND d.block_number = tx.block_number
+    {% if not is_incremental() %}
+    AND tx.block_time >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND tx.block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('tokens', 'erc20') }} e1 ON e1.contract_address = d.token_bought_address
+    AND e1.blockchain = 'optimism'
+LEFT JOIN {{ source('tokens', 'erc20') }} e2 on e2.contract_address = d.token_sold_address
+    AND e2.blockchain = 'optimism'
+LEFT JOIN {{ source('prices', 'usd') }} p1 ON p1.minute = date_trunc('minute', d.block_time)
+    AND p1.contract_address = d.token_bought_address
+    AND p1.blockchain = 'optimism'
+    {% if not is_incremental() %}
+    AND p1.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p1.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('prices', 'usd') }} p2 ON p2.minute = date_trunc('minute', d.block_time)
+    AND p2.contract_address = d.token_sold_address
+    AND p2.blockchain = 'optimism'
+    {% if not is_incremental() %}
+    AND p2.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p2.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}

--- a/models/paraswap/optimism/paraswap_v6_optimism_trades.sql
+++ b/models/paraswap/optimism/paraswap_v6_optimism_trades.sql
@@ -42,7 +42,7 @@ with dexs AS (
             CAST(-1 as integer) AS evt_index
         FROM {{ ref('paraswap_v6_optimism_trades_decoded') }}     
         {% if is_incremental() %}
-        WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+        WHERE blockTime >= date_trunc('day', now() - interval '7' day)
         {% endif %}      
 )
 

--- a/models/paraswap/optimism/paraswap_v6_optimism_trades_decoded.sql
+++ b/models/paraswap/optimism/paraswap_v6_optimism_trades_decoded.sql
@@ -1,0 +1,16 @@
+{{ config(
+    schema = 'paraswap_v6_optimism',
+    alias = 'trades_decoded',    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
+    post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{{ paraswap_v6_trades_master('optimism', 'paraswap', 'AugustusV6') }}

--- a/models/paraswap/optimism/paraswap_v6_optimism_trades_decoded.sql
+++ b/models/paraswap/optimism/paraswap_v6_optimism_trades_decoded.sql
@@ -5,11 +5,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
-    post_hook='{{ expose_spells(\'["optimism"]\',
-                                "project",
-                                "paraswap_v6",
-                                \'["eptighte", "mwamedacen"]\') }}'
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress']
     )
 }}
 

--- a/models/paraswap/polygon/paraswap_polygon_schema.yml
+++ b/models/paraswap/polygon/paraswap_polygon_schema.yml
@@ -145,6 +145,58 @@ models:
       - *trace_address
       - *evt_index
 
+  - name: paraswap_v6_polygon_trades
+    meta:
+      blockchain: polygon
+      sector: dex
+      project: paraswap_v6
+      contributors: eptighte, mwamedacen
+    config:
+      tags: ['polygon','paraswap_v6','trades', 'paraswap','dex']
+    description: >
+        Paraswap V6 contract aggregator trades on polygon
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - tx_hash
+            - method
+            - trace_address                        
+      - check_dex_aggregator_seed:
+         blockchain: polygon
+         project: paraswap
+         version: 6
+    columns:
+      - *blockchain
+      - *project
+      - *version  
+      - *block_date
+      - *block_time
+      - *token_bought_symbol
+      - *token_sold_symbol
+      - *token_pair
+      - *token_bought_amount
+      - *token_sold_amount
+      - *token_bought_amount_raw
+      - *token_sold_amount_raw
+      - *amount_usd
+      - *token_bought_address
+      - *token_sold_address
+      - *taker
+      - *maker
+      - *project_contract_address
+      - *tx_hash
+      - *tx_from
+      - *tx_to
+      - *trace_address
+      - *evt_index       
+      - &method
+        name: method
+        description: "Method"   
+
   - name: paraswap_polygon_trades
     meta:
       blockchain: polygon
@@ -179,3 +231,63 @@ models:
       - *tx_to
       - *trace_address
       - *evt_index
+
+  - name: paraswap_v6_polygon_trades_decoded
+    description: "Paraswap V6 trades decoded"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - txHash
+            - method
+            - callTraceAddress                        
+    columns:
+      - name: blockTime
+        description: "Block time"        
+      - name: blockNumber
+        description: "Block number"        
+      - name: txHash
+        description: "Transaction hash"        
+      - name: projectContractAddress
+        description: "Project contract address"        
+      - name: callTraceAddress
+        description: "Call trace address"        
+      - name: srcToken
+        description: "Source token"        
+      - name: destToken
+        description: "Destination token"        
+      - name: fromAmount
+        description: "From amount"        
+      - name: spentAmount
+        description: "Spent amount"        
+      - name: toAmount
+        description: "To amount"        
+      - name: quotedAmount
+        description: "Quoted amount"        
+      - name: receivedAmount
+        description: "Received amount"        
+      - name: metadata
+        description: "Metadata"        
+      - name: beneficiary
+        description: "Beneficiary"
+      - name: method
+        description: "Method"
+      - name: side
+        description: "Side"        
+      - name: feeCode
+        description: "Fee code"
+      - name: partnerShare
+        description: "Partner share"
+      - name: paraswapShare
+        description: "Paraswap share"
+      - name: partnerAddress
+        description: "Partner address"
+      - name: feeBps
+        description: "Fee in basis points"
+      - name: isReferral
+        description: "Is referral"
+      - name: isTakeSurplus
+        description: "Is take surplus"

--- a/models/paraswap/polygon/paraswap_polygon_trades.sql
+++ b/models/paraswap/polygon/paraswap_polygon_trades.sql
@@ -7,6 +7,7 @@
 {% set paraswap_models = [
     ref('paraswap_v4_polygon_trades')
     ,ref('paraswap_v5_polygon_trades')
+    ,ref('paraswap_v6_polygon_trades')
 ] %}
 
 

--- a/models/paraswap/polygon/paraswap_v6_polygon_trades.sql
+++ b/models/paraswap/polygon/paraswap_v6_polygon_trades.sql
@@ -1,0 +1,135 @@
+{{ config(
+    schema = 'paraswap_v6_polygon',
+    alias = 'trades',    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'method', 'trace_address'],
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{% set project_start_date = '2024-03-01' %}
+
+with dexs AS (
+    SELECT 
+        blockTime AS block_time,
+        blockNumber AS block_number,
+        from_hex(beneficiary) AS taker, 
+        null AS maker,  -- TODO: can parse from traces
+        receivedAmount AS token_bought_amount_raw,
+        fromAmount AS token_sold_amount_raw,
+        CAST(NULL AS double) AS amount_usd,  
+        method,              
+        CASE 
+            WHEN from_hex(destToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+            THEN 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WMATIC 
+            ELSE from_hex(destToken)
+        END AS token_bought_address,        
+        CASE 
+            WHEN from_hex(srcToken) = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+            THEN 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WMATIC 
+            ELSE from_hex(srcToken)
+        END AS token_sold_address,
+        projectContractAddress as project_contract_address,
+        txHash AS tx_hash, 
+        callTraceAddress AS trace_address,
+        CAST(-1 as integer) AS evt_index
+    FROM {{ ref('paraswap_v6_polygon_trades_decoded') }}     
+    {% if is_incremental() %}
+    WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+),
+
+price_missed_previous AS (
+    SELECT minute, contract_address, decimals, symbol, price
+    FROM {{ source('prices', 'usd') }}
+    WHERE contract_address = 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WMATIC
+    ORDER BY minute
+    LIMIT 1
+),
+
+--  WMATIC price may be missed for latest swaps
+price_missed_next AS (
+    SELECT minute, contract_address, decimals, symbol, price
+    FROM {{ source('prices', 'usd') }}
+    WHERE contract_address = 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WMATIC
+    ORDER BY minute desc
+    LIMIT 1
+)
+
+SELECT 'polygon' AS blockchain,
+    'paraswap' AS project,
+    '6' AS version,
+    cast(date_trunc('day', d.block_time) as date) as block_date,
+    cast(date_trunc('month', d.block_time) as date) as block_month,    
+    d.block_time,
+    method,
+    e1.symbol AS token_bought_symbol,
+    e2.symbol AS token_sold_symbol,
+    CASE
+        WHEN lower(e1.symbol) > lower(e2.symbol) THEN concat(e2.symbol, '-', e1.symbol)
+        ELSE concat(e1.symbol, '-', e2.symbol)
+    END AS token_pair,
+    d.token_bought_amount_raw / power(10, e1.decimals) AS token_bought_amount,
+    d.token_sold_amount_raw / power(10, e2.decimals) AS token_sold_amount,
+    d.token_bought_amount_raw,
+    d.token_sold_amount_raw,    
+    coalesce(
+        d.amount_usd
+        ,(d.token_bought_amount_raw / power(10, e1.decimals)) * coalesce(p1.price, p_prev1.price, p_next1.price)
+        ,(d.token_sold_amount_raw / power(10, e2.decimals)) * coalesce(p2.price, p_prev2.price, p_next2.price)
+    ) AS amount_usd,
+    d.token_bought_address,    
+    d.token_sold_address,    
+    coalesce(d.taker, tx."from") AS taker,
+    coalesce(d.maker, tx."from") as maker,
+    d.project_contract_address,
+    d.tx_hash,
+    tx."from" AS tx_from,
+    tx.to AS tx_to,
+    d.trace_address,
+    d.evt_index
+FROM dexs d
+INNER JOIN {{ source('polygon', 'transactions') }} tx ON d.tx_hash = tx.hash
+    AND d.block_number = tx.block_number
+    {% if not is_incremental() %}
+    AND tx.block_time >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND tx.block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN {{ source('tokens', 'erc20') }} e1 ON e1.contract_address = d.token_bought_address
+    AND e1.blockchain = 'polygon'
+LEFT JOIN {{ source('tokens', 'erc20') }} e2 on e2.contract_address = d.token_sold_address
+    AND e2.blockchain = 'polygon'
+LEFT JOIN {{ source('prices', 'usd') }} p1 ON p1.minute = date_trunc('minute', d.block_time)
+    AND p1.contract_address = d.token_bought_address
+    AND p1.blockchain = 'polygon'
+    {% if not is_incremental() %}
+    AND p1.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p1.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN price_missed_previous p_prev1 ON d.token_bought_address = p_prev1.contract_address
+    AND d.block_time < p_prev1.minute -- Swap before first price record time
+LEFT JOIN price_missed_next p_next1 ON d.token_bought_address = p_next1.contract_address
+    AND d.block_time > p_next1.minute -- Swap after last price record time
+LEFT JOIN {{ source('prices', 'usd') }} p2 ON p2.minute = date_trunc('minute', d.block_time)
+    AND p2.contract_address = d.token_sold_address
+    AND p2.blockchain = 'polygon'
+    {% if not is_incremental() %}
+    AND p2.minute >= TIMESTAMP '{{project_start_date}}'
+    {% endif %}
+    {% if is_incremental() %}
+    AND p2.minute >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+LEFT JOIN price_missed_previous p_prev2 ON d.token_sold_address = p_prev2.contract_address
+    AND d.block_time < p_prev2.minute -- Swap before first price record time
+LEFT JOIN price_missed_next p_next2 ON d.token_sold_address = p_next2.contract_address
+    AND d.block_time > p_next2.minute -- Swap after last price record time

--- a/models/paraswap/polygon/paraswap_v6_polygon_trades.sql
+++ b/models/paraswap/polygon/paraswap_v6_polygon_trades.sql
@@ -41,7 +41,7 @@ with dexs AS (
         CAST(-1 as integer) AS evt_index
     FROM {{ ref('paraswap_v6_polygon_trades_decoded') }}     
     {% if is_incremental() %}
-    WHERE p.evt_block_time >= date_trunc('day', now() - interval '7' day)
+    WHERE blockTime >= date_trunc('day', now() - interval '7' day)
     {% endif %}
 ),
 

--- a/models/paraswap/polygon/paraswap_v6_polygon_trades_decoded.sql
+++ b/models/paraswap/polygon/paraswap_v6_polygon_trades_decoded.sql
@@ -1,0 +1,16 @@
+{{ config(
+    schema = 'paraswap_v6_polygon',
+    alias = 'trades_decoded',    
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
+    post_hook='{{ expose_spells(\'["polygon"]\',
+                                "project",
+                                "paraswap_v6",
+                                \'["eptighte", "mwamedacen"]\') }}'
+    )
+}}
+
+{{ paraswap_v6_trades_master('polygon', 'paraswap', 'AugustusV6') }}

--- a/models/paraswap/polygon/paraswap_v6_polygon_trades_decoded.sql
+++ b/models/paraswap/polygon/paraswap_v6_polygon_trades_decoded.sql
@@ -5,11 +5,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress'],
-    post_hook='{{ expose_spells(\'["polygon"]\',
-                                "project",
-                                "paraswap_v6",
-                                \'["eptighte", "mwamedacen"]\') }}'
+    unique_key = ['block_date', 'blockchain', 'project', 'version', 'txHash', 'method', 'callTraceAddress']    
     )
 }}
 

--- a/sources/paraswap/arbitrum/paraswap_arbitrum_sources.yml
+++ b/sources/paraswap/arbitrum/paraswap_arbitrum_sources.yml
@@ -13,3 +13,24 @@ sources:
         loaded_at_field: evt_block_time
       - name: AugustusSwapper_evt_SwappedDirect
         loaded_at_field: evt_block_time
+      # v6 
+      - name: AugustusV6_call_swapExactAmountIn
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV1
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnBalancerV2
+        loaded_at_field: call_block_time        
+      - name: AugustusV6_call_swapExactAmountOut
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnBalancerV2
+        loaded_at_field: call_block_time

--- a/sources/paraswap/avalanche_c/paraswap_avalanche_c_sources.yml
+++ b/sources/paraswap/avalanche_c/paraswap_avalanche_c_sources.yml
@@ -21,3 +21,25 @@ sources:
         loaded_at_field: evt_block_time
       - name: AugustusSwapperV5_evt_SwappedDirect
         loaded_at_field: evt_block_time
+      # v6 
+      - name: AugustusV6_call_swapExactAmountIn
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV1
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnBalancerV2
+        loaded_at_field: call_block_time        
+      - name: AugustusV6_call_swapExactAmountOut
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnBalancerV2
+        loaded_at_field: call_block_time        
+  

--- a/sources/paraswap/base/paraswap_base_sources.yml
+++ b/sources/paraswap/base/paraswap_base_sources.yml
@@ -1,9 +1,9 @@
 version: 2
 
-sources: 
+sources:
   - name: paraswap_base
     freshness:
-          warn_after: { count: 12, period: hour }
+      warn_after: { count: 12, period: hour }
     description: >
       Decoded event table for swaps on paraswap
     tables:
@@ -11,3 +11,24 @@ sources:
         loaded_at_field: evt_block_time
       - name: AugustusSwapper_evt_SwappedV3
         loaded_at_field: evt_block_time
+      # v6
+      - name: AugustusV6_call_swapExactAmountIn
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV1
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnBalancerV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOut
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnBalancerV2
+        loaded_at_field: call_block_time

--- a/sources/paraswap/base/paraswap_base_sources.yml
+++ b/sources/paraswap/base/paraswap_base_sources.yml
@@ -1,9 +1,9 @@
 version: 2
 
-sources:
+sources: 
   - name: paraswap_base
     freshness:
-      warn_after: { count: 12, period: hour }
+          warn_after: { count: 12, period: hour }
     description: >
       Decoded event table for swaps on paraswap
     tables:

--- a/sources/paraswap/bnb/paraswap_bnb_sources.yml
+++ b/sources/paraswap/bnb/paraswap_bnb_sources.yml
@@ -25,3 +25,24 @@ sources:
         loaded_at_field: evt_block_time
       - name: AugustusSwapperV5_evt_SwappedDirect
         loaded_at_field: evt_block_time
+      # v6 
+      - name: AugustusV6_call_swapExactAmountIn
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV1
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnBalancerV2
+        loaded_at_field: call_block_time        
+      - name: AugustusV6_call_swapExactAmountOut
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnBalancerV2
+        loaded_at_field: call_block_time  

--- a/sources/paraswap/ethereum/paraswap_ethereum_sources.yml
+++ b/sources/paraswap/ethereum/paraswap_ethereum_sources.yml
@@ -55,3 +55,24 @@ sources:
         loaded_at_field: call_block_time
       - name: AugustusSwapper6_0_evt_SwappedDirect
         loaded_at_field: evt_block_time
+      # v6      
+      - name: AugustusV6_call_swapExactAmountIn # ptest_v4_ethereum.ptest_v4_call_swapExactAmountIn       
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV1
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnBalancerV2
+        loaded_at_field: call_block_time        
+      - name: AugustusV6_call_swapExactAmountOut
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnBalancerV2
+        loaded_at_field: call_block_time

--- a/sources/paraswap/ethereum/paraswap_ethereum_sources.yml
+++ b/sources/paraswap/ethereum/paraswap_ethereum_sources.yml
@@ -56,7 +56,7 @@ sources:
       - name: AugustusSwapper6_0_evt_SwappedDirect
         loaded_at_field: evt_block_time
       # v6      
-      - name: AugustusV6_call_swapExactAmountIn # ptest_v4_ethereum.ptest_v4_call_swapExactAmountIn       
+      - name: AugustusV6_call_swapExactAmountIn
         loaded_at_field: call_block_time
       - name: AugustusV6_call_swapExactAmountInOnUniswapV2
         loaded_at_field: call_block_time

--- a/sources/paraswap/fantom/paraswap_fantom_sources.yml
+++ b/sources/paraswap/fantom/paraswap_fantom_sources.yml
@@ -21,3 +21,25 @@ sources:
         loaded_at_field: evt_block_time
       - name: AugustusSwapperV5_evt_SwappedDirect
         loaded_at_field: evt_block_time
+      # v6 
+      - name: AugustusV6_call_swapExactAmountIn
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV1
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnBalancerV2
+        loaded_at_field: call_block_time        
+      - name: AugustusV6_call_swapExactAmountOut
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnBalancerV2
+        loaded_at_field: call_block_time        
+  

--- a/sources/paraswap/optimism/paraswap_optimism_sources.yml
+++ b/sources/paraswap/optimism/paraswap_optimism_sources.yml
@@ -13,3 +13,24 @@ sources:
         loaded_at_field: evt_block_time
       - name: AugustusSwapper_evt_SwappedDirect
         loaded_at_field: evt_block_time
+      # v6 
+      - name: AugustusV6_call_swapExactAmountIn
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV1
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnBalancerV2
+        loaded_at_field: call_block_time        
+      - name: AugustusV6_call_swapExactAmountOut
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnBalancerV2
+        loaded_at_field: call_block_time

--- a/sources/paraswap/polygon/paraswap_polygon_sources.yml
+++ b/sources/paraswap/polygon/paraswap_polygon_sources.yml
@@ -24,4 +24,25 @@ sources:
       - name: AugustusSwapperV5_evt_SwappedV3
         loaded_at_field: evt_block_time
       - name: AugustusSwapperV5_evt_SwappedDirect
-        loaded_at_field: evt_block_time
+        loaded_at_field: evt_block_time      
+      # v6      
+      - name: AugustusV6_call_swapExactAmountIn
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV1
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnCurveV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountInOnBalancerV2
+        loaded_at_field: call_block_time        
+      - name: AugustusV6_call_swapExactAmountOut
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV2
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnUniswapV3
+        loaded_at_field: call_block_time
+      - name: AugustusV6_call_swapExactAmountOutOnBalancerV2
+        loaded_at_field: call_block_time        


### PR DESCRIPTION
The intents of the PR:
- add support for new Paraswap Augustus V6 contract in the dex.trades module
- add a model that keeps decoded data from these contracts 

The changes related to all EVM chains Paraswap runs on, except polygon zkevm as it's not supported by Dune at the time of writing