### PR TITLE
EAS schemas - bug fix

### DIFF
--- a/macros/models/_sector/attestation/eas.sql
+++ b/macros/models/_sector/attestation/eas.sql
@@ -44,7 +44,7 @@ select
   er.evt_tx_hash as tx_hash,
   er.evt_index
 from src_SchemaRegistry_evt_Registered er
-  join src_SchemaRegistry_call_register cr on er.evt_tx_hash = cr.call_tx_hash
+  join src_SchemaRegistry_call_register cr on er.evt_tx_hash = cr.call_tx_hash and er.uid = cr.output_0
 where cr.call_success
 
 {% endmacro %}

--- a/macros/models/_sector/attestation/eas.sql
+++ b/macros/models/_sector/attestation/eas.sql
@@ -44,7 +44,7 @@ select
   er.evt_tx_hash as tx_hash,
   er.evt_index
 from src_SchemaRegistry_evt_Registered er
-  join src_SchemaRegistry_call_register cr on er.evt_tx_hash = cr.call_tx_hash and er.uid = cr.output_0
+  join src_SchemaRegistry_call_register cr on er.evt_tx_hash = cr.call_tx_hash and er.{{ uid_column_name }} = cr.output_0
 where cr.call_success
 
 {% endmacro %}

--- a/models/_sector/attestation/eas/optimism/eas_optimism_schemas.sql
+++ b/models/_sector/attestation/eas/optimism/eas_optimism_schemas.sql
@@ -10,40 +10,11 @@
   )
 }}
 
-with eas as (
-  {{
-    eas_schemas(
-      blockchain = 'optimism',
-      project = 'eas',
-      version = '1',
-      decoded_project_name = 'attestationstation_v1'
-    )
-  }}
-)
-, dedupe as (
-  select distinct
-    schema_uid
-  from
-  (
-    select
-      schema_uid
-      , count(1) as count
-    from
-      eas
-    group by
-      schema_uid
-    having
-      count(1) > 1
-    )
-)
-select
-  *
-from
-  eas
-where
-  schema_uid not in (
-    select
-      schema_uid
-    from
-      dedupe
+{{
+  eas_schemas(
+    blockchain = 'optimism',
+    project = 'eas',
+    version = '1',
+    decoded_project_name = 'attestationstation_v1'
   )
+}}


### PR DESCRIPTION
### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [ ] Adding to existing spell lineage
- [x] Bug fix

---

- **Description:** current logic assumes only 1 EAS schema can be created per tx, which optimism proves it wrong
- **Steps to reproduce:** [sample tx](https://optimistic.etherscan.io/tx/0xccf2e1b79be8b005fa5f6cd531e4aa0895a715b5a7e65003376a599c366c0bab) - 6 schemas created here
- **Implementation details:** fixed join in the query to ensure `evt` joins to only 1 corresponding `call`
- **Test instructions:** if the logic is still wrong, CI run will fail on uniqueness check
- **Related issue(s):** #6032 

---
