### PR TITLE
transform balancer spells to incremental

### DIFF
--- a/macros/models/_project/balancer/balancer_bpt_supply_macro.sql
+++ b/macros/models/_project/balancer/balancer_bpt_supply_macro.sql
@@ -28,7 +28,7 @@ WITH pool_labels AS (
         WHERE blockchain = '{{blockchain}}'   
         AND version = '{{version}}'
         {% if is_incremental() %}
-        WHERE {{ incremental_predicate('block_date') }}
+        AND {{ incremental_predicate('block_date') }}
         {% endif %}
         GROUP BY 1, 2
     ),

--- a/macros/models/_project/balancer/balancer_liquidity_macro.sql
+++ b/macros/models/_project/balancer/balancer_liquidity_macro.sql
@@ -80,6 +80,9 @@ WITH pool_labels AS (
             AVG(price) as eth_price
         FROM {{ source('prices', 'usd') }}
         WHERE symbol = 'ETH'
+        {% if is_incremental() %}
+        AND {{ incremental_predicate('minute') }}
+        {% endif %}
         GROUP BY 1
     ),
 

--- a/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
+++ b/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
@@ -25,6 +25,9 @@ WITH pool_labels AS (
             AVG(price) AS price
         FROM {{ source('prices', 'usd') }}
         WHERE blockchain = '{{blockchain}}'
+        {% if is_incremental() %}
+        AND {{ incremental_predicate('minute') }}
+        {% endif %}
         GROUP BY 1, 2, 3
 
     ),
@@ -36,6 +39,9 @@ WITH pool_labels AS (
             approx_percentile(median_price, 0.5) AS price,
             sum(sample_size) AS sample_size
         FROM {{ ref('dex_prices') }}
+        {% if is_incremental() %}
+        WHERE {{ incremental_predicate('hour') }}
+        {% endif %}
         GROUP BY 1, 2
         HAVING sum(sample_size) > 3
     ),
@@ -70,6 +76,9 @@ WITH pool_labels AS (
         AND l.blockchain = s.blockchain AND s.day = l.day AND s.supply > 0
         WHERE l.blockchain = '{{blockchain}}'
         AND l.version = '{{version}}'
+        {% if is_incremental() %}
+        AND {{ incremental_predicate('l.day') }}
+        {% endif %}
         GROUP BY 1, 2, 3
     ),
 
@@ -91,6 +100,9 @@ WITH pool_labels AS (
             SUM(protocol_fees) AS protocol_fee_amount_raw
         FROM {{ source('balancer_v2_' + blockchain, 'Vault_evt_PoolBalanceChanged') }} b
         CROSS JOIN unnest("protocolFeeAmounts", "tokens") AS t(protocol_fees, token)   
+        {% if is_incremental() %}
+        WHERE {{ incremental_predicate('evt_block_time') }}
+        {% endif %}
         GROUP BY 1, 2, 3 
 
         UNION ALL          
@@ -105,6 +117,9 @@ WITH pool_labels AS (
             ON t.contract_address = b.poolAddress
             AND t."from" = 0x0000000000000000000000000000000000000000
             AND t.to = 0xce88686553686DA562CE7Cea497CE749DA109f9F --ProtocolFeesCollector address, which is the same across all chains   
+        {% if is_incremental() %}
+        WHERE {{ incremental_predicate('t.evt_block_time') }}
+        {% endif %}
         GROUP BY 1, 2, 3
     ),
 

--- a/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
+++ b/macros/models/_project/balancer/balancer_protocol_fee_macro.sql
@@ -73,7 +73,11 @@ WITH pool_labels AS (
             SUM(protocol_liquidity_usd / supply) AS price
         FROM {{ ref('balancer_liquidity') }} l
         LEFT JOIN {{ ref('balancer_bpt_supply') }} s ON s.token_address = l.pool_address 
-        AND l.blockchain = s.blockchain AND s.day = l.day AND s.supply > 0
+        AND l.blockchain = s.blockchain AND s.day = l.day 
+        {% if is_incremental() %}
+        AND {{ incremental_predicate('s.day') }}
+        {% endif %}
+        AND s.supply > 0
         WHERE l.blockchain = '{{blockchain}}'
         AND l.version = '{{version}}'
         {% if is_incremental() %}

--- a/models/balancer/arbitrum/balancer_arbitrum_schema.yml
+++ b/models/balancer/arbitrum/balancer_arbitrum_schema.yml
@@ -288,6 +288,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:
@@ -362,9 +363,11 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - blockchain
             - day
+            - blockchain
             - contract_address
+            - pool_id
+            - token_address
     columns:
       - name: blockchain
       - name: day
@@ -435,6 +438,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:

--- a/models/balancer/arbitrum/balancer_arbitrum_schema.yml
+++ b/models/balancer/arbitrum/balancer_arbitrum_schema.yml
@@ -366,8 +366,6 @@ models:
             - day
             - blockchain
             - contract_address
-            - pool_id
-            - token_address
     columns:
       - name: blockchain
       - name: day

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_bpt_prices.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_bpt_prices.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_arbitrum',
         alias = 'bpt_prices',        
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'contract_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_bpt_supply.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_bpt_supply.sql
@@ -3,8 +3,11 @@
 {{ config(
         schema = 'balancer_v2_arbitrum',
         alias = 'bpt_supply',
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_liquidity.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_liquidity.sql
@@ -5,8 +5,11 @@
     config(
         schema = 'balancer_v2_arbitrum',
         alias = 'liquidity',
-        materialized = 'table',
+        materialized = 'incremental',
         file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
         post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
                         "project",
                         "balancer_v2",

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_liquidity.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_liquidity.sql
@@ -10,10 +10,6 @@
         incremental_strategy = 'merge',
         unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
-        post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
-                        "project",
-                        "balancer_v2",
-                        \'["stefenon", "viniabussafi"]\') }}'
     )
 }}
 

--- a/models/balancer/arbitrum/balancer_v2_arbitrum_protocol_fee.sql
+++ b/models/balancer/arbitrum/balancer_v2_arbitrum_protocol_fee.sql
@@ -3,9 +3,12 @@
 {{
     config(
         schema = 'balancer_v2_arbitrum',
-        alias = 'protocol_fee', 
-        materialized = 'table',
-        file_format = 'delta'
+        alias = 'protocol_fee',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/avalanche_c/balancer_avalanche_c_schema.yml
+++ b/models/balancer/avalanche_c/balancer_avalanche_c_schema.yml
@@ -245,6 +245,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:
@@ -287,9 +288,11 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - blockchain
             - day
+            - blockchain
             - contract_address
+            - pool_id
+            - token_address
     columns:
       - name: blockchain
       - name: day
@@ -408,6 +411,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:

--- a/models/balancer/avalanche_c/balancer_avalanche_c_schema.yml
+++ b/models/balancer/avalanche_c/balancer_avalanche_c_schema.yml
@@ -291,8 +291,6 @@ models:
             - day
             - blockchain
             - contract_address
-            - pool_id
-            - token_address
     columns:
       - name: blockchain
       - name: day

--- a/models/balancer/avalanche_c/balancer_v2_avalanche_c_bpt_prices.sql
+++ b/models/balancer/avalanche_c/balancer_v2_avalanche_c_bpt_prices.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_avalanche_c',
         alias = 'bpt_prices',        
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'contract_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/avalanche_c/balancer_v2_avalanche_c_bpt_supply.sql
+++ b/models/balancer/avalanche_c/balancer_v2_avalanche_c_bpt_supply.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_avalanche_c',
         alias = 'bpt_supply',
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
 
     )
 }}

--- a/models/balancer/avalanche_c/balancer_v2_avalanche_c_liquidity.sql
+++ b/models/balancer/avalanche_c/balancer_v2_avalanche_c_liquidity.sql
@@ -5,8 +5,11 @@
     config(
         schema = 'balancer_v2_avalanche_c',
         alias = 'liquidity',
-        materialized = 'table',
+        materialized = 'incremental',
         file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
         post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
                         "project",
                         "balancer_v2",

--- a/models/balancer/avalanche_c/balancer_v2_avalanche_c_liquidity.sql
+++ b/models/balancer/avalanche_c/balancer_v2_avalanche_c_liquidity.sql
@@ -10,10 +10,6 @@
         incremental_strategy = 'merge',
         unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
-        post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
-                        "project",
-                        "balancer_v2",
-                        \'["stefenon", "viniabussafi"]\') }}'
     )
 }}
 

--- a/models/balancer/avalanche_c/balancer_v2_avalanche_c_protocol_fee.sql
+++ b/models/balancer/avalanche_c/balancer_v2_avalanche_c_protocol_fee.sql
@@ -3,9 +3,12 @@
 {{
     config(
         schema = 'balancer_v2_avalanche_c',
-        alias = 'protocol_fee', 
-        materialized = 'table',
-        file_format = 'delta'
+        alias = 'protocol_fee',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/base/balancer_base_schema.yml
+++ b/models/balancer/base/balancer_base_schema.yml
@@ -318,8 +318,6 @@ models:
             - day
             - blockchain
             - contract_address
-            - pool_id
-            - token_address
     columns:
       - name: blockchain
       - name: day

--- a/models/balancer/base/balancer_base_schema.yml
+++ b/models/balancer/base/balancer_base_schema.yml
@@ -272,6 +272,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:
@@ -314,9 +315,11 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - blockchain
             - day
+            - blockchain
             - contract_address
+            - pool_id
+            - token_address
     columns:
       - name: blockchain
       - name: day
@@ -409,6 +412,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:

--- a/models/balancer/base/balancer_v2_base_bpt_prices.sql
+++ b/models/balancer/base/balancer_v2_base_bpt_prices.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_base',
         alias = 'bpt_prices',        
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'contract_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/base/balancer_v2_base_bpt_supply.sql
+++ b/models/balancer/base/balancer_v2_base_bpt_supply.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_base',
         alias = 'bpt_supply',
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
 
     )
 }}

--- a/models/balancer/base/balancer_v2_base_liquidity.sql
+++ b/models/balancer/base/balancer_v2_base_liquidity.sql
@@ -5,8 +5,11 @@
     config(
         schema = 'balancer_v2_base',
         alias = 'liquidity',
-        materialized = 'table',
+        materialized = 'incremental',
         file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
         post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
                         "project",
                         "balancer_v2",

--- a/models/balancer/base/balancer_v2_base_liquidity.sql
+++ b/models/balancer/base/balancer_v2_base_liquidity.sql
@@ -10,10 +10,6 @@
         incremental_strategy = 'merge',
         unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
-        post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
-                        "project",
-                        "balancer_v2",
-                        \'["stefenon", "viniabussafi"]\') }}'
     )
 }}
 

--- a/models/balancer/base/balancer_v2_base_protocol_fee.sql
+++ b/models/balancer/base/balancer_v2_base_protocol_fee.sql
@@ -3,9 +3,12 @@
 {{
     config(
         schema = 'balancer_v2_base',
-        alias = 'protocol_fee', 
-        materialized = 'table',
-        file_format = 'delta'
+        alias = 'protocol_fee',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/ethereum/balancer_ethereum_schema.yml
+++ b/models/balancer/ethereum/balancer_ethereum_schema.yml
@@ -649,8 +649,6 @@ models:
             - day
             - blockchain
             - contract_address
-            - pool_id
-            - token_address
     columns:
       - name: blockchain
       - name: day

--- a/models/balancer/ethereum/balancer_ethereum_schema.yml
+++ b/models/balancer/ethereum/balancer_ethereum_schema.yml
@@ -481,6 +481,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:
@@ -576,6 +577,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:
@@ -644,9 +646,11 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - blockchain
             - day
+            - blockchain
             - contract_address
+            - pool_id
+            - token_address
     columns:
       - name: blockchain
       - name: day
@@ -668,6 +672,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:

--- a/models/balancer/ethereum/balancer_v1_ethereum_liquidity.sql
+++ b/models/balancer/ethereum/balancer_v1_ethereum_liquidity.sql
@@ -66,7 +66,7 @@ WITH pool_labels AS (
             cumulative_amount / POWER(10, COALESCE(t.decimals, p1.decimals)) AS token_balance,
             cumulative_amount / POWER(10, COALESCE(t.decimals, p1.decimals)) * COALESCE(p1.price, 0) AS protocol_liquidity_usd
         FROM cumulative_balance b
-        LEFT JOIN {{ ref('tokens_ethereum_erc20') }} t ON t.contract_address = b.token
+        LEFT JOIN {{ source('tokens', 'erc20') }} t ON t.contract_address = b.token AND t.blockchain = 'ethereum'
         LEFT JOIN prices p1 ON p1.day = b.day
         AND p1.token = b.token
     ),
@@ -106,6 +106,6 @@ WITH pool_labels AS (
         INNER JOIN {{ ref('balancer_v1_ethereum_pools_tokens_weights') }} w ON b.pool = w.pool_id
         AND w.token_address = c.token 
         AND CAST (w.normalized_weight as DOUBLE) > CAST (0 as DOUBLE)
-        LEFT JOIN {{ source('tokens', 'erc20') }} t  t ON t.contract_address = w.token_address AND t.blockchain = 'ethereum'
+        LEFT JOIN {{ source('tokens', 'erc20') }} t ON t.contract_address = w.token_address AND t.blockchain = 'ethereum'
         LEFT JOIN pool_labels p ON p.address = w.pool_id
         LEFT JOIN eth_prices e ON e.day = b.day

--- a/models/balancer/ethereum/balancer_v1_ethereum_liquidity.sql
+++ b/models/balancer/ethereum/balancer_v1_ethereum_liquidity.sql
@@ -106,6 +106,6 @@ WITH pool_labels AS (
         INNER JOIN {{ ref('balancer_v1_ethereum_pools_tokens_weights') }} w ON b.pool = w.pool_id
         AND w.token_address = c.token 
         AND CAST (w.normalized_weight as DOUBLE) > CAST (0 as DOUBLE)
-        LEFT JOIN {{ source('tokens_ethereum', 'erc20') }} t ON t.contract_address = w.token_address
+        LEFT JOIN {{ source('tokens', 'erc20') }} t  t ON t.contract_address = w.token_address AND t.blockchain = 'ethereum'
         LEFT JOIN pool_labels p ON p.address = w.pool_id
         LEFT JOIN eth_prices e ON e.day = b.day

--- a/models/balancer/ethereum/balancer_v1_ethereum_liquidity.sql
+++ b/models/balancer/ethereum/balancer_v1_ethereum_liquidity.sql
@@ -26,7 +26,7 @@ WITH pool_labels AS (
         FROM {{ source('prices', 'usd') }}
         WHERE blockchain = 'ethereum'
         {% if is_incremental() %}
-        WHERE {{ incremental_predicate('minute') }}
+        AND {{ incremental_predicate('minute') }}
         {% endif %}
         GROUP BY 1, 2, 3
     ),

--- a/models/balancer/ethereum/balancer_v1_ethereum_liquidity.sql
+++ b/models/balancer/ethereum/balancer_v1_ethereum_liquidity.sql
@@ -39,7 +39,7 @@ WITH pool_labels AS (
         WHERE blockchain = 'ethereum'
         AND symbol = 'ETH'
         {% if is_incremental() %}
-        WHERE {{ incremental_predicate('minute') }}
+        AND {{ incremental_predicate('minute') }}
         {% endif %}
         GROUP BY 1
     ),

--- a/models/balancer/ethereum/balancer_v2_ethereum_bpt_prices.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_bpt_prices.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_ethereum',
         alias = 'bpt_prices',        
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'contract_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/ethereum/balancer_v2_ethereum_bpt_supply.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_bpt_supply.sql
@@ -4,8 +4,11 @@
     config(
         schema='balancer_v2_ethereum',
         alias = 'bpt_supply',
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
 
     )
 }}

--- a/models/balancer/ethereum/balancer_v2_ethereum_liquidity.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_liquidity.sql
@@ -5,8 +5,11 @@
     config(
         schema = 'balancer_v2_ethereum',
         alias = 'liquidity',
-        materialized = 'table',
+        materialized = 'incremental',
         file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
         post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
                         "project",
                         "balancer_v2",

--- a/models/balancer/ethereum/balancer_v2_ethereum_liquidity.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_liquidity.sql
@@ -10,10 +10,6 @@
         incremental_strategy = 'merge',
         unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
-        post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
-                        "project",
-                        "balancer_v2",
-                        \'["stefenon", "viniabussafi"]\') }}'
     )
 }}
 

--- a/models/balancer/ethereum/balancer_v2_ethereum_protocol_fee.sql
+++ b/models/balancer/ethereum/balancer_v2_ethereum_protocol_fee.sql
@@ -3,9 +3,12 @@
 {{
     config(
        schema = 'balancer_v2_ethereum',
-        alias = 'protocol_fee', 
-        materialized = 'table',
-        file_format = 'delta'
+        alias = 'protocol_fee',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/gnosis/balancer_gnosis_schema.yml
+++ b/models/balancer/gnosis/balancer_gnosis_schema.yml
@@ -149,8 +149,6 @@ models:
             - day
             - blockchain
             - contract_address
-            - pool_id
-            - token_address
     columns:
       - name: blockchain
       - name: day

--- a/models/balancer/gnosis/balancer_gnosis_schema.yml
+++ b/models/balancer/gnosis/balancer_gnosis_schema.yml
@@ -146,9 +146,11 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - blockchain
             - day
+            - blockchain
             - contract_address
+            - pool_id
+            - token_address
     columns:
       - name: blockchain
       - name: day
@@ -284,6 +286,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:
@@ -407,6 +410,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:

--- a/models/balancer/gnosis/balancer_v2_gnosis_bpt_prices.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_bpt_prices.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_gnosis',
         alias = 'bpt_prices',        
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'contract_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/gnosis/balancer_v2_gnosis_bpt_supply.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_bpt_supply.sql
@@ -4,8 +4,11 @@
     config(
     schema = 'balancer_v2_gnosis',
         alias = 'bpt_supply',
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/gnosis/balancer_v2_gnosis_liquidity.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_liquidity.sql
@@ -5,8 +5,11 @@
     config(
     schema = 'balancer_v2_gnosis',
         alias = 'liquidity',
-        materialized = 'table',
+        materialized = 'incremental',
         file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
         post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
                         "project",
                         "balancer_v2",

--- a/models/balancer/gnosis/balancer_v2_gnosis_liquidity.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_liquidity.sql
@@ -10,10 +10,6 @@
         incremental_strategy = 'merge',
         unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
-        post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
-                        "project",
-                        "balancer_v2",
-                        \'["stefenon", "viniabussafi"]\') }}'
     )
 }}
 

--- a/models/balancer/gnosis/balancer_v2_gnosis_protocol_fee.sql
+++ b/models/balancer/gnosis/balancer_v2_gnosis_protocol_fee.sql
@@ -3,9 +3,12 @@
 {{
     config(
         schema='balancer_v2_gnosis',
-        alias = 'protocol_fee', 
-        materialized = 'table',
-        file_format = 'delta'
+        alias = 'protocol_fee',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/optimism/balancer_optimism_schema.yml
+++ b/models/balancer/optimism/balancer_optimism_schema.yml
@@ -359,8 +359,6 @@ models:
             - day
             - blockchain
             - contract_address
-            - pool_id
-            - token_address
     columns:
       - name: blockchain
       - name: day

--- a/models/balancer/optimism/balancer_optimism_schema.yml
+++ b/models/balancer/optimism/balancer_optimism_schema.yml
@@ -249,6 +249,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:
@@ -355,9 +356,11 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - blockchain
             - day
+            - blockchain
             - contract_address
+            - pool_id
+            - token_address
     columns:
       - name: blockchain
       - name: day
@@ -467,6 +470,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:

--- a/models/balancer/optimism/balancer_v2_optimism_bpt_prices.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_bpt_prices.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_optimism',
         alias = 'bpt_prices',        
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'contract_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/optimism/balancer_v2_optimism_bpt_supply.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_bpt_supply.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_optimism',
         alias = 'bpt_supply',
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/optimism/balancer_v2_optimism_liquidity.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_liquidity.sql
@@ -10,10 +10,6 @@
         incremental_strategy = 'merge',
         unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
-        post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
-                        "project",
-                        "balancer_v2",
-                        \'["stefenon", "viniabussafi"]\') }}'
     )
 }}
 

--- a/models/balancer/optimism/balancer_v2_optimism_liquidity.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_liquidity.sql
@@ -5,8 +5,11 @@
     config(
         schema = 'balancer_v2_optimism',
         alias = 'liquidity',
-        materialized = 'table',
+        materialized = 'incremental',
         file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
         post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
                         "project",
                         "balancer_v2",

--- a/models/balancer/optimism/balancer_v2_optimism_protocol_fee.sql
+++ b/models/balancer/optimism/balancer_v2_optimism_protocol_fee.sql
@@ -3,9 +3,12 @@
 {{
     config(
         schema = 'balancer_v2_optimism',
-        alias = 'protocol_fee', 
-        materialized = 'table',
-        file_format = 'delta'
+        alias = 'protocol_fee',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/polygon/balancer_polygon_schema.yml
+++ b/models/balancer/polygon/balancer_polygon_schema.yml
@@ -349,8 +349,6 @@ models:
             - day
             - blockchain
             - contract_address
-            - pool_id
-            - token_address
     columns:
       - name: blockchain
       - name: day

--- a/models/balancer/polygon/balancer_polygon_schema.yml
+++ b/models/balancer/polygon/balancer_polygon_schema.yml
@@ -249,6 +249,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:
@@ -345,9 +346,11 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - blockchain
             - day
+            - blockchain
             - contract_address
+            - pool_id
+            - token_address
     columns:
       - name: blockchain
       - name: day
@@ -457,6 +460,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:

--- a/models/balancer/polygon/balancer_v2_polygon_bpt_prices.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_bpt_prices.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_polygon',
         alias = 'bpt_prices',        
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'contract_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/polygon/balancer_v2_polygon_bpt_supply.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_bpt_supply.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_polygon',
         alias = 'bpt_supply',
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/polygon/balancer_v2_polygon_liquidity.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_liquidity.sql
@@ -5,8 +5,11 @@
     config(
         schema = 'balancer_v2_polygon',
         alias = 'liquidity',
-        materialized = 'table',
+        materialized = 'incremental',
         file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
         post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
                         "project",
                         "balancer_v2",

--- a/models/balancer/polygon/balancer_v2_polygon_liquidity.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_liquidity.sql
@@ -10,10 +10,6 @@
         incremental_strategy = 'merge',
         unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
-        post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
-                        "project",
-                        "balancer_v2",
-                        \'["stefenon", "viniabussafi"]\') }}'
     )
 }}
 

--- a/models/balancer/polygon/balancer_v2_polygon_protocol_fee.sql
+++ b/models/balancer/polygon/balancer_v2_polygon_protocol_fee.sql
@@ -3,9 +3,12 @@
 {{
     config(
         schema = 'balancer_v2_polygon',
-        alias = 'protocol_fee', 
-        materialized = 'table',
-        file_format = 'delta'
+        alias = 'protocol_fee',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/zkevm/balancer_v2_zkevm_bpt_prices.sql
+++ b/models/balancer/zkevm/balancer_v2_zkevm_bpt_prices.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_zkevm',
         alias = 'bpt_prices',        
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'contract_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/zkevm/balancer_v2_zkevm_bpt_supply.sql
+++ b/models/balancer/zkevm/balancer_v2_zkevm_bpt_supply.sql
@@ -4,8 +4,11 @@
     config(
         schema = 'balancer_v2_zkevm',
         alias = 'bpt_supply',
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/zkevm/balancer_v2_zkevm_liquidity.sql
+++ b/models/balancer/zkevm/balancer_v2_zkevm_liquidity.sql
@@ -5,8 +5,11 @@
     config(
         schema = 'balancer_v2_zkevm',
         alias = 'liquidity',
-        materialized = 'table',
+        materialized = 'incremental',
         file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
         post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
                         "project",
                         "balancer_v2",

--- a/models/balancer/zkevm/balancer_v2_zkevm_liquidity.sql
+++ b/models/balancer/zkevm/balancer_v2_zkevm_liquidity.sql
@@ -10,10 +10,6 @@
         incremental_strategy = 'merge',
         unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
-        post_hook="{{ expose_spells('[\"" + blockchain + '"]' + '\',
-                        "project",
-                        "balancer_v2",
-                        \'["stefenon", "viniabussafi"]\') }}'
     )
 }}
 

--- a/models/balancer/zkevm/balancer_v2_zkevm_protocol_fee.sql
+++ b/models/balancer/zkevm/balancer_v2_zkevm_protocol_fee.sql
@@ -3,9 +3,12 @@
 {{
     config(
         schema = 'balancer_v2_zkevm',
-        alias = 'protocol_fee', 
-        materialized = 'table',
-        file_format = 'delta'
+        alias = 'protocol_fee',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
     )
 }}
 

--- a/models/balancer/zkevm/balancer_zkevm_schema.yml
+++ b/models/balancer/zkevm/balancer_zkevm_schema.yml
@@ -249,6 +249,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:
@@ -322,9 +323,11 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - blockchain
             - day
+            - blockchain
             - contract_address
+            - pool_id
+            - token_address
     columns:
       - name: blockchain
       - name: day
@@ -385,6 +388,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - day
+            - blockchain
             - pool_id
             - token_address
     columns:

--- a/models/balancer/zkevm/balancer_zkevm_schema.yml
+++ b/models/balancer/zkevm/balancer_zkevm_schema.yml
@@ -326,8 +326,6 @@ models:
             - day
             - blockchain
             - contract_address
-            - pool_id
-            - token_address
     columns:
       - name: blockchain
       - name: day

--- a/models/beethoven_x/fantom/beethoven_x_fantom_liquidity.sql
+++ b/models/beethoven_x/fantom/beethoven_x_fantom_liquidity.sql
@@ -2,8 +2,11 @@
     config(
         schema='beethoven_x_fantom',
         alias = 'liquidity',
-        materialized = 'table',
+        materialized = 'incremental',
         file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
         post_hook='{{ expose_spells(\'["fantom"]\',
                         "project",
                         "beethoven_x",

--- a/models/beethoven_x/fantom/beethoven_x_fantom_liquidity.sql
+++ b/models/beethoven_x/fantom/beethoven_x_fantom_liquidity.sql
@@ -2,11 +2,8 @@
     config(
         schema='beethoven_x_fantom',
         alias = 'liquidity',
-        materialized = 'incremental',
+        materialized = 'table',
         file_format = 'delta',
-        incremental_strategy = 'merge',
-        unique_key = ['day', 'blockchain', 'pool_id', 'token_address'],
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
         post_hook='{{ expose_spells(\'["fantom"]\',
                         "project",
                         "beethoven_x",


### PR DESCRIPTION
This PR transforms a few balancer spells (protocol fees, liquidity, bpt prices and bpt supply) into incremental, in order to have them updated on a higher frequency.