### PR TITLE
Remove incremental predicate on the join with boost_deployed

### DIFF
--- a/models/boost/boost_claimed.sql
+++ b/models/boost/boost_claimed.sql
@@ -50,10 +50,6 @@ quest_claims_enriched as (
     from quest_claimed_data c
     left join {{ ref("boost_deployed") }} b
     on c.boost_address = b.boost_address
-    {% if is_incremental() %}
-    and
-        {{ incremental_predicate('b.creation_time') }}
-    {% endif %}
     where block_time > date '2023-11-12'
     {% if is_incremental() %}
     and


### PR DESCRIPTION
This is a follow up PR to the previous [PR on Boost's spells ](https://github.com/duneanalytics/spellbook/pull/5313).
One of the models, `boost.claimed` has a join with `boost.deployed`. With incremental predicate, it's missing a lot of data (see [this](https://dune.com/queries/3551367)) because it only looks at the most recent date, not the entire dataset.

This PR is to remove that because the join actually needs the entire `boost.deployed` model.  `boost.deployed` is also very light (<20k rows)