### PR TITLE
add missing column in tirador_solana_bot_trades to fix dex_solana_bot_trades

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/dex_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/dex_solana_bot_trades.sql
@@ -32,7 +32,7 @@
 SELECT block_time,
        block_date,
        block_month,
-       bot, -- Test if this works now
+       bot,
        blockchain,
        amount_usd,
        type,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/dex_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/dex_solana_bot_trades.sql
@@ -32,7 +32,7 @@
 SELECT block_time,
        block_date,
        block_month,
-       bot,
+       bot, -- Test if this works now
        blockchain,
        amount_usd,
        type,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/tirador_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/tirador_solana_bot_trades.sql
@@ -41,7 +41,6 @@ WITH
       CAST(date_trunc('day', trades.block_time) AS date) AS block_date,
       CAST(date_trunc('month', trades.block_time) AS date) AS block_month,
       'solana' AS blockchain,
-      'Tirador' AS bot,
       amount_usd,
       IF(
         token_sold_mint_address = '{{wsol_token}}',
@@ -112,6 +111,7 @@ SELECT
   block_time,
   block_date,
   block_month,
+  'Tirador' AS bot,
   blockchain,
   amount_usd,
   type,


### PR DESCRIPTION
### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [ ] Adding to existing spell lineage
- [x] Bug fix

---

### For bug fixes

- **Description:** The `dex_solana.bot_trades` table isn't compiling / adding a new column, because a dependent table (`tirador_solana_bot_trades`) is missing the `bot` column (see https://github.com/duneanalytics/spellbook/issues/6610). This PR adds the column to the output of this table.
- **Steps to reproduce:** `dbt compile --select "dex_solana_bot_trades"`
- **Implementation details:** `dbt compile --select "tirador_solana_bot_trades"`
- **Test instructions:** Not quite sure, I think automation should ensure the query runs
- **Related issue(s):** [[Link to related issues, if any]](https://github.com/duneanalytics/spellbook/issues/6610)

