### PR TITLE
1inch arbitrum AR: exclude troubled tx

### DIFF
--- a/models/oneinch/arbitrum/oneinch_arbitrum_ar.sql
+++ b/models/oneinch/arbitrum/oneinch_arbitrum_ar.sql
@@ -15,9 +15,14 @@
 }}
 
 
+with ar as (
+    {{ 
+        oneinch_ar_macro(
+            blockchain = blockchain
+        )
+    }}
+)
 
-{{ 
-    oneinch_ar_macro(
-        blockchain = blockchain
-    )
-}}
+select *
+from ar
+where tx_hash != 0x6d36e922c7885c9d2d2cd57ef1cc9d47f0aefad9331c7d2493c43971d0e06816


### PR DESCRIPTION
fyi @grkhr 
i think this is most efficient quick fix to avoid modifying the macro, which would kickoff all blockchains. this ideally only runs arbitrum. this is the one troubled tx it appears.