### PR TITLE
`tokens.erc20` add another token to exclude list

### DIFF
--- a/tokens/models/tokens/tokens_erc20.sql
+++ b/tokens/models/tokens/tokens_erc20.sql
@@ -67,7 +67,9 @@ with
         automated_source
     where
         contract_address not in (
-            0xeb9951021698b42e4399f9cbb6267aa35f82d59d --incorrect decimal assignment in raw source
+            --incorrect decimal assignment in raw source
+            0xeb9951021698b42e4399f9cbb6267aa35f82d59d
+            , 0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5
         )
 ), static_source as (
     {% for key, value in static_models.items() %}


### PR DESCRIPTION
incorrect decimal assignment, leading to downstream impact on spells calculations

```
  select *
  from dune.definedfi.dataset_tokens
  where address = 0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5
```

vs.

https://etherscan.io/token/0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5