### PR TITLE
compound v3: exclude due to missing decoded sources

### DIFF
--- a/models/_sector/lending/borrow/arbitrum/platforms/compound_v3_arbitrum_base_borrow.sql
+++ b/models/_sector/lending/borrow/arbitrum/platforms/compound_v3_arbitrum_base_borrow.sql
@@ -1,5 +1,6 @@
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'compound_v3_arbitrum',
     alias = 'base_borrow',
     materialized = 'incremental',

--- a/models/_sector/lending/borrow/base/platforms/compound_v3_base_base_borrow.sql
+++ b/models/_sector/lending/borrow/base/platforms/compound_v3_base_base_borrow.sql
@@ -1,5 +1,6 @@
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'compound_v3_base',
     alias = 'base_borrow',
     materialized = 'incremental',

--- a/models/_sector/lending/borrow/ethereum/platforms/compound_v3_ethereum_base_borrow.sql
+++ b/models/_sector/lending/borrow/ethereum/platforms/compound_v3_ethereum_base_borrow.sql
@@ -1,5 +1,6 @@
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'compound_v3_ethereum',
     alias = 'base_borrow',
     materialized = 'incremental',

--- a/models/_sector/lending/supply/arbitrum/platforms/compound_v3_arbitrum_base_supply.sql
+++ b/models/_sector/lending/supply/arbitrum/platforms/compound_v3_arbitrum_base_supply.sql
@@ -1,5 +1,6 @@
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'compound_v3_arbitrum',
     alias = 'base_supply',
     materialized = 'incremental',

--- a/models/_sector/lending/supply/base/platforms/compound_v3_base_base_supply.sql
+++ b/models/_sector/lending/supply/base/platforms/compound_v3_base_base_supply.sql
@@ -1,5 +1,6 @@
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'compound_v3_base',
     alias = 'base_supply',
     materialized = 'incremental',

--- a/models/_sector/lending/supply/ethereum/platforms/compound_v3_ethereum_base_supply.sql
+++ b/models/_sector/lending/supply/ethereum/platforms/compound_v3_ethereum_base_supply.sql
@@ -1,5 +1,6 @@
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'compound_v3_ethereum',
     alias = 'base_supply',
     materialized = 'incremental',


### PR DESCRIPTION
fyi @tomfutago @hildobby as two main contributors towards lending sector spells. it appears compound v3 decoded tables were either removed or renamed. i tried to take a quick glance, but nothing was obvious to me. here are tables:
```
"delta_prod"."compound_v3_arbitrum"."Comet_evt_Withdraw"
"delta_prod"."compound_v3_arbitrum"."Comet_evt_Transfer"
"delta_prod"."compound_v3_arbitrum"."cUSDCv3Native_evt_Withdraw"
"delta_prod"."compound_v3_arbitrum"."cUSDCv3Native_evt_Transfer"
"delta_prod"."compound_v3_arbitrum"."Comet_evt_Supply"
"delta_prod"."compound_v3_arbitrum"."cUSDCv3Native_evt_Supply"
"delta_prod"."compound_v3_arbitrum"."Comet_evt_AbsorbDebt"
"delta_prod"."compound_v3_arbitrum"."cUSDCv3Native_evt_AbsorbDebt"
```

i've also reached out internally to see what may have happened to get these updated to correct names.