### PR TITLE
add account_type column to token_accounts solana

### DIFF
--- a/solana/models/solana_utils/solana_utils_schema.yml
+++ b/solana/models/solana_utils/solana_utils_schema.yml
@@ -14,6 +14,8 @@ models:
         name: token_mint_address
       - &address
         name: address
+      - &account_type
+        name: account_type
       - &updated_at
         name: updated_at
   

--- a/solana/models/solana_utils/solana_utils_token_accounts.sql
+++ b/solana/models/solana_utils/solana_utils_token_accounts.sql
@@ -25,7 +25,6 @@ WITH
             {% endif %}
             group by 1
       )
-
 SELECT
 *
 , case when nft.account_mint is not null then 'nft'

--- a/solana/models/solana_utils/solana_utils_token_accounts.sql
+++ b/solana/models/solana_utils/solana_utils_token_accounts.sql
@@ -29,8 +29,7 @@ WITH
 SELECT 
 * 
 , case when nft.account_mint is not null then 'nft' 
-      when token_mint_address is not null then 'fungible'
-      else 'basic' 
+      else 'fungible'
       end as account_type
 FROM distinct_accounts da
 LEFT JOIN {{ ref('tokens_solana_nft')}} nft ON da.token_mint_address = nft.account_mint

--- a/solana/models/solana_utils/solana_utils_token_accounts.sql
+++ b/solana/models/solana_utils/solana_utils_token_accounts.sql
@@ -12,10 +12,10 @@
                                     \'["ilemi"]\') }}')
 }}
 
-WITH 
+WITH
       distinct_accounts as (
             SELECT
-                  aa.address 
+                  aa.address
                   , max_by(aa.token_balance_owner, aa.block_time) as token_balance_owner
                   , max_by(aa.token_mint_address, aa.block_time) as token_mint_address
             FROM {{ source('solana','account_activity') }} aa
@@ -25,10 +25,10 @@ WITH
             {% endif %}
             group by 1
       )
-      
-SELECT 
-* 
-, case when nft.account_mint is not null then 'nft' 
+
+SELECT
+*
+, case when nft.account_mint is not null then 'nft'
       else 'fungible'
       end as account_type
 FROM distinct_accounts da

--- a/solana/models/solana_utils/solana_utils_token_accounts.sql
+++ b/solana/models/solana_utils/solana_utils_token_accounts.sql
@@ -26,4 +26,11 @@ WITH
             group by 1
       )
       
-SELECT * FROM distinct_accounts
+SELECT 
+* 
+, case when nft.account_mint is not null then 'nft' 
+      when token_mint_address is not null then 'fungible'
+      else 'basic' 
+      end as account_type
+FROM distinct_accounts da
+LEFT JOIN {{ ref('tokens_solana_nft')}} nft ON da.token_mint_address = nft.account_mint


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [x] Adding to existing spell lineage
- [ ] Bug fix

@aalan3 mentioned it would be good if added an account type column to token_accounts, so we can filter on the heavy JOINs. I'm adding it here.