### PR TITLE
exclude tokens_solana_fees_history

### DIFF
--- a/dbt_subprojects/solana/models/tokens/solana/tokens_solana_fees_history.sql
+++ b/dbt_subprojects/solana/models/tokens/solana/tokens_solana_fees_history.sql
@@ -12,7 +12,7 @@
                                     "tokens",
                                     \'["ilemi"]\') }}')
 }}
-
+-- change to trigger CI
 --we need the fee basis points and maximum fee for token2022 transfers because the fee amount is not emitted in transferChecked
 SELECT
 call_account_arguments[1] as account_mint

--- a/dbt_subprojects/solana/models/tokens/solana/tokens_solana_fees_history.sql
+++ b/dbt_subprojects/solana/models/tokens/solana/tokens_solana_fees_history.sql
@@ -2,6 +2,7 @@
   config(
         schema = 'tokens_solana',
         alias = 'fees_history',
+        tags = ['prod_exclude'],
         materialized = 'incremental',
         file_format = 'delta',
         incremental_strategy = 'merge',
@@ -12,7 +13,6 @@
                                     "tokens",
                                     \'["ilemi"]\') }}')
 }}
--- change to trigger CI
 --we need the fee basis points and maximum fee for token2022 transfers because the fee amount is not emitted in transferChecked
 SELECT
 call_account_arguments[1] as account_mint

--- a/dbt_subprojects/solana/models/tokens/solana/tokens_solana_schema.yml
+++ b/dbt_subprojects/solana/models/tokens/solana/tokens_solana_schema.yml
@@ -37,6 +37,11 @@ models:
     config:
       tags: ['table', 'metadata', 'fess', 'solana']
     description: "fee updates on token2022 tokens"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - account_mint
+            - fee_time
     columns:
       - name: account_mint
         description: "fungible token mint address on Solana"
@@ -112,7 +117,7 @@ models:
       - name: from_token_account
       - name: to_token_account
       - name: token_version
-      - name: tx_signer 
+      - name: tx_signer
       - name: tx_id
       - name: outer_instruction_index
       - name: inner_instruction_index


### PR DESCRIPTION
Temporarily exclude `tokens_solana_fees_history` as it is producing recurring duplicates.
@andrewhong5297 can you take a look at this and find the best way to resolve?
 
I've also noted that the join here will introduce duplicates in spl transfers if there are more `fee_time` values that match the condition, not sure if that's desirable?
https://github.com/duneanalytics/spellbook/blob/10d60866435f6509869e3c08109f680028ed07c1/dbt_subprojects/solana/models/tokens/solana/tokens_solana_token22_spl_transfers.sql#L40

PR from previous duplicate: https://github.com/duneanalytics/spellbook/pull/6436
cc: @jeff-dude 