### PR TITLE
nft solana: remove opensea for now while excluded in prod

### DIFF
--- a/solana/models/_sector/nft/nft_solana_old_trades.sql
+++ b/solana/models/_sector/nft/nft_solana_old_trades.sql
@@ -9,7 +9,6 @@
 -- while we refactor more marketplace models, they should be removed here and added to the chain specific base_trades unions.
 {% set nft_models = [
 ref('magiceden_solana_events')
-,ref('opensea_solana_events')
 ] %}
 
 


### PR DESCRIPTION
fyi @andrewhong5297 @0xRobin @aalan3 
opensea on solana has `prod_exclude` tag. i'm not 100% sure the reason, so rather than re-include, i will remove from view for now. plz coordinate together on next steps for opensea data here