### PR TITLE
Labels fix: ignore transfers above 1 trillion

### DIFF
--- a/models/_sector/labels/labels_counterparty_activity_daily.sql
+++ b/models/_sector/labels/labels_counterparty_activity_daily.sql
@@ -26,6 +26,7 @@ from {{source('labels','owner_addresses')}} l
 inner join {{ref('tokens_transfers')}} t
  on t.blockchain = l.blockchain
  and "to" = l.address
+ and amount_usd < pow(10,12)
  {% if is_incremental() %}
  and {{ incremental_predicate('block_time') }}
  {% endif %}
@@ -47,6 +48,7 @@ from {{source('labels','owner_addresses')}} l
 inner join {{ref('tokens_transfers')}} t
  on t.blockchain = l.blockchain
  and "from" = l.address
+ and amount_usd < pow(10,12)
  {% if is_incremental() %}
  and {{ incremental_predicate('block_time') }}
  {% endif %}

--- a/models/_sector/labels/labels_transfer_summary.sql
+++ b/models/_sector/labels/labels_transfer_summary.sql
@@ -25,6 +25,7 @@ from {{source('labels','owner_addresses')}} l
 inner join {{ref('tokens_transfers')}} t
 on t.blockchain = l.blockchain
  and "to" = l.address
+ and amount_usd < pow(10,12)
 group by 1,2
 )
 
@@ -42,6 +43,7 @@ from {{source('labels','owner_addresses')}} l
 inner join {{ref('tokens_transfers')}} t
 on t.blockchain = l.blockchain
  and "from" = l.address
+ and amount_usd < pow(10,12)
 group by 1,2
 )
 

--- a/models/_sector/labels/labels_transfer_summary_daily.sql
+++ b/models/_sector/labels/labels_transfer_summary_daily.sql
@@ -25,6 +25,7 @@ from {{source('labels','owner_addresses')}} l
 inner join {{ref('tokens_transfers')}} t
 on t.blockchain = l.blockchain
  and "to" = l.address
+ and amount_usd < pow(10,12)
  {% if is_incremental() %}
  and {{ incremental_predicate('block_time') }}
  {% endif %}
@@ -42,6 +43,7 @@ from {{source('labels','owner_addresses')}} l
 inner join {{ref('tokens_transfers')}} t
 on t.blockchain = l.blockchain
  and "from" = l.address
+ and amount_usd < pow(10,12)
  {% if is_incremental() %}
  and {{ incremental_predicate('block_time') }}
  {% endif %}


### PR DESCRIPTION
This transaction messed with the total stats:
https://etherscan.io/tx/0x35937ed72826da00bdaa784b4b13e703fecbb89e168f900276860f9c68f87d76

Solution is to ignore any transfers with an insane amount