### PR TITLE
Validator identities

### DIFF
--- a/dbt_subprojects/solana/models/_sector/staking/solana/staking_solana_schema.yml
+++ b/dbt_subprojects/solana/models/_sector/staking/solana/staking_solana_schema.yml
@@ -37,3 +37,23 @@ models:
       - name: outer_instruction_index
       - name: inner_instruction_index
       - name: tx_id
+  - name: staking_solana_vote_account_identities
+    meta:
+      blockchain: solana
+      sector: staking
+      contributors: ilemi
+    config:
+      tags: ['solana', 'staking', 'identity','vote']
+    description: get identities behind vote accounts (needed to calculate fee rewards correctly)
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_time
+            - vote_identity
+            - vote_account
+    columns:
+      - name: vote_identity
+        description: the identity account behind the vote account (will recieve the fees)
+      - name: vote_account
+        description: the vote account address
+      - name: block_time

--- a/dbt_subprojects/solana/models/_sector/staking/solana/staking_solana_vote_account_identities.sql
+++ b/dbt_subprojects/solana/models/_sector/staking/solana/staking_solana_vote_account_identities.sql
@@ -26,18 +26,18 @@ AND tx.success
 WHERE {{incremental_predicate('tx.block_time')}}
 {% endif %}
 
---UNION ALL 
+UNION ALL 
 
---SELECT 
-    --ix.account_arguments[1] as vote_account
-    --, ix.account_arguments[2] as vote_identity
-    --, tx.block_time
---FROM {{ source('solana','vote_transactions') }} tx
---LEFT JOIN unnest(instructions) as ix ON true
---WHERE ix.executing_account = 'Vote111111111111111111111111111111111111111'
---AND cardinality(ix.account_arguments) >= 3
---AND bytearray_substring(from_base58(ix.data),1,1) = 0x04 --UpdateValidatorIdentity
---AND tx.success
---{% if is_incremental() %}
---WHERE {{incremental_predicate('tx.block_time')}}
---{% endif %}
+SELECT 
+    ix.account_arguments[1] as vote_account
+    , ix.account_arguments[2] as vote_identity
+    , tx.block_time
+FROM {{ source('solana','vote_transactions') }} tx
+LEFT JOIN unnest(instructions) as ix ON true
+WHERE ix.executing_account = 'Vote111111111111111111111111111111111111111'
+AND cardinality(ix.account_arguments) >= 3
+AND bytearray_substring(from_base58(ix.data),1,1) = 0x04 --UpdateValidatorIdentity
+AND tx.success
+{% if is_incremental() %}
+WHERE {{incremental_predicate('tx.block_time')}}
+{% endif %}

--- a/dbt_subprojects/solana/models/_sector/staking/solana/staking_solana_vote_account_identities.sql
+++ b/dbt_subprojects/solana/models/_sector/staking/solana/staking_solana_vote_account_identities.sql
@@ -1,0 +1,43 @@
+{{ config(
+    schema = 'staking_solana'
+    , alias = 'vote_account_identities'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_time', 'vote_identity', 'vote_account']
+    , post_hook='{{ expose_spells(\'["solana"]\',
+                                "sector",
+                                "staking",
+                                \'["ilemi"]\') }}')
+}}
+
+-- https://docs.rs/solana-vote-program/1.18.18/solana_vote_program/vote_instruction/enum.VoteInstruction.html
+SELECT 
+    ix.account_arguments[1] as vote_account
+    , ix.account_arguments[4] as vote_identity
+    , tx.block_time
+FROM {{ source('solana','vote_transactions') }} tx
+LEFT JOIN unnest(instructions) as ix ON true
+WHERE ix.executing_account = 'Vote111111111111111111111111111111111111111'
+AND cardinality(ix.account_arguments) >= 4
+AND bytearray_substring(from_base58(ix.data),1,1) = 0x00 --init
+AND tx.success
+{% if is_incremental() %}
+WHERE {{incremental_predicate('tx.block_time')}}
+{% endif %}
+
+UNION ALL 
+
+SELECT 
+    ix.account_arguments[1] as vote_account
+    , ix.account_arguments[2] as vote_identity
+    , tx.block_time
+FROM {{ source('solana','vote_transactions') }} tx
+LEFT JOIN unnest(instructions) as ix ON true
+WHERE ix.executing_account = 'Vote111111111111111111111111111111111111111'
+AND cardinality(ix.account_arguments) >= 3
+AND bytearray_substring(from_base58(ix.data),1,1) = 0x04 --UpdateValidatorIdentity
+AND tx.success
+{% if is_incremental() %}
+WHERE {{incremental_predicate('tx.block_time')}}
+{% endif %}

--- a/dbt_subprojects/solana/models/_sector/staking/solana/staking_solana_vote_account_identities.sql
+++ b/dbt_subprojects/solana/models/_sector/staking/solana/staking_solana_vote_account_identities.sql
@@ -26,18 +26,18 @@ AND tx.success
 WHERE {{incremental_predicate('tx.block_time')}}
 {% endif %}
 
-UNION ALL 
+--UNION ALL 
 
-SELECT 
-    ix.account_arguments[1] as vote_account
-    , ix.account_arguments[2] as vote_identity
-    , tx.block_time
-FROM {{ source('solana','vote_transactions') }} tx
-LEFT JOIN unnest(instructions) as ix ON true
-WHERE ix.executing_account = 'Vote111111111111111111111111111111111111111'
-AND cardinality(ix.account_arguments) >= 3
-AND bytearray_substring(from_base58(ix.data),1,1) = 0x04 --UpdateValidatorIdentity
-AND tx.success
-{% if is_incremental() %}
-WHERE {{incremental_predicate('tx.block_time')}}
-{% endif %}
+--SELECT 
+    --ix.account_arguments[1] as vote_account
+    --, ix.account_arguments[2] as vote_identity
+    --, tx.block_time
+--FROM {{ source('solana','vote_transactions') }} tx
+--LEFT JOIN unnest(instructions) as ix ON true
+--WHERE ix.executing_account = 'Vote111111111111111111111111111111111111111'
+--AND cardinality(ix.account_arguments) >= 3
+--AND bytearray_substring(from_base58(ix.data),1,1) = 0x04 --UpdateValidatorIdentity
+--AND tx.success
+--{% if is_incremental() %}
+--WHERE {{incremental_predicate('tx.block_time')}}
+--{% endif %}

--- a/sources/_base_sources/solana_base_sources.yml
+++ b/sources/_base_sources/solana_base_sources.yml
@@ -7,6 +7,8 @@ sources:
     freshness:
       warn_after: { count: 12, period: hour }
     tables:
+      - name: vote_transactions
+        loaded_at_field: block_time
       - name: transactions
         loaded_at_field: block_time
         description: "A Solana transaction contains a compact-array of signatures, followed by a message. Each item in the signatures array is a digital signature of the given message.."


### PR DESCRIPTION
Moving the "vote identities" table from https://github.com/duneanalytics/spellbook/pull/6496 into this PR to run on it's own as it's timing out right now.

"staking_solana.vote_account_identities": this table connects the owners of the vote accounts over time. This is necessary to easily attribute/connect block proposal rewards (fee/rent type specifically). I may need help figuring out some better filters on vote_transactions since that table is gigantic.