### PR TITLE
Materialize dex raw pools

### DIFF
--- a/models/dex/dex_raw_pools.sql
+++ b/models/dex/dex_raw_pools.sql
@@ -1,8 +1,10 @@
 {{ config(
         schema='dex',
         alias = 'raw_pools',
-        materialized = 'view',
+        materialized = 'incremental',
         file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.creation_block_time')],
         unique_key = ['blockchain', 'pool'],
         post_hook='{{ expose_spells(\'["ethereum", "polygon", "bnb", "avalanche_c", "gnosis", "fantom", "optimism", "arbitrum", "celo", "base", "zksync", "zora"]\',
                         "sector",
@@ -17,6 +19,6 @@
 select * from {{ ref('dex_raw_pool_creations') }}
 where (blockchain, pool) not in (
     select blockchain, pool from {{ ref('dex_raw_pool_initializations') }}
-    group by blockchain, pool 
+    group by blockchain, pool
     having count(*) > 1
 )

--- a/models/dex/dex_raw_pools.sql
+++ b/models/dex/dex_raw_pools.sql
@@ -22,3 +22,6 @@ where (blockchain, pool) not in (
     group by blockchain, pool
     having count(*) > 1
 )
+{% if is_incremental() %}
+    and {{incremental_predicate('creation_block_time')}}
+{% endif %}


### PR DESCRIPTION
This spell is used as input for a lot of the oneinch spells. We should materialize it to improve performance of the downstream spells.
