### PR TITLE
Quick fix for balancer.bpt_supply

### DIFF
--- a/macros/models/_project/balancer/balancer_bpt_supply_macro.sql
+++ b/macros/models/_project/balancer/balancer_bpt_supply_macro.sql
@@ -79,12 +79,12 @@ WITH pool_labels AS (
     joins AS (
         SELECT 
             DATE_TRUNC('day', evt_block_time) AS block_date, 
-            tokenOut,
+            tokenOut AS token,
             pool_type,
             CASE WHEN pool_type IN ('weighted') 
             THEN 0
             ELSE SUM(amountOut / POWER(10, 18)) 
-            END AS ajoins
+            END AS amount
         FROM {{ source('balancer_v2_' + blockchain, 'Vault_evt_Swap') }} 
         LEFT JOIN pool_labels ON BYTEARRAY_SUBSTRING(poolId, 1, 20) = address
         WHERE tokenOut = BYTEARRAY_SUBSTRING(poolId, 1, 20)       
@@ -94,25 +94,37 @@ WITH pool_labels AS (
     exits AS (
         SELECT 
             DATE_TRUNC('day', evt_block_time) AS block_date, 
-            tokenIn,
+            tokenIn AS token,
             pool_type,
             CASE WHEN pool_type IN ('weighted') 
             THEN 0
-            ELSE SUM(amountIn / POWER(10, 18)) 
-            END AS aexits
+            ELSE SUM( -amountIn / POWER(10, 18)) 
+            END AS amount
         FROM {{ source('balancer_v2_' + blockchain, 'Vault_evt_Swap') }} 
         LEFT JOIN pool_labels ON BYTEARRAY_SUBSTRING(poolId, 1, 20) = address
         WHERE tokenIn = BYTEARRAY_SUBSTRING(poolId, 1, 20)        
         GROUP BY 1, 2, 3
     ),
 
+    joins_and_exits_1 AS (
+        SELECT 
+            *
+        FROM joins 
+        
+        UNION ALL
+        
+        SELECT 
+            *
+        FROM exits
+            ),
+
     joins_and_exits AS (
         SELECT 
-            j.block_date, 
-            j.tokenOut AS bpt, 
-            SUM(COALESCE(ajoins, 0) - COALESCE(aexits, 0)) OVER (PARTITION BY j.tokenOut ORDER BY j.block_date ASC) AS adelta
-        FROM joins j
-        FULL OUTER JOIN exits e ON j.block_date = e.block_date AND e.tokenIn = j.tokenOut
+            block_date, 
+            token AS bpt, 
+            LEAD(block_date, 1, NOW()) OVER (PARTITION BY token ORDER BY block_date) AS day_of_next_change,
+            SUM(amount) OVER (PARTITION BY token ORDER BY block_date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS adelta
+        FROM joins_and_exits_1
     ),
 
     calendar AS (
@@ -130,7 +142,7 @@ WITH pool_labels AS (
         COALESCE(SUM(b.supply - COALESCE(preminted_bpts, 0) + COALESCE(adelta, 0)),0) AS supply
     FROM calendar c 
     LEFT JOIN balances b ON b.day <= c.day AND c.day < b.day_of_next_change
-    LEFT JOIN joins_and_exits j ON c.day = j.block_date AND b.token = j.bpt
+    LEFT JOIN joins_and_exits j ON j.block_date <= c.day AND c.day < j.day_of_next_change AND b.token = j.bpt
     LEFT JOIN premints p ON b.token = p.bpt
     LEFT JOIN pool_labels l ON b.token = l.address
     WHERE l.pool_type IN ('weighted', 'LBP', 'investment', 'stable', 'linear', 'ECLP', 'managed', 'FX')


### PR DESCRIPTION
This PR introduces a quick fix to the `joins_and_exits` CTE on the `balancer.bpt_supply` macro. The previous query, which used a join condition for the `joins` and `exits` CTEs was causing a few gaps on the data and skewing results.