### PR TITLE
lynex linea: exclude due to incorrect decoded source

### DIFF
--- a/models/_sector/dex/trades/linea/platforms/lynex_linea_base_trades.sql
+++ b/models/_sector/dex/trades/linea/platforms/lynex_linea_base_trades.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'lynex_linea',
         alias = 'base_trades',
         materialized = 'incremental',


### PR DESCRIPTION
the source decoded table is believed to be incorrect, so it has been removed and likely to be fixed. we can re-enable when that is prepared.