### PR TITLE
Don't materialize rolling celo transfers

### DIFF
--- a/models/transfers/celo/erc20/transfers_celo_erc20_rolling_day.sql
+++ b/models/transfers/celo/erc20/transfers_celo_erc20_rolling_day.sql
@@ -2,12 +2,6 @@
     config(
 
         alias = 'erc20_rolling_day',
-        partition_by = ['block_month'],
-        materialized = 'incremental',
-        file_format = 'delta',
-        incremental_strategy = 'merge',
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_day')],
-        unique_key = ['wallet_address', 'token_address', 'block_day'],
         post_hook='{{ expose_spells(\'["celo"]\',
                                     "sector",
                                     "transfers",

--- a/models/transfers/celo/erc20/transfers_celo_erc20_rolling_hour.sql
+++ b/models/transfers/celo/erc20/transfers_celo_erc20_rolling_hour.sql
@@ -2,11 +2,6 @@
     config(
 
         alias = 'erc20_rolling_hour',
-        partition_by = ['block_month'],
-        materialized = 'incremental',
-        file_format = 'delta',
-        incremental_strategy = 'merge',incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_hour')],
-        unique_key = ['wallet_address', 'token_address', 'block_hour'],
         post_hook='{{ expose_spells(\'["celo"]\',
                                     "sector",
                                     "transfers",


### PR DESCRIPTION
Materializing these takes a very long time and has almost no usage. Will keep these around until there's balances for Celo but after that these can be dropped.