### PR TITLE
Temporarily exclude lifinity

### DIFF
--- a/models/lifinity/lifinity_v1_trades.sql
+++ b/models/lifinity/lifinity_v1_trades.sql
@@ -4,6 +4,7 @@
         schema = 'lifinity_v1',
         alias = 'trades',
         partition_by = ['block_month'],
+        tags = ['prod_exclude'],
         materialized = 'incremental',
         file_format = 'delta',
         incremental_strategy = 'merge',

--- a/models/lifinity/lifinity_v2_trades.sql
+++ b/models/lifinity/lifinity_v2_trades.sql
@@ -5,6 +5,7 @@
         alias = 'trades',
         partition_by = ['block_month'],
         materialized = 'incremental',
+        tags = ['prod_exclude'],
         file_format = 'delta',
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],


### PR DESCRIPTION
Excluding due to this error:
` TrinoUserError(type=USER_ERROR, name=INVALID_FUNCTION_ARGUMENT, message="Array subscript must be less than or equal to array length: 4 > 3", query_id=20240612_153201_16653_7ym7k)`