### PR TITLE
safe zksync: exclude failing model

### DIFF
--- a/models/safe/zksync/safe_zksync_eth_transfers.sql
+++ b/models/safe/zksync/safe_zksync_eth_transfers.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         materialized='incremental',
         schema = 'safe_zksync',
         alias = 'eth_transfers',


### PR DESCRIPTION
fyi @danielpartida 
we are hitting an odd error on this one:
```
14:33:21    Database Error in model safe_zksync_eth_transfers (models/safe/zksync/safe_zksync_eth_transfers.sql)
  TrinoQueryError(type=INTERNAL_ERROR, name=GENERIC_INTERNAL_ERROR, message="low must be less than or equal to high. Actual: low=Slice{base=[B@1924116f, baseOffset=0, length=32}, high=Slice{base=[B@e80f6c7, baseOffset=0, length=32}", query_id=20240619_142246_70673_5i678)
```

my best guess is how `trace_address` column is being built, since the error mentions slices and it's an array? it also appears to only happen on the merge statement, since running the query as a select returns fine.

let us know if you find any solution here, otherwise we can attempt to look a bit too. i will need to exclude for now.