### PR TITLE
`tokens.erc20` add CTE to allow manual filter of bad token metadata

### DIFF
--- a/tokens/models/tokens/tokens_erc20.sql
+++ b/tokens/models/tokens/tokens_erc20.sql
@@ -60,6 +60,15 @@ with
         raw_source
     where
         rn = 1
+), clean_automated_source as (
+    select
+        *
+    from
+        automated_source
+    where
+        contract_address not in (
+            0xeb9951021698b42e4399f9cbb6267aa35f82d59d --incorrect decimal assignment in raw source
+        )
 ), static_source as (
     {% for key, value in static_models.items() %}
     select
@@ -93,7 +102,7 @@ with
 select
     *
 from
-    automated_source
+    clean_automated_source
 union all
 select
     *


### PR DESCRIPTION
ideally this is short-term, until we build a process of how to handle this at the source
fyi @aalan3 @couralex6 @Hosuke @0xRobin 

found this issue from our test in the dex schema file, which queries for `amount_usd` inflated out of proportion. three trades in `cow_protocol_ethereum_trades` traded this token and chose it  for price assignment.

when we refactor `dex_aggregator.trades`, this wouldn't have happened as we would have selected the "trusted token" for price assignment in our new process.

queries for reference:
```
select *
from dune.definedfi.dataset_tokens --tokens.erc20
where address = 0xeb9951021698b42e4399f9cbb6267aa35f82d59d
```

```
with
  meet_condition as (
    select
      *
    from
      dex_aggregator.trades
  ),
  validation_errors as (
    select
      *
    from
      meet_condition
    where
      -- never true, defaults to an empty result set. Exists to ensure any combo of the `or` clauses below succeeds
      1 = 2
      -- records with a value <= max_value are permitted. The `not` flips this to find records that don't meet the rule.
      or not amount_usd <= 1000000000
  )
select
  *
from
  validation_errors
```