### PR TITLE
fix 1inch trade pair

### DIFF
--- a/dex/models/_projects/oneinch/oneinch_lop_own_trades.sql
+++ b/dex/models/_projects/oneinch/oneinch_lop_own_trades.sql
@@ -19,7 +19,10 @@ select
     , block_number
     , coalesce(dst_token_symbol, '') as token_bought_symbol
     , coalesce(src_token_symbol, '') as token_sold_symbol
-    , array_join(array_sort(array[coalesce(src_token_symbol, ''), coalesce(dst_token_symbol, '')]), '-') as token_pair
+    , case
+        when lower(src_token_symbol) > lower(dst_token_symbol) then concat(dst_token_symbol, '-', src_token_symbol)
+        else concat(src_token_symbol, '-', dst_token_symbol)
+        end AS token_pair
     , cast(dst_token_amount as double) / pow(10, dst_token_decimals) as token_bought_amount
     , cast(src_token_amount as double) / pow(10, src_token_decimals) as token_sold_amount
     , dst_token_amount as token_bought_amount_raw


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [ ] Adding to existing spell lineage
- [x] Bug fix

**Note:** You can safely discard any section below which doesn't apply based on selection above

---

### For bug fixes
If you are fixing a bug, please provide the following information:

- **Description:** 1inch LOP trades return `trade_pair` with symbols incorrectly sorted.
- **Implementation details:** Implemented the same logic as in `dex.trades` spells.

---

Thank you for your contribution!