### PR TITLE
uniswap v3 pools on mainnet

### DIFF
--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_uniswap_v3_pools.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_uniswap_v3_pools.sql
@@ -122,6 +122,20 @@ group by 1
     AND blockchain = 'ethereum'
     AND contract_address IN (SELECT address  FROM tokens      )
     GROUP BY 1, 2,3,4
+    UNION ALL --mETH prices before 2023-12-31
+    SELECT DISTINCT
+      DATE_TRUNC('day', minute) AS time,
+      0xd5f7838f5c461feff7fe49ea5ebaf7728bb0adfa  AS token, --mETH
+      decimals, 
+      'mETH',
+      AVG(price) AS price
+    FROM
+      {{source('prices','usd')}} p
+    WHERE DATE_TRUNC('day', p.minute) <= DATE '2023-12-30'
+    AND DATE_TRUNC('day', p.minute) >=  DATE '2023-12-01'
+    AND blockchain = 'ethereum'
+    AND symbol = 'WETH'
+    GROUP BY 1, 2,3,4
     UNION ALL
     SELECT DISTINCT
       DATE_TRUNC('day', minute),

--- a/models/lido/liquidity/ethereum/lido_liquidity_ethereum_uniswap_v3_pools.sql
+++ b/models/lido/liquidity/ethereum/lido_liquidity_ethereum_uniswap_v3_pools.sql
@@ -8,7 +8,7 @@
     post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "project",
                                 "lido_liquidity",
-                                \'["ppclunghe", "gregshestakovlido"]\') }}'
+                                \'["pipistrella", "zergil1397"]\') }}'
     )
 }}
 


### PR DESCRIPTION
New version of spell for Ethereum uniswap v3 wstETH pools: mETH price before Dec 31 are considered equal ETH prices, in this way we can have mETH:wstETH pool in pool close to real reserves (negative reserves in current version of spell) 
