### PR TITLE
[EASY] Fix missing USD pricing on certain zkSync nft.trades

### DIFF
--- a/models/_sector/nft/trades/chains/zksync/platforms/mint_square_zksync_base_trades.sql
+++ b/models/_sector/nft/trades/chains/zksync/platforms/mint_square_zksync_base_trades.sql
@@ -107,6 +107,11 @@ WITH mintsquare_trades AS (
         , m.nft_amount
         , m.buyer
         , m.seller
+        , CASE
+            WHEN currency = 0x0000000000000000000000000000000000000000 THEN 0x000000000000000000000000000000000000800a -- Fix ETH
+            WHEN currency = 0x8Ebe4A94740515945ad826238Fc4D56c6B8b0e60 THEN 0x5aea5775959fbc2557cc8789bc1bf90a239d9a91 -- Fix WETH
+            ELSE currency
+          END AS currency_contract
         , m.currency_contract
         , m.price_raw
         , CAST(COALESCE((pf.fee_percentage/100) * CAST(m.price_raw AS uint256),  DOUBLE '0') AS UINT256) AS platform_fee_amount_raw


### PR DESCRIPTION
Should be an easy one, just needed to fix some matching on contracts for pricing

- Replace 0x000 contract with proper ETH contract
- Replace non-primary WETH contract with the proper WETH contract