### PR TITLE
magiceden on polygon: remove troubled tx causing dupes

### DIFF
--- a/models/_sector/nft/trades/chains/polygon/platforms/magiceden_polygon_base_trades.sql
+++ b/models/_sector/nft/trades/chains/polygon/platforms/magiceden_polygon_base_trades.sql
@@ -5,7 +5,6 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_number','tx_hash','sub_tx_trade_id'],
-    tags=["prod_exclude"],
     )
 }}
 
@@ -45,6 +44,11 @@ WITH erc721_trades AS (
         {% if is_incremental() %}
         AND evt_block_time >= date_trunc('day', now() - interval '7' day)
         {% endif %}
+        /*
+            below tx contains duplicates at the source, according to unique keys assigned to this model 
+            todo: investigate if fix is needed, remove filter if fixed
+        */
+        AND evt_tx_hash != 0xf70a24c003e88feebf58da309198cd8b83648734a0700794a4475818cd08c253
 )
 , erc1155_trades as (
 
@@ -76,6 +80,11 @@ WITH erc721_trades AS (
         {% if is_incremental() %}
         AND evt_block_time >= date_trunc('day', now() - interval '7' day)
         {% endif %}
+        /*
+            below tx contains duplicates at the source, according to unique keys assigned to this model 
+            todo: investigate if fix is needed, remove filter if fixed
+        */
+        AND evt_tx_hash != 0xf70a24c003e88feebf58da309198cd8b83648734a0700794a4475818cd08c253
 )
 
 ,erc721_fees as (


### PR DESCRIPTION
fyi @0xRobin @couralex6 @aalan3 
follow up on #5806 

query for dupes:
```
with
  upstream_dupes as (
    select
      block_number,
      tx_hash,
      sub_tx_trade_id,
      count(1)
    from
      magiceden_polygon.base_trades
    group by
      block_number,
      tx_hash,
      sub_tx_trade_id
    having
      count(1) > 1
  ),
  downstream_dupes as (
    select
      project,
      project_version,
      tx_hash,
      sub_tx_trade_id,
      count(1)
    from
      nft.base_trades
    --   nft.trades_beta
    group by
      project,
      project_version,
      tx_hash,
      sub_tx_trade_id
    having
      count(1) > 1
  )
select
  *
from
  downstream_dupes
```