### PR TITLE
[EASY] syncswap update | `dex.trades` 

### DIFF
--- a/models/_sector/dex/trades/zksync/platforms/syncswap_zksync_base_trades.sql
+++ b/models/_sector/dex/trades/zksync/platforms/syncswap_zksync_base_trades.sql
@@ -21,42 +21,40 @@ WITH
         SELECT pool, token0, token1
         FROM {{ source('syncswap_zksync', 'SyncSwapStablePoolFactory_evt_PoolCreated') }}
     )
+    
+    , base AS (
+        SELECT * FROM {{ source('syncswap_zksync', 'SyncSwapStablePool_evt_Swap') }}
+        {% if is_incremental() %}
+        WHERE {{incremental_predicate('evt_block_time')}}
+        {% else %}
+        WHERE evt_block_time >= timestamp '{{syncswap_start_date}}'
+        {% endif %}
 
-    , logs AS ( 
-        SELECT 
-            *
-            , bytearray_substring(topic1, 13, 20) AS caller
-            , bytearray_substring(topic2, 13, 20) AS swapper
-            , varbinary_to_uint256(bytearray_substring(data, 1, 32)) AS token_0_in
-            , varbinary_to_uint256(bytearray_substring(data, 33, 32)) AS token_1_in
-            , varbinary_to_uint256(bytearray_substring(data, 65, 32)) AS token_0_out
-            , varbinary_to_uint256(bytearray_substring(data, 97, 32)) AS token_1_out
-        FROM {{ source('zksync', 'logs') }}
-        LEFT JOIN pools ON contract_address = pool
-        WHERE contract_address IN (SELECT pool FROM pools) 
-            AND topic0 = 0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822 -- swap
-            {% if is_incremental() %}
-            AND {{incremental_predicate('block_time')}}
-            {% else %}
-            AND block_time >= timestamp '{{syncswap_start_date}}'
-            {% endif %}
+        UNION
+        SELECT * FROM {{ source('syncswap_zksync', 'SyncSwapClassicPool_evt_Swap') }}
+        {% if is_incremental() %}
+        WHERE {{incremental_predicate('evt_block_time')}}
+        {% else %}
+        WHERE evt_block_time >= timestamp '{{syncswap_start_date}}'
+        {% endif %}
     )
     
 SELECT
     'zksync' AS blockchain
     , 'syncswap' As project
     , '1' AS version
-    , CAST(date_trunc('month', block_time) AS DATE) AS block_month
-    , CAST(date_trunc('day', block_time) AS DATE) AS block_date
-    , block_time AS block_time
-    , block_number AS block_number
-    , IF(token_0_out = 0, token_1_out, token_0_out) AS token_bought_amount_raw
-    , IF(token_0_in = 0, token_1_in, token_0_in) AS token_sold_amount_raw
-    , IF(token_0_out = 0, token1, token0) AS token_bought_address
-    , IF(token_0_in = 0, token1, token0) AS token_sold_address
-    , tx_from AS taker
+    , CAST(date_trunc('month', evt_block_time) AS DATE) AS block_month
+    , CAST(date_trunc('day', evt_block_time) AS DATE) AS block_date
+    , evt_block_time AS block_time
+    , evt_block_number AS block_number
+    , IF(amount0Out = 0, amount1Out, amount0Out) AS token_bought_amount_raw
+    , IF(amount0In = 0, amount1In, amount0In) AS token_sold_amount_raw
+    , IF(amount0Out = 0, token1, token0) AS token_bought_address
+    , IF(amount0In = 0, token1, token0) AS token_sold_address
+    , to AS taker
     , CAST(NULL AS VARBINARY) AS maker
     , contract_address AS project_contract_address
-    , tx_hash
-    , index AS evt_index
-FROM logs
+    , evt_tx_hash AS tx_hash
+    , evt_index
+FROM base
+LEFT JOIN pools ON pool = contract_address 

--- a/sources/_sector/dex/trades/zksync/_sources.yml
+++ b/sources/_sector/dex/trades/zksync/_sources.yml
@@ -16,7 +16,10 @@ sources:
   - name: syncswap_zksync
     tables:
       - name: SyncSwapClassicPoolFactory_evt_PoolCreated
+      - name: SyncSwapClassicPool_evt_Swap
       - name: SyncSwapStablePoolFactory_evt_PoolCreated
+      - name: SyncSwapStablePool_evt_Swap
+
   - name: mute_zksync
     tables:
       - name: MuteSwitchFactoryDynamic_evt_PairCreated

--- a/sources/_sector/dex/trades/zksync/_sources.yml
+++ b/sources/_sector/dex/trades/zksync/_sources.yml
@@ -19,7 +19,6 @@ sources:
       - name: SyncSwapClassicPool_evt_Swap
       - name: SyncSwapStablePoolFactory_evt_PoolCreated
       - name: SyncSwapStablePool_evt_Swap
-
   - name: mute_zksync
     tables:
       - name: MuteSwitchFactoryDynamic_evt_PairCreated


### PR DESCRIPTION
Changes:
- Use a decoded table now instead of raw logs
- Taker is now determined by the `to` column in the decoded table and not the raw log column `tx_from`

Ready for review @Hosuke 