### PR TITLE
Update Fee data for Mintsquare NFT marketplace

### DIFF
--- a/models/_sector/nft/trades/chains/zksync/platforms/mint_square_zksync_base_trades.sql
+++ b/models/_sector/nft/trades/chains/zksync/platforms/mint_square_zksync_base_trades.sql
@@ -115,7 +115,7 @@ WITH mintsquare_trades AS (
         , m.price_raw
         , CAST(COALESCE((pf.fee_percentage/100) * CAST(m.price_raw AS uint256),  DOUBLE '0') AS UINT256) AS platform_fee_amount_raw
         , COALESCE(roy.amount, uint256 '0') AS royalty_fee_amount_raw
-        , CAST('0xdeedc46dd3136962c74031e50990ad3319a09d0b' AS varbinary) AS platform_fee_address
+        , from_hex('0xdeedc46dd3136962c74031e50990ad3319a09d0b') AS platform_fee_address
         , roy.royaltyRecipient AS royalty_fee_address
         , m.evt_index AS sub_tx_trade_id
     FROM mintsquare_trades m

--- a/models/_sector/nft/trades/chains/zksync/platforms/mint_square_zksync_base_trades.sql
+++ b/models/_sector/nft/trades/chains/zksync/platforms/mint_square_zksync_base_trades.sql
@@ -115,7 +115,7 @@ WITH mintsquare_trades AS (
         , m.price_raw
         , CAST(COALESCE((pf.fee_percentage/100) * CAST(m.price_raw AS uint256),  DOUBLE '0') AS UINT256) AS platform_fee_amount_raw
         , COALESCE(roy.amount, uint256 '0') AS royalty_fee_amount_raw
-        , CAST(null AS varbinary) AS platform_fee_address
+        , CAST('0xdeedc46dd3136962c74031e50990ad3319a09d0b' AS varbinary) AS platform_fee_address
         , roy.royaltyRecipient AS royalty_fee_address
         , m.evt_index AS sub_tx_trade_id
     FROM mintsquare_trades m


### PR DESCRIPTION
Hardcode the `platform_fee_address` as identified by manual inspection of trades and matching on the existing `platform_fee_amount_raw`