### PR TITLE
Added user level balance tracking for Yield Yak YRT tokens

### DIFF
--- a/macros/models/_project/yield_yak/yield_yak_user_yrt_balances.sql
+++ b/macros/models/_project/yield_yak/yield_yak_user_yrt_balances.sql
@@ -1,0 +1,129 @@
+{%- macro yield_yak_user_yrt_balances(
+        blockchain = null
+    )
+-%}
+
+{%- set future_date = '2099-12-31 00:00:00.000' -%}
+{%- set namespace_blockchain = 'yield_yak_' + blockchain -%}
+
+WITH
+
+{% if is_incremental() -%}
+latest_balances AS (
+    SELECT
+        t.user_address
+        , t.contract_address
+        , t.from_time
+        , t.yrt_balance
+    FROM
+    {{ this }} t
+    WHERE
+        t.to_time = TIMESTAMP '{{ future_date }}'
+),
+existing_contracts AS (
+    SELECT
+        contract_address
+        , MAX(from_time) AS max_from_time
+    FROM latest_balances
+    GROUP BY contract_address
+),
+{% endif -%}
+
+new_transfers AS (
+    {%- for strategy in yield_yak_strategies(blockchain) %}
+        SELECT
+            s.contract_address
+            , s.evt_block_time AS block_time
+            , s.evt_block_number AS block_number
+            , s."from" AS user_address
+            , -1 * CAST(s.value AS INT256) AS net_transfer_amount
+        FROM {{ source(namespace_blockchain, strategy + '_evt_Transfer') }} s
+        {%- if is_incremental() %}
+        LEFT JOIN
+        existing_contracts c
+            ON c.contract_address = s.contract_address
+        WHERE
+            (({{ incremental_predicate('s.evt_block_time') }}
+            AND s.evt_block_time > c.max_from_time)
+            OR c.contract_address IS NULL) -- This line allows for new contract_addresses being appended that were not already included in previous runs but also allows their entire historical data to be loaded
+            AND s."from" != s."to"
+        {%- endif %}
+        {%- if not is_incremental() %}
+        WHERE
+            s."from" != s."to"
+        {%- endif %}
+        UNION ALL
+        SELECT
+            s.contract_address
+            , s.evt_block_time AS block_time
+            , s.evt_block_number AS block_number
+            , s."to" AS user_address
+            , CAST(s.value AS INT256) AS net_transfer_amount
+        FROM {{ source(namespace_blockchain, strategy + '_evt_Transfer') }} s
+        {%- if is_incremental() %}
+        LEFT JOIN
+        existing_contracts c
+            ON c.contract_address = s.contract_address
+        WHERE
+            (({{ incremental_predicate('s.evt_block_time') }}
+            AND s.evt_block_time > c.max_from_time)
+            OR c.contract_address IS NULL) -- This line allows for new contract_addresses being appended that were not already included in previous runs but also allows their entire historical data to be loaded
+            AND s."from" != s."to"
+        {%- endif %}
+        {%- if not is_incremental() %}
+        WHERE
+            s."from" != s."to"
+        {%- endif %}
+        {% if not loop.last -%}
+        UNION ALL
+        {%- endif -%}
+    {%- endfor %}
+),
+
+combined_table AS (
+    SELECT
+        nt.contract_address
+        , nt.block_time
+        , nt.block_number
+        , nt.user_address
+        , SUM(nt.net_transfer_amount) AS net_transfer_amount
+    FROM new_transfers nt
+    GROUP BY
+        nt.contract_address
+        , nt.block_time
+        , nt.block_number
+        , nt.user_address
+    HAVING SUM(nt.net_transfer_amount) != 0  -- Not interested in anything which results in a net transfer of 0 within a single block.
+    {%- if is_incremental() %}
+    -- In this we add the current balances in as if they were a single Transfer event taking place at "from_time"
+    UNION ALL
+    SELECT
+        b.contract_address
+        , b.from_time AS block_time
+        , 0 AS block_number
+        , b.user_address
+        , b.yrt_balance AS net_transfer_amount
+    FROM latest_balances b
+    {%- endif %}
+)
+
+SELECT
+    '{{ blockchain }}' AS blockchain
+    , user_address
+    , contract_address
+    , from_time
+    , to_time
+    , yrt_balance
+FROM (
+    SELECT
+        user_address
+        , contract_address
+        , block_time AS from_time
+        , COALESCE(date_add('millisecond', -1, LEAD(block_time) OVER (PARTITION BY user_address, contract_address ORDER BY block_number)), TIMESTAMP '{{ future_date }}') AS to_time
+        , SUM(net_transfer_amount) OVER (PARTITION BY user_address, contract_address ORDER BY block_number) AS yrt_balance
+    FROM combined_table
+)
+WHERE
+    to_time >= from_time -- Have this so that we aren't including rows where the balance changes within a single block or within a single millisecond.
+
+{%- endmacro -%}

--- a/models/yield_yak/arbitrum/yield_yak_arbitrum_schema.yml
+++ b/models/yield_yak/arbitrum/yield_yak_arbitrum_schema.yml
@@ -134,7 +134,7 @@ models:
         description: "Block number of the deposit/withdraw/reinvest"
       - &user_address
         name: user_address
-        description: "Address of the wallet which made the deposit"
+        description: "Address of the wallet which made the deposit/withdraw/reinvest"
       - &deposit_amount
         name: deposit_amount
         description: "Amount of deposit tokens deposited into the strategy"
@@ -234,3 +234,30 @@ models:
       - &deposit_token_balance
         name: deposit_token_balance
         description: "Balance of deposit tokens held in the contract in the time window specified"
+  - name: yield_yak_arbitrum_user_yrt_balances
+    meta:
+      blockchain: arbitrum
+      project: yield_yak
+      contributors: angus_1
+    config:
+      tags: ['arbitrum', 'yield', 'aggregator', 'yield_yak', 'auto-compound']
+    description: >
+        yield yak user-level YRT balances on arbitrum as a temporal table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - user_address
+            - contract_address
+            - from_time
+    columns:
+      - *blockchain
+      - name: user_address
+        description: Address which holds the YRT
+      - *contract_address
+      - name: from_time
+        description: "UTC time from which the user held this balance of the contract_address YRT"
+      - name: to_time
+        description: "UTC time until which the user held this balance of the contract_address YRT"
+      - &yrt_balance
+        name: yrt_balance
+        description: "Balance of YRT tokens held by the user_address in the time window specified"

--- a/models/yield_yak/arbitrum/yield_yak_arbitrum_user_yrt_balances.sql
+++ b/models/yield_yak/arbitrum/yield_yak_arbitrum_user_yrt_balances.sql
@@ -1,0 +1,17 @@
+{{
+    config(
+        schema = 'yield_yak_arbitrum',
+        alias = 'user_yrt_balances',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['user_address', 'contract_address', 'from_time'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.to_time')]
+    )
+}}
+
+{{
+    yield_yak_user_yrt_balances(
+        blockchain = 'arbitrum'
+    )
+}}

--- a/models/yield_yak/avalanche_c/yield_yak_avalanche_c_schema.yml
+++ b/models/yield_yak/avalanche_c/yield_yak_avalanche_c_schema.yml
@@ -134,7 +134,7 @@ models:
         description: "Block number of the deposit/withdraw/reinvest"
       - &user_address
         name: user_address
-        description: "Address of the wallet which made the deposit"
+        description: "Address of the wallet which made the deposit/withdraw/reinvest"
       - &deposit_amount
         name: deposit_amount
         description: "Amount of deposit tokens deposited into the strategy"
@@ -234,3 +234,30 @@ models:
       - &deposit_token_balance
         name: deposit_token_balance
         description: "Balance of deposit tokens held in the contract in the time window specified"
+  - name: yield_yak_avalanche_c_user_yrt_balances
+    meta:
+      blockchain: avalanche_c
+      project: yield_yak
+      contributors: angus_1
+    config:
+      tags: ['avalanche_c', 'yield', 'aggregator', 'yield_yak', 'auto-compound']
+    description: >
+        yield yak user-level YRT balances on avalanche_c as a temporal table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - user_address
+            - contract_address
+            - from_time
+    columns:
+      - *blockchain
+      - name: user_address
+        description: Address which holds the YRT
+      - *contract_address
+      - name: from_time
+        description: "UTC time from which the user held this balance of the contract_address YRT"
+      - name: to_time
+        description: "UTC time until which the user held this balance of the contract_address YRT"
+      - &yrt_balance
+        name: yrt_balance
+        description: "Balance of YRT tokens held by the user_address in the time window specified"

--- a/models/yield_yak/avalanche_c/yield_yak_avalanche_c_user_yrt_balances.sql
+++ b/models/yield_yak/avalanche_c/yield_yak_avalanche_c_user_yrt_balances.sql
@@ -1,0 +1,17 @@
+{{
+    config(
+        schema = 'yield_yak_avalanche_c',
+        alias = 'user_yrt_balances',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['user_address', 'contract_address', 'from_time'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.to_time')]
+    )
+}}
+
+{{
+    yield_yak_user_yrt_balances(
+        blockchain = 'avalanche_c'
+    )
+}}

--- a/models/yield_yak/yield_yak_schema.yml
+++ b/models/yield_yak/yield_yak_schema.yml
@@ -118,7 +118,7 @@ models:
         description: "Block number of the deposit/withdraw/reinvest"
       - &user_address
         name: user_address
-        description: "Address of the wallet which made the deposit"
+        description: "Address of the wallet which made the deposit/withdraw/reinvest"
       - &deposit_amount
         name: deposit_amount
         description: "Amount of deposit tokens deposited into the strategy"
@@ -221,3 +221,31 @@ models:
       - &deposit_token_balance
         name: deposit_token_balance
         description: "Balance of deposit tokens held in the contract in the time window specified"
+  - name: yield_yak_user_yrt_balances
+    meta:
+      blockchain: avalanche_c, arbitrum
+      project: yield_yak
+      contributors: angus_1
+    config:
+      tags: ['avalanche_c', 'arbitrum', 'yield', 'aggregator', 'yield_yak', 'auto-compound']
+    description: >
+        yield yak user-level YRT balances as a temporal table
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - user_address
+            - contract_address
+            - from_time
+    columns:
+      - *blockchain
+      - name: user_address
+        description: Address which holds the YRT
+      - *contract_address
+      - name: from_time
+        description: "UTC time from which the user held this balance of the contract_address YRT"
+      - name: to_time
+        description: "UTC time until which the user held this balance of the contract_address YRT"
+      - &yrt_balance
+        name: yrt_balance
+        description: "Balance of YRT tokens held by the user_address in the time window specified"

--- a/models/yield_yak/yield_yak_user_yrt_balances.sql
+++ b/models/yield_yak/yield_yak_user_yrt_balances.sql
@@ -1,0 +1,33 @@
+{{ config(
+	    schema = 'yield_yak',
+        alias = 'user_yrt_balances',
+        post_hook='{{ expose_spells(
+                      blockchains = \'["arbitrum", "avalanche_c"]\',
+                      spell_type = "project",
+                      spell_name = "yield_yak",
+                      contributors = \'["angus_1"]\') }}'
+        )
+}}
+
+{%- set yield_yak_models = [
+ref('yield_yak_avalanche_c_user_yrt_balances')
+,ref('yield_yak_arbitrum_user_yrt_balances')
+] -%}
+
+
+SELECT *
+FROM (
+    {%- for balances_model in yield_yak_models %}
+    SELECT
+        blockchain
+        , user_address
+        , contract_address
+        , from_time
+        , to_time
+        , yrt_balance
+    FROM {{ balances_model }}
+    {% if not loop.last -%}
+    UNION ALL
+    {%- endif -%}
+    {%- endfor %}
+)

--- a/sources/yield_yak/arbitrum/yield_yak_arbitrum_sources.yml
+++ b/sources/yield_yak/arbitrum/yield_yak_arbitrum_sources.yml
@@ -26,11 +26,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: AutoPoolStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: AutoPoolStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: BalancerDirectJoinStrategy_evt_Deposit
         loaded_at_field: evt_block_time
       - name: BalancerDirectJoinStrategy_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: BalancerDirectJoinStrategy_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: BalancerDirectJoinStrategy_evt_Transfer
         loaded_at_field: evt_block_time
       - name: BoostedPendleStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -38,11 +42,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: BoostedPendleStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: BoostedPendleStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: CompoundingBets_evt_Deposit
         loaded_at_field: evt_block_time
       - name: CompoundingBets_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: CompoundingBets_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: CompoundingBets_evt_Transfer
         loaded_at_field: evt_block_time
       - name: CompoundingJoe_evt_Deposit
         loaded_at_field: evt_block_time
@@ -50,11 +58,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: CompoundingJoe_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: CompoundingJoe_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: CompoundingYYStaking_evt_Deposit
         loaded_at_field: evt_block_time
       - name: CompoundingYYStaking_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: CompoundingYYStaking_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: CompoundingYYStaking_evt_Transfer
         loaded_at_field: evt_block_time
       - name: DeltaPrimeDepositorStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -62,11 +74,19 @@ sources:
         loaded_at_field: evt_block_time
       - name: DeltaPrimeDepositorStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: DeltaPrimeDepositorStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: GmxStrategyForGLPArbitrum_evt_Deposit
+        loaded_at_field: evt_block_time
+      - name: DeltaPrimeDepositorStrategy_evt_WTransfer
         loaded_at_field: evt_block_time
       - name: GmxStrategyForGLPArbitrum_evt_Withdraw
         loaded_at_field: evt_block_time
+      - name: DeltaPrimeDepositorStrategy_evt_RTransfer
+        loaded_at_field: evt_block_time
       - name: GmxStrategyForGLPArbitrum_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: GmxStrategyForGLPArbitrum_evt_Transfer
         loaded_at_field: evt_block_time
       - name: LevelStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -74,11 +94,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: LevelStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: LevelStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: PendleStrategy_evt_Deposit
         loaded_at_field: evt_block_time
       - name: PendleStrategy_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: PendleStrategy_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: PendleStrategy_evt_Transfer
         loaded_at_field: evt_block_time
       - name: SiloStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -86,11 +110,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: SiloStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: SiloStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: SushiStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: SushiStrategyForLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: SushiStrategyForLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: SushiStrategyForLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: SynapseStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -98,15 +126,21 @@ sources:
         loaded_at_field: evt_block_time
       - name: SynapseStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: SynapseStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: SynapseStrategyV2_evt_Deposit
         loaded_at_field: evt_block_time
       - name: SynapseStrategyV2_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: SynapseStrategyV2_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: SynapseStrategyV2_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: WombexStrategy_evt_Deposit
         loaded_at_field: evt_block_time
       - name: WombexStrategy_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: WombexStrategy_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: WombexStrategy_evt_Transfer
         loaded_at_field: evt_block_time

--- a/sources/yield_yak/avalanche_c/yield_yak_avalanche_c_sources.yml
+++ b/sources/yield_yak/avalanche_c/yield_yak_avalanche_c_sources.yml
@@ -26,11 +26,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: AaveStrategyAvaxV1_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: AaveStrategyAvaxV1_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: AaveStrategyV1_evt_Deposit
         loaded_at_field: evt_block_time
       - name: AaveStrategyV1_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: AaveStrategyV1_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: AaveStrategyV1_evt_Transfer
         loaded_at_field: evt_block_time
       - name: AaveV3StrategyAvaxV1_evt_Deposit
         loaded_at_field: evt_block_time
@@ -38,11 +42,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: AaveV3StrategyAvaxV1_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: AaveV3StrategyAvaxV1_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: AaveV3StrategyV1_evt_Deposit
         loaded_at_field: evt_block_time
       - name: AaveV3StrategyV1_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: AaveV3StrategyV1_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: AaveV3StrategyV1_evt_Transfer
         loaded_at_field: evt_block_time
       - name: AnkrAvaxPlatypusStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -50,11 +58,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: AnkrAvaxPlatypusStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: AnkrAvaxPlatypusStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: AutoPoolStrategy_evt_Deposit
         loaded_at_field: evt_block_time
       - name: AutoPoolStrategy_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: AutoPoolStrategy_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: AutoPoolStrategy_evt_Transfer
         loaded_at_field: evt_block_time
       - name: AxialStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
@@ -62,11 +74,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: AxialStrategyForLP_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: AxialStrategyForLP_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: AxialStrategyForMetapoolLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: AxialStrategyForMetapoolLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: AxialStrategyForMetapoolLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: AxialStrategyForMetapoolLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: BalancerDirectJoinStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -74,11 +90,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: BalancerDirectJoinStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: BalancerDirectJoinStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: BenqiStrategyAvaxV1_evt_Deposit
         loaded_at_field: evt_block_time
       - name: BenqiStrategyAvaxV1_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: BenqiStrategyAvaxV1_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: BenqiStrategyAvaxV1_evt_Transfer
         loaded_at_field: evt_block_time
       - name: BenqiStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
@@ -86,11 +106,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: BenqiStrategyForLP_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: BenqiStrategyForLP_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: BenqiStrategyQiV1_evt_Deposit
         loaded_at_field: evt_block_time
       - name: BenqiStrategyQiV1_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: BenqiStrategyQiV1_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: BenqiStrategyQiV1_evt_Transfer
         loaded_at_field: evt_block_time
       - name: BenqiStrategyQiV2_evt_Deposit
         loaded_at_field: evt_block_time
@@ -98,11 +122,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: BenqiStrategyQiV2_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: BenqiStrategyQiV2_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: BenqiStrategyV1_evt_Deposit
         loaded_at_field: evt_block_time
       - name: BenqiStrategyV1_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: BenqiStrategyV1_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: BenqiStrategyV1_evt_Transfer
         loaded_at_field: evt_block_time
       - name: BenqiStrategyV2_evt_Deposit
         loaded_at_field: evt_block_time
@@ -110,11 +138,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: BenqiStrategyV2_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: BenqiStrategyV2_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: BenqiStrategyV3_evt_Deposit
         loaded_at_field: evt_block_time
       - name: BenqiStrategyV3_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: BenqiStrategyV3_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: BenqiStrategyV3_evt_Transfer
         loaded_at_field: evt_block_time
       - name: BirdyStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
@@ -122,11 +154,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: BirdyStrategyForLP_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: BirdyStrategyForLP_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: BlizzStrategyAvaxV1_evt_Deposit
         loaded_at_field: evt_block_time
       - name: BlizzStrategyAvaxV1_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: BlizzStrategyAvaxV1_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: BlizzStrategyAvaxV1_evt_Transfer
         loaded_at_field: evt_block_time
       - name: BlizzStrategyV1_evt_Deposit
         loaded_at_field: evt_block_time
@@ -134,11 +170,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: BlizzStrategyV1_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: BlizzStrategyV1_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: BoostedJoeStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: BoostedJoeStrategyForLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: BoostedJoeStrategyForLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: BoostedJoeStrategyForLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: CompoundingBamboo_evt_Deposit
         loaded_at_field: evt_block_time
@@ -146,11 +186,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: CompoundingBamboo_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: CompoundingBamboo_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: CompoundingBets_evt_Deposit
         loaded_at_field: evt_block_time
       - name: CompoundingBets_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: CompoundingBets_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: CompoundingBets_evt_Transfer
         loaded_at_field: evt_block_time
       - name: CompoundingBlp_evt_Deposit
         loaded_at_field: evt_block_time
@@ -158,11 +202,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: CompoundingBlp_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: CompoundingBlp_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: CompoundingGondola_evt_Deposit
         loaded_at_field: evt_block_time
       - name: CompoundingGondola_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: CompoundingGondola_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: CompoundingGondola_evt_Transfer
         loaded_at_field: evt_block_time
       - name: CompoundingJoe_evt_Deposit
         loaded_at_field: evt_block_time
@@ -170,11 +218,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: CompoundingJoe_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: CompoundingJoe_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: CompoundingJoeV3_evt_Deposit
         loaded_at_field: evt_block_time
       - name: CompoundingJoeV3_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: CompoundingJoeV3_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: CompoundingJoeV3_evt_Transfer
         loaded_at_field: evt_block_time
       - name: CompoundingXava_evt_Deposit
         loaded_at_field: evt_block_time
@@ -182,11 +234,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: CompoundingXava_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: CompoundingXava_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: CompoundingYYStaking_evt_Deposit
         loaded_at_field: evt_block_time
       - name: CompoundingYYStaking_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: CompoundingYYStaking_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: CompoundingYYStaking_evt_Transfer
         loaded_at_field: evt_block_time
       - name: CurveStrategyForLPV1_evt_Deposit
         loaded_at_field: evt_block_time
@@ -194,11 +250,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: CurveStrategyForLPV1_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: CurveStrategyForLPV1_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: CycleStrategyV1_evt_Deposit
         loaded_at_field: evt_block_time
       - name: CycleStrategyV1_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: CycleStrategyV1_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: CycleStrategyV1_evt_Transfer
         loaded_at_field: evt_block_time
       - name: DeltaPrimeDepositorStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -206,11 +266,19 @@ sources:
         loaded_at_field: evt_block_time
       - name: DeltaPrimeDepositorStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: DeltaPrimeDepositorStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: DexStrategyAVAXWithSwapV2_evt_Deposit
+        loaded_at_field: evt_block_time
+      - name: DeltaPrimeDepositorStrategy_evt_WTransfer
         loaded_at_field: evt_block_time
       - name: DexStrategyAVAXWithSwapV2_evt_Withdraw
         loaded_at_field: evt_block_time
+      - name: DeltaPrimeDepositorStrategy_evt_RTransfer
+        loaded_at_field: evt_block_time
       - name: DexStrategyAVAXWithSwapV2_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: DexStrategyAVAXWithSwapV2_evt_Transfer
         loaded_at_field: evt_block_time
       - name: DexStrategySA_evt_Deposit
         loaded_at_field: evt_block_time
@@ -218,11 +286,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: DexStrategySA_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: DexStrategySA_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: DexStrategySAWithSwap_evt_Deposit
         loaded_at_field: evt_block_time
       - name: DexStrategySAWithSwap_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: DexStrategySAWithSwap_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: DexStrategySAWithSwap_evt_Transfer
         loaded_at_field: evt_block_time
       - name: DexStrategySAWithSwapV2_evt_Deposit
         loaded_at_field: evt_block_time
@@ -230,11 +302,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: DexStrategySAWithSwapV2_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: DexStrategySAWithSwapV2_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: DexStrategyV4_evt_Deposit
         loaded_at_field: evt_block_time
       - name: DexStrategyV4_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: DexStrategyV4_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: DexStrategyV4_evt_Transfer
         loaded_at_field: evt_block_time
       - name: DexStrategyV5_evt_Deposit
         loaded_at_field: evt_block_time
@@ -242,11 +318,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: DexStrategyV5_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: DexStrategyV5_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: DexStrategyV5Reflection_evt_Deposit
         loaded_at_field: evt_block_time
       - name: DexStrategyV5Reflection_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: DexStrategyV5Reflection_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: DexStrategyV5Reflection_evt_Transfer
         loaded_at_field: evt_block_time
       - name: DexStrategyV6_evt_Deposit
         loaded_at_field: evt_block_time
@@ -254,11 +334,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: DexStrategyV6_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: DexStrategyV6_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: DexStrategyV6a_evt_Deposit
         loaded_at_field: evt_block_time
       - name: DexStrategyV6a_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: DexStrategyV6a_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: DexStrategyV6a_evt_Transfer
         loaded_at_field: evt_block_time
       - name: EchidnaStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -266,11 +350,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: EchidnaStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: EchidnaStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: EchidnaStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: EchidnaStrategyForLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: EchidnaStrategyForLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: EchidnaStrategyForLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: ElevenStrategyForLPV1_evt_Deposit
         loaded_at_field: evt_block_time
@@ -278,11 +366,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: ElevenStrategyForLPV1_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: ElevenStrategyForLPV1_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: ElkStrategyV1_evt_Deposit
         loaded_at_field: evt_block_time
       - name: ElkStrategyV1_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: ElkStrategyV1_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: ElkStrategyV1_evt_Transfer
         loaded_at_field: evt_block_time
       - name: FrostStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
@@ -290,11 +382,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: FrostStrategyForLP_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: FrostStrategyForLP_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: FrostStrategyForSA_evt_Deposit
         loaded_at_field: evt_block_time
       - name: FrostStrategyForSA_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: FrostStrategyForSA_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: FrostStrategyForSA_evt_Transfer
         loaded_at_field: evt_block_time
       - name: GlacierStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -302,11 +398,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: GlacierStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: GlacierStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: GmxStrategyForGLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: GmxStrategyForGLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: GmxStrategyForGLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: GmxStrategyForGLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: GmxStrategyForGMX_evt_Deposit
         loaded_at_field: evt_block_time
@@ -314,11 +414,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: GmxStrategyForGMX_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: GmxStrategyForGMX_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: GondolaStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: GondolaStrategyForLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolBTC_evt_Deposit
         loaded_at_field: evt_block_time
@@ -326,11 +430,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolBTC_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: GondolaStrategyForPoolBTC_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolDAI_evt_Deposit
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolDAI_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolDAI_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: GondolaStrategyForPoolDAI_evt_Transfer
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolDAIeUSDTe_evt_Deposit
         loaded_at_field: evt_block_time
@@ -338,11 +446,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolDAIeUSDTe_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: GondolaStrategyForPoolDAIeUSDTe_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolETH_evt_Deposit
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolETH_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolETH_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: GondolaStrategyForPoolETH_evt_Transfer
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolUSDT_evt_Deposit
         loaded_at_field: evt_block_time
@@ -350,11 +462,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolUSDT_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: GondolaStrategyForPoolUSDT_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolV2_evt_Deposit
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolV2_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: GondolaStrategyForPoolV2_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: GondolaStrategyForPoolV2_evt_Transfer
         loaded_at_field: evt_block_time
       - name: HakuStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
@@ -362,11 +478,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: HakuStrategyForLP_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: HakuStrategyForLP_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: JoeLendingStrategyAvaxV1_evt_Deposit
         loaded_at_field: evt_block_time
       - name: JoeLendingStrategyAvaxV1_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: JoeLendingStrategyAvaxV1_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: JoeLendingStrategyAvaxV1_evt_Transfer
         loaded_at_field: evt_block_time
       - name: JoeLendingStrategyV1_evt_Deposit
         loaded_at_field: evt_block_time
@@ -374,11 +494,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: JoeLendingStrategyV1_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: JoeLendingStrategyV1_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: JoeLendingStrategyV2_evt_Deposit
         loaded_at_field: evt_block_time
       - name: JoeLendingStrategyV2_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: JoeLendingStrategyV2_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: JoeLendingStrategyV2_evt_Transfer
         loaded_at_field: evt_block_time
       - name: JoeStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
@@ -386,11 +510,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: JoeStrategyForLP_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: JoeStrategyForLP_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: JoeStrategyV1_evt_Deposit
         loaded_at_field: evt_block_time
       - name: JoeStrategyV1_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: JoeStrategyV1_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: JoeStrategyV1_evt_Transfer
         loaded_at_field: evt_block_time
       - name: JoeStrategyV2_evt_Deposit
         loaded_at_field: evt_block_time
@@ -398,11 +526,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: JoeStrategyV2_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: JoeStrategyV2_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: JoeStrategyV3_evt_Deposit
         loaded_at_field: evt_block_time
       - name: JoeStrategyV3_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: JoeStrategyV3_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: JoeStrategyV3_evt_Transfer
         loaded_at_field: evt_block_time
       - name: JoeStrategyV4_evt_Deposit
         loaded_at_field: evt_block_time
@@ -410,11 +542,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: JoeStrategyV4_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: JoeStrategyV4_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: KassandraIndexStrategy_evt_Deposit
         loaded_at_field: evt_block_time
       - name: KassandraIndexStrategy_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: KassandraIndexStrategy_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: KassandraIndexStrategy_evt_Transfer
         loaded_at_field: evt_block_time
       - name: KassandraIndexStrategyK3C_evt_Deposit
         loaded_at_field: evt_block_time
@@ -422,11 +558,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: KassandraIndexStrategyK3C_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: KassandraIndexStrategyK3C_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: KassandraStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: KassandraStrategyForLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: KassandraStrategyForLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: KassandraStrategyForLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: KassandraStrategyForSA_evt_Deposit
         loaded_at_field: evt_block_time
@@ -434,11 +574,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: KassandraStrategyForSA_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: KassandraStrategyForSA_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: LydiaStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: LydiaStrategyForLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: LydiaStrategyForLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: LydiaStrategyForLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: LydiaStrategyForLPa_evt_Deposit
         loaded_at_field: evt_block_time
@@ -446,11 +590,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: LydiaStrategyForLPa_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: LydiaStrategyForLPa_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: LydiaStrategyForLPb_evt_Deposit
         loaded_at_field: evt_block_time
       - name: LydiaStrategyForLPb_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: LydiaStrategyForLPb_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: LydiaStrategyForLPb_evt_Transfer
         loaded_at_field: evt_block_time
       - name: MarginswapStrategyV1_evt_Deposit
         loaded_at_field: evt_block_time
@@ -458,11 +606,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: MarginswapStrategyV1_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: MarginswapStrategyV1_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: MasterYakStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: MasterYakStrategyForLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: MasterYakStrategyForLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: MasterYakStrategyForLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: MasterYakStrategyForSA_evt_Deposit
         loaded_at_field: evt_block_time
@@ -470,11 +622,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: MasterYakStrategyForSA_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: MasterYakStrategyForSA_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: MemeRushStrategy_evt_Deposit
         loaded_at_field: evt_block_time
       - name: MemeRushStrategy_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: MemeRushStrategy_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: MemeRushStrategy_evt_Transfer
         loaded_at_field: evt_block_time
       - name: MoreMoneyStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -482,11 +638,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: MoreMoneyStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: MoreMoneyStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: OliveStrategyForLPb_evt_Deposit
         loaded_at_field: evt_block_time
       - name: OliveStrategyForLPb_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: OliveStrategyForLPb_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: OliveStrategyForLPb_evt_Transfer
         loaded_at_field: evt_block_time
       - name: OliveStrategyForSA_evt_Deposit
         loaded_at_field: evt_block_time
@@ -494,11 +654,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: OliveStrategyForSA_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: OliveStrategyForSA_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: PangolinV2StrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: PangolinV2StrategyForLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: PangolinV2StrategyForLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: PangolinV2StrategyForLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: PangolinV2VariableRewardsStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
@@ -506,11 +670,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: PangolinV2VariableRewardsStrategyForLP_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: PangolinV2VariableRewardsStrategyForLP_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: PenguinStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: PenguinStrategyForLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: PenguinStrategyForLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: PenguinStrategyForLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: PenguinStrategyForLPb_evt_Deposit
         loaded_at_field: evt_block_time
@@ -518,11 +686,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: PenguinStrategyForLPb_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: PenguinStrategyForLPb_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: PlatypusStrategy_evt_Deposit
         loaded_at_field: evt_block_time
       - name: PlatypusStrategy_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: PlatypusStrategy_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: PlatypusStrategy_evt_Transfer
         loaded_at_field: evt_block_time
       - name: SonicStrategyForSA_evt_Deposit
         loaded_at_field: evt_block_time
@@ -530,11 +702,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: SonicStrategyForSA_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: SonicStrategyForSA_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: StableVaultStrategyForS3F_evt_Deposit
         loaded_at_field: evt_block_time
       - name: StableVaultStrategyForS3F_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: StableVaultStrategyForS3F_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: StableVaultStrategyForS3F_evt_Transfer
         loaded_at_field: evt_block_time
       - name: StargateStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
@@ -542,11 +718,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: StargateStrategyForLP_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: StargateStrategyForLP_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: StormStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: StormStrategyForLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: StormStrategyForLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: StormStrategyForLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: StormStrategyForSA_evt_Deposit
         loaded_at_field: evt_block_time
@@ -554,11 +734,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: StormStrategyForSA_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: StormStrategyForSA_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: SynapseStrategy_evt_Deposit
         loaded_at_field: evt_block_time
       - name: SynapseStrategy_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: SynapseStrategy_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: SynapseStrategy_evt_Transfer
         loaded_at_field: evt_block_time
       - name: UnipoolStrategyV1_evt_Deposit
         loaded_at_field: evt_block_time
@@ -566,11 +750,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: UnipoolStrategyV1_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: UnipoolStrategyV1_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: UspPlatypusStrategy_evt_Deposit
         loaded_at_field: evt_block_time
       - name: UspPlatypusStrategy_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: UspPlatypusStrategy_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: UspPlatypusStrategy_evt_Transfer
         loaded_at_field: evt_block_time
       - name: VectorStrategyForDexLP_evt_Deposit
         loaded_at_field: evt_block_time
@@ -578,11 +766,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: VectorStrategyForDexLP_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: VectorStrategyForDexLP_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: VectorStrategyForSA_evt_Deposit
         loaded_at_field: evt_block_time
       - name: VectorStrategyForSA_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: VectorStrategyForSA_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: VectorStrategyForSA_evt_Transfer
         loaded_at_field: evt_block_time
       - name: VectorStrategyForSAV2_evt_Deposit
         loaded_at_field: evt_block_time
@@ -590,11 +782,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: VectorStrategyForSAV2_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: VectorStrategyForSAV2_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: WombatStrategy_evt_Deposit
         loaded_at_field: evt_block_time
       - name: WombatStrategy_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: WombatStrategy_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: WombatStrategy_evt_Transfer
         loaded_at_field: evt_block_time
       - name: WoofiSuperchargerStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -602,11 +798,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: WoofiSuperchargerStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: WoofiSuperchargerStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: XavaStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: XavaStrategyForLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: XavaStrategyForLP_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: XavaStrategyForLP_evt_Transfer
         loaded_at_field: evt_block_time
       - name: YYAvaxJoeStrategy_evt_Deposit
         loaded_at_field: evt_block_time
@@ -614,11 +814,15 @@ sources:
         loaded_at_field: evt_block_time
       - name: YYAvaxJoeStrategy_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: YYAvaxJoeStrategy_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: YYAvaxPlatypusStrategy_evt_Deposit
         loaded_at_field: evt_block_time
       - name: YYAvaxPlatypusStrategy_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: YYAvaxPlatypusStrategy_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: YYAvaxPlatypusStrategy_evt_Transfer
         loaded_at_field: evt_block_time
       - name: YetiStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
@@ -626,15 +830,21 @@ sources:
         loaded_at_field: evt_block_time
       - name: YetiStrategyForLP_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: YetiStrategyForLP_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: ZabuStrategyForLP_evt_Deposit
         loaded_at_field: evt_block_time
       - name: ZabuStrategyForLP_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: ZabuStrategyForLP_evt_Reinvest
         loaded_at_field: evt_block_time
+      - name: ZabuStrategyForLP_evt_Transfer
+        loaded_at_field: evt_block_time
       - name: ZabuStrategyForSA_evt_Deposit
         loaded_at_field: evt_block_time
       - name: ZabuStrategyForSA_evt_Withdraw
         loaded_at_field: evt_block_time
       - name: ZabuStrategyForSA_evt_Reinvest
+        loaded_at_field: evt_block_time
+      - name: ZabuStrategyForSA_evt_Transfer
         loaded_at_field: evt_block_time


### PR DESCRIPTION
This PR adds a temporal model for Yak Receipt Token (YRT) balances for the Yield Yak strategies, using `Transfer` events. It allows us to track wallet-level balances in each of the strategies over time, and in combination with the strategy-level balances model, will enable individual users to monitor their deposit token balances over time. It will also make the tracking of the `totalSupply` of any of these YRT tokens pretty straightforward too as we can just track the negative balance of the zero address.

I've taken a similar approach to previous models (e.g. `yield_yak_balances.sql` macro), but if there are any questions on any of it please let me know.