### PR TITLE
add lifinity back to solana dex trades

### DIFF
--- a/solana/models/_sector/dex/dex_solana_base_trades.sql
+++ b/solana/models/_sector/dex/dex_solana_base_trades.sql
@@ -18,6 +18,8 @@
     ref('orca_whirlpool_trades')
     , ref('raydium_v3_trades')
     , ref('raydium_v4_trades')
+    , ref('lifinity_v1_trades')
+    , ref('lifinity_v2_trades')
     , ref('phoenix_v1_trades')
     , ref('meteora_v1_solana_trades')
     , ref('meteora_v2_solana_trades')


### PR DESCRIPTION
we merged lifnity fixes, but forgot to add them back to the base trades view. adding it here. 