### PR TITLE
Fix Ethereum `gas.fees`

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_sector/gas/fees/ethereum/gas_ethereum_fees.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/gas/fees/ethereum/gas_ethereum_fees.sql
@@ -55,7 +55,7 @@ SELECT
      txns.type AS transaction_type
 FROM {{ source('ethereum', 'transactions') }} txns
 INNER JOIN {{ source('ethereum', 'blocks') }} blocks ON txns.block_number = blocks.number
-INNER JOIN {{ source('ethereum', 'blobs_submissions') }} blob ON txns.hash = blob.tx_hash
+LEFT JOIN {{ source('ethereum', 'blobs_submissions') }} blob ON txns.hash = blob.tx_hash
 LEFT JOIN {{ source('prices', 'usd') }} p ON p.minute = date_trunc('minute', txns.block_time)
      AND p.blockchain = 'ethereum'
      AND p.symbol = 'WETH'


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Update!
Please build spells in the proper [subproject](../dbt_subprojects/) directory. For more information, please see the main [readme](../README.md), which also links to a GH discussion with the option to ask questions.

### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [ ] Adding to existing spell lineage
- [X] Bug fix

**Note:** You can safely discard any section below which doesn't apply based on selection above

---

### For bug fixes
If you are fixing a bug, please provide the following information:

- **Description:** Truncated data on gas.fees due to https://github.com/duneanalytics/spellbook/pull/6441
- **Steps to reproduce:** gas.fees for Ethereum only starts from 2024-03-13, when EIP4844 went live, while it should be over the full Ethereum history
- **Implementation details:** Change from INNER JOIN to LEFT JOIN


---

Thank you for your contribution!