### PR TITLE
Test Missing Null Uniques -  transfers_base_eth.sql

### DIFF
--- a/models/transfers/base/transfers_base_eth.sql
+++ b/models/transfers/base/transfers_base_eth.sql
@@ -25,7 +25,7 @@ with eth_transfers as (
         ,r.block_time as tx_block_time
         ,r.block_number as tx_block_number
         ,substring(to_hex(t.data), 1, 10) as tx_method_id
-        ,cast(r.tx_hash as varchar) || '-' || array_join(r.trace_address,',') as unique_transfer_id
+        ,cast(r.tx_hash as varchar) || '-' || COALESCE( NULLIF(array_join(r.trace_address,','),''), '_') as unique_transfer_id
         ,t.to AS tx_to
         ,t."from" AS tx_from
     from {{ source('base', 'traces') }} as r


### PR DESCRIPTION
Optimism Portal transfers are missing from op chains' eth transfer spells.

Testing if the issue stems from the null trace address in the unique ID field cc @chuxinh .