### PR TITLE
op tokens metadata: fix broken col names

### DIFF
--- a/tokens/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping.sql
+++ b/tokens/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping.sql
@@ -24,7 +24,7 @@ SELECT l1_token, l2_token
         ORDER BY COALESCE(et.decimals, map.decimals) ASC NULLS LAST, COALESCE(map.symbol, et.symbol) DESC NULLS LAST) AS rnk
 FROM (
 
-        SELECT _l1Token AS l1_token, _l2Token AS l2_token, NULL AS symbol, NULL AS decimals
+        SELECT l1Token AS l1_token, l2Token AS l2_token, NULL AS symbol, NULL AS decimals
             FROM {{source( 'optimism_ethereum', 'L1StandardBridge_evt_ERC20DepositInitiated' ) }}
         WHERE evt_tx_hash != 0x460965f169a99b3d372cd749621a3652ad232d1b1580fd77424eacc2e973b672 --bad event emitted
         {% if is_incremental() %}


### PR DESCRIPTION
fyi @MSilb7 
did you resubmit this decoded table possibly?
curious why column names changed. it started failing in prod.