### PR TITLE
fix `tokens.erc20` cleaner approach to dupes, add test

### DIFF
--- a/tokens/models/tokens/tokens_erc20.sql
+++ b/tokens/models/tokens/tokens_erc20.sql
@@ -77,13 +77,25 @@ with
     union all
     {% endif %}
     {% endfor %}
+), clean_static_source as (
+    select
+        s.blockchain,
+        s.contract_address,
+        s.symbol,
+        s.decimals
+    from
+        static_source as s
+        left join automated_source as a on s.blockchain = a.blockchain
+        and s.contract_address = a.contract_address
+    where
+        a.contract_address is null
 )
 select
     *
 from
     automated_source
-union distinct
+union all
 select
     *
 from
-    static_source
+    clean_static_source

--- a/tokens/models/tokens/tokens_schema.yml
+++ b/tokens/models/tokens/tokens_schema.yml
@@ -10,6 +10,11 @@ models:
       tags: ['tokens','erc20', 'arbitrum', 'avalanche_c', 'bnb','ethereum', 'gnosis','optimism', 'fantom', 'base']
     description: >
         Crosschain ERC20 tokens
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - contract_address
     columns:
       - name: contract_address
         description: "ERC20 Token's contract address"


### PR DESCRIPTION
fyi @Hosuke @0xRobin @aalan3 @couralex6 
`union distinct` wasn't as efficient as intended, as it's case sensitive on `symbol` field and output dupes
also added a unique test to catch in CI