### PR TITLE
simplify `dbt compile` step in CI pipeline

### DIFF
--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -42,7 +42,7 @@ jobs:
         run: "./scripts/ensure_cluster.sh"
 
       - name: dbt compile to create manifest to compare to
-        run: "dbt --warn-error compile $PROFILE --project-dir ${PROJECT_DIR}"
+        run: "dbt --warn-error compile --project-dir ${PROJECT_DIR}"
 
       - name: check schemas
         run: |

--- a/models/_trino_upgrade/trino_upgrade_tevaera_zksync_base_trades.sql
+++ b/models/_trino_upgrade/trino_upgrade_tevaera_zksync_base_trades.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'trino_upgrade_tevaera_zksync',
         alias = 'base_trades',
         materialized = 'incremental',

--- a/models/_trino_upgrade/trino_upgrade_tevaera_zksync_base_trades.sql
+++ b/models/_trino_upgrade/trino_upgrade_tevaera_zksync_base_trades.sql
@@ -1,6 +1,5 @@
 {{
     config(
-        tags = ['prod_exclude'],
         schema = 'trino_upgrade_tevaera_zksync',
         alias = 'base_trades',
         materialized = 'incremental',


### PR DESCRIPTION
thought process:
- initial commit, let the normal CI run to see runtimes
- remove the profile flag from compile step to force the dummy profile at root of spellbook to be used (similar to wizard flow)
- ideally no queries run on compile due to this setup
- goal: much faster compile in CI