### PR TITLE
paraswap: bugfix wrong address formatting in v6.1

### DIFF
--- a/macros/models/_project/paraswap/v6/paraswap_v6_balancer_v2_method.sql
+++ b/macros/models/_project/paraswap/v6/paraswap_v6_balancer_v2_method.sql
@@ -144,14 +144,14 @@ select
                           case
                             when try_cast(srcToken as uint256) = uint256 '0' then '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
                             else try_cast(
-                              from_hex(regexp_replace(srcToken, '(00){12}')) as varchar
-                            ) -- shrink address to to bytes20
+                              from_hex(regexp_replace(srcToken, '^(0x)?(00){12}')) as varchar
+                            ) -- shrink hex to get address format (bytes20)
                           end as srcToken,
                           case
                             when try_cast(destToken as uint256) = uint256 '0' then '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
                             else try_cast(
-                              from_hex(regexp_replace(destToken, '(00){12}')) as varchar
-                            ) -- shrink address to to bytes20
+                              from_hex(regexp_replace(destToken, '^(0x)?(00){12}')) as varchar
+                            ) -- shrink hex to get address format (bytes20)
                           end as destToken,
                           fromAmount,
                           toAmount,
@@ -161,7 +161,8 @@ select
                           output_receivedAmount,
                           JSON_EXTRACT_SCALAR(balancerData, '$.metadata') AS metadata,
                           try_cast(
-                            from_hex(regexp_replace(beneficiary, '(00){12}')) as varchar
+                            from_hex(regexp_replace(beneficiary, '^(0x)?(00){12}')) as varchar
+                            -- shrink hex to get address format (bytes20)
                           ) as beneficiary,
                           partnerAndFee,
                           output_partnerShare,


### PR DESCRIPTION
Follow-up of https://github.com/duneanalytics/spellbook/pull/6018 and https://github.com/duneanalytics/spellbook/pull/6002, this PR fixes wrong formatting of addresses where addresses with 12 zeros used to get shrunk (ex: 0x4200000000000000000000000000000000000006 -> 0x4200000000000006)