### PR TITLE
eas optimism: attempt to avoid duplicates

### DIFF
--- a/models/_sector/attestation/eas/optimism/eas_optimism_schemas.sql
+++ b/models/_sector/attestation/eas/optimism/eas_optimism_schemas.sql
@@ -20,14 +20,30 @@ with eas as (
     )
   }}
 )
-
-select *
-from eas
-where schema_uid not in (
-  0x026b0f2bfcb9d0e91cb3c2f6c8e84872615c6d5028edec1c9f360a54ae6595d8
-  ,0x655a5addcf762e79f17ed35afc9e985a9912d57bd02835d529154954dd07a03d
-  ,0x5d2ec81b1de9d7919b34b41de87073a6f97c914b6c143df0aa15d84d5c5ba391
-  ,0xed7c89d83e631fc93115ac5cb92260b859dc70ff3ba8d686cd5e5b54800d0137
-  ,0x11bd7f94b4ce942bd11d1e02e94a3ab386993845211dc937fd0076e38f0c084e
-  ,0x45ca2f188d07f561fa0c4c83ffe204a86780c59cd39b1dcefcea6e64540adde4
+, dedupe as (
+  select distinct
+    schema_uid
+  from
+  (
+    select
+      schema_uid
+      , count(1) as count
+    from
+      eas
+    group by
+      schema_uid
+    having
+      count(1) > 1
+    )
 )
+select
+  *
+from
+  eas
+where
+  schema_uid not in (
+    select
+      schema_uid
+    from
+      dedupe
+  )


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [ ] Adding to existing spell lineage
- [x] Bug fix

### For bug fixes
If you are fixing a bug, please provide the following information:

- **Description:** second time in three weeks where this model fails repeatedly in prod on merge duplicates coming from the source
- **Steps to reproduce:** 
```
with
  src as (
    with
      eas as (
        with
          src_SchemaRegistry_evt_Registered as (
            select
              *
            from
              "delta_prod"."attestationstation_v1_optimism"."SchemaRegistry_evt_Registered"
          ),
          src_SchemaRegistry_call_register as (
            select
              *
            from
              "delta_prod"."attestationstation_v1_optimism"."SchemaRegistry_call_register"
          )
        select
          'optimism' as blockchain,
          'eas' as project,
          '1' as version,
          er.uid as schema_uid,
          er.registerer,
          cr.resolver,
          cr.schema,
          transform(split(cr.schema, ','), x -> split(trim(x), ' ')) as schema_array, -- array of 2-element arrays [[data_type,field_name],[...]]
          cr.revocable as is_revocable,
          er.contract_address,
          er.evt_block_number as block_number,
          er.evt_block_time as block_time,
          er.evt_tx_hash as tx_hash,
          er.evt_index
        from
          src_SchemaRegistry_evt_Registered er
          join src_SchemaRegistry_call_register cr on er.evt_tx_hash = cr.call_tx_hash
        where
          cr.call_success
      )
    select
      *
    from
      eas
    where
      schema_uid not in (
        0x026b0f2bfcb9d0e91cb3c2f6c8e84872615c6d5028edec1c9f360a54ae6595d8,
        0x655a5addcf762e79f17ed35afc9e985a9912d57bd02835d529154954dd07a03d,
        0x5d2ec81b1de9d7919b34b41de87073a6f97c914b6c143df0aa15d84d5c5ba391,
        0xed7c89d83e631fc93115ac5cb92260b859dc70ff3ba8d686cd5e5b54800d0137,
        0x11bd7f94b4ce942bd11d1e02e94a3ab386993845211dc937fd0076e38f0c084e,
        0x45ca2f188d07f561fa0c4c83ffe204a86780c59cd39b1dcefcea6e64540adde4
      )
  )
select
  schema_uid,
  count(1)
from
  src
group by
  schema_uid
having
  count(1) > 1
```
- **Implementation details:** force a dedupe CTE to prevent from happening, not a long term type of fix
- **Test instructions:** ensure CI runs properly
- **Related issue(s):** none