### PR TITLE
paraswap: bugfix broken decoding due to missing call_success filter

### DIFF
--- a/macros/models/_project/paraswap/v6/paraswap_v6_balancer_v2_method.sql
+++ b/macros/models/_project/paraswap/v6/paraswap_v6_balancer_v2_method.sql
@@ -9,10 +9,12 @@ WITH
                           /* cutting down balancer data into bytes32 words to RLP decode assetOffset and assetsSize later */
                           regexp_extract_all(substr(try_cast(data as varchar), 11), '.{64}') as sData
                         FROM
-                          {{ srcTable }} 
-                          {% if is_incremental() %}
-                            WHERE call_block_time >= date_trunc('day', now() - interval '7' day)
-                          {% endif %}      
+                          {{ srcTable }}
+                          WHERE 
+                            call_success = TRUE
+                            {% if is_incremental() %}
+                              AND call_block_time >= date_trunc('day', now() - interval '7' day)
+                            {% endif %}      
                       )
                     SELECT
                       *,{% if inOrOut == 'in' %}


### PR DESCRIPTION
follow up of https://github.com/duneanalytics/spellbook/pull/6002, fix parsing of non successful  trace records