### PR TITLE
solana fees history: filter out dupes

### DIFF
--- a/solana/models/tokens/solana/tokens_solana_fees_history.sql
+++ b/solana/models/tokens/solana/tokens_solana_fees_history.sql
@@ -42,6 +42,7 @@ call_account_arguments[1] as account_mint
 , call_block_time as fee_time
 FROM {{ source('spl_token_2022_solana','spl_token_2022_call_transferFeeExtension') }}
 WHERE bytearray_substring(call_data,1+1,1) = 0x00 --https://github.com/solana-labs/solana-program-library/blob/8f50c6fabc6ec87ada229e923030381f573e0aed/token/program-2022/src/extension/transfer_fee/instruction.rs#L38
+    AND call_account_arguments[1] != '9Fy4NYzaUTA4qayuhSMPjUq5YMAiBR7BMmAXCiUHMRdt' --returns duplicates
 {% if is_incremental() %}
 AND {{incremental_predicate('call_block_time')}}
 {% endif %}
@@ -56,6 +57,7 @@ call_account_arguments[1] as account_mint
 , call_block_time as fee_time
 FROM {{ source('spl_token_2022_solana','spl_token_2022_call_transferFeeExtension') }}
 WHERE bytearray_substring(call_data,1+1,1) = 0x05 --https://github.com/solana-labs/solana-program-library/blob/8f50c6fabc6ec87ada229e923030381f573e0aed/token/program-2022/src/extension/transfer_fee/instruction.rs#L147
+    AND call_account_arguments[1] != '9Fy4NYzaUTA4qayuhSMPjUq5YMAiBR7BMmAXCiUHMRdt' --returns duplicates
 {% if is_incremental() %}
 AND {{incremental_predicate('call_block_time')}}
 {% endif %}


### PR DESCRIPTION
fyi @andrewhong5297 
prod started failing on this one. looks like the below started creating dupes. felt safer to filter this one out rather than switch to `union` or exclude from prod completely.

```
with
  spell as (
    --we need the fee basis points and maximum fee for token2022 transfers because the fee amount is not emitted in transferChecked
    SELECT
      call_account_arguments[1] as account_mint,
      try(
        bytearray_to_uint256 (
          bytearray_reverse (
            bytearray_substring (
              call_data,
              1 + 1 + 1 + 1 + 1 + case
                when bytearray_substring (call_data, 1 + 1 + 1, 1) = 0x01
                and bytearray_substring (call_data, 1 + 1 + 1 + 32 + 1, 1) = 0x01 then 64
                when bytearray_substring (call_data, 1 + 1 + 1, 1) = 0x01
                and bytearray_substring (call_data, 1 + 1 + 1 + 32 + 1, 1) = 0x00 then 32
                when bytearray_substring (call_data, 1 + 1 + 1, 1) = 0x00
                and bytearray_substring (call_data, 1 + 1 + 1 + 1, 1) = 0x01 then 32
                when bytearray_substring (call_data, 1 + 1 + 1, 1) = 0x00
                and bytearray_substring (call_data, 1 + 1 + 1 + 1, 1) = 0x00 then 0
              end --variations of COPTION enums for first two arguments
,
              2
            )
          )
        )
      ) as fee_basis,
      try(
        bytearray_to_uint256 (
          bytearray_reverse (
            bytearray_substring (
              call_data,
              1 + 1 + 1 + 1 + 1 + case
                when bytearray_substring (call_data, 1 + 1 + 1, 1) = 0x01
                and bytearray_substring (call_data, 1 + 1 + 1 + 32 + 1, 1) = 0x01 then 64
                when bytearray_substring (call_data, 1 + 1 + 1, 1) = 0x01
                and bytearray_substring (call_data, 1 + 1 + 1 + 32 + 1, 1) = 0x00 then 32
                when bytearray_substring (call_data, 1 + 1 + 1, 1) = 0x00
                and bytearray_substring (call_data, 1 + 1 + 1 + 1, 1) = 0x01 then 32
                when bytearray_substring (call_data, 1 + 1 + 1, 1) = 0x00
                and bytearray_substring (call_data, 1 + 1 + 1 + 1, 1) = 0x00 then 0
              end + 2,
              16
            )
          )
        )
      ) as fee_maximum,
      call_block_time as fee_time
    FROM
      "delta_prod"."spl_token_2022_solana"."spl_token_2022_call_transferFeeExtension"
    WHERE
      bytearray_substring (call_data, 1 + 1, 1) = 0x00 --https://github.com/solana-labs/solana-program-library/blob/8f50c6fabc6ec87ada229e923030381f573e0aed/token/program-2022/src/extension/transfer_fee/instruction.rs#L38
    UNION ALL
    SELECT
      call_account_arguments[1] as account_mint,
      try(
        bytearray_to_uint256 (
          bytearray_reverse (bytearray_substring (call_data, 1 + 1 + 1, 2))
        )
      ) as fee_basis,
      try(
        bytearray_to_uint256 (
          bytearray_reverse (
            bytearray_substring (call_data, 1 + 1 + 1 + 2, 16)
          )
        )
      ) as fee_maximum,
      call_block_time as fee_time
    FROM
      "delta_prod"."spl_token_2022_solana"."spl_token_2022_call_transferFeeExtension"
    WHERE
      bytearray_substring (call_data, 1 + 1, 1) = 0x05 --https://github.com/solana-labs/solana-program-library/blob/8f50c6fabc6ec87ada229e923030381f573e0aed/token/program-2022/src/extension/transfer_fee/instruction.rs#L147
  ),
  find_dupes as (
    select
      account_mint,
      fee_time,
      count(1)
    from
      spell
    group by
      account_mint,
      fee_time
    having
      count(1) > 1
  ),
  dig_in_details as (
    select
      *
    from
      spell
    where
      account_mint = '9Fy4NYzaUTA4qayuhSMPjUq5YMAiBR7BMmAXCiUHMRdt'
  )
select
  *
from
  dig_in_details
```