### PR TITLE
Cleanup seaport decoded tables

### DIFF
--- a/macros/models/_sector/nft/platforms/seaport_v3_trades.sql
+++ b/macros/models/_sector/nft/platforms/seaport_v3_trades.sql
@@ -285,11 +285,7 @@ with source_ethereum_transactions as (
                   ,contract_address as platform_contract_address
             from (select *
                     from {{ Seaport_call_matchOrders }}
-                    {% if blockchain in ('ethereum', 'polygon') %}
-                    cross join unnest(output_0) with ordinality as foo(execution,execution_idx)
-                    {% else %}
                     cross join unnest(output_executions) with ordinality as foo(execution,execution_idx)
-                    {% endif %}
                    where call_success
                      and contract_address = 0x00000000006c3852cbef3e08e8df289169ede581  -- Seaport v1.1
                  {% if not is_incremental() %}

--- a/macros/models/_sector/nft/platforms/seaport_v3_trades.sql
+++ b/macros/models/_sector/nft/platforms/seaport_v3_trades.sql
@@ -272,17 +272,10 @@ with source_ethereum_transactions as (
                   ,dense_rank() over (partition by call_tx_hash order by call_trace_address) as evt_index
                   ,'match_ord' as sub_type
                   ,execution_idx as sub_idx
-                  {% if blockchain in ('ethereum', 'polygon') %}
-                  ,from_hex(json_extract_scalar(json_extract_scalar("_0"[1],'$.parameters'),'$.zone')) as zone
-                  ,from_hex(json_extract_scalar(json_extract_scalar("_0"[1],'$.parameters'),'$.offerer')) as offerer
-                  ,json_extract_scalar(json_extract_scalar(json_extract_scalar("_0"[1],'$.parameters'),'$.offer[0]'),'$.itemType') as offer_first_item
-                  ,json_extract_scalar(json_extract_scalar(json_extract_scalar("_0"[1],'$.parameters'),'$.consideration[0]'),'$.itemType') as consider_first_item
-                  {% else %}
                   ,from_hex(json_extract_scalar(json_extract_scalar(orders[1],'$.parameters'),'$.zone')) as zone
                   ,from_hex(json_extract_scalar(json_extract_scalar(orders[1],'$.parameters'),'$.offerer')) as offerer
                   ,json_extract_scalar(json_extract_scalar(json_extract_scalar(orders[1],'$.parameters'),'$.offer[0]'),'$.itemType') as offer_first_item
                   ,json_extract_scalar(json_extract_scalar(json_extract_scalar(orders[1],'$.parameters'),'$.consideration[0]'),'$.itemType') as consider_first_item
-                  {% endif %}
                   ,from_hex(json_extract_scalar(execution,'$.offerer')) as sender
                   ,from_hex(json_extract_scalar(json_extract_scalar(execution,'$.item'),'$.token')) as token_contract_address
                   ,json_extract_scalar(json_extract_scalar(execution,'$.item'),'$.amount') as original_amount

--- a/models/opensea/optimism/opensea_v3_optimism_events.sql
+++ b/models/opensea/optimism/opensea_v3_optimism_events.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'opensea_v3_optimism',
     alias = 'events',
-    
+
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -19,9 +19,9 @@ WITH fee_wallets as (
      {{ seaport_v3_trades(
      blockchain = 'optimism'
      ,source_transactions = source('optimism','transactions')
-     ,Seaport_evt_OrderFulfilled = source('opensea_optimism','Seaport_evt_OrderFulfilled')
-     ,Seaport_call_matchAdvancedOrders = source('opensea_optimism','Seaport_call_matchAdvancedOrders')
-     ,Seaport_call_matchOrders = source('opensea_optimism','Seaport_call_matchOrders')
+     ,Seaport_evt_OrderFulfilled = source('seaport_optimism','Seaport_evt_OrderFulfilled')
+     ,Seaport_call_matchAdvancedOrders = source('seaport_optimism','Seaport_call_matchAdvancedOrders')
+     ,Seaport_call_matchOrders = source('seaport_optimism','Seaport_call_matchOrders')
      ,fee_wallet_list_cte = 'fee_wallets'
      ,native_token_address = '0x0000000000000000000000000000000000000000'
      ,alternative_token_address = '0x4200000000000000000000000000000000000006'

--- a/models/seaport/optimism/seaport_optimism_base_pairs.sql
+++ b/models/seaport/optimism/seaport_optimism_base_pairs.sql
@@ -1,5 +1,5 @@
 {{ config(
-    
+
     alias = 'base_pairs',
     partition_by = ['block_date'],
     materialized = 'incremental',
@@ -35,7 +35,7 @@ with iv_offer_consideration as (
                 when '2' then 'erc721'
                 when '3' then 'erc1155'
                 else 'etc'
-            end as consideration_first_item_type       
+            end as consideration_first_item_type
             ,offerer as sender
             ,recipient as receiver
             ,zone
@@ -70,7 +70,7 @@ with iv_offer_consideration as (
             , zone
             , offer_idx
             , offer_item
-        from {{ source('opensea_optimism', 'Seaport_evt_OrderFulfilled') }}
+        from {{ source('seaport_optimism', 'Seaport_evt_OrderFulfilled') }}
         cross join unnest(offer) with ordinality as foo(offer_item, offer_idx)
         {% if not is_incremental() %}
         where evt_block_time >= TIMESTAMP '{{c_seaport_first_date}}'  -- seaport first txn
@@ -99,7 +99,7 @@ with iv_offer_consideration as (
                 when '2' then 'erc721'
                 when '3' then 'erc1155'
                 else 'etc'
-            end as consideration_first_item_type        
+            end as consideration_first_item_type
             ,recipient as sender
             ,from_hex(json_extract_scalar(consideration_item,'$.recipient')) as receiver
             ,zone
@@ -132,7 +132,7 @@ with iv_offer_consideration as (
             , zone
             , consideration_item
             , consideration_idx
-        from {{ source('opensea_optimism','Seaport_evt_OrderFulfilled') }}
+        from {{ source('seaport_optimism','Seaport_evt_OrderFulfilled') }}
         cross join unnest(consideration) with ordinality as foo(consideration_item,consideration_idx)
         {% if not is_incremental() %}
         where evt_block_time >= TIMESTAMP '{{c_seaport_first_date}}'  -- seaport first txn

--- a/sources/seaport/optimism/seaport_optimism_sources.yml
+++ b/sources/seaport/optimism/seaport_optimism_sources.yml
@@ -1,30 +1,6 @@
 version: 2
 
 sources:
-  - name: opensea_optimism
-    freshness:
-      warn_after: { count: 24, period: hour }
-    tables:
-      - name: Seaport_evt_OrderFulfilled
-        loaded_at_field: evt_block_time
-        description: "" # to-do
-        columns:
-          - name: consideration
-          - name: contract_address
-          - name: evt_block_number
-          - name: evt_block_time
-          - name: evt_index
-          - name: evt_tx_hash
-          - name: offer
-          - name: offerer
-          - name: orderHash
-          - name: recipient
-          - name: zone
-      - name: Seaport_call_matchAdvancedOrders
-        loaded_at_field: call_block_time
-      - name: Seaport_call_matchOrders
-        loaded_at_field: call_block_time
-
   - name: seaport_optimism
     freshness:
       warn_after: { count: 24, period: hour }


### PR DESCRIPTION
Cleanup:
- change seaport schema from `opensea` -> `seaport` on optimism
- I reconciled all sources over all chains with the produce team so we don't have unnamed columns (`_output`, `_0`)