### PR TITLE
Solana transfers: Change to LEFT join

### DIFF
--- a/models/tokens/solana/tokens_solana_transfers.sql
+++ b/models/tokens/solana/tokens_solana_transfers.sql
@@ -76,7 +76,7 @@ SELECT
     , outer_executing_account
 FROM base tr
 --get token and accounts
-INNER JOIN {{ ref('solana_utils_token_accounts') }} tk_s ON tk_s.address = tr.from_token_account
-INNER JOIN {{ ref('solana_utils_token_accounts') }} tk_d ON tk_d.address = tr.to_token_account
+LEFT JOIN {{ ref('solana_utils_token_accounts') }} tk_s ON tk_s.address = tr.from_token_account
+LEFT JOIN {{ ref('solana_utils_token_accounts') }} tk_d ON tk_d.address = tr.to_token_account
 WHERE 1=1
 -- AND call_block_time > now() - interval '90' day --for faster CI testing


### PR DESCRIPTION
Token accounts can actually be null and this is causing incorrect values currently

Fixes https://github.com/duneanalytics/spellbook/issues/6160.