### PR TITLE
attempt to fix 0x lineage: list out columns in views

### DIFF
--- a/dbt_subprojects/dex/models/_projects/zeroex/zeroex_api_fills_deduped.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/zeroex_api_fills_deduped.sql
@@ -33,7 +33,29 @@ SELECT *
 FROM (
     {% for model in zeroex_models %}
     SELECT
-      *
+      blockchain
+      ,version
+      ,block_month
+      ,block_date
+      ,block_time
+      ,maker_symbol
+      ,taker_symbol
+      ,token_pair
+      ,maker_token_amount
+      ,taker_token_amount
+      ,maker_token_amount_raw
+      ,taker_token_amount_raw
+      ,volume_usd
+      ,maker_token
+      ,taker_token
+      ,taker
+      ,maker
+      ,contract_address
+      ,tx_hash
+      ,tx_from
+      ,tx_to
+      ,trace_address
+      ,evt_index
     FROM {{ model }}
     {% if not loop.last %}
     UNION ALL

--- a/dbt_subprojects/dex/models/_projects/zeroex/zeroex_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/zeroex_trades.sql
@@ -44,12 +44,9 @@ FROM (
       tx_to  as tx_to,
       trace_address,
       evt_index  as evt_index
-
     FROM {{ model }}
     {% if not loop.last %}
-
     UNION ALL
-
     {% endif %}
     {% endfor %}
 )

--- a/dbt_subprojects/dex/models/aggregator_trades/dex_aggregator_trades.sql
+++ b/dbt_subprojects/dex/models/aggregator_trades/dex_aggregator_trades.sql
@@ -1,6 +1,5 @@
 
 {{ config(
-        
         schema ='dex_aggregator',
         alias = 'trades',
         materialized = 'incremental',


### PR DESCRIPTION
fyi @RantumBits 
downstream spell `dex_aggregator.trades` is failing after 0x merges. here is error:
```
16:04:40    Database Error in model dex_aggregator_trades (models/aggregator_trades/dex_aggregator_trades.sql)
  TrinoUserError(type=USER_ERROR, name=INVALID_CAST_ARGUMENT, message="Overflow in INT256 cast of UINT256: 115792089237316195423570985008687907853269984665640564039457584007913129639935", query_id=20240730_160115_00738_ey36i)
  compiled Code at [target/run/dex/models/aggregator_trades/dex_aggregator_trades.sql](https://cloud.getdbt.com/api/v2/accounts/58579/runs/309173122/artifacts/run/dex/models/aggregator_trades/dex_aggregator_trades.sql)
```

i'm wondering if adding the new spells into the view with `select *` broke the order of columns, leading to incorrect values in column(s) converting to uint256. not 100% sure honestly. giving this a shot.