### PR TITLE
Incremental predicate chainlink

### DIFF
--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_fulfilled_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_fulfilled_transactions AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_fulfilled_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('arbitrum', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('arbitrum', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'arbitrum' as blockchain,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_arbitrum_ccip_transmitted_fulfilled') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_arbitrum_ccip_transmitted_reverted') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM ccip_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_arbitrum_ccip_operator_meta') }} ccip_operator_meta ON ccip_operator_meta.node_address = ccip_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ccip_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_nop_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_nop_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_nop_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -20,7 +20,7 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
@@ -38,22 +38,22 @@ FROM
   {{ref('chainlink_arbitrum_ccip_nop_paid_logs')}} nop_logs
   LEFT JOIN {{ref('chainlink_arbitrum_ccip_admin_meta')}} admin_meta ON admin_meta.admin_address = nop_logs.nop_address
 {% if is_incremental() %}
-  WHERE block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY
   2, 4
   ),
   nop_reward_daily AS (
-    SELECT 
+    SELECT
       nop_paid.date_start,
       cast(date_trunc('month', nop_paid.date_start) as date) as date_month,
       nop_paid.operator_name,
-      nop_paid.nop_address,   
+      nop_paid.nop_address,
       nop_paid.token_amount as token_amount,
       (nop_paid.token_amount * lud.usd_amount) as usd_amount
-    FROM 
+    FROM
       nop_paid
     LEFT JOIN link_usd_daily lud ON lud.date_start = nop_paid.date_start
     ORDER BY date_start
@@ -66,7 +66,7 @@ SELECT
   nop_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   nop_reward_daily
 ORDER BY
   2, 5

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_request_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
 ethereum_agg AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_request_daily.sql
@@ -23,7 +23,7 @@ ethereum_agg AS (
                 WHERE
                     eth.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND eth.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('eth.block_time') }}
                 {% endif %}
             ) AS fulfilled_requests,
             (
@@ -34,7 +34,7 @@ ethereum_agg AS (
                 WHERE
                     rev.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND rev.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('rev.block_time') }}
                 {% endif %}
             ) AS reverted_requests
         FROM
@@ -52,7 +52,7 @@ ethereum_agg AS (
             ) AS seq
             CROSS JOIN UNNEST (seq.date_sequence) AS t (date_start)
             {% if is_incremental() %}
-                    WHERE date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    WHERE {{ incremental_predicate('date_start') }}
             {% endif %}
             ) date_series
     ),
@@ -67,7 +67,7 @@ ethereum_agg AS (
         FROM
             ethereum_agg
     )
-SELECT 
+SELECT
   ccip_request_daily.blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_reverted_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('arbitrum', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('arbitrum', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'arbitrum' as blockchain,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_reverted_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_reverted_transactions AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_reward_daily.sql
@@ -28,29 +28,29 @@ WITH
             {{ source('prices', 'usd') }} price
         JOIN token_meta ON price.symbol = token_meta.token_symbol
         {% if is_incremental() %}
-            WHERE price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        {% endif %} 
+            WHERE {{ incremental_predicate('price.minute') }}
+        {% endif %}
         GROUP BY
             1, token_meta.token_symbol
         ORDER BY
             1
     ),
     ccip_reward_daily AS (
-        SELECT 
+        SELECT
             ccip_send_requested_daily.date_start,
-            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,  
+            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,
             SUM(ccip_send_requested_daily.fee_amount) as token_amount,
             SUM((ccip_send_requested_daily.fee_amount * tud.usd_amount)) as usd_amount,
             ccip_send_requested_daily.token as token
-        FROM 
+        FROM
             {{ref('chainlink_arbitrum_ccip_send_requested_daily')}} ccip_send_requested_daily
         LEFT JOIN token_usd_daily tud ON tud.date_start = ccip_send_requested_daily.date_start AND tud.symbol = ccip_send_requested_daily.token
         {% if is_incremental() %}
-            WHERE ccip_send_requested_daily.date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        {% endif %}    
+            WHERE {{ incremental_predicate('ccip_send_requested_daily.date_start') }}
+        {% endif %}
         GROUP BY 1, 5
     )
-    
+
 SELECT
     'arbitrum' as blockchain,
     date_start,
@@ -58,7 +58,7 @@ SELECT
     token_amount,
     usd_amount,
     token
-FROM 
+FROM
     ccip_reward_daily
 ORDER BY
     2, 6

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_reward_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
     token_meta AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_send_requested_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_send_requested_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ SELECT
 FROM
   {{ref('chainlink_arbitrum_ccip_send_requested')}} ccip_send_requested
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 5, 6
 ORDER BY

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_send_requested_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'arbitrum' as blockchain,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_fulfilled.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_fulfilled',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_fulfilled_transactions AS (
     SELECT
@@ -38,12 +38,12 @@ WITH
       {{ source('arbitrum', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_arbitrum_ccip_transmitted_logs') }} ccip_tx ON ccip_tx.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND ccip_tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_tx.block_time') }}
       {% endif %}
       LEFT JOIN arbitrum_usd ON date_trunc('minute', tx.block_time) = arbitrum_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_fulfilled.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   arbitrum_usd AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_fulfilled.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_reverted.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_reverted',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_reverted_transactions AS (
     SELECT
@@ -38,14 +38,14 @@ WITH
       {{ ref('chainlink_arbitrum_ccip_transmitted_logs') }} tx
       LEFT JOIN {{ source('arbitrum', 'transactions') }} tx2 ON tx2.hash = tx.tx_hash
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('tx.block_time') }}
       {% endif %}
       LEFT JOIN arbitrum_usd ON date_trunc('minute', tx.block_time) = arbitrum_usd.block_time
     WHERE
       tx2.success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.tx_hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_reverted.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   arbitrum_usd AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_reverted.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_submission_transactions AS (
     SELECT
@@ -40,12 +40,12 @@ WITH
       {{ source('arbitrum', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_arbitrum_fm_gas_submission_logs') }} fm_gas_submission_logs ON fm_gas_submission_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND fm_gas_submission_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('fm_gas_submission_logs.block_time') }}
       {% endif %}
       LEFT JOIN arbitrum_usd ON date_trunc('minute', tx.block_time) = arbitrum_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   arbitrum_usd AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_arbitrum_fm_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_arbitrum_fm_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM fm_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   fm_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -55,7 +55,7 @@ WITH
     FROM fm_request_daily_meta
     LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   arbitrum_usd AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -28,8 +28,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -77,16 +77,16 @@ WITH
       1, 2
   ),
   fm_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_arbitrum_fm_reward_evt_transfer_daily')}} fm_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = fm_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = fm_reward_evt_transfer_daily.admin_address
@@ -101,7 +101,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   fm_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ FROM
   {{ref('chainlink_arbitrum_fm_reward_evt_transfer')}} fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reward_evt_transfer_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'arbitrum' as blockchain,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_fulfilled_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["arbitrum"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_fulfilled_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   arbitrum_usd AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_fulfilled_transactions AS (
     SELECT
@@ -45,8 +45,8 @@ WITH
       RIGHT JOIN {{ ref('chainlink_arbitrum_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
       LEFT JOIN arbitrum_usd ON date_trunc('minute', tx.block_time) = arbitrum_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -28,7 +28,7 @@ WITH
       {{ ref('chainlink_arbitrum_ocr_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -45,7 +45,7 @@ WITH
       {{ ref('chainlink_arbitrum_ocr_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -57,7 +57,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -90,7 +90,7 @@ WITH
     FROM ocr_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -101,7 +101,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ocr_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,7 +23,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -38,8 +38,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -59,7 +59,7 @@ WITH
     FROM ocr_request_daily_meta
     LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_request_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_reverted_transactions AS (
     SELECT
@@ -46,8 +46,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reverted_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["arbitrum"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reverted_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   arbitrum_usd AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -32,8 +32,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -81,16 +81,16 @@ WITH
       1, 2
   ),
   ocr_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_arbitrum_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
@@ -105,7 +105,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   ocr_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'arbitrum' as blockchain,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -27,8 +27,8 @@ FROM
   {{ref('chainlink_arbitrum_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_price_feeds.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds',
     partition_by=['block_month'],
     materialized='incremental',
@@ -27,11 +27,11 @@ SELECT 'arbitrum' as blockchain,
        c.proxy_address,
        c.aggregator_address,
        c.oracle_price / POWER(10, 0) as underlying_token_price,
-       CASE 
+       CASE
            WHEN cardinality(split(c.feed_name, ' / ')) = 1 THEN c.feed_name
            ELSE element_at(split(c.feed_name, ' / '), 1)
        END AS base,
-       CASE 
+       CASE
            WHEN cardinality(split(c.feed_name, ' / ')) = 1 THEN NULL
            ELSE element_at(split(c.feed_name, ' / '), 2)
        END AS quote
@@ -39,14 +39,14 @@ FROM
 (
     SELECT
         l.block_time,
-        cast(date_trunc('day', l.block_time) as date) as block_date, 
-        cast(date_trunc('month', l.block_time) as date) as block_month, 
+        cast(date_trunc('day', l.block_time) as date) as block_date,
+        cast(date_trunc('month', l.block_time) as date) as block_month,
         l.block_number,
         cfa.feed_name,
         cfa.proxy_address,
         MAX(cfa.aggregator_address) as aggregator_address,
         AVG(
-           CAST(bytearray_to_uint256(bytearray_substring(l.topic1, 3, 64)) as DOUBLE) 
+           CAST(bytearray_to_uint256(bytearray_substring(l.topic1, 3, 64)) as DOUBLE)
            / POWER(10, cfa.decimals)
         ) as oracle_price
     FROM
@@ -56,10 +56,10 @@ FROM
     WHERE
         l.topic0 = 0x0559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5f
         {% if not is_incremental() %}
-        AND l.block_time >= cast('{{project_start_date}}' as date) 
+        AND l.block_time >= cast('{{project_start_date}}' as date)
         {% endif %}
         {% if is_incremental() %}
-        AND l.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('l.block_time') }}
         {% endif %}
     GROUP BY
         1, 2, 3, 4, 5, 6

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_price_feeds.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2021-08-31' %}
 
 SELECT 'arbitrum' as blockchain,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_price_feeds_hourly.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds_hourly',
     partition_by=['block_month'],
     materialized='incremental',
@@ -25,7 +25,7 @@ WITH hourly_sequence_meta AS (
         AND price.minute >= timestamp '{{project_start_date}}'
       {% endif %}
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('price.minute') }}
       {% endif %}
     GROUP BY
       1
@@ -70,7 +70,7 @@ aggregated_price_feeds AS (
           hourly_sequence.hr >= timestamp '{{project_start_date}}'
         {% endif %}
         {% if is_incremental() %}
-          hourly_sequence.hr >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+          {{ incremental_predicate('hourly_sequence.hr') }}
         {% endif %}
     GROUP BY
         hourly_sequence.hr, hourly_sequence.feed_name, hourly_sequence.proxy_address, hourly_sequence.aggregator_address

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_price_feeds_hourly.sql
@@ -11,7 +11,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2019-10-01' %}
 
 WITH hourly_sequence_meta AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_arbitrum_vrf_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_arbitrum_vrf_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -84,7 +84,7 @@ WITH
       fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
     FROM vrf_gas_daily_meta
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -94,7 +94,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   vrf_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_request_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_request_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       total_requests
     FROM vrf_request_daily_meta
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_request_fulfilled_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_request_fulfilled_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_request_fulfilled_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -21,8 +21,8 @@ SELECT
 FROM
   {{ref('chainlink_arbitrum_vrf_request_fulfilled')}} vrf_request_fulfilled
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_request_fulfilled_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_request_fulfilled_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'arbitrum' as blockchain,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   arbitrum_usd AS (

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   vrf_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (
@@ -20,20 +19,20 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
       1
   ),
   vrf_reward_daily AS (
-    SELECT 
+    SELECT
       vrf_daily.date_start,
       cast(date_trunc('month', vrf_daily.date_start) as date) as date_month,
-      vrf_daily.operator_address,      
+      vrf_daily.operator_address,
       COALESCE(vrf_daily.token_amount, 0) as token_amount,
       COALESCE(vrf_daily.token_amount * lud.usd_amount, 0)  as usd_amount
-    FROM 
+    FROM
       {{ref('chainlink_arbitrum_vrf_request_fulfilled_daily')}} vrf_daily
     LEFT JOIN link_usd_daily lud ON lud.date_start = vrf_daily.date_start
     ORDER BY date_start
@@ -45,7 +44,7 @@ SELECT
   operator_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   vrf_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'AVAX'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   automation_fulfilled_transactions AS (
     SELECT
@@ -38,12 +38,12 @@ WITH
       {{ source('avalanche_c', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_avalanche_c_automation_upkeep_performed_logs') }} automation_upkeep_performed_logs ON automation_upkeep_performed_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND automation_upkeep_performed_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('automation_upkeep_performed_logs.block_time') }}
       {% endif %}
       LEFT JOIN avalanche_c_usd ON date_trunc('minute', tx.block_time) = avalanche_c_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   avalanche_c_usd AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_avalanche_c_automation_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_avalanche_c_automation_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM automation_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_avalanche_c_automation_meta') }} automation_meta ON automation_meta.keeper_address = automation_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   automation_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_performed_daily.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['date_start', 'keeper_address']
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.date_month')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_performed_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_performed_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ SELECT
 FROM
   {{ref('chainlink_avalanche_c_automation_performed')}} automation_performed
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_performed_daily.sql
@@ -6,7 +6,7 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['date_start', 'keeper_address']
+    unique_key=['date_start', 'keeper_address'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.date_month')]
   )
 }}

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_performed_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'avalanche_c' as blockchain,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_request_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_request_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       total_requests
     FROM automation_request_daily_meta
   )
-SELECT 
+SELECT
   automation_request_daily.blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   avalanche_c_usd AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'AVAX'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   automation_reverted_transactions AS (
     SELECT
@@ -40,8 +40,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (
@@ -20,21 +19,21 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
       1
   ),
   automation_reward_daily AS (
-    SELECT 
+    SELECT
       automation_performed_daily.date_start,
       cast(date_trunc('month', automation_performed_daily.date_start) as date) as date_month,
       automation_performed_daily.operator_name,
-      automation_performed_daily.keeper_address,   
+      automation_performed_daily.keeper_address,
       automation_performed_daily.token_amount as token_amount,
       (automation_performed_daily.token_amount * lud.usd_amount) as usd_amount
-    FROM 
+    FROM
       {{ref('chainlink_avalanche_c_automation_performed_daily')}} automation_performed_daily
     LEFT JOIN link_usd_daily lud ON lud.date_start = automation_performed_daily.date_start
     ORDER BY date_start
@@ -47,7 +46,7 @@ SELECT
   keeper_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   automation_reward_daily
 ORDER BY
   2, 5

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_fulfilled_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_fulfilled_transactions AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_fulfilled_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('avalanche_c', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('avalanche_c', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'avalanche_c' as blockchain,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_avalanche_c_ccip_transmitted_fulfilled') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_avalanche_c_ccip_transmitted_reverted') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -85,7 +85,7 @@ WITH
     FROM ccip_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_avalanche_c_ccip_operator_meta') }} ccip_operator_meta ON ccip_operator_meta.node_address = ccip_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -96,7 +96,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ccip_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_nop_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_nop_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -20,7 +20,7 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
@@ -38,22 +38,22 @@ FROM
   {{ref('chainlink_avalanche_c_ccip_nop_paid_logs')}} nop_logs
   LEFT JOIN {{ref('chainlink_avalanche_c_ccip_admin_meta')}} admin_meta ON admin_meta.admin_address = nop_logs.nop_address
 {% if is_incremental() %}
-  WHERE block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY
   2, 4
   ),
   nop_reward_daily AS (
-    SELECT 
+    SELECT
       nop_paid.date_start,
       cast(date_trunc('month', nop_paid.date_start) as date) as date_month,
       nop_paid.operator_name,
-      nop_paid.nop_address,   
+      nop_paid.nop_address,
       nop_paid.token_amount as token_amount,
       (nop_paid.token_amount * lud.usd_amount) as usd_amount
-    FROM 
+    FROM
       nop_paid
     LEFT JOIN link_usd_daily lud ON lud.date_start = nop_paid.date_start
     ORDER BY date_start
@@ -66,7 +66,7 @@ SELECT
   nop_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   nop_reward_daily
 ORDER BY
   2, 5

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_nop_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_request_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
 ethereum_agg AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_request_daily.sql
@@ -23,7 +23,7 @@ ethereum_agg AS (
                 WHERE
                     eth.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND eth.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('eth.block_time') }}
                 {% endif %}
             ) AS fulfilled_requests,
             (
@@ -34,7 +34,7 @@ ethereum_agg AS (
                 WHERE
                     rev.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND rev.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('rev.block_time') }}
                 {% endif %}
             ) AS reverted_requests
         FROM
@@ -52,7 +52,7 @@ ethereum_agg AS (
             ) AS seq
             CROSS JOIN UNNEST (seq.date_sequence) AS t (date_start)
             {% if is_incremental() %}
-                    WHERE date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    WHERE {{ incremental_predicate('date_start') }}
             {% endif %}
             ) date_series
     ),
@@ -67,7 +67,7 @@ ethereum_agg AS (
         FROM
             ethereum_agg
     )
-SELECT 
+SELECT
   ccip_request_daily.blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_reverted_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_reverted_transactions AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_reverted_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('avalanche_c', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('avalanche_c', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'avalanche_c' as blockchain,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_reward_daily.sql
@@ -28,7 +28,7 @@ WITH
             {{ source('prices', 'usd') }} price
         JOIN token_meta ON price.symbol = token_meta.token_symbol
         {% if is_incremental() %}
-            WHERE price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            WHERE {{ incremental_predicate('price.minute') }}
         {% endif %}
         GROUP BY
             1, token_meta.token_symbol
@@ -36,21 +36,21 @@ WITH
             1
     ),
     ccip_reward_daily AS (
-        SELECT 
+        SELECT
             ccip_send_requested_daily.date_start,
-            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,  
+            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,
             SUM(ccip_send_requested_daily.fee_amount) as token_amount,
             SUM((ccip_send_requested_daily.fee_amount * tud.usd_amount)) as usd_amount,
             ccip_send_requested_daily.token as token
-        FROM 
+        FROM
             {{ref('chainlink_avalanche_c_ccip_send_requested_daily')}} ccip_send_requested_daily
         LEFT JOIN token_usd_daily tud ON tud.date_start = ccip_send_requested_daily.date_start AND tud.symbol = ccip_send_requested_daily.token
         {% if is_incremental() %}
-            WHERE ccip_send_requested_daily.date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        {% endif %}  
+            WHERE {{ incremental_predicate('ccip_send_requested_daily.date_start') }}
+        {% endif %}
         GROUP BY 1, 5
     )
-    
+
 SELECT
     'avalanche_c' as blockchain,
     date_start,
@@ -58,7 +58,7 @@ SELECT
     token_amount,
     usd_amount,
     token
-FROM 
+FROM
     ccip_reward_daily
 ORDER BY
     2, 6

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_reward_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
     token_meta AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_send_requested_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_send_requested_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ SELECT
 FROM
   {{ref('chainlink_avalanche_c_ccip_send_requested')}} ccip_send_requested
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 5, 6
 ORDER BY

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_send_requested_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'avalanche_c' as blockchain,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_fulfilled.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   avalanche_c_usd AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_fulfilled.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_fulfilled.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_fulfilled',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'AVAX'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_fulfilled_transactions AS (
     SELECT
@@ -38,12 +38,12 @@ WITH
       {{ source('avalanche_c', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_avalanche_c_ccip_transmitted_logs') }} ccip_tx ON ccip_tx.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND ccip_tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_tx.block_time') }}
       {% endif %}
       LEFT JOIN avalanche_c_usd ON date_trunc('minute', tx.block_time) = avalanche_c_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_reverted.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_reverted',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'AVAX'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_reverted_transactions AS (
     SELECT
@@ -38,14 +38,14 @@ WITH
       {{ ref('chainlink_avalanche_c_ccip_transmitted_logs') }} tx
       LEFT JOIN {{ source('avalanche_c', 'transactions') }} tx2 ON tx2.hash = tx.tx_hash
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('tx.block_time') }}
       {% endif %}
       LEFT JOIN avalanche_c_usd ON date_trunc('minute', tx.block_time) = avalanche_c_usd.block_time
     WHERE
       tx2.success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.tx_hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_reverted.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   avalanche_c_usd AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_reverted.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   avalanche_c_usd AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'AVAX'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_submission_transactions AS (
     SELECT
@@ -40,12 +40,12 @@ WITH
       {{ source('avalanche_c', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_avalanche_c_fm_gas_submission_logs') }} fm_gas_submission_logs ON fm_gas_submission_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND fm_gas_submission_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('fm_gas_submission_logs.block_time') }}
       {% endif %}
       LEFT JOIN avalanche_c_usd ON date_trunc('minute', tx.block_time) = avalanche_c_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_avalanche_c_fm_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_avalanche_c_fm_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM fm_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   fm_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -55,7 +55,7 @@ WITH
     FROM fm_request_daily_meta
     LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'AVAX'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   avalanche_c_usd AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -28,8 +28,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -77,16 +77,16 @@ WITH
       1, 2
   ),
   fm_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_avalanche_c_fm_reward_evt_transfer_daily')}} fm_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = fm_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = fm_reward_evt_transfer_daily.admin_address
@@ -101,7 +101,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   fm_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ FROM
   {{ref('chainlink_avalanche_c_fm_reward_evt_transfer')}} fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reward_evt_transfer_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'avalanche_c' as blockchain,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_fulfilled_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   avalanche_c_usd AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_fulfilled_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["avalanche_c"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'AVAX'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_fulfilled_transactions AS (
     SELECT
@@ -43,8 +43,8 @@ WITH
       RIGHT JOIN {{ ref('chainlink_avalanche_c_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
       LEFT JOIN avalanche_c_usd ON date_trunc('minute', tx.block_time) = avalanche_c_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -28,7 +28,7 @@ WITH
       {{ ref('chainlink_avalanche_c_ocr_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -45,7 +45,7 @@ WITH
       {{ ref('chainlink_avalanche_c_ocr_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -57,7 +57,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -90,7 +90,7 @@ WITH
     FROM ocr_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -101,7 +101,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ocr_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_gas_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,7 +23,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -38,8 +38,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -59,7 +59,7 @@ WITH
     FROM ocr_request_daily_meta
     LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_request_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reverted_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   avalanche_c_usd AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'AVAX'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_reverted_transactions AS (
     SELECT
@@ -44,8 +44,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reverted_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["avalanche_c"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -32,8 +32,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -81,16 +81,16 @@ WITH
       1, 2
   ),
   ocr_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_avalanche_c_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
@@ -105,7 +105,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   ocr_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -27,8 +27,8 @@ FROM
   {{ref('chainlink_avalanche_c_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'avalanche_c' as blockchain,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_price_feeds.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2020-09-21' %}
 
 SELECT 'avalanche_c' as blockchain,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_price_feeds.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds',
     partition_by=['block_month'],
     materialized='incremental',
@@ -27,11 +27,11 @@ SELECT 'avalanche_c' as blockchain,
        c.proxy_address,
        c.aggregator_address,
        c.oracle_price / POWER(10, 0) as underlying_token_price,
-       CASE 
+       CASE
            WHEN cardinality(split(c.feed_name, ' / ')) = 1 THEN c.feed_name
            ELSE element_at(split(c.feed_name, ' / '), 1)
        END AS base,
-       CASE 
+       CASE
            WHEN cardinality(split(c.feed_name, ' / ')) = 1 THEN NULL
            ELSE element_at(split(c.feed_name, ' / '), 2)
        END AS quote
@@ -39,14 +39,14 @@ FROM
 (
     SELECT
         l.block_time,
-        cast(date_trunc('day', l.block_time) as date) as block_date, 
-        cast(date_trunc('month', l.block_time) as date) as block_month, 
+        cast(date_trunc('day', l.block_time) as date) as block_date,
+        cast(date_trunc('month', l.block_time) as date) as block_month,
         l.block_number,
         cfa.feed_name,
         cfa.proxy_address,
         MAX(cfa.aggregator_address) as aggregator_address,
         AVG(
-           CAST(bytearray_to_uint256(bytearray_substring(l.topic1, 3, 64)) as DOUBLE) 
+           CAST(bytearray_to_uint256(bytearray_substring(l.topic1, 3, 64)) as DOUBLE)
            / POWER(10, cfa.decimals)
         ) as oracle_price
     FROM
@@ -56,10 +56,10 @@ FROM
     WHERE
         l.topic0 = 0x0559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5f
         {% if not is_incremental() %}
-        AND l.block_time >= cast('{{project_start_date}}' as date) 
+        AND l.block_time >= cast('{{project_start_date}}' as date)
         {% endif %}
         {% if is_incremental() %}
-        AND l.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('l.block_time') }}
         {% endif %}
     GROUP BY
         1, 2, 3, 4, 5, 6

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_price_feeds_hourly.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds_hourly',
     partition_by=['block_month'],
     materialized='incremental',
@@ -25,7 +25,7 @@ WITH hourly_sequence_meta AS (
         AND price.minute >= timestamp '{{project_start_date}}'
       {% endif %}
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('price.minute') }}
       {% endif %}
     GROUP BY
       1
@@ -70,7 +70,7 @@ aggregated_price_feeds AS (
           hourly_sequence.hr >= timestamp '{{project_start_date}}'
         {% endif %}
         {% if is_incremental() %}
-          hourly_sequence.hr >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+          {{ incremental_predicate('hourly_sequence.hr') }}
         {% endif %}
     GROUP BY
         hourly_sequence.hr, hourly_sequence.feed_name, hourly_sequence.proxy_address, hourly_sequence.aggregator_address

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_price_feeds_hourly.sql
@@ -11,7 +11,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2019-10-01' %}
 
 WITH hourly_sequence_meta AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_fulfilled_transactions.sql
@@ -1,12 +1,13 @@
 {{
   config(
-    
+
     alias='vrf_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 
@@ -22,7 +23,7 @@ WITH
       {% if is_incremental() %}
         AND
            {{ incremental_predicate('minute') }}
-      {% endif %}      
+      {% endif %}
   ),
   vrf_fulfilled_transactions AS (
     SELECT
@@ -39,14 +40,14 @@ WITH
       {{ source('avalanche_c', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_avalanche_c_vrf_v1_random_fulfilled_logs') }} vrf_v1_logs ON vrf_v1_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND 
+        AND
           {{ incremental_predicate('tx.block_time') }}
       {% endif %}
       LEFT JOIN avalanche_c_usd ON date_trunc('minute', tx.block_time) = avalanche_c_usd.block_time
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
-    {% endif %}      
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,
@@ -75,7 +76,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
-    {% endif %}      
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_avalanche_c_vrf_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_avalanche_c_vrf_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -85,7 +85,7 @@ WITH
       fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
     FROM vrf_gas_daily_meta
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -95,7 +95,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   vrf_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_request_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_request_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       total_requests
     FROM vrf_request_daily_meta
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_request_fulfilled_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_request_fulfilled_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_request_fulfilled_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -21,8 +21,8 @@ SELECT
 FROM
   {{ref('chainlink_avalanche_c_vrf_request_fulfilled')}} vrf_request_fulfilled
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_request_fulfilled_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_request_fulfilled_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'avalanche_c' as blockchain,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   avalanche_c_usd AS (

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'AVAX'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   vrf_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (
@@ -20,20 +19,20 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
       1
   ),
   vrf_reward_daily AS (
-    SELECT 
+    SELECT
       vrf_daily.date_start,
       cast(date_trunc('month', vrf_daily.date_start) as date) as date_month,
-      vrf_daily.operator_address,      
+      vrf_daily.operator_address,
       COALESCE(vrf_daily.token_amount, 0) as token_amount,
       COALESCE(vrf_daily.token_amount * lud.usd_amount, 0)  as usd_amount
-    FROM 
+    FROM
       {{ref('chainlink_avalanche_c_vrf_request_fulfilled_daily')}} vrf_daily
     LEFT JOIN link_usd_daily lud ON lud.date_start = vrf_daily.date_start
     ORDER BY date_start
@@ -45,7 +44,7 @@ SELECT
   operator_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   vrf_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_fulfilled_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_fulfilled_transactions AS (

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_fulfilled_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('base', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('base', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'base' as blockchain,

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_base_ccip_transmitted_fulfilled') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_base_ccip_transmitted_reverted') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM ccip_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_base_ccip_operator_meta') }} ccip_operator_meta ON ccip_operator_meta.node_address = ccip_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ccip_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_nop_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_nop_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_nop_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -20,7 +20,7 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
@@ -38,22 +38,22 @@ FROM
   {{ref('chainlink_base_ccip_nop_paid_logs')}} nop_logs
   LEFT JOIN {{ref('chainlink_base_ccip_admin_meta')}} admin_meta ON admin_meta.admin_address = nop_logs.nop_address
 {% if is_incremental() %}
-  WHERE block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY
   2, 4
   ),
   nop_reward_daily AS (
-    SELECT 
+    SELECT
       nop_paid.date_start,
       cast(date_trunc('month', nop_paid.date_start) as date) as date_month,
       nop_paid.operator_name,
-      nop_paid.nop_address,   
+      nop_paid.nop_address,
       nop_paid.token_amount as token_amount,
       (nop_paid.token_amount * lud.usd_amount) as usd_amount
-    FROM 
+    FROM
       nop_paid
     LEFT JOIN link_usd_daily lud ON lud.date_start = nop_paid.date_start
     ORDER BY date_start
@@ -66,7 +66,7 @@ SELECT
   nop_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   nop_reward_daily
 ORDER BY
   2, 5

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_request_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
 ethereum_agg AS (

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_request_daily.sql
@@ -23,7 +23,7 @@ ethereum_agg AS (
                 WHERE
                     eth.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND eth.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('eth.block_time') }}
                 {% endif %}
             ) AS fulfilled_requests,
             (
@@ -34,7 +34,7 @@ ethereum_agg AS (
                 WHERE
                     rev.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND rev.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('rev.block_time') }}
                 {% endif %}
             ) AS reverted_requests
         FROM
@@ -52,7 +52,7 @@ ethereum_agg AS (
             ) AS seq
             CROSS JOIN UNNEST (seq.date_sequence) AS t (date_start)
             {% if is_incremental() %}
-                    WHERE date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    WHERE {{ incremental_predicate('date_start') }}
             {% endif %}
             ) date_series
     ),
@@ -67,7 +67,7 @@ ethereum_agg AS (
         FROM
             ethereum_agg
     )
-SELECT 
+SELECT
   ccip_request_daily.blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_reverted_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_reverted_transactions AS (

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_reverted_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('base', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('base', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'base' as blockchain,

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_reward_daily.sql
@@ -28,7 +28,7 @@ WITH
             {{ source('prices', 'usd') }} price
         JOIN token_meta ON price.symbol = token_meta.token_symbol
         {% if is_incremental() %}
-            WHERE price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            WHERE {{ incremental_predicate('price.minute') }}
         {% endif %}
         GROUP BY
             1, token_meta.token_symbol
@@ -36,21 +36,21 @@ WITH
             1
     ),
     ccip_reward_daily AS (
-        SELECT 
+        SELECT
             ccip_send_requested_daily.date_start,
-            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,  
+            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,
             SUM(ccip_send_requested_daily.fee_amount) as token_amount,
             SUM((ccip_send_requested_daily.fee_amount * tud.usd_amount)) as usd_amount,
             ccip_send_requested_daily.token as token
-        FROM 
+        FROM
             {{ref('chainlink_base_ccip_send_requested_daily')}} ccip_send_requested_daily
         LEFT JOIN token_usd_daily tud ON tud.date_start = ccip_send_requested_daily.date_start AND tud.symbol = ccip_send_requested_daily.token
         {% if is_incremental() %}
-            WHERE ccip_send_requested_daily.date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        {% endif %}  
+            WHERE {{ incremental_predicate('ccip_send_requested_daily.date_start') }}
+        {% endif %}
         GROUP BY 1, 5
     )
-    
+
 SELECT
     'base' as blockchain,
     date_start,
@@ -58,7 +58,7 @@ SELECT
     token_amount,
     usd_amount,
     token
-FROM 
+FROM
     ccip_reward_daily
 ORDER BY
     2, 6

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_reward_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
     token_meta AS (

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_send_requested_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'base' as blockchain,

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_send_requested_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_send_requested_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ SELECT
 FROM
   {{ref('chainlink_base_ccip_send_requested')}} ccip_send_requested
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 5, 6
 ORDER BY

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_fulfilled.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_fulfilled',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_fulfilled_transactions AS (
     SELECT
@@ -38,12 +38,12 @@ WITH
       {{ source('base', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_base_ccip_transmitted_logs') }} ccip_tx ON ccip_tx.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND ccip_tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_tx.block_time') }}
       {% endif %}
       LEFT JOIN base_usd ON date_trunc('minute', tx.block_time) = base_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_fulfilled.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   base_usd AS (

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_fulfilled.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_reverted.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   base_usd AS (

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_reverted.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_reverted.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_reverted',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_reverted_transactions AS (
     SELECT
@@ -38,14 +38,14 @@ WITH
       {{ ref('chainlink_base_ccip_transmitted_logs') }} tx
       LEFT JOIN {{ source('base', 'transactions') }} tx2 ON tx2.hash = tx.tx_hash
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('tx.block_time') }}
       {% endif %}
       LEFT JOIN base_usd ON date_trunc('minute', tx.block_time) = base_usd.block_time
     WHERE
       tx2.success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.tx_hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   bnb_usd AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'BNB'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   automation_fulfilled_transactions AS (
     SELECT
@@ -38,12 +38,12 @@ WITH
       {{ source('bnb', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_bnb_automation_upkeep_performed_logs') }} automation_upkeep_performed_logs ON automation_upkeep_performed_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND automation_upkeep_performed_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('automation_upkeep_performed_logs.block_time') }}
       {% endif %}
       LEFT JOIN bnb_usd ON date_trunc('minute', tx.block_time) = bnb_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_bnb_automation_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_bnb_automation_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM automation_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_bnb_automation_meta') }} automation_meta ON automation_meta.keeper_address = automation_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   automation_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_performed_daily.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['date_start', 'keeper_address']
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.date_month')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_performed_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'bnb' as blockchain,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_performed_daily.sql
@@ -6,7 +6,7 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['date_start', 'keeper_address']
+    unique_key=['date_start', 'keeper_address'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.date_month')]
   )
 }}

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_performed_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_performed_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ SELECT
 FROM
   {{ref('chainlink_bnb_automation_performed')}} automation_performed
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_request_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_request_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       total_requests
     FROM automation_request_daily_meta
   )
-SELECT 
+SELECT
   automation_request_daily.blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'BNB'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   automation_reverted_transactions AS (
     SELECT
@@ -40,8 +40,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   bnb_usd AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (
@@ -20,21 +19,21 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
       1
   ),
   automation_reward_daily AS (
-    SELECT 
+    SELECT
       automation_performed_daily.date_start,
       cast(date_trunc('month', automation_performed_daily.date_start) as date) as date_month,
       automation_performed_daily.operator_name,
-      automation_performed_daily.keeper_address,   
+      automation_performed_daily.keeper_address,
       automation_performed_daily.token_amount as token_amount,
       (automation_performed_daily.token_amount * lud.usd_amount) as usd_amount
-    FROM 
+    FROM
       {{ref('chainlink_bnb_automation_performed_daily')}} automation_performed_daily
     LEFT JOIN link_usd_daily lud ON lud.date_start = automation_performed_daily.date_start
     ORDER BY date_start
@@ -47,7 +46,7 @@ SELECT
   keeper_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   automation_reward_daily
 ORDER BY
   2, 5

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_fulfilled_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('bnb', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('bnb', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'bnb' as blockchain,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_fulfilled_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_fulfilled_transactions AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_bnb_ccip_transmitted_fulfilled') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_bnb_ccip_transmitted_reverted') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM ccip_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_bnb_ccip_operator_meta') }} ccip_operator_meta ON ccip_operator_meta.node_address = ccip_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ccip_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_nop_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_nop_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_nop_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -20,7 +20,7 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
@@ -38,22 +38,22 @@ FROM
   {{ref('chainlink_bnb_ccip_nop_paid_logs')}} nop_logs
   LEFT JOIN {{ref('chainlink_bnb_ccip_admin_meta')}} admin_meta ON admin_meta.admin_address = nop_logs.nop_address
 {% if is_incremental() %}
-  WHERE block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY
   2, 4
   ),
   nop_reward_daily AS (
-    SELECT 
+    SELECT
       nop_paid.date_start,
       cast(date_trunc('month', nop_paid.date_start) as date) as date_month,
       nop_paid.operator_name,
-      nop_paid.nop_address,   
+      nop_paid.nop_address,
       nop_paid.token_amount as token_amount,
       (nop_paid.token_amount * lud.usd_amount) as usd_amount
-    FROM 
+    FROM
       nop_paid
     LEFT JOIN link_usd_daily lud ON lud.date_start = nop_paid.date_start
     ORDER BY date_start
@@ -66,7 +66,7 @@ SELECT
   nop_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   nop_reward_daily
 ORDER BY
   2, 5

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_request_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
 ethereum_agg AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_request_daily.sql
@@ -23,7 +23,7 @@ ethereum_agg AS (
                 WHERE
                     eth.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND eth.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('eth.block_time') }}
                 {% endif %}
             ) AS fulfilled_requests,
             (
@@ -34,7 +34,7 @@ ethereum_agg AS (
                 WHERE
                     rev.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND rev.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('rev.block_time') }}
                 {% endif %}
             ) AS reverted_requests
         FROM
@@ -52,7 +52,7 @@ ethereum_agg AS (
             ) AS seq
             CROSS JOIN UNNEST (seq.date_sequence) AS t (date_start)
             {% if is_incremental() %}
-                    WHERE date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    WHERE {{ incremental_predicate('date_start') }}
             {% endif %}
             ) date_series
     ),
@@ -67,7 +67,7 @@ ethereum_agg AS (
         FROM
             ethereum_agg
     )
-SELECT 
+SELECT
   ccip_request_daily.blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_reverted_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('bnb', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('bnb', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'bnb' as blockchain,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_reverted_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_reverted_transactions AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_reward_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
     token_meta AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_reward_daily.sql
@@ -28,7 +28,7 @@ WITH
             {{ source('prices', 'usd') }} price
         JOIN token_meta ON price.symbol = token_meta.token_symbol
         {% if is_incremental() %}
-            WHERE price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            WHERE {{ incremental_predicate('price.minute') }}
         {% endif %}
         GROUP BY
             1, token_meta.token_symbol
@@ -36,21 +36,21 @@ WITH
             1
     ),
     ccip_reward_daily AS (
-        SELECT 
+        SELECT
             ccip_send_requested_daily.date_start,
-            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,  
+            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,
             SUM(ccip_send_requested_daily.fee_amount) as token_amount,
             SUM((ccip_send_requested_daily.fee_amount * tud.usd_amount)) as usd_amount,
             ccip_send_requested_daily.token as token
-        FROM 
+        FROM
             {{ref('chainlink_bnb_ccip_send_requested_daily')}} ccip_send_requested_daily
         LEFT JOIN token_usd_daily tud ON tud.date_start = ccip_send_requested_daily.date_start AND tud.symbol = ccip_send_requested_daily.token
         {% if is_incremental() %}
-            WHERE ccip_send_requested_daily.date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        {% endif %}  
+            WHERE {{ incremental_predicate('ccip_send_requested_daily.date_start') }}
+        {% endif %}
         GROUP BY 1, 5
     )
-    
+
 SELECT
     'bnb' as blockchain,
     date_start,
@@ -58,7 +58,7 @@ SELECT
     token_amount,
     usd_amount,
     token
-FROM 
+FROM
     ccip_reward_daily
 ORDER BY
     2, 6

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_send_requested_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'bnb' as blockchain,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_send_requested_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_send_requested_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ SELECT
 FROM
   {{ref('chainlink_bnb_ccip_send_requested')}} ccip_send_requested
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 5, 6
 ORDER BY

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_fulfilled.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_fulfilled',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'BNB'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_fulfilled_transactions AS (
     SELECT
@@ -38,12 +38,12 @@ WITH
       {{ source('bnb', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_bnb_ccip_transmitted_logs') }} ccip_tx ON ccip_tx.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND ccip_tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_tx.block_time') }}
       {% endif %}
       LEFT JOIN bnb_usd ON date_trunc('minute', tx.block_time) = bnb_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_fulfilled.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_fulfilled.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   bnb_usd AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_reverted.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_reverted',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'BNB'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_reverted_transactions AS (
     SELECT
@@ -38,14 +38,14 @@ WITH
       {{ ref('chainlink_bnb_ccip_transmitted_logs') }} tx
       LEFT JOIN {{ source('bnb', 'transactions') }} tx2 ON tx2.hash = tx.tx_hash
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('tx.block_time') }}
       {% endif %}
       LEFT JOIN bnb_usd ON date_trunc('minute', tx.block_time) = bnb_usd.block_time
     WHERE
       tx2.success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.tx_hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_reverted.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_reverted.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   bnb_usd AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'BNB'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_submission_transactions AS (
     SELECT
@@ -40,12 +40,12 @@ WITH
       {{ source('bnb', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_bnb_fm_gas_submission_logs') }} fm_gas_submission_logs ON fm_gas_submission_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND fm_gas_submission_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('fm_gas_submission_logs.block_time') }}
       {% endif %}
       LEFT JOIN bnb_usd ON date_trunc('minute', tx.block_time) = bnb_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   bnb_usd AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_bnb_fm_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_bnb_fm_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM fm_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   fm_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -55,7 +55,7 @@ WITH
     FROM fm_request_daily_meta
     LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'BNB'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   bnb_usd AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -28,8 +28,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -77,16 +77,16 @@ WITH
       1, 2
   ),
   fm_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_bnb_fm_reward_evt_transfer_daily')}} fm_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = fm_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = fm_reward_evt_transfer_daily.admin_address
@@ -101,7 +101,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   fm_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ FROM
   {{ref('chainlink_bnb_fm_reward_evt_transfer')}} fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reward_evt_transfer_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'bnb' as blockchain,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_fulfilled_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   bnb_usd AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'BNB'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_fulfilled_transactions AS (
     SELECT
@@ -43,8 +43,8 @@ WITH
       RIGHT JOIN {{ ref('chainlink_bnb_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
       LEFT JOIN bnb_usd ON date_trunc('minute', tx.block_time) = bnb_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_fulfilled_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["bnb"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -28,7 +28,7 @@ WITH
       {{ ref('chainlink_bnb_ocr_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -45,7 +45,7 @@ WITH
       {{ ref('chainlink_bnb_ocr_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -57,7 +57,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -90,7 +90,7 @@ WITH
     FROM ocr_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -101,7 +101,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ocr_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_gas_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,7 +23,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -38,8 +38,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -59,7 +59,7 @@ WITH
     FROM ocr_request_daily_meta
     LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_request_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reverted_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   bnb_usd AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'BNB'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_reverted_transactions AS (
     SELECT
@@ -44,8 +44,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reverted_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["bnb"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reward_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -32,8 +32,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -81,16 +81,16 @@ WITH
       1, 2
   ),
   ocr_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_bnb_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
@@ -105,7 +105,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   ocr_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'bnb' as blockchain,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -27,8 +27,8 @@ FROM
   {{ref('chainlink_bnb_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_price_feeds.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2020-08-29' %}
 
 SELECT 'bnb' as blockchain,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_price_feeds.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds',
     partition_by=['block_month'],
     materialized='incremental',
@@ -27,11 +27,11 @@ SELECT 'bnb' as blockchain,
        c.proxy_address,
        c.aggregator_address,
        c.oracle_price / POWER(10, 0) as underlying_token_price,
-       CASE 
+       CASE
            WHEN cardinality(split(c.feed_name, ' / ')) = 1 THEN c.feed_name
            ELSE element_at(split(c.feed_name, ' / '), 1)
        END AS base,
-       CASE 
+       CASE
            WHEN cardinality(split(c.feed_name, ' / ')) = 1 THEN NULL
            ELSE element_at(split(c.feed_name, ' / '), 2)
        END AS quote
@@ -39,14 +39,14 @@ FROM
 (
     SELECT
         l.block_time,
-        cast(date_trunc('day', l.block_time) as date) as block_date, 
-        cast(date_trunc('month', l.block_time) as date) as block_month, 
+        cast(date_trunc('day', l.block_time) as date) as block_date,
+        cast(date_trunc('month', l.block_time) as date) as block_month,
         l.block_number,
         cfa.feed_name,
         cfa.proxy_address,
         MAX(cfa.aggregator_address) as aggregator_address,
         AVG(
-           CAST(bytearray_to_uint256(bytearray_substring(l.topic1, 3, 64)) as DOUBLE) 
+           CAST(bytearray_to_uint256(bytearray_substring(l.topic1, 3, 64)) as DOUBLE)
            / POWER(10, cfa.decimals)
         ) as oracle_price
     FROM
@@ -56,10 +56,10 @@ FROM
     WHERE
         l.topic0 = 0x0559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5f
         {% if not is_incremental() %}
-        AND l.block_time >= cast('{{project_start_date}}' as date) 
+        AND l.block_time >= cast('{{project_start_date}}' as date)
         {% endif %}
         {% if is_incremental() %}
-        AND l.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('l.block_time') }}
         {% endif %}
     GROUP BY
         1, 2, 3, 4, 5, 6

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_price_feeds_hourly.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds_hourly',
     partition_by=['block_month'],
     materialized='incremental',
@@ -25,7 +25,7 @@ WITH hourly_sequence_meta AS (
         AND price.minute >= timestamp '{{project_start_date}}'
       {% endif %}
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('price.minute') }}
       {% endif %}
     GROUP BY
       1
@@ -70,7 +70,7 @@ aggregated_price_feeds AS (
           hourly_sequence.hr >= timestamp '{{project_start_date}}'
         {% endif %}
         {% if is_incremental() %}
-          hourly_sequence.hr >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+          {{ incremental_predicate('hourly_sequence.hr') }}
         {% endif %}
     GROUP BY
         hourly_sequence.hr, hourly_sequence.feed_name, hourly_sequence.proxy_address, hourly_sequence.aggregator_address

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_price_feeds_hourly.sql
@@ -11,7 +11,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2019-10-01' %}
 
 WITH hourly_sequence_meta AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_fulfilled_transactions.sql
@@ -1,12 +1,13 @@
 {{
   config(
-    
+
     alias='vrf_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 
@@ -22,7 +23,7 @@ WITH
       {% if is_incremental() %}
         AND
            {{ incremental_predicate('minute') }}
-      {% endif %}      
+      {% endif %}
   ),
   vrf_fulfilled_transactions AS (
     SELECT
@@ -39,14 +40,14 @@ WITH
       {{ source('bnb', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_bnb_vrf_v1_random_fulfilled_logs') }} vrf_v1_logs ON vrf_v1_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND 
+        AND
           {{ incremental_predicate('tx.block_time') }}
       {% endif %}
       LEFT JOIN bnb_usd ON date_trunc('minute', tx.block_time) = bnb_usd.block_time
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
-    {% endif %}      
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,
@@ -75,7 +76,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
-    {% endif %}      
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_bnb_vrf_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_bnb_vrf_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -84,7 +84,7 @@ WITH
       fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
     FROM vrf_gas_daily_meta
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -94,7 +94,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   vrf_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_request_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_request_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       total_requests
     FROM vrf_request_daily_meta
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_request_fulfilled_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_request_fulfilled_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'bnb' as blockchain,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_request_fulfilled_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_request_fulfilled_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_request_fulfilled_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -21,8 +21,8 @@ SELECT
 FROM
   {{ref('chainlink_bnb_vrf_request_fulfilled')}} vrf_request_fulfilled
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'BNB'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   vrf_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   bnb_usd AS (

--- a/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (
@@ -20,20 +19,20 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
       1
   ),
   vrf_reward_daily AS (
-    SELECT 
+    SELECT
       vrf_daily.date_start,
       cast(date_trunc('month', vrf_daily.date_start) as date) as date_month,
-      vrf_daily.operator_address,      
+      vrf_daily.operator_address,
       COALESCE(vrf_daily.token_amount, 0) as token_amount,
       COALESCE(vrf_daily.token_amount * lud.usd_amount, 0)  as usd_amount
-    FROM 
+    FROM
       {{ref('chainlink_bnb_vrf_request_fulfilled_daily')}} vrf_daily
     LEFT JOIN link_usd_daily lud ON lud.date_start = vrf_daily.date_start
     ORDER BY date_start
@@ -45,7 +44,7 @@ SELECT
   operator_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   vrf_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ethereum_usd AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   automation_fulfilled_transactions AS (
     SELECT
@@ -38,12 +38,12 @@ WITH
       {{ source('ethereum', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_ethereum_automation_upkeep_performed_logs') }} automation_upkeep_performed_logs ON automation_upkeep_performed_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND automation_upkeep_performed_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('automation_upkeep_performed_logs.block_time') }}
       {% endif %}
       LEFT JOIN ethereum_usd ON date_trunc('minute', tx.block_time) = ethereum_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_performed_daily.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['date_start', 'keeper_address']
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.date_month')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_performed_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'ethereum' as blockchain,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_performed_daily.sql
@@ -6,7 +6,7 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['date_start', 'keeper_address']
+    unique_key=['date_start', 'keeper_address'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.date_month')]
   )
 }}

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_performed_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_performed_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ SELECT
 FROM
   {{ref('chainlink_ethereum_automation_performed')}} automation_performed
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_request_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_request_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       total_requests
     FROM automation_request_daily_meta
   )
-SELECT 
+SELECT
   automation_request_daily.blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ethereum_usd AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   automation_reverted_transactions AS (
     SELECT
@@ -40,8 +40,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (
@@ -20,21 +19,21 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
       1
   ),
   automation_reward_daily AS (
-    SELECT 
+    SELECT
       automation_performed_daily.date_start,
       cast(date_trunc('month', automation_performed_daily.date_start) as date) as date_month,
       automation_performed_daily.operator_name,
-      automation_performed_daily.keeper_address,   
+      automation_performed_daily.keeper_address,
       automation_performed_daily.token_amount as token_amount,
       (automation_performed_daily.token_amount * lud.usd_amount) as usd_amount
-    FROM 
+    FROM
       {{ref('chainlink_ethereum_automation_performed_daily')}} automation_performed_daily
     LEFT JOIN link_usd_daily lud ON lud.date_start = automation_performed_daily.date_start
     ORDER BY date_start
@@ -47,7 +46,7 @@ SELECT
   keeper_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   automation_reward_daily
 ORDER BY
   2, 5

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_fulfilled_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_fulfilled_transactions AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_fulfilled_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('ethereum', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('ethereum', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'ethereum' as blockchain,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_ethereum_ccip_transmitted_fulfilled') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_ethereum_ccip_transmitted_reverted') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM ccip_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_ethereum_ccip_operator_meta') }} ccip_operator_meta ON ccip_operator_meta.node_address = ccip_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ccip_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_nop_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_nop_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -20,7 +20,7 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
@@ -38,22 +38,22 @@ FROM
   {{ref('chainlink_ethereum_ccip_nop_paid_logs')}} nop_logs
   LEFT JOIN {{ref('chainlink_ethereum_ccip_admin_meta')}} admin_meta ON admin_meta.admin_address = nop_logs.nop_address
 {% if is_incremental() %}
-  WHERE block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY
   2, 4
   ),
   nop_reward_daily AS (
-    SELECT 
+    SELECT
       nop_paid.date_start,
       cast(date_trunc('month', nop_paid.date_start) as date) as date_month,
       nop_paid.operator_name,
-      nop_paid.nop_address,   
+      nop_paid.nop_address,
       nop_paid.token_amount as token_amount,
       (nop_paid.token_amount * lud.usd_amount) as usd_amount
-    FROM 
+    FROM
       nop_paid
     LEFT JOIN link_usd_daily lud ON lud.date_start = nop_paid.date_start
     ORDER BY date_start
@@ -66,7 +66,7 @@ SELECT
   nop_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   nop_reward_daily
 ORDER BY
   2, 5

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_nop_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_request_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
 ethereum_agg AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_request_daily.sql
@@ -23,7 +23,7 @@ ethereum_agg AS (
                 WHERE
                     eth.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND eth.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('eth.block_time') }}
                 {% endif %}
             ) AS fulfilled_requests,
             (
@@ -34,7 +34,7 @@ ethereum_agg AS (
                 WHERE
                     rev.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND rev.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('rev.block_time') }}
                 {% endif %}
             ) AS reverted_requests
         FROM
@@ -52,7 +52,7 @@ ethereum_agg AS (
             ) AS seq
             CROSS JOIN UNNEST (seq.date_sequence) AS t (date_start)
             {% if is_incremental() %}
-                    WHERE date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    WHERE {{ incremental_predicate('date_start') }}
             {% endif %}
             ) date_series
     ),
@@ -67,7 +67,7 @@ ethereum_agg AS (
         FROM
             ethereum_agg
     )
-SELECT 
+SELECT
   ccip_request_daily.blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_reverted_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('ethereum', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('ethereum', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'ethereum' as blockchain,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_reverted_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_reverted_transactions AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_reward_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
     token_meta AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_reward_daily.sql
@@ -28,7 +28,7 @@ WITH
             {{ source('prices', 'usd') }} price
         JOIN token_meta ON price.symbol = token_meta.token_symbol
         {% if is_incremental() %}
-            WHERE price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            WHERE {{ incremental_predicate('price.minute') }}
         {% endif %}
         GROUP BY
             1, token_meta.token_symbol
@@ -36,21 +36,21 @@ WITH
             1
     ),
     ccip_reward_daily AS (
-        SELECT 
+        SELECT
             ccip_send_requested_daily.date_start,
-            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,  
+            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,
             SUM(ccip_send_requested_daily.fee_amount) as token_amount,
             SUM((ccip_send_requested_daily.fee_amount * tud.usd_amount)) as usd_amount,
             ccip_send_requested_daily.token as token
-        FROM 
+        FROM
             {{ref('chainlink_ethereum_ccip_send_requested_daily')}} ccip_send_requested_daily
         LEFT JOIN token_usd_daily tud ON tud.date_start = ccip_send_requested_daily.date_start AND tud.symbol = ccip_send_requested_daily.token
         {% if is_incremental() %}
-            WHERE ccip_send_requested_daily.date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        {% endif %}  
+            WHERE {{ incremental_predicate('ccip_send_requested_daily.date_start') }}
+        {% endif %}
         GROUP BY 1, 5
     )
-    
+
 SELECT
     'ethereum' as blockchain,
     date_start,
@@ -58,7 +58,7 @@ SELECT
     token_amount,
     usd_amount,
     token
-FROM 
+FROM
     ccip_reward_daily
 ORDER BY
     2, 6

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_send_requested_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'ethereum' as blockchain,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_send_requested_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_send_requested_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ SELECT
 FROM
   {{ref('chainlink_ethereum_ccip_send_requested')}} ccip_send_requested
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 5, 6
 ORDER BY

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_fulfilled.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ethereum_usd AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_fulfilled.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_fulfilled.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_fulfilled',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_fulfilled_transactions AS (
     SELECT
@@ -38,12 +38,12 @@ WITH
       {{ source('ethereum', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_ethereum_ccip_transmitted_logs') }} ccip_tx ON ccip_tx.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND ccip_tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_tx.block_time') }}
       {% endif %}
       LEFT JOIN ethereum_usd ON date_trunc('minute', tx.block_time) = ethereum_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_reverted.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_reverted',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_reverted_transactions AS (
     SELECT
@@ -38,14 +38,14 @@ WITH
       {{ ref('chainlink_ethereum_ccip_transmitted_logs') }} tx
       LEFT JOIN {{ source('ethereum', 'transactions') }} tx2 ON tx2.hash = tx.tx_hash
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('tx.block_time') }}
       {% endif %}
       LEFT JOIN ethereum_usd ON date_trunc('minute', tx.block_time) = ethereum_usd.block_time
     WHERE
       tx2.success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.tx_hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_reverted.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ethereum_usd AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_reverted.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ethereum_usd AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_submission_transactions AS (
     SELECT
@@ -40,12 +40,12 @@ WITH
       {{ source('ethereum', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_ethereum_fm_gas_submission_logs') }} fm_gas_submission_logs ON fm_gas_submission_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND fm_gas_submission_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('fm_gas_submission_logs.block_time') }}
       {% endif %}
       LEFT JOIN ethereum_usd ON date_trunc('minute', tx.block_time) = ethereum_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_ethereum_fm_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_ethereum_fm_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM fm_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   fm_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -55,7 +55,7 @@ WITH
     FROM fm_request_daily_meta
     LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ethereum_usd AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -28,8 +28,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -77,16 +77,16 @@ WITH
       1, 2
   ),
   fm_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_ethereum_fm_reward_evt_transfer_daily')}} fm_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = fm_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = fm_reward_evt_transfer_daily.admin_address
@@ -101,7 +101,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   fm_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reward_evt_transfer_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'ethereum' as blockchain,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ FROM
   {{ref('chainlink_ethereum_fm_reward_evt_transfer')}} fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_fulfilled_transactions AS (
     SELECT
@@ -43,8 +43,8 @@ WITH
       RIGHT JOIN {{ ref('chainlink_ethereum_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
       LEFT JOIN ethereum_usd ON date_trunc('minute', tx.block_time) = ethereum_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_fulfilled_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ethereum_usd AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_fulfilled_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -28,7 +28,7 @@ WITH
       {{ ref('chainlink_ethereum_ocr_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -45,7 +45,7 @@ WITH
       {{ ref('chainlink_ethereum_ocr_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -57,7 +57,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -90,7 +90,7 @@ WITH
     FROM ocr_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -101,7 +101,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ocr_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_gas_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,7 +23,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -38,8 +38,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -59,7 +59,7 @@ WITH
     FROM ocr_request_daily_meta
     LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_request_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reverted_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ethereum_usd AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_reverted_transactions AS (
     SELECT
@@ -44,8 +44,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reverted_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -32,8 +32,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -81,16 +81,16 @@ WITH
       1, 2
   ),
   ocr_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_ethereum_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
@@ -105,7 +105,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   ocr_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'ethereum' as blockchain,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -27,8 +27,8 @@ FROM
   {{ref('chainlink_ethereum_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_price_feeds.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds',
     partition_by=['block_month'],
     materialized='incremental',
@@ -27,11 +27,11 @@ SELECT 'ethereum' as blockchain,
        c.proxy_address,
        c.aggregator_address,
        c.oracle_price / POWER(10, 0) as underlying_token_price,
-       CASE 
+       CASE
            WHEN cardinality(split(c.feed_name, ' / ')) = 1 THEN c.feed_name
            ELSE element_at(split(c.feed_name, ' / '), 1)
        END AS base,
-       CASE 
+       CASE
            WHEN cardinality(split(c.feed_name, ' / ')) = 1 THEN NULL
            ELSE element_at(split(c.feed_name, ' / '), 2)
        END AS quote
@@ -39,14 +39,14 @@ FROM
 (
     SELECT
         l.block_time,
-        cast(date_trunc('day', l.block_time) as date) as block_date, 
-        cast(date_trunc('month', l.block_time) as date) as block_month, 
+        cast(date_trunc('day', l.block_time) as date) as block_date,
+        cast(date_trunc('month', l.block_time) as date) as block_month,
         l.block_number,
         cfa.feed_name,
         cfa.proxy_address,
         MAX(cfa.aggregator_address) as aggregator_address,
         AVG(
-           CAST(bytearray_to_uint256(bytearray_substring(l.topic1, 3, 64)) as DOUBLE) 
+           CAST(bytearray_to_uint256(bytearray_substring(l.topic1, 3, 64)) as DOUBLE)
            / POWER(10, cfa.decimals)
         ) as oracle_price
     FROM
@@ -56,10 +56,10 @@ FROM
     WHERE
         l.topic0 = 0x0559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5f
         {% if not is_incremental() %}
-        AND l.block_time >= cast('{{project_start_date}}' as date) 
+        AND l.block_time >= cast('{{project_start_date}}' as date)
         {% endif %}
         {% if is_incremental() %}
-        AND l.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('l.block_time') }}
         {% endif %}
     GROUP BY
         1, 2, 3, 4, 5, 6

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_price_feeds.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2015-07-30' %}
 
 SELECT 'ethereum' as blockchain,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_price_feeds_hourly.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds_hourly',
     partition_by=['block_month'],
     materialized='incremental',
@@ -25,7 +25,7 @@ WITH hourly_sequence_meta AS (
         AND price.minute >= timestamp '{{project_start_date}}'
       {% endif %}
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('price.minute') }}
       {% endif %}
     GROUP BY
       1
@@ -70,7 +70,7 @@ aggregated_price_feeds AS (
           hourly_sequence.hr >= timestamp '{{project_start_date}}'
         {% endif %}
         {% if is_incremental() %}
-          hourly_sequence.hr >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+          {{ incremental_predicate('hourly_sequence.hr') }}
         {% endif %}
     GROUP BY
         hourly_sequence.hr, hourly_sequence.feed_name, hourly_sequence.proxy_address, hourly_sequence.aggregator_address

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_price_feeds_hourly.sql
@@ -11,7 +11,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2019-10-01' %}
 
 WITH hourly_sequence_meta AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_fulfilled_transactions.sql
@@ -1,12 +1,13 @@
 {{
   config(
-    
+
     alias='vrf_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 
@@ -22,7 +23,7 @@ WITH
       {% if is_incremental() %}
         AND
            {{ incremental_predicate('minute') }}
-      {% endif %}      
+      {% endif %}
   ),
   vrf_fulfilled_transactions AS (
     SELECT
@@ -39,14 +40,14 @@ WITH
       {{ source('ethereum', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_ethereum_vrf_v1_random_fulfilled_logs') }} vrf_v1_logs ON vrf_v1_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND 
+        AND
           {{ incremental_predicate('tx.block_time') }}
       {% endif %}
       LEFT JOIN ethereum_usd ON date_trunc('minute', tx.block_time) = ethereum_usd.block_time
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
-    {% endif %}      
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,
@@ -75,7 +76,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
-    {% endif %}      
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_ethereum_vrf_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_ethereum_vrf_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -84,7 +84,7 @@ WITH
       fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
     FROM vrf_gas_daily_meta
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -94,7 +94,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   vrf_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_request_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_request_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       total_requests
     FROM vrf_request_daily_meta
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_request_fulfilled_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_request_fulfilled_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'ethereum' as blockchain,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_request_fulfilled_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_request_fulfilled_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_request_fulfilled_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -21,8 +21,8 @@ SELECT
 FROM
   {{ref('chainlink_ethereum_vrf_request_fulfilled')}} vrf_request_fulfilled
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ethereum_usd AS (

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   vrf_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (
@@ -20,20 +19,20 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
       1
   ),
   vrf_reward_daily AS (
-    SELECT 
+    SELECT
       vrf_daily.date_start,
       cast(date_trunc('month', vrf_daily.date_start) as date) as date_month,
-      vrf_daily.operator_address,      
+      vrf_daily.operator_address,
       COALESCE(vrf_daily.token_amount, 0) as token_amount,
       COALESCE(vrf_daily.token_amount * lud.usd_amount, 0)  as usd_amount
-    FROM 
+    FROM
       {{ref('chainlink_ethereum_vrf_request_fulfilled_daily')}} vrf_daily
     LEFT JOIN link_usd_daily lud ON lud.date_start = vrf_daily.date_start
     ORDER BY date_start
@@ -45,7 +44,7 @@ SELECT
   operator_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   vrf_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'FTM'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   automation_fulfilled_transactions AS (
     SELECT
@@ -38,12 +38,12 @@ WITH
       {{ source('fantom', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_fantom_automation_upkeep_performed_logs') }} automation_upkeep_performed_logs ON automation_upkeep_performed_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND automation_upkeep_performed_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('automation_upkeep_performed_logs.block_time') }}
       {% endif %}
       LEFT JOIN fantom_usd ON date_trunc('minute', tx.block_time) = fantom_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   fantom_usd AS (

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_fantom_automation_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_fantom_automation_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM automation_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_fantom_automation_meta') }} automation_meta ON automation_meta.keeper_address = automation_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   automation_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_performed_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'fantom' as blockchain,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_performed_daily.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['date_start', 'keeper_address']
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.date_month')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_performed_daily.sql
@@ -6,7 +6,7 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['date_start', 'keeper_address']
+    unique_key=['date_start', 'keeper_address'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.date_month')]
   )
 }}

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_performed_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_performed_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ SELECT
 FROM
   {{ref('chainlink_fantom_automation_performed')}} automation_performed
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_request_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_request_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       total_requests
     FROM automation_request_daily_meta
   )
-SELECT 
+SELECT
   automation_request_daily.blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   fantom_usd AS (

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'FTM'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   automation_reverted_transactions AS (
     SELECT
@@ -40,8 +40,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (
@@ -20,21 +19,21 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
       1
   ),
   automation_reward_daily AS (
-    SELECT 
+    SELECT
       automation_performed_daily.date_start,
       cast(date_trunc('month', automation_performed_daily.date_start) as date) as date_month,
       automation_performed_daily.operator_name,
-      automation_performed_daily.keeper_address,   
+      automation_performed_daily.keeper_address,
       automation_performed_daily.token_amount as token_amount,
       (automation_performed_daily.token_amount * lud.usd_amount) as usd_amount
-    FROM 
+    FROM
       {{ref('chainlink_fantom_automation_performed_daily')}} automation_performed_daily
     LEFT JOIN link_usd_daily lud ON lud.date_start = automation_performed_daily.date_start
     ORDER BY date_start
@@ -47,7 +46,7 @@ SELECT
   keeper_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   automation_reward_daily
 ORDER BY
   2, 5

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   fantom_usd AS (

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'FTM'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_submission_transactions AS (
     SELECT
@@ -40,12 +40,12 @@ WITH
       {{ source('fantom', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_fantom_fm_gas_submission_logs') }} fm_gas_submission_logs ON fm_gas_submission_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND fm_gas_submission_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('fm_gas_submission_logs.block_time') }}
       {% endif %}
       LEFT JOIN fantom_usd ON date_trunc('minute', tx.block_time) = fantom_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_fantom_fm_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_fantom_fm_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM fm_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   fm_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -55,7 +55,7 @@ WITH
     FROM fm_request_daily_meta
     LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'FTM'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   fantom_usd AS (

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -28,8 +28,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -77,16 +77,16 @@ WITH
       1, 2
   ),
   fm_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_fantom_fm_reward_evt_transfer_daily')}} fm_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = fm_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = fm_reward_evt_transfer_daily.admin_address
@@ -101,7 +101,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   fm_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reward_evt_transfer_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'fantom' as blockchain,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ FROM
   {{ref('chainlink_fantom_fm_reward_evt_transfer')}} fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_fulfilled_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   fantom_usd AS (

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_fulfilled_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["fantom"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'FTM'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_fulfilled_transactions AS (
     SELECT
@@ -43,8 +43,8 @@ WITH
       RIGHT JOIN {{ ref('chainlink_fantom_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
       LEFT JOIN fantom_usd ON date_trunc('minute', tx.block_time) = fantom_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -28,7 +28,7 @@ WITH
       {{ ref('chainlink_fantom_ocr_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -45,7 +45,7 @@ WITH
       {{ ref('chainlink_fantom_ocr_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -57,7 +57,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -90,7 +90,7 @@ WITH
     FROM ocr_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -101,7 +101,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ocr_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_gas_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,7 +23,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -38,8 +38,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -59,7 +59,7 @@ WITH
     FROM ocr_request_daily_meta
     LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_request_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'FTM'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_reverted_transactions AS (
     SELECT
@@ -44,8 +44,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reverted_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   fantom_usd AS (

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reverted_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["fantom"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reward_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -32,8 +32,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -81,16 +81,16 @@ WITH
       1, 2
   ),
   ocr_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_fantom_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
@@ -105,7 +105,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   ocr_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -27,8 +27,8 @@ FROM
   {{ref('chainlink_fantom_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'fantom' as blockchain,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_price_feeds.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2019-12-28' %}
 
 SELECT 'fantom' as blockchain,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_price_feeds.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds',
     partition_by=['block_month'],
     materialized='incremental',
@@ -27,11 +27,11 @@ SELECT 'fantom' as blockchain,
        c.proxy_address,
        c.aggregator_address,
        c.oracle_price / POWER(10, 0) as underlying_token_price,
-       CASE 
+       CASE
            WHEN cardinality(split(c.feed_name, ' / ')) = 1 THEN c.feed_name
            ELSE element_at(split(c.feed_name, ' / '), 1)
        END AS base,
-       CASE 
+       CASE
            WHEN cardinality(split(c.feed_name, ' / ')) = 1 THEN NULL
            ELSE element_at(split(c.feed_name, ' / '), 2)
        END AS quote
@@ -39,14 +39,14 @@ FROM
 (
     SELECT
         l.block_time,
-        cast(date_trunc('day', l.block_time) as date) as block_date, 
-        cast(date_trunc('month', l.block_time) as date) as block_month, 
+        cast(date_trunc('day', l.block_time) as date) as block_date,
+        cast(date_trunc('month', l.block_time) as date) as block_month,
         l.block_number,
         cfa.feed_name,
         cfa.proxy_address,
         MAX(cfa.aggregator_address) as aggregator_address,
         AVG(
-           CAST(bytearray_to_uint256(bytearray_substring(l.topic1, 3, 64)) as DOUBLE) 
+           CAST(bytearray_to_uint256(bytearray_substring(l.topic1, 3, 64)) as DOUBLE)
            / POWER(10, cfa.decimals)
         ) as oracle_price
     FROM
@@ -56,10 +56,10 @@ FROM
     WHERE
         l.topic0 = 0x0559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5f
         {% if not is_incremental() %}
-        AND l.block_time >= cast('{{project_start_date}}' as date) 
+        AND l.block_time >= cast('{{project_start_date}}' as date)
         {% endif %}
         {% if is_incremental() %}
-        AND l.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('l.block_time') }}
         {% endif %}
     GROUP BY
         1, 2, 3, 4, 5, 6

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_price_feeds_hourly.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds_hourly',
     partition_by=['block_month'],
     materialized='incremental',
@@ -25,7 +25,7 @@ WITH hourly_sequence_meta AS (
         AND price.minute >= timestamp '{{project_start_date}}'
       {% endif %}
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('price.minute') }}
       {% endif %}
     GROUP BY
       1
@@ -70,7 +70,7 @@ aggregated_price_feeds AS (
           hourly_sequence.hr >= timestamp '{{project_start_date}}'
         {% endif %}
         {% if is_incremental() %}
-          hourly_sequence.hr >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+          {{ incremental_predicate('hourly_sequence.hr') }}
         {% endif %}
     GROUP BY
         hourly_sequence.hr, hourly_sequence.feed_name, hourly_sequence.proxy_address, hourly_sequence.aggregator_address

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_price_feeds_hourly.sql
@@ -11,7 +11,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2019-10-01' %}
 
 WITH hourly_sequence_meta AS (

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_fulfilled_transactions.sql
@@ -1,12 +1,13 @@
 {{
   config(
-    
+
     alias='vrf_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 
@@ -22,7 +23,7 @@ WITH
       {% if is_incremental() %}
         AND
            {{ incremental_predicate('minute') }}
-      {% endif %}      
+      {% endif %}
   ),
   vrf_fulfilled_transactions AS (
     SELECT
@@ -44,7 +45,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
-    {% endif %}      
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,
@@ -71,7 +72,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
-    {% endif %}      
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_fantom_vrf_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_fantom_vrf_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -84,7 +84,7 @@ WITH
       fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
     FROM vrf_gas_daily_meta
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -94,7 +94,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   vrf_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_request_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_request_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       total_requests
     FROM vrf_request_daily_meta
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_request_fulfilled_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_request_fulfilled_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'fantom' as blockchain,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_request_fulfilled_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_request_fulfilled_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_request_fulfilled_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -21,8 +21,8 @@ SELECT
 FROM
   {{ref('chainlink_fantom_vrf_request_fulfilled')}} vrf_request_fulfilled
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'FTM'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   vrf_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   fantom_usd AS (

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (
@@ -20,20 +19,20 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
       1
   ),
   vrf_reward_daily AS (
-    SELECT 
+    SELECT
       vrf_daily.date_start,
       cast(date_trunc('month', vrf_daily.date_start) as date) as date_month,
-      vrf_daily.operator_address,      
+      vrf_daily.operator_address,
       COALESCE(vrf_daily.token_amount, 0) as token_amount,
       COALESCE(vrf_daily.token_amount * lud.usd_amount, 0)  as usd_amount
-    FROM 
+    FROM
       {{ref('chainlink_fantom_vrf_request_fulfilled_daily')}} vrf_daily
     LEFT JOIN link_usd_daily lud ON lud.date_start = vrf_daily.date_start
     ORDER BY date_start
@@ -45,7 +44,7 @@ SELECT
   operator_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   vrf_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'XDAI'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_submission_transactions AS (
     SELECT
@@ -40,12 +40,12 @@ WITH
       {{ source('gnosis', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_gnosis_fm_gas_submission_logs') }} fm_gas_submission_logs ON fm_gas_submission_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND fm_gas_submission_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('fm_gas_submission_logs.block_time') }}
       {% endif %}
       LEFT JOIN gnosis_usd ON date_trunc('minute', tx.block_time) = gnosis_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   gnosis_usd AS (

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_gnosis_fm_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_gnosis_fm_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM fm_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   fm_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -55,7 +55,7 @@ WITH
     FROM fm_request_daily_meta
     LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'XDAI'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   gnosis_usd AS (

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -28,8 +28,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -77,16 +77,16 @@ WITH
       1, 2
   ),
   fm_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_gnosis_fm_reward_evt_transfer_daily')}} fm_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = fm_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = fm_reward_evt_transfer_daily.admin_address
@@ -101,7 +101,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   fm_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ FROM
   {{ref('chainlink_gnosis_fm_reward_evt_transfer')}} fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reward_evt_transfer_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'gnosis' as blockchain,

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_fulfilled_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["gnosis"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'XDAI'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_fulfilled_transactions AS (
     SELECT
@@ -43,8 +43,8 @@ WITH
       RIGHT JOIN {{ ref('chainlink_gnosis_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
       LEFT JOIN gnosis_usd ON date_trunc('minute', tx.block_time) = gnosis_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_fulfilled_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   gnosis_usd AS (

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -28,7 +28,7 @@ WITH
       {{ ref('chainlink_gnosis_ocr_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -45,7 +45,7 @@ WITH
       {{ ref('chainlink_gnosis_ocr_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -57,7 +57,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -90,7 +90,7 @@ WITH
     FROM ocr_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -101,7 +101,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ocr_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_gas_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,7 +23,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -38,8 +38,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -59,7 +59,7 @@ WITH
     FROM ocr_request_daily_meta
     LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_request_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reverted_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["gnosis"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'XDAI'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_reverted_transactions AS (
     SELECT
@@ -44,8 +44,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reverted_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   gnosis_usd AS (

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -32,8 +32,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -81,16 +81,16 @@ WITH
       1, 2
   ),
   ocr_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_gnosis_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
@@ -105,7 +105,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   ocr_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -27,8 +27,8 @@ FROM
   {{ref('chainlink_gnosis_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'gnosis' as blockchain,

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_price_feeds.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds',
     partition_by=['block_month'],
     materialized='incremental',
@@ -27,11 +27,11 @@ SELECT 'gnosis' as blockchain,
        c.proxy_address,
        c.aggregator_address,
        c.oracle_price / POWER(10, 0) as underlying_token_price,
-       CASE 
+       CASE
            WHEN cardinality(split(c.feed_name, ' / ')) = 1 THEN c.feed_name
            ELSE element_at(split(c.feed_name, ' / '), 1)
        END AS base,
-       CASE 
+       CASE
            WHEN cardinality(split(c.feed_name, ' / ')) = 1 THEN NULL
            ELSE element_at(split(c.feed_name, ' / '), 2)
        END AS quote
@@ -39,14 +39,14 @@ FROM
 (
     SELECT
         l.block_time,
-        cast(date_trunc('day', l.block_time) as date) as block_date, 
-        cast(date_trunc('month', l.block_time) as date) as block_month, 
+        cast(date_trunc('day', l.block_time) as date) as block_date,
+        cast(date_trunc('month', l.block_time) as date) as block_month,
         l.block_number,
         cfa.feed_name,
         cfa.proxy_address,
         MAX(cfa.aggregator_address) as aggregator_address,
         AVG(
-           CAST(bytearray_to_uint256(bytearray_substring(l.topic1, 3, 64)) as DOUBLE) 
+           CAST(bytearray_to_uint256(bytearray_substring(l.topic1, 3, 64)) as DOUBLE)
            / POWER(10, cfa.decimals)
         ) as oracle_price
     FROM
@@ -56,10 +56,10 @@ FROM
     WHERE
         l.topic0 = 0x0559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5f
         {% if not is_incremental() %}
-        AND l.block_time >= cast('{{project_start_date}}' as date) 
+        AND l.block_time >= cast('{{project_start_date}}' as date)
         {% endif %}
         {% if is_incremental() %}
-        AND l.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('l.block_time') }}
         {% endif %}
     GROUP BY
         1, 2, 3, 4, 5, 6

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_price_feeds.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2019-10-01' %}
 
 SELECT 'gnosis' as blockchain,

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_price_feeds_hourly.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds_hourly',
     partition_by=['block_month'],
     materialized='incremental',
@@ -25,7 +25,7 @@ WITH hourly_sequence_meta AS (
         AND price.minute >= timestamp '{{project_start_date}}'
       {% endif %}
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('price.minute') }}
       {% endif %}
     GROUP BY
       1
@@ -70,7 +70,7 @@ aggregated_price_feeds AS (
           hourly_sequence.hr >= timestamp '{{project_start_date}}'
         {% endif %}
         {% if is_incremental() %}
-          hourly_sequence.hr >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+          {{ incremental_predicate('hourly_sequence.hr') }}
         {% endif %}
     GROUP BY
         hourly_sequence.hr, hourly_sequence.feed_name, hourly_sequence.proxy_address, hourly_sequence.aggregator_address

--- a/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_price_feeds_hourly.sql
@@ -11,7 +11,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2019-10-01' %}
 
 WITH hourly_sequence_meta AS (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_fulfilled_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('optimism', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('optimism', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'optimism' as blockchain,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_fulfilled_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_fulfilled_transactions AS (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_optimism_ccip_transmitted_fulfilled') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_optimism_ccip_transmitted_reverted') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM ccip_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_optimism_ccip_operator_meta') }} ccip_operator_meta ON ccip_operator_meta.node_address = ccip_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ccip_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_nop_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_nop_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -20,7 +20,7 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
@@ -38,22 +38,22 @@ FROM
   {{ref('chainlink_optimism_ccip_nop_paid_logs')}} nop_logs
   LEFT JOIN {{ref('chainlink_optimism_ccip_admin_meta')}} admin_meta ON admin_meta.admin_address = nop_logs.nop_address
 {% if is_incremental() %}
-  WHERE block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY
   2, 4
   ),
   nop_reward_daily AS (
-    SELECT 
+    SELECT
       nop_paid.date_start,
       cast(date_trunc('month', nop_paid.date_start) as date) as date_month,
       nop_paid.operator_name,
-      nop_paid.nop_address,   
+      nop_paid.nop_address,
       nop_paid.token_amount as token_amount,
       (nop_paid.token_amount * lud.usd_amount) as usd_amount
-    FROM 
+    FROM
       nop_paid
     LEFT JOIN link_usd_daily lud ON lud.date_start = nop_paid.date_start
     ORDER BY date_start
@@ -66,7 +66,7 @@ SELECT
   nop_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   nop_reward_daily
 ORDER BY
   2, 5

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_nop_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_request_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
 ethereum_agg AS (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_request_daily.sql
@@ -23,7 +23,7 @@ ethereum_agg AS (
                 WHERE
                     eth.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND eth.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('eth.block_time') }}
                 {% endif %}
             ) AS fulfilled_requests,
             (
@@ -34,7 +34,7 @@ ethereum_agg AS (
                 WHERE
                     rev.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND rev.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('rev.block_time') }}
                 {% endif %}
             ) AS reverted_requests
         FROM
@@ -52,7 +52,7 @@ ethereum_agg AS (
             ) AS seq
             CROSS JOIN UNNEST (seq.date_sequence) AS t (date_start)
             {% if is_incremental() %}
-                    WHERE date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    WHERE {{ incremental_predicate('date_start') }}
             {% endif %}
             ) date_series
     ),
@@ -67,7 +67,7 @@ ethereum_agg AS (
         FROM
             ethereum_agg
     )
-SELECT 
+SELECT
   ccip_request_daily.blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_reverted_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('optimism', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('optimism', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'optimism' as blockchain,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_reverted_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_reverted_transactions AS (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_reward_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
     token_meta AS (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_reward_daily.sql
@@ -28,7 +28,7 @@ WITH
             {{ source('prices', 'usd') }} price
         JOIN token_meta ON price.symbol = token_meta.token_symbol
         {% if is_incremental() %}
-            WHERE price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            WHERE {{ incremental_predicate('price.minute') }}
         {% endif %}
         GROUP BY
             1, token_meta.token_symbol
@@ -36,21 +36,21 @@ WITH
             1
     ),
     ccip_reward_daily AS (
-        SELECT 
+        SELECT
             ccip_send_requested_daily.date_start,
-            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,  
+            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,
             SUM(ccip_send_requested_daily.fee_amount) as token_amount,
             SUM((ccip_send_requested_daily.fee_amount * tud.usd_amount)) as usd_amount,
             ccip_send_requested_daily.token as token
-        FROM 
+        FROM
             {{ref('chainlink_optimism_ccip_send_requested_daily')}} ccip_send_requested_daily
         LEFT JOIN token_usd_daily tud ON tud.date_start = ccip_send_requested_daily.date_start AND tud.symbol = ccip_send_requested_daily.token
         {% if is_incremental() %}
-            WHERE ccip_send_requested_daily.date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        {% endif %}  
+            WHERE {{ incremental_predicate('ccip_send_requested_daily.date_start') }}
+        {% endif %}
         GROUP BY 1, 5
     )
-    
+
 SELECT
     'optimism' as blockchain,
     date_start,
@@ -58,7 +58,7 @@ SELECT
     token_amount,
     usd_amount,
     token
-FROM 
+FROM
     ccip_reward_daily
 ORDER BY
     2, 6

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_send_requested_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_send_requested_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ SELECT
 FROM
   {{ref('chainlink_optimism_ccip_send_requested')}} ccip_send_requested
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 5, 6
 ORDER BY

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_send_requested_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'optimism' as blockchain,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_fulfilled.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_fulfilled',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_fulfilled_transactions AS (
     SELECT
@@ -38,12 +38,12 @@ WITH
       {{ source('optimism', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_optimism_ccip_transmitted_logs') }} ccip_tx ON ccip_tx.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND ccip_tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_tx.block_time') }}
       {% endif %}
       LEFT JOIN optimism_usd ON date_trunc('minute', tx.block_time) = optimism_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_fulfilled.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   optimism_usd AS (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_fulfilled.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_reverted.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   optimism_usd AS (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_reverted.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_reverted.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_reverted',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_reverted_transactions AS (
     SELECT
@@ -38,14 +38,14 @@ WITH
       {{ ref('chainlink_optimism_ccip_transmitted_logs') }} tx
       LEFT JOIN {{ source('optimism', 'transactions') }} tx2 ON tx2.hash = tx.tx_hash
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('tx.block_time') }}
       {% endif %}
       LEFT JOIN optimism_usd ON date_trunc('minute', tx.block_time) = optimism_usd.block_time
     WHERE
       tx2.success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.tx_hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_submission_transactions AS (
     SELECT
@@ -40,12 +40,12 @@ WITH
       {{ source('optimism', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_optimism_fm_gas_submission_logs') }} fm_gas_submission_logs ON fm_gas_submission_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND fm_gas_submission_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('fm_gas_submission_logs.block_time') }}
       {% endif %}
       LEFT JOIN optimism_usd ON date_trunc('minute', tx.block_time) = optimism_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   optimism_usd AS (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_optimism_fm_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_optimism_fm_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM fm_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   fm_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -55,7 +55,7 @@ WITH
     FROM fm_request_daily_meta
     LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   optimism_usd AS (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -28,8 +28,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -77,16 +77,16 @@ WITH
       1, 2
   ),
   fm_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_optimism_fm_reward_evt_transfer_daily')}} fm_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = fm_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = fm_reward_evt_transfer_daily.admin_address
@@ -101,7 +101,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   fm_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reward_evt_transfer_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'optimism' as blockchain,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ FROM
   {{ref('chainlink_optimism_fm_reward_evt_transfer')}} fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_fulfilled_transactions AS (
     SELECT
@@ -45,8 +45,8 @@ WITH
       RIGHT JOIN {{ ref('chainlink_optimism_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
       LEFT JOIN optimism_usd ON date_trunc('minute', tx.block_time) = optimism_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_fulfilled_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   optimism_usd AS (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_fulfilled_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["optimism"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -28,7 +28,7 @@ WITH
       {{ ref('chainlink_optimism_ocr_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -45,7 +45,7 @@ WITH
       {{ ref('chainlink_optimism_ocr_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -57,7 +57,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -90,7 +90,7 @@ WITH
     FROM ocr_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -101,7 +101,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ocr_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_gas_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,7 +23,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -38,8 +38,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -59,7 +59,7 @@ WITH
     FROM ocr_request_daily_meta
     LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_request_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reverted_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   optimism_usd AS (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reverted_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["optimism"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'ETH'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_reverted_transactions AS (
     SELECT
@@ -46,8 +46,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reward_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -32,8 +32,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -81,16 +81,16 @@ WITH
       1, 2
   ),
   ocr_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(ocr_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_optimism_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
@@ -105,7 +105,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   ocr_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -27,8 +27,8 @@ FROM
   {{ref('chainlink_optimism_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'optimism' as blockchain,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_price_feeds.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds',
     partition_by=['block_month'],
     materialized='incremental',
@@ -59,7 +59,7 @@ FROM
         AND l.block_time >= cast('{{project_start_date}}' as date)
         {% endif %}
         {% if is_incremental() %}
-        AND l.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('l.block_time') }}
         {% endif %}
     GROUP BY
         1, 2, 3, 4, 5, 6

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_price_feeds.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2021-06-23' %}
 
 SELECT 'optimism' as blockchain,

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_price_feeds_hourly.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds_hourly',
     partition_by=['block_month'],
     materialized='incremental',
@@ -25,7 +25,7 @@ WITH hourly_sequence_meta AS (
         AND price.minute >= timestamp '{{project_start_date}}'
       {% endif %}
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('price.minute') }}
       {% endif %}
     GROUP BY
       1
@@ -70,7 +70,7 @@ aggregated_price_feeds AS (
           hourly_sequence.hr >= timestamp '{{project_start_date}}'
         {% endif %}
         {% if is_incremental() %}
-          hourly_sequence.hr >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+          {{ incremental_predicate('hourly_sequence.hr') }}
         {% endif %}
     GROUP BY
         hourly_sequence.hr, hourly_sequence.feed_name, hourly_sequence.proxy_address, hourly_sequence.aggregator_address

--- a/daily_spellbook/models/chainlink/optimism/chainlink_optimism_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/optimism/chainlink_optimism_price_feeds_hourly.sql
@@ -11,7 +11,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2019-10-01' %}
 
 WITH hourly_sequence_meta AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'MATIC'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   automation_fulfilled_transactions AS (
     SELECT
@@ -38,12 +38,12 @@ WITH
       {{ source('polygon', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_polygon_automation_upkeep_performed_logs') }} automation_upkeep_performed_logs ON automation_upkeep_performed_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND automation_upkeep_performed_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('automation_upkeep_performed_logs.block_time') }}
       {% endif %}
       LEFT JOIN polygon_usd ON date_trunc('minute', tx.block_time) = polygon_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   polygon_usd AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_polygon_automation_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_polygon_automation_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM automation_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_polygon_automation_meta') }} automation_meta ON automation_meta.keeper_address = automation_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   automation_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_performed_daily.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['date_start', 'keeper_address']
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.date_month')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_performed_daily.sql
@@ -6,7 +6,7 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['date_start', 'keeper_address']
+    unique_key=['date_start', 'keeper_address'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.date_month')]
   )
 }}

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_performed_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_performed_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ SELECT
 FROM
   {{ref('chainlink_polygon_automation_performed')}} automation_performed
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_performed_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_performed_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'polygon' as blockchain,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_request_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_request_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       total_requests
     FROM automation_request_daily_meta
   )
-SELECT 
+SELECT
   automation_request_daily.blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   polygon_usd AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'MATIC'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   automation_reverted_transactions AS (
     SELECT
@@ -40,8 +40,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='automation_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (
@@ -20,21 +19,21 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
       1
   ),
   automation_reward_daily AS (
-    SELECT 
+    SELECT
       automation_performed_daily.date_start,
       cast(date_trunc('month', automation_performed_daily.date_start) as date) as date_month,
       automation_performed_daily.operator_name,
-      automation_performed_daily.keeper_address,   
+      automation_performed_daily.keeper_address,
       automation_performed_daily.token_amount as token_amount,
       (automation_performed_daily.token_amount * lud.usd_amount) as usd_amount
-    FROM 
+    FROM
       {{ref('chainlink_polygon_automation_performed_daily')}} automation_performed_daily
     LEFT JOIN link_usd_daily lud ON lud.date_start = automation_performed_daily.date_start
     ORDER BY date_start
@@ -47,7 +46,7 @@ SELECT
   keeper_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   automation_reward_daily
 ORDER BY
   2, 5

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_fulfilled_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('polygon', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('polygon', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = true
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'polygon' as blockchain,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_fulfilled_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_fulfilled_transactions AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_polygon_ccip_transmitted_fulfilled') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_polygon_ccip_transmitted_reverted') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM ccip_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_polygon_ccip_operator_meta') }} ccip_operator_meta ON ccip_operator_meta.node_address = ccip_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ccip_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_nop_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_nop_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_nop_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_nop_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -20,7 +20,7 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
@@ -38,22 +38,22 @@ FROM
   {{ref('chainlink_polygon_ccip_nop_paid_logs')}} nop_logs
   LEFT JOIN {{ref('chainlink_polygon_ccip_admin_meta')}} admin_meta ON admin_meta.admin_address = nop_logs.nop_address
 {% if is_incremental() %}
-  WHERE block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY
   2, 4
   ),
   nop_reward_daily AS (
-    SELECT 
+    SELECT
       nop_paid.date_start,
       cast(date_trunc('month', nop_paid.date_start) as date) as date_month,
       nop_paid.operator_name,
-      nop_paid.nop_address,   
+      nop_paid.nop_address,
       nop_paid.token_amount as token_amount,
       (nop_paid.token_amount * lud.usd_amount) as usd_amount
-    FROM 
+    FROM
       nop_paid
     LEFT JOIN link_usd_daily lud ON lud.date_start = nop_paid.date_start
     ORDER BY date_start
@@ -66,7 +66,7 @@ SELECT
   nop_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   nop_reward_daily
 ORDER BY
   2, 5

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_request_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
 ethereum_agg AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_request_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_request_daily.sql
@@ -23,7 +23,7 @@ ethereum_agg AS (
                 WHERE
                     eth.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND eth.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('eth.block_time') }}
                 {% endif %}
             ) AS fulfilled_requests,
             (
@@ -34,7 +34,7 @@ ethereum_agg AS (
                 WHERE
                     rev.date_start = date_series.date_start
                 {% if is_incremental() %}
-                    AND rev.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    AND {{ incremental_predicate('rev.block_time') }}
                 {% endif %}
             ) AS reverted_requests
         FROM
@@ -52,7 +52,7 @@ ethereum_agg AS (
             ) AS seq
             CROSS JOIN UNNEST (seq.date_sequence) AS t (date_start)
             {% if is_incremental() %}
-                    WHERE date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+                    WHERE {{ incremental_predicate('date_start') }}
             {% endif %}
             ) date_series
     ),
@@ -67,7 +67,7 @@ ethereum_agg AS (
         FROM
             ethereum_agg
     )
-SELECT 
+SELECT
   ccip_request_daily.blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_reverted_transactions.sql
@@ -23,12 +23,12 @@ WITH
       LEFT JOIN {{ source('polygon', 'transactions') }} tx ON
         ccip_send_logs_v1.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1.block_time') }}
       {% endif %}
 
     UNION
@@ -44,14 +44,14 @@ WITH
       LEFT JOIN {{ source('polygon', 'transactions') }} tx ON
         ccip_send_logs_v1_2.tx_hash = tx.hash
         {% if is_incremental() %}
-            AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            AND {{ incremental_predicate('tx.block_time') }}
         {% endif %}
       WHERE
         tx.success = false
       {% if is_incremental() %}
-        AND ccip_send_logs_v1_2.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_send_logs_v1_2.block_time') }}
       {% endif %}
-        
+
   )
 SELECT
  'polygon' as blockchain,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_reverted_transactions.sql
@@ -8,7 +8,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   ccip_reverted_transactions AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_reward_daily.sql
@@ -28,7 +28,7 @@ WITH
             {{ source('prices', 'usd') }} price
         JOIN token_meta ON price.symbol = token_meta.token_symbol
         {% if is_incremental() %}
-            WHERE price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+            WHERE {{ incremental_predicate('price.minute') }}
         {% endif %}
         GROUP BY
             1, token_meta.token_symbol
@@ -36,21 +36,21 @@ WITH
             1
     ),
     ccip_reward_daily AS (
-        SELECT 
+        SELECT
             ccip_send_requested_daily.date_start,
-            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,  
+            cast(date_trunc('month', ccip_send_requested_daily.date_start) as date) as date_month,
             SUM(ccip_send_requested_daily.fee_amount) as token_amount,
             SUM((ccip_send_requested_daily.fee_amount * tud.usd_amount)) as usd_amount,
             ccip_send_requested_daily.token as token
-        FROM 
+        FROM
             {{ref('chainlink_polygon_ccip_send_requested_daily')}} ccip_send_requested_daily
         LEFT JOIN token_usd_daily tud ON tud.date_start = ccip_send_requested_daily.date_start AND tud.symbol = ccip_send_requested_daily.token
         {% if is_incremental() %}
-            WHERE ccip_send_requested_daily.date_start >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        {% endif %}  
+            WHERE {{ incremental_predicate('ccip_send_requested_daily.date_start') }}
+        {% endif %}
         GROUP BY 1, 5
     )
-    
+
 SELECT
     'polygon' as blockchain,
     date_start,
@@ -58,7 +58,7 @@ SELECT
     token_amount,
     usd_amount,
     token
-FROM 
+FROM
     ccip_reward_daily
 ORDER BY
     2, 6

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_reward_daily.sql
@@ -9,7 +9,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
     token_meta AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_send_requested_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'polygon' as blockchain,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_send_requested_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_send_requested_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_send_requested_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ SELECT
 FROM
   {{ref('chainlink_polygon_ccip_send_requested')}} ccip_send_requested
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 5, 6
 ORDER BY

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_fulfilled.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_fulfilled',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'MATIC'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_fulfilled_transactions AS (
     SELECT
@@ -38,12 +38,12 @@ WITH
       {{ source('polygon', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_polygon_ccip_transmitted_logs') }} ccip_tx ON ccip_tx.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND ccip_tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('ccip_tx.block_time') }}
       {% endif %}
       LEFT JOIN polygon_usd ON date_trunc('minute', tx.block_time) = polygon_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_fulfilled.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   polygon_usd AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_fulfilled.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_fulfilled.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_reverted.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   polygon_usd AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_reverted.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_reverted.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_reverted.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ccip_transmitted_reverted',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'MATIC'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ccip_reverted_transactions AS (
     SELECT
@@ -38,14 +38,14 @@ WITH
       {{ ref('chainlink_polygon_ccip_transmitted_logs') }} tx
       LEFT JOIN {{ source('polygon', 'transactions') }} tx2 ON tx2.hash = tx.tx_hash
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('tx.block_time') }}
       {% endif %}
       LEFT JOIN polygon_usd ON date_trunc('minute', tx.block_time) = polygon_usd.block_time
     WHERE
       tx2.success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.tx_hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_fulfilled_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   polygon_usd AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_fulfilled_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'MATIC'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_submission_transactions AS (
     SELECT
@@ -40,12 +40,12 @@ WITH
       {{ source('polygon', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_polygon_fm_gas_submission_logs') }} fm_gas_submission_logs ON fm_gas_submission_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND fm_gas_submission_logs.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('fm_gas_submission_logs.block_time') }}
       {% endif %}
       LEFT JOIN polygon_usd ON date_trunc('minute', tx.block_time) = polygon_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_polygon_fm_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_polygon_fm_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -86,7 +86,7 @@ WITH
     FROM fm_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -97,7 +97,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   fm_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -55,7 +55,7 @@ WITH
     FROM fm_request_daily_meta
     LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_node_meta') }} fm_operator_node_meta ON fm_operator_node_meta.node_address = fm_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_request_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'MATIC'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   fm_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   polygon_usd AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reward_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -28,8 +28,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -77,16 +77,16 @@ WITH
       1, 2
   ),
   fm_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
-      ocr_operator_admin_meta.operator_name,      
+      ocr_operator_admin_meta.operator_name,
       COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE(fm_reward_evt_transfer_daily.token_amount / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_polygon_fm_reward_evt_transfer_daily')}} fm_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = fm_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = fm_reward_evt_transfer_daily.admin_address
@@ -101,7 +101,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   fm_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='fm_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,8 +23,8 @@ FROM
   {{ref('chainlink_polygon_fm_reward_evt_transfer')}} fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reward_evt_transfer_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'polygon' as blockchain,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_fulfilled_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'MATIC'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_fulfilled_transactions AS (
     SELECT
@@ -43,8 +43,8 @@ WITH
       RIGHT JOIN {{ ref('chainlink_polygon_ocr_gas_transmission_logs') }} ocr_gas_transmission_logs ON ocr_gas_transmission_logs.tx_hash = tx.hash
       LEFT JOIN polygon_usd ON date_trunc('minute', tx.block_time) = polygon_usd.block_time
     {% if is_incremental() %}
-      WHERE tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-    {% endif %}      
+      WHERE {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_fulfilled_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["polygon"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_fulfilled_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   polygon_usd AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -28,7 +28,7 @@ WITH
       {{ ref('chainlink_polygon_ocr_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -45,7 +45,7 @@ WITH
       {{ ref('chainlink_polygon_ocr_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -57,7 +57,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -90,7 +90,7 @@ WITH
     FROM ocr_gas_daily_meta
     LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_gas_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -101,7 +101,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   ocr_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_gas_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -23,7 +23,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -38,8 +38,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        OR reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        OR {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -59,7 +59,7 @@ WITH
     FROM ocr_request_daily_meta
     LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_node_meta') }} ocr_operator_node_meta ON ocr_operator_node_meta.node_address = ocr_request_daily_meta.node_address
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_request_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_request_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reverted_transactions.sql
@@ -7,6 +7,7 @@
     file_format='delta',
     incremental_strategy='merge',
     unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["polygon"]\',
                                 "project",
                                 "chainlink",

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -26,8 +26,8 @@ WITH
     WHERE
       symbol = 'MATIC'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   ocr_reverted_transactions AS (
     SELECT
@@ -44,8 +44,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reverted_transactions.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   polygon_usd AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reward_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   admin_address_meta as (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -32,8 +32,8 @@ WITH
     WHERE
       price.symbol = 'LINK'
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('price.minute') }}
+      {% endif %}
     GROUP BY
       1
     ORDER BY
@@ -81,16 +81,16 @@ WITH
       1, 2
   ),
   ocr_reward_daily AS (
-    SELECT 
+    SELECT
       payment_meta.date_start,
       cast(date_trunc('month', payment_meta.date_start) as date) as date_month,
       payment_meta.admin_address,
       ocr_operator_admin_meta.operator_name,
       COALESCE((ocr_reward_evt_transfer_daily.token_amount + COALESCE(reconcile_daily.token_amount, 0)) / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) as token_amount,
       (COALESCE((ocr_reward_evt_transfer_daily.token_amount + COALESCE(reconcile_daily.token_amount, 0)) / EXTRACT(DAY FROM next_payment_date - prev_payment_date), 0) * payment_meta.usd_amount) as usd_amount
-    FROM 
+    FROM
       payment_meta
-    LEFT JOIN 
+    LEFT JOIN
       {{ref('chainlink_polygon_ocr_reward_evt_transfer_daily')}} ocr_reward_evt_transfer_daily ON
         payment_meta.next_payment_date = ocr_reward_evt_transfer_daily.date_start AND
         payment_meta.admin_address = ocr_reward_evt_transfer_daily.admin_address
@@ -109,7 +109,7 @@ SELECT
   operator_name,
   token_amount,
   usd_amount
-FROM 
+FROM
   ocr_reward_daily
 ORDER BY
   2, 4

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer_daily.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'polygon' as blockchain,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='ocr_reward_evt_transfer_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -27,8 +27,8 @@ FROM
   {{ref('chainlink_polygon_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_price_feeds.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds',
     partition_by=['block_month'],
     materialized='incremental',
@@ -59,7 +59,7 @@ FROM
         AND l.block_time >= cast('{{project_start_date}}' as date)
         {% endif %}
         {% if is_incremental() %}
-        AND l.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('l.block_time') }}
         {% endif %}
     GROUP BY
         1, 2, 3, 4, 5, 6

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_price_feeds.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_price_feeds.sql
@@ -14,7 +14,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2020-10-26' %}
 
 SELECT 'polygon' as blockchain,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_price_feeds_hourly.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='price_feeds_hourly',
     partition_by=['block_month'],
     materialized='incremental',
@@ -25,7 +25,7 @@ WITH hourly_sequence_meta AS (
         AND price.minute >= timestamp '{{project_start_date}}'
       {% endif %}
       {% if is_incremental() %}
-        AND price.minute >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+        AND {{ incremental_predicate('price.minute') }}
       {% endif %}
     GROUP BY
       1
@@ -70,7 +70,7 @@ aggregated_price_feeds AS (
           hourly_sequence.hr >= timestamp '{{project_start_date}}'
         {% endif %}
         {% if is_incremental() %}
-          hourly_sequence.hr >= date_trunc('hour', now() - interval '{{incremental_interval}}' day)
+          {{ incremental_predicate('hourly_sequence.hr') }}
         {% endif %}
     GROUP BY
         hourly_sequence.hr, hourly_sequence.feed_name, hourly_sequence.proxy_address, hourly_sequence.aggregator_address

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_price_feeds_hourly.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_price_feeds_hourly.sql
@@ -11,7 +11,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set project_start_date = '2019-10-01' %}
 
 WITH hourly_sequence_meta AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_fulfilled_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_fulfilled_transactions.sql
@@ -1,12 +1,13 @@
 {{
   config(
-    
+
     alias='vrf_fulfilled_transactions',
     partition_by=['date_month'],
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 
@@ -22,7 +23,7 @@ WITH
       {% if is_incremental() %}
         AND
           {{ incremental_predicate('minute') }}
-      {% endif %}      
+      {% endif %}
   ),
   vrf_fulfilled_transactions AS (
     SELECT
@@ -39,14 +40,14 @@ WITH
       {{ source('polygon', 'transactions') }} tx
       RIGHT JOIN {{ ref('chainlink_polygon_vrf_v1_random_fulfilled_logs') }} vrf_v1_logs ON vrf_v1_logs.tx_hash = tx.hash
       {% if is_incremental() %}
-        AND 
+        AND
           {{ incremental_predicate('tx.block_time') }}
       {% endif %}
       LEFT JOIN polygon_usd ON date_trunc('minute', tx.block_time) = polygon_usd.block_time
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
-    {% endif %}      
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,
@@ -75,7 +76,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
-    {% endif %}      
+    {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_gas_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_gas_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_gas_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_gas_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -24,7 +24,7 @@ WITH
       {{ ref('chainlink_polygon_vrf_fulfilled_transactions') }} fulfilled
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -41,7 +41,7 @@ WITH
       {{ ref('chainlink_polygon_vrf_reverted_transactions') }} reverted
     {% if is_incremental() %}
       WHERE
-        reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       COALESCE(
         fulfilled.date_start,
         reverted.date_start
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -84,7 +84,7 @@ WITH
       fulfilled_usd_amount + reverted_usd_amount as total_usd_amount
     FROM vrf_gas_daily_meta
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,
@@ -94,7 +94,7 @@ SELECT
   reverted_token_amount,
   reverted_usd_amount,
   total_token_amount,
-  total_usd_amount    
+  total_usd_amount
 FROM
   vrf_gas_daily
 ORDER BY

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_request_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_request_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 {% set truncate_by = 'day' %}
 
 WITH

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_request_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_request_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_request_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -19,7 +19,7 @@ WITH
       COALESCE(
         cast(date_trunc('{{truncate_by}}', fulfilled.block_time) as date),
         cast(date_trunc('{{truncate_by}}', reverted.block_time) as date)
-      ) AS "date_start",      
+      ) AS "date_start",
       COALESCE(
         fulfilled.node_address,
         reverted.node_address
@@ -34,8 +34,8 @@ WITH
         reverted.node_address = fulfilled.node_address
     {% if is_incremental() %}
       WHERE
-        fulfilled.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-        AND reverted.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
+        {{ incremental_predicate('fulfilled.block_time') }}
+        AND {{ incremental_predicate('reverted.block_time') }}
     {% endif %}
     GROUP BY
       1, 2
@@ -53,7 +53,7 @@ WITH
       total_requests
     FROM vrf_request_daily_meta
   )
-SELECT 
+SELECT
   blockchain,
   date_start,
   date_month,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_request_fulfilled_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_request_fulfilled_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_request_fulfilled_daily',
     partition_by=['date_month'],
     materialized='incremental',
@@ -21,8 +21,8 @@ SELECT
 FROM
   {{ref('chainlink_polygon_vrf_request_fulfilled')}} vrf_request_fulfilled
 {% if is_incremental() %}
-  WHERE evt_block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-{% endif %}      
+  WHERE {{ incremental_predicate('evt_block_time') }}
+{% endif %}
 GROUP BY
   2, 4
 ORDER BY

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_request_fulfilled_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_request_fulfilled_daily.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 SELECT
   'polygon' as blockchain,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_reverted_transactions.sql
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   polygon_usd AS (

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_reverted_transactions.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_reverted_transactions',
     partition_by=['date_month'],
     materialized='incremental',
@@ -22,8 +22,8 @@ WITH
     WHERE
       symbol = 'MATIC'
       {% if is_incremental() %}
-        AND minute >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('minute') }}
+      {% endif %}
   ),
   vrf_reverted_transactions AS (
     SELECT
@@ -42,8 +42,8 @@ WITH
     WHERE
       success = false
       {% if is_incremental() %}
-        AND tx.block_time >= date_trunc('day', now() - interval '{{incremental_interval}}' day)
-      {% endif %}      
+        AND {{ incremental_predicate('tx.block_time') }}
+      {% endif %}
     GROUP BY
       tx.hash,
       tx.index,

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_reverted_transactions.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_reverted_transactions.sql
@@ -6,7 +6,8 @@
     materialized='incremental',
     file_format='delta',
     incremental_strategy='merge',
-    unique_key=['tx_hash', 'tx_index', 'node_address']
+    unique_key=['tx_hash', 'tx_index', 'node_address'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
   )
 }}
 

--- a/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_reward_daily.sql
+++ b/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_reward_daily.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    
+
     alias='vrf_reward_daily',
     partition_by = ['date_month'],
     materialized = 'incremental',
@@ -10,7 +10,6 @@
   )
 }}
 
-{% set incremental_interval = '7' %}
 
 WITH
   link_usd_daily AS (
@@ -20,20 +19,20 @@ WITH
     FROM
       {{ source('prices', 'usd') }} price
     WHERE
-      price.symbol = 'LINK'     
+      price.symbol = 'LINK'
     GROUP BY
       1
     ORDER BY
       1
   ),
   vrf_reward_daily AS (
-    SELECT 
+    SELECT
       vrf_daily.date_start,
       cast(date_trunc('month', vrf_daily.date_start) as date) as date_month,
-      vrf_daily.operator_address,      
+      vrf_daily.operator_address,
       COALESCE(vrf_daily.token_amount, 0) as token_amount,
       COALESCE(vrf_daily.token_amount * lud.usd_amount, 0)  as usd_amount
-    FROM 
+    FROM
       {{ref('chainlink_polygon_vrf_request_fulfilled_daily')}} vrf_daily
     LEFT JOIN link_usd_daily lud ON lud.date_start = vrf_daily.date_start
     ORDER BY date_start
@@ -45,7 +44,7 @@ SELECT
   operator_address,
   token_amount,
   usd_amount
-FROM 
+FROM
   vrf_reward_daily
 ORDER BY
   2, 4


### PR DESCRIPTION
This changes the chainlink models to use the `incremental_predicate` macro and adds a incremental predicate strategy (`incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_month')]`. I didn't add the strategy everywhere because there are so many models but these should be the most heavy models. 

I used the following regex for search and replacing for the macro `(\w+\.\w+|\w+) >= date_trunc\(.*?\).*?\)`. This can be used for other models as well. 