### PR TITLE
`op_token_distributions_optimism_transfer_mapping` exclude due to engine error

### DIFF
--- a/models/op/token_distributions/optimism/op_token_distributions_optimism_transfer_mapping.sql
+++ b/models/op/token_distributions/optimism/op_token_distributions_optimism_transfer_mapping.sql
@@ -1,6 +1,6 @@
 {{ config(
+    tags = ['prod_exclude'],
     alias = 'transfer_mapping',
-    
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',


### PR DESCRIPTION
error in prod, three runs in a row:
```
19:52:40    Database Error in model op_token_distributions_optimism_transfer_mapping (models/op/token_distributions/optimism/op_token_distributions_optimism_transfer_mapping.sql)
  TrinoQueryError(type=INTERNAL_ERROR, name=OPTIMIZER_TIMEOUT, message="The optimizer exhausted the time limit of 180000 ms: Top rules: {
  		io.trino.sql.planner.iterative.rule.ReorderJoins: 182047 ms, 170 invocations, 47 applications }", query_id=20240424_194055_86940_ingwa)
  compiled Code at target/run/spellbook/models/op/token_distributions/optimism/op_token_distributions_optimism_transfer_mapping.sql
```

fyi @MSilb7 @chuxinh 
not sure if there is any way you can optimize the query to re-enable it?
maybe changing some left joins to inner joins?