### PR TITLE
make epochs table instead of incremental

### DIFF
--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_epochs.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_epochs.sql
@@ -2,11 +2,9 @@
   config(
         schema = 'solana_utils',
         alias = 'epochs',
-        materialized='incremental',
+        materialized='table',
         file_format = 'delta',
-        incremental_strategy = 'merge',
         unique_key = ['block_slot'],
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",
                                     "solana_utils",
@@ -25,9 +23,6 @@ with
                 order by slot desc) as last_block_epoch
             , slot % 432000 as epoch_progress --blocks into epoch. might not always start at 0 because of skipped block slots. remember "height" shows actual non-skipped blocks but epoch follows total blocks.
         FROM {{ source('solana','blocks') }}
-        {% if is_incremental() %}
-        WHERE {{incremental_predicate('time')}}
-        {% endif %}
     )
     
 SELECT 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Update!
Please build spells in the proper [subproject](../dbt_subprojects/) directory. For more information, please see the main [readme](../README.md), which also links to a GH discussion with the option to ask questions.

### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [ ] Adding to existing spell lineage
- [x] Bug fix

I'm making solana_utils.epoch a table to refresh fully each time versus incremental, because the incremental is messing with the row_number() to get `first_block_epoch`. because each time it runs, it will add a new first_block_epoch window function ordering which then messes up the query. Open to creative solutions here too if anyone thinks of one, too late in the night for me to find one haha