### PR TITLE
`opensea_v3_polygon_events` exclude from prod due to missing column

### DIFF
--- a/models/opensea/polygon/opensea_v3_polygon_events.sql
+++ b/models/opensea/polygon/opensea_v3_polygon_events.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'opensea_v3_polygon',
     alias = 'events',
-    
+    tags = ['prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',


### PR DESCRIPTION
fyi @0xRobin -- it appears a column is now missing in the decoded table, failing the model in prod

```
select
  *
from
  "delta_prod"."seaport_polygon"."Seaport_call_matchOrders"
  cross join unnest (output_executions)
with
  ordinality as foo (execution, execution_idx)
where
  call_success
  and contract_address = 0x00000000006c3852cbef3e08e8df289169ede581 -- Seaport v1.1
  and call_block_time >= timestamp '2022-07-01' -- seaport first txn
limit
  10
```