### PR TITLE
Updatedof the number of decimals for GROK

### DIFF
--- a/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -1716,7 +1716,7 @@ FROM
     ('pooh-pooh', 'ethereum', 'POOH',0xb69753c06bb5c366be51e73bfc0cc2e3dc07e371,18),
     ('mumu-mumu', 'ethereum', 'MUMU',0x2f573070e6090b3264fe707e2c9f201716f123c7,18),
     ('wrld-nft-worlds', 'ethereum', 'WRLD',0xd5d86fc8d5c0ea1ac1ac5dfab6e529c9967a45e9,18),
-    ('grok-grok-eth', 'ethereum', 'GROK',0x8390a1da07e376ef7add4be859ba74fb83aa02d5,18),
+    ('grok-grok-eth', 'ethereum', 'GROK',0x8390a1da07e376ef7add4be859ba74fb83aa02d5,9),
     ('deai-zero1-token', 'ethereum', 'DEAI',0x1495bc9e44af1f8bcb62278d2bec4540cf0c05ea,18),
     ('dsync-destra-network', 'ethereum', 'DSYNC',0xf94e7d0710709388bce3161c32b4eea56d3f91cc,18),
     ('ethfi-etherfi', 'ethereum', 'ETHFI',0xfe0c30065b384f05761f15d0cc899d4f9f9cc0eb,18),

--- a/models/prices/gnosis/prices_gnosis_tokens.sql
+++ b/models/prices/gnosis/prices_gnosis_tokens.sql
@@ -31,5 +31,5 @@ FROM
     ('crv-curve-dao-token', 'gnosis', 'CRV', 0x712b3d230f3c1c19db860d80619288b1f0bdd0bd, 18),
     ('link-chainlink', 'gnosis', 'LINK', 0xe2e73a1c69ecf83f464efce6a5be353a37ca09b2, 18),
     ('sushi-sushi', 'gnosis', 'SUSHI', 0x2995d1317dcd4f0ab89f4ae60f3f020a4f17c7ce, 18),
-    ('wsteth-wrapped-liquid-staked-ether-20', 'gnosis', 'WSTETH', 0x6c76971f98945ae98dd7d4dfca8711ebea946ea6, 18)     
+    ('wsteth-wrapped-liquid-staked-ether-20', 'gnosis', 'WSTETH', 0x6c76971f98945ae98dd7d4dfca8711ebea946ea6, 18)  
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)


### PR DESCRIPTION
The number of decimals for GROK : 0x8390a1da07e376ef7add4be859ba74fb83aa02d5 was inconsistent on ethereum chain for the table prices. It is still correct for the table tokens