### PR TITLE
polygon zkevm: exclude models with missing source tables

### DIFF
--- a/models/_sector/dex/trades/zkevm/platforms/pancakeswap_v3_zkevm_base_trades.sql
+++ b/models/_sector/dex/trades/zkevm/platforms/pancakeswap_v3_zkevm_base_trades.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'pancakeswap_v3_zkevm',
         alias = 'base_trades',
         materialized = 'incremental',

--- a/models/balancer/zkevm/balancer_v2_zkevm_flashloans.sql
+++ b/models/balancer/zkevm/balancer_v2_zkevm_flashloans.sql
@@ -1,5 +1,6 @@
 {{ config(
      partition_by = ['block_month']
+      , tags = ['prod_exclude']
       , schema = 'balancer_v2_zkevm'
       , alias = 'flashloans'
       , materialized = 'incremental'

--- a/models/balancer/zkevm/balancer_v2_zkevm_pools_fees.sql
+++ b/models/balancer/zkevm/balancer_v2_zkevm_pools_fees.sql
@@ -1,6 +1,7 @@
 {{
     config(
         schema = 'balancer_v2_zkevm',
+        tags = ['prod_exclude'],
         alias = 'pools_fees',
         materialized = 'incremental',
         file_format = 'delta',

--- a/models/balancer/zkevm/balancer_v2_zkevm_pools_tokens_weights.sql
+++ b/models/balancer/zkevm/balancer_v2_zkevm_pools_tokens_weights.sql
@@ -1,6 +1,7 @@
 {{
     config(
         schema='balancer_v2_zkevm',
+        tags = ['prod_exclude'],
         alias = 'pools_tokens_weights',
         materialized = 'incremental',
         file_format = 'delta',

--- a/models/balancer/zkevm/balancer_v2_zkevm_transfers_bpt.sql
+++ b/models/balancer/zkevm/balancer_v2_zkevm_transfers_bpt.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'balancer_v2_zkevm',
         alias = 'transfers_bpt',
         partition_by = ['block_month'],


### PR DESCRIPTION
fyi @viniabussafi @chef-seaweed 
looks like decoded tables disappeared or got renamed. the source can't be found in these.
i've reached out to our internal team to see what happened. we will look to fix and re-include asap.
```
13:45:14    Database Error in model balancer_v2_zkevm_flashloans (models/balancer/zkevm/balancer_v2_zkevm_flashloans.sql)
  TrinoUserError(type=USER_ERROR, name=TABLE_NOT_FOUND, message="line 20:10: Table 'delta_prod.balancer_v2_zkevm.vault_evt_flashloan' does not exist", query_id=20240508_125202_01498_q676a)
13:45:14  
13:45:14
13:45:14    Database Error in model balancer_v2_zkevm_pools_fees (models/balancer/zkevm/balancer_v2_zkevm_pools_fees.sql)
  TrinoUserError(type=USER_ERROR, name=TABLE_NOT_FOUND, message="line 16:9: Table 'delta_prod.balancer_v2_zkevm.vault_evt_poolregistered' does not exist", query_id=20240508_125202_01506_q676a)
13:45:14  
13:45:14
13:45:14    Database Error in model balancer_v2_zkevm_pools_tokens_weights (models/balancer/zkevm/balancer_v2_zkevm_pools_tokens_weights.sql)
  TrinoUserError(type=USER_ERROR, name=TABLE_NOT_FOUND, message="line 16:10: Table 'delta_prod.balancer_v2_zkevm.vault_evt_poolregistered' does not exist", query_id=20240508_125202_01508_q676a)
13:45:14  
13:45:14
13:45:14    Database Error in model balancer_v2_zkevm_transfers_bpt (models/balancer/zkevm/balancer_v2_zkevm_transfers_bpt.sql)
  TrinoUserError(type=USER_ERROR, name=TABLE_NOT_FOUND, message="line 17:9: Table 'delta_prod.balancer_v2_zkevm.vault_evt_poolregistered' does not exist", query_id=20240508_125203_01517_q676a)
13:45:14    Database Error in model pancakeswap_v3_zkevm_base_trades (models/_sector/dex/trades/zkevm/platforms/pancakeswap_v3_zkevm_base_trades.sql)
  TrinoUserError(type=USER_ERROR, name=TABLE_NOT_FOUND, message="line 34:9: Table 'delta_prod.pancakeswap_v3_zkevm.pancakev3factory_evt_poolcreated' does not exist", query_id=20240508_131715_09174_q676a)
```