### PR TITLE
Fix for balancer.protocol_fee

### DIFF
--- a/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
+++ b/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
@@ -64,7 +64,7 @@ WITH pool_labels AS (
         WHERE (price < previous_price * 1e4 AND price > previous_price / 1e4)
     ),
 
-    bpt_prices AS( --special calculation for this spell, in order to achieve completeness without relying on prices.usd
+    bpt_prices_1 AS ( --special calculation for this spell, in order to achieve completeness without relying on prices.usd
         SELECT 
             l.day,
             s.token_address AS token,
@@ -77,6 +77,15 @@ WITH pool_labels AS (
         AND l.version = '{{version}}'
         AND s.supply > 0
         GROUP BY 1, 2, 3
+    ),
+
+    bpt_prices AS (
+        SELECT  
+            day,
+            token,
+            decimals,
+            price,
+            LEAD(DAY, 1, NOW()) OVER (PARTITION BY token ORDER BY DAY) AS day_of_next_change
     ),
 
     daily_protocol_fee_collected AS (
@@ -128,8 +137,8 @@ WITH pool_labels AS (
             ON p2.token = d.token_address
             AND p2.day = d.day
         LEFT JOIN bpt_prices p3
-            ON p3.token = d.token_address
-            AND p3.day = d.day
+            ON p3.day <= d.day
+            AND d.day < p3.day_of_next_change
         LEFT JOIN {{ source('tokens', 'erc20') }} t 
             ON t.contract_address = d.token_address
             AND t.blockchain = '{{blockchain}}'

--- a/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
+++ b/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
@@ -86,6 +86,7 @@ WITH pool_labels AS (
             decimals,
             price,
             LEAD(DAY, 1, NOW()) OVER (PARTITION BY token ORDER BY DAY) AS day_of_next_change
+        FROM bpt_prices_1
     ),
 
     daily_protocol_fee_collected AS (

--- a/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
+++ b/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
@@ -138,7 +138,7 @@ WITH pool_labels AS (
             ON p2.token = d.token_address
             AND p2.day = d.day
         LEFT JOIN bpt_prices p3
-            ON p2.token = d.token_address
+            ON p3.token = d.token_address
             AND p3.day <= d.day
             AND d.day < p3.day_of_next_change     
         LEFT JOIN {{ source('tokens', 'erc20') }} t 

--- a/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
+++ b/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
@@ -138,8 +138,9 @@ WITH pool_labels AS (
             ON p2.token = d.token_address
             AND p2.day = d.day
         LEFT JOIN bpt_prices p3
-            ON p3.day <= d.day
-            AND d.day < p3.day_of_next_change
+            ON p2.token = d.token_address
+            AND p3.day <= d.day
+            AND d.day < p3.day_of_next_change     
         LEFT JOIN {{ source('tokens', 'erc20') }} t 
             ON t.contract_address = d.token_address
             AND t.blockchain = '{{blockchain}}'


### PR DESCRIPTION
https://github.com/duneanalytics/spellbook/pull/5592 still didn't have the expected effect on populating incremental runs for the balancer.protocol_fee macro. I believe that it's due to the bpt_prices CTE querying 2 tables that are updated daily. 
This PR updated the join condition for bpt prices in a way that matches records from bpt_prices where the day is on or before the day in decorated_protocol_fees. If my assumption that this should fix the issue is wrong, I'm open to other suggestions.
Thank you!