### PR TITLE
add missing factory to curve pools

### DIFF
--- a/dex/models/_projects/curvefi/ethereum/_schema.yml
+++ b/dex/models/_projects/curvefi/ethereum/_schema.yml
@@ -70,7 +70,7 @@ models:
     meta:
       blockchain: ethereum
       project: curvefi
-      contributors: [agaperste, yulesa, ilemi]
+      contributors: [agaperste, yulesa, ilemi, viniabussafi]
     config:
       tags: ["ethereum", "curvefi", "view_pools", "view"]
     description: >

--- a/dex/models/_projects/curvefi/ethereum/curvefi_ethereum_view_pools.sql
+++ b/dex/models/_projects/curvefi/ethereum/curvefi_ethereum_view_pools.sql
@@ -6,7 +6,7 @@
     post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "project",
                                 "curvefi",
-                                \'["yulesa", "agaperste", "ilemi"]\') }}'
+                                \'["yulesa", "agaperste", "ilemi", "viniabussafi"]\') }}'
     )
  }}
 
@@ -217,7 +217,39 @@ v1_stableswap as (
         ) }} dp
         ON p.call_block_time = dp.evt_block_time
         AND p.call_tx_hash = dp.evt_tx_hash
-)
+),
+
+v1_stableswap_ng as (
+    SELECT
+        'Factory V1 Stableswap Plain NG' AS version,
+        dp._name AS name,
+        dp._symbol AS symbol,
+        dp.output_0 AS pool_address,
+        dp._A AS A,        
+        dp._fee AS mid_fee,
+        dp._fee AS out_fee,
+        dp.output_0 AS token_address,
+        dp.output_0 AS deposit_contract,
+        p.coins[1] AS coin0,
+        p.coins[2] AS coin1,
+        COALESCE(try(p.coins[3]),CAST(NULL as varbinary)) as coin2,
+        COALESCE(try(p.coins[4]),CAST(NULL as varbinary)) as coin3,
+        CAST(NULL as varbinary) AS undercoin0,
+        CAST(NULL as varbinary) AS undercoin1,
+        CAST(NULL as varbinary) AS undercoin2,
+        CAST(NULL as varbinary) AS undercoin3
+    FROM
+        {{ source(
+            'curvefi_ethereum',
+            'CurveStableswapFactoryNG_evt_PlainPoolDeployed'
+        ) }} as p
+        LEFT JOIN {{ source(
+            'curvefi_ethereum',
+            'CurveStableswapFactoryNG_call_deploy_plain_pool'
+        ) }} dp
+        ON p.call_block_time = dp.evt_block_time
+        AND p.call_tx_hash = dp.evt_tx_hash
+),
 
 , v1_pools_deployed AS (
     SELECT
@@ -282,6 +314,27 @@ v1_stableswap as (
         undercoin3
     FROM
         v1_stableswap
+    UNION ALL
+    SELECT
+        version,
+        name,
+        symbol,
+        pool_address,
+        A,
+        mid_fee,
+        out_fee,
+        token_address,
+        deposit_contract,
+        coin0,
+        coin1,
+        coin2,
+        coin3,
+        undercoin0,
+        undercoin1,
+        undercoin2,
+        undercoin3
+    FROM
+        v1_stableswap_ng
 ),
 ---------------------------------------------------------------- V2 Pools ----------------------------------------------------------------
 v2_pools_deployed AS (

--- a/dex/models/_projects/curvefi/ethereum/curvefi_ethereum_view_pools.sql
+++ b/dex/models/_projects/curvefi/ethereum/curvefi_ethereum_view_pools.sql
@@ -247,8 +247,8 @@ v1_stableswap_ng as (
             'curvefi_ethereum',
             'CurveStableswapFactoryNG_call_deploy_plain_pool'
         ) }} dp
-        ON p.call_block_time = dp.evt_block_time
-        AND p.call_tx_hash = dp.evt_tx_hash
+        ON dp.call_block_time = p.evt_block_time
+        AND dp.call_tx_hash = p.evt_tx_hash
 ),
 
 v1_pools_deployed AS (

--- a/dex/models/_projects/curvefi/ethereum/curvefi_ethereum_view_pools.sql
+++ b/dex/models/_projects/curvefi/ethereum/curvefi_ethereum_view_pools.sql
@@ -66,7 +66,7 @@ plain_calls AS (
     FROM
         {{ source(
             'curvefi_ethereum',
-            '1'
+            'CurveFactory_call_deploy_plain_pool'
         ) }}
     WHERE
         call_success

--- a/dex/models/_projects/curvefi/ethereum/curvefi_ethereum_view_pools.sql
+++ b/dex/models/_projects/curvefi/ethereum/curvefi_ethereum_view_pools.sql
@@ -66,7 +66,7 @@ plain_calls AS (
     FROM
         {{ source(
             'curvefi_ethereum',
-            'CurveFactory_call_deploy_plain_pool'
+            '1'
         ) }}
     WHERE
         call_success
@@ -251,7 +251,7 @@ v1_stableswap_ng as (
         AND p.call_tx_hash = dp.evt_tx_hash
 ),
 
-, v1_pools_deployed AS (
+v1_pools_deployed AS (
     SELECT
         version,
         name,

--- a/sources/curvefi/ethereum/curvefi_ethereum_sources.yml
+++ b/sources/curvefi/ethereum/curvefi_ethereum_sources.yml
@@ -79,6 +79,10 @@ sources:
         loaded_at_field: call_block_time
       - name: crvUSD_StableswapFactory_call_deploy_metapool
         loaded_at_field: evt_block_time
+      - name: CurveStableswapFactoryNG_evt_PlainPoolDeployed
+        loaded_at_field: call_block_time
+      - name: CurveStableswapFactoryNG_call_deploy_plain_pool
+        loaded_at_field: call_block_time                
   - name: curvefi_v2_ethereum
     description: "decoded events and function calls for curve.fi v2 on ethereum"
     freshness: # default freshness


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [x] Adding to existing spell lineage
- [ ] Bug fix


### For adding to existing spell lineage
If you are adding to an existing spell lineage, please provide the following information:

- **Description:** 
This PR adds the [CurveStableswapFactoryNG](https://etherscan.io/address/0x6a8cbed756804b16e05e741edabd5cb544ae21bf#code) to the curvefi_ethereum_view_pools spell, since there are some missing pools on Curve's dex trades, such as https://etherscan.io/address/0xdb74dfdd3bb46be8ce6c33dc9d82777bcfc3ded5
@mendesfabio 