### PR TITLE
dodo bnb: exclude from prod due to dupes

### DIFF
--- a/dbt_subprojects/dex/models/trades/bnb/platforms/dodo_bnb_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/bnb/platforms/dodo_bnb_base_trades.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'dodo_bnb',
         alias = 'base_trades',
         materialized = 'incremental',
@@ -9,6 +10,9 @@
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     )
 }}
+
+--note: this model has been excluded due to tx_hash and evt_index being non-unique in the source data
+--please check git history for PR which explains in more detail
 
 {% set config_markets %}
     WITH dodo_view_markets (market_contract_address, base_token_symbol, quote_token_symbol, base_token_address, quote_token_address) AS 


### PR DESCRIPTION
fyi @Hosuke 
not sure who the original author is to tag, but i need to exclude dodo on bnb due to model creating duplicates on tx hash/evt index. it looks like some tx's are coming through multiple decoded tables. i would say we don't need to take action on this, as we can exclude and comment why to point back to as needed.

query to show dupes:
```
with
  spell as (
    -- copy/paste dbt compile raw sql output of troubled spell
    WITH
      markets (
        market_contract_address,
        base_token_symbol,
        quote_token_symbol,
        base_token_address,
        quote_token_address
      ) AS (
        WITH
          dodo_view_markets (
            market_contract_address,
            base_token_symbol,
            quote_token_symbol,
            base_token_address,
            quote_token_address
          ) AS (
            VALUES
              (
                0x327134dE48fcDD75320f4c32498D1980470249ae,
                'WBNB',
                'BUSD',
                0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c,
                0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56
              ),
              (
                0x5BDCf4962FDED6B7156E710400F4C4c031f600dC,
                'KOGE',
                'WBNB',
                0xe6DF05CE8C8301223373CF5B969AFCb1498c5528,
                0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c
              ),
              (
                0xBe60d4c4250438344bEC816Ec2deC99925dEb4c7,
                'BUSD',
                'USDT',
                0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56,
                0x55d398326f99059fF775485246999027B3197955
              ),
              (
                0xC64a1d5C819B3c9113cE3DB32B66D5D2b05B4CEf,
                'BTCB',
                'BUSD',
                0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c,
                0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56
              ),
              (
                0x89E5015ff12E4536691aBfe5f115B1cB37a35465,
                'ETH',
                'BUSD',
                0x2170Ed0880ac9A755fd29B2688956BD959F933F8,
                0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56
              ),
              (
                0x6064DBD0fF10BFeD5a797807042e9f63F18Cfe10,
                'USDC',
                'BUSD',
                0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d,
                0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56
              ),
              (
                0xb1327B6402ddbA34584Ab59fbe8Ac7cbF43f6353,
                'DOT',
                'BUSD',
                0x7083609fCE4d1d8Dc0C979AAb8c869Ea2C873402,
                0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56
              ),
              (
                0x8d078451a63D118bACC9Cc46698cc416f81C93E2,
                'LINK',
                'BUSD',
                0xF8A0BF9cF54Bb92F17374d9e9A321E6a111a51bD,
                0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56
              ),
              (
                0x82AfF931d74F0645Ce80e8f419b94c8F93952686,
                'WBNB',
                'USDT',
                0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c,
                0x55d398326f99059fF775485246999027B3197955
              )
          )
        SELECT
          *
        FROM
          dodo_view_markets
      ),
      base_token_dexs AS (
        -- dodo v1 sell
        SELECT
          '1' AS version,
          s.evt_block_number AS block_number,
          s.evt_block_time AS block_time,
          s.seller AS taker,
          CAST(NULL AS VARBINARY) AS maker,
          s.payBase AS token_bought_amount_raw,
          s.receiveQuote AS token_sold_amount_raw,
          m.base_token_address AS token_bought_address,
          m.quote_token_address AS token_sold_address,
          s.contract_address AS project_contract_address,
          s.evt_tx_hash AS tx_hash,
          s.evt_index
        FROM
          "delta_prod"."dodoex_bnb"."DODO_evt_SellBaseToken" s
          LEFT JOIN markets m ON s.contract_address = m.market_contract_address
        UNION ALL
        -- dodo v1 buy
        SELECT
          '1' AS version,
          b.evt_block_number AS block_number,
          b.evt_block_time AS block_time,
          b.buyer AS taker,
          CAST(NULL AS VARBINARY) AS maker,
          b.receiveBase AS token_bought_amount_raw,
          b.payQuote AS token_sold_amount_raw,
          m.base_token_address AS token_bought_address,
          m.quote_token_address AS token_sold_address,
          b.contract_address AS project_contract_address,
          b.evt_tx_hash AS tx_hash,
          b.evt_index
        FROM
          "delta_prod"."dodoex_bnb"."DODO_evt_BuyBaseToken" b
          LEFT JOIN markets m ON b.contract_address = m.market_contract_address
      ),
      other_dexs AS (
        SELECT
          '2_dvm' as version,
          evt_block_number AS block_number,
          evt_block_time AS block_time,
          trader AS taker,
          receiver AS maker,
          fromAmount AS token_bought_amount_raw,
          toAmount AS token_sold_amount_raw,
          fromToken AS token_bought_address,
          toToken AS token_sold_address,
          contract_address AS project_contract_address,
          evt_tx_hash AS tx_hash,
          evt_index
        FROM
          "delta_prod"."dodoex_bnb"."DVM_evt_DODOSwap"
        UNION ALL
        SELECT
          '2_dpp' as version,
          evt_block_number AS block_number,
          evt_block_time AS block_time,
          trader AS taker,
          receiver AS maker,
          fromAmount AS token_bought_amount_raw,
          toAmount AS token_sold_amount_raw,
          fromToken AS token_bought_address,
          toToken AS token_sold_address,
          contract_address AS project_contract_address,
          evt_tx_hash AS tx_hash,
          evt_index
        FROM
          "delta_prod"."dodoex_bnb"."DPP_evt_DODOSwap"
        UNION ALL
        SELECT
          '2_dpp' as version,
          evt_block_number AS block_number,
          evt_block_time AS block_time,
          trader AS taker,
          receiver AS maker,
          fromAmount AS token_bought_amount_raw,
          toAmount AS token_sold_amount_raw,
          fromToken AS token_bought_address,
          toToken AS token_sold_address,
          contract_address AS project_contract_address,
          evt_tx_hash AS tx_hash,
          evt_index
        FROM
          "delta_prod"."dodoex_bnb"."DPPAdvanced_evt_DODOSwap"
        UNION ALL
        SELECT
          '2_dpp' as version,
          evt_block_number AS block_number,
          evt_block_time AS block_time,
          trader AS taker,
          receiver AS maker,
          fromAmount AS token_bought_amount_raw,
          toAmount AS token_sold_amount_raw,
          fromToken AS token_bought_address,
          toToken AS token_sold_address,
          contract_address AS project_contract_address,
          evt_tx_hash AS tx_hash,
          evt_index
        FROM
          "delta_prod"."dodoex_bnb"."DPPOracle_evt_DODOSwap"
        UNION ALL
        SELECT
          '2_dsp' as version,
          evt_block_number AS block_number,
          evt_block_time AS block_time,
          trader AS taker,
          receiver AS maker,
          fromAmount AS token_bought_amount_raw,
          toAmount AS token_sold_amount_raw,
          fromToken AS token_bought_address,
          toToken AS token_sold_address,
          contract_address AS project_contract_address,
          evt_tx_hash AS tx_hash,
          evt_index
        FROM
          "delta_prod"."dodoex_bnb"."DSP_evt_DODOSwap"
      ),
      dexs AS (
        SELECT
          *
        FROM
          base_token_dexs
        UNION ALL
        SELECT
          *
        FROM
          other_dexs
      )
    SELECT
      'bnb' AS blockchain,
      'dodo' AS project,
      dexs.version,
      CAST(date_trunc('month', dexs.block_time) AS date) AS block_month,
      CAST(date_trunc('day', dexs.block_time) AS date) AS block_date,
      dexs.block_time,
      dexs.block_number,
      dexs.token_bought_amount_raw,
      dexs.token_sold_amount_raw,
      dexs.token_bought_address,
      dexs.token_sold_address,
      dexs.taker,
      dexs.maker,
      dexs.project_contract_address,
      dexs.tx_hash,
      dexs.evt_index
    FROM
      dexs
  ),
  dupes as (
    -- find dupes based on unique key assignment
    select
      tx_hash,
      evt_index,
      count(1)
    from
      spell
    group by
      tx_hash,
      evt_index
    having
      count(1) > 1
  ),
  tgt as (
    -- confirm dupes written to target
    select
      tx_hash,
      evt_index,
      count(1)
    from
      dodo_bnb.base_trades
    group by
      tx_hash,
      evt_index
    having
      count(1) > 1
  )
  -- join dupes back to see details
select
  spell.*
from
  spell
  join dupes on spell.tx_hash = dupes.tx_hash
  and spell.evt_index = dupes.evt_index
```

query digging into source decoded tables to show issue:
```
select
  'dvm',
  *
from
  "delta_prod"."dodoex_bnb"."DVM_evt_DODOSwap"
where
  evt_tx_hash = 0x017c881b57f4aac7ed826a434d1d54023c356f30cd17eab347eb7a135ee4821b
  and evt_index = 27
union all
select
  'dsp',
  *
from
  "delta_prod"."dodoex_bnb"."DSP_evt_DODOSwap"
where
  evt_tx_hash = 0x017c881b57f4aac7ed826a434d1d54023c356f30cd17eab347eb7a135ee4821b
  and evt_index = 27
```