### PR TITLE
Zeroex api fills performance

### DIFF
--- a/models/zeroex/bnb/zeroex_bnb_api_fills.sql
+++ b/models/zeroex/bnb/zeroex_bnb_api_fills.sql
@@ -347,6 +347,7 @@ uni_v2_swap as (
 
 
 )
+-- TODO: this is really slow, need to optimize
 , uni_v2_pair_creation as (
     SELECT
         bytearray_substring(data,13,20) as pair,

--- a/models/zeroex/polygon/zeroex_polygon_api_fills.sql
+++ b/models/zeroex/polygon/zeroex_polygon_api_fills.sql
@@ -173,7 +173,7 @@ ERC20BridgeTransfer AS (
     WHERE topic0 = 0x349fc08071558d8e3aa92dec9396e4e9f2dfecd6bb9065759d1932e7da43b8a9
 
     {% if is_incremental() %}
-    AND {{ incremental_predicate('zeroex_tx.block_time') }}
+    AND {{ incremental_predicate('logs.block_time') }}
     {% endif %}
     {% if not is_incremental() %}
     AND zeroex_tx.block_time >= cast('{{zeroex_v3_start_date}}' as date)


### PR DESCRIPTION
Didn't find much to change here but left a comment as well on the bnb_fills where it's doing a full scan on logs which is most of runtime for that query. I'm not sure if there's a decoded table we can use for that instead