### PR TITLE
bonkbot trades: failing on dupes

### DIFF
--- a/models/_sector/dex/bot_trades/solana/platforms/bonkbot_solana_bot_trades.sql
+++ b/models/_sector/dex/bot_trades/solana/platforms/bonkbot_solana_bot_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     alias = 'bot_trades',
     schema = 'bonkbot_solana',
     partition_by = ['block_month'],


### PR DESCRIPTION
fyi @whalehunting 
```
10:55:03    Database Error in model bonkbot_solana_bot_trades (models/_sector/dex/bot_trades/solana/platforms/bonkbot_solana_bot_trades.sql)
  TrinoUserError(type=USER_ERROR, name=MERGE_TARGET_ROW_MULTIPLE_MATCHES, message="One MERGE target table row matched more than one source row", query_id=20240614_104717_08379_w94v9)
```

please take a moment to compile the query and find where duplicates are introduced in source. it just started failing, so can likely filter to last few days for better runtime. the unique keys are either not unique enough or a bug was introduced