### PR TITLE
referral rewards: remove model with dupes

### DIFF
--- a/models/_sector/referral/rewards/referral_rewards.sql
+++ b/models/_sector/referral/rewards/referral_rewards.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'referral',
     alias = 'rewards',
     partition_by = ['blockchain','project','block_month'],


### PR DESCRIPTION
fyi @0xRobin 
this started to fail with duplicates. i didn't see any in the actual spell, so the source query must start producing dupes. i would imagine in the enrichment macro?
i need to exclude for now to get some merges to run