### PR TITLE
chore: add price feed for SECT token

### DIFF
--- a/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -1727,7 +1727,8 @@ FROM
     ('olas-autonolas', 'ethereum', 'OLAS', 0x0001a500a6b18995b03f44bb040a5ffc28e45cb0, 18),
     ('mnt-mantle', 'ethereum', 'MNT', 0x3c3a81e81dc49a522a592e7622a7e711c06bf354, 18),
     ('arkm-arkham', 'ethereum', 'ARKM', 0x6e2a43be0b1d33b726f0ca3b8de60b3482b8b050, 18),
-    ('floki-floki-inu', 'ethereum', 'FLOKI', 0xcf0c122c6b73ff809c693db761e7baebe62b6a2e, 18)
+    ('floki-floki-inu', 'ethereum', 'FLOKI', 0xcf0c122c6b73ff809c693db761e7baebe62b6a2e, 18),
+    ('sect-sect-bot', 'ethereum', 'SECT', 0x24edded3f03abb2e9d047464294133378bddb596, 18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)
 where contract_address not in (
     -- bad price feeds


### PR DESCRIPTION
Adds price feed for the SECT token on ethereum

https://coinpaprika.com/coin/sect-sect-bot/
https://etherscan.io/token/0x24edded3f03abb2e9d047464294133378bddb596