### PR TITLE
bebop ethereum: remove troubled model

### DIFF
--- a/dex/models/_projects/bebop/ethereum/bebop_blend_ethereum_trades.sql
+++ b/dex/models/_projects/bebop/ethereum/bebop_blend_ethereum_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'bebop_blend_ethereum',
     alias = 'trades',
     partition_by = ['block_month'],

--- a/dex/models/_projects/bebop/ethereum/bebop_ethereum_trades.sql
+++ b/dex/models/_projects/bebop/ethereum/bebop_ethereum_trades.sql
@@ -11,8 +11,7 @@
 
 {% set bebop_models = [
     ref('bebop_rfq_ethereum_trades'),
-    ref('bebop_jam_ethereum_trades'),
-    ref('bebop_blend_ethereum_trades')
+    ref('bebop_jam_ethereum_trades')
 ] %}
 
 SELECT *


### PR DESCRIPTION
fyi @B1boid 
it appears this is not fixed. there must be an issue with the unique keys and merge statement. or there are truly duplicates.
```
select
  block_date,
  blockchain,
  project,
  version,
  tx_hash,
  evt_index,
  trace_address,
  count(1)
from
  dex_aggregator.trades
group by
  block_date,
  blockchain,
  project,
  version,
  tx_hash,
  evt_index,
  trace_address
having
  count(1) > 1
```