### PR TITLE
Duplicates dodo dex

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/dodo_compatible_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/dodo_compatible_trades.sql
@@ -89,7 +89,7 @@ other_dexs AS (
         WHERE {{ incremental_predicate('evt_block_time') }}
         {% endif %}
         {% if not loop.last %}
-        UNION ALL
+        UNION DISTINCT
         {% endif %}
     {% endfor %}
 ),

--- a/dbt_subprojects/dex/models/trades/arbitrum/platforms/dodo_arbitrum_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/arbitrum/platforms/dodo_arbitrum_base_trades.sql
@@ -10,8 +10,6 @@
     )
 }}
 
--- trigger CI
-
 {% set config_markets %}
     WITH dodo_view_markets (market_contract_address, base_token_symbol, quote_token_symbol, base_token_address, quote_token_address) AS
     (
@@ -25,9 +23,9 @@
 
 {%
     set config_other_sources = [
-        {'version': '2_dvm', 'source': 'DVM_evt_DODOSwap'},
-        {'version': '2_dpp', 'source': 'DPPOracle_evt_DODOSwap'},
-        {'version': '2_dsp', 'source': 'DSP_evt_DODOSwap'},
+        {'version': '2', 'source': 'DVM_evt_DODOSwap'},
+        {'version': '2', 'source': 'DPPOracle_evt_DODOSwap'},
+        {'version': '2', 'source': 'DSP_evt_DODOSwap'},
     ]
 %}
 

--- a/dbt_subprojects/dex/models/trades/arbitrum/platforms/dodo_arbitrum_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/arbitrum/platforms/dodo_arbitrum_base_trades.sql
@@ -10,8 +10,10 @@
     )
 }}
 
+-- trigger CI
+
 {% set config_markets %}
-    WITH dodo_view_markets (market_contract_address, base_token_symbol, quote_token_symbol, base_token_address, quote_token_address) AS 
+    WITH dodo_view_markets (market_contract_address, base_token_symbol, quote_token_symbol, base_token_address, quote_token_address) AS
     (
         VALUES
         (0xFE176A2b1e1F67250d2903B8d25f56C0DaBcd6b2, 'WETH', 'USDC', 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1, 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8),

--- a/dbt_subprojects/dex/models/trades/base/platforms/dodo_base_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/base/platforms/dodo_base_base_trades.sql
@@ -12,7 +12,7 @@
 
 {%
     set config_other_sources = [
-        {'version': '2_dpp', 'source': 'DPPOracle_evt_DODOSwap'},
+        {'version': '2', 'source': 'DPPOracle_evt_DODOSwap'},
     ]
 %}
 

--- a/dbt_subprojects/dex/models/trades/bnb/platforms/dodo_bnb_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/bnb/platforms/dodo_bnb_base_trades.sql
@@ -1,6 +1,5 @@
 {{
     config(
-        tags = ['prod_exclude'],
         schema = 'dodo_bnb',
         alias = 'base_trades',
         materialized = 'incremental',
@@ -15,7 +14,7 @@
 --please check git history for PR which explains in more detail
 
 {% set config_markets %}
-    WITH dodo_view_markets (market_contract_address, base_token_symbol, quote_token_symbol, base_token_address, quote_token_address) AS 
+    WITH dodo_view_markets (market_contract_address, base_token_symbol, quote_token_symbol, base_token_address, quote_token_address) AS
     (
         VALUES
         (0x327134dE48fcDD75320f4c32498D1980470249ae, 'WBNB', 'BUSD', 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c, 0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56),
@@ -33,11 +32,11 @@
 
 {%
     set config_other_sources = [
-        {'version': '2_dvm', 'source': 'DVM_evt_DODOSwap'},
-        {'version': '2_dpp', 'source': 'DPP_evt_DODOSwap'},
-        {'version': '2_dpp', 'source': 'DPPAdvanced_evt_DODOSwap'},
-        {'version': '2_dpp', 'source': 'DPPOracle_evt_DODOSwap'},
-        {'version': '2_dsp', 'source': 'DSP_evt_DODOSwap'},
+        {'version': '2', 'source': 'DVM_evt_DODOSwap'},
+        {'version': '2', 'source': 'DPP_evt_DODOSwap'},
+        {'version': '2', 'source': 'DPPAdvanced_evt_DODOSwap'},
+        {'version': '2', 'source': 'DPPOracle_evt_DODOSwap'},
+        {'version': '2', 'source': 'DSP_evt_DODOSwap'},
     ]
 %}
 

--- a/dbt_subprojects/dex/models/trades/bnb/platforms/dodo_bnb_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/bnb/platforms/dodo_bnb_base_trades.sql
@@ -10,8 +10,6 @@
     )
 }}
 
---note: this model has been excluded due to tx_hash and evt_index being non-unique in the source data
---please check git history for PR which explains in more detail
 
 {% set config_markets %}
     WITH dodo_view_markets (market_contract_address, base_token_symbol, quote_token_symbol, base_token_address, quote_token_address) AS

--- a/dbt_subprojects/dex/models/trades/ethereum/platforms/dodo_ethereum_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/ethereum/platforms/dodo_ethereum_base_trades.sql
@@ -11,7 +11,7 @@
 }}
 
 {% set config_markets %}
-    WITH dodo_view_markets (market_contract_address, base_token_symbol, quote_token_symbol, base_token_address, quote_token_address) AS 
+    WITH dodo_view_markets (market_contract_address, base_token_symbol, quote_token_symbol, base_token_address, quote_token_address) AS
     (
         VALUES
         (0x75c23271661d9d143dcb617222bc4bec783eff34, 'WETH', 'USDC', 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48),
@@ -36,9 +36,9 @@
 
 {%
     set config_other_sources = [
-        {'version': '2_dvm', 'source': 'DVM_evt_DODOSwap'},
-        {'version': '2_dpp', 'source': 'DPP_evt_DODOSwap'},
-        {'version': '2_dsp', 'source': 'DSP_evt_DODOSwap'},
+        {'version': '2', 'source': 'DVM_evt_DODOSwap'},
+        {'version': '2', 'source': 'DPP_evt_DODOSwap'},
+        {'version': '2', 'source': 'DSP_evt_DODOSwap'},
     ]
 %}
 

--- a/dbt_subprojects/dex/models/trades/optimism/platforms/dodo_optimism_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/optimism/platforms/dodo_optimism_base_trades.sql
@@ -12,9 +12,9 @@
 
 {%
     set config_other_sources = [
-        {'version': '2_dvm', 'source': 'DVM_evt_DODOSwap'},
-        {'version': '2_dpp', 'source': 'DPP_evt_DODOSwap'},
-        {'version': '2_dsp', 'source': 'DSP_evt_DODOSwap'},
+        {'version': '2', 'source': 'DVM_evt_DODOSwap'},
+        {'version': '2', 'source': 'DPP_evt_DODOSwap'},
+        {'version': '2', 'source': 'DSP_evt_DODOSwap'},
     ]
 %}
 

--- a/dbt_subprojects/dex/models/trades/polygon/platforms/dodo_polygon_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/polygon/platforms/dodo_polygon_base_trades.sql
@@ -11,7 +11,7 @@
 }}
 
 {% set config_markets %}
-    WITH dodo_view_markets (market_contract_address, base_token_symbol, quote_token_symbol, base_token_address, quote_token_address) AS 
+    WITH dodo_view_markets (market_contract_address, base_token_symbol, quote_token_symbol, base_token_address, quote_token_address) AS
     (
         VALUES
         (0x813fddeccd0401c4fa73b092b074802440544e52, 'USDC', 'USDT', 0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174, 0xc2132D05D31c914a87C6611C10748AEb04B58e8F)
@@ -21,11 +21,11 @@
 
 {%
     set config_other_sources = [
-        {'version': '2_dvm', 'source': 'DVM_evt_DODOSwap'},
-        {'version': '2_dpp', 'source': 'DPP_evt_DODOSwap'},
-        {'version': '2_dpp', 'source': 'DPPAdvanced_evt_DODOSwap'},
-        {'version': '2_dpp', 'source': 'DPPOracle_evt_DODOSwap'},
-        {'version': '2_dsp', 'source': 'DSP_evt_DODOSwap'},
+        {'version': '2', 'source': 'DVM_evt_DODOSwap'},
+        {'version': '2', 'source': 'DPP_evt_DODOSwap'},
+        {'version': '2', 'source': 'DPPAdvanced_evt_DODOSwap'},
+        {'version': '2', 'source': 'DPPOracle_evt_DODOSwap'},
+        {'version': '2', 'source': 'DSP_evt_DODOSwap'},
     ]
 %}
 


### PR DESCRIPTION
- `union distinct` instead of `union all` to resolve duplicate decodings
- changing all dodo versions from `2_[DSP|DVM|..]` to just `2` 