### PR TITLE
Exclude failing model: lido_liquidity_zksync

### DIFF
--- a/models/lido/liquidity/zksync/lido_liquidity_zksync_syncswap_pools.sql
+++ b/models/lido/liquidity/zksync/lido_liquidity_zksync_syncswap_pools.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema='lido_liquidity_zksync',
     alias = 'syncswap_pools',
-     
+    tags=['prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',


### PR DESCRIPTION
@ppclunghe these models are failing due to the underlying table being missing. 