### PR TITLE
Fix nft wallet metrics overflow error

### DIFF
--- a/dbt_subprojects/nft/models/nft_metrics/ethereum/nft_ethereum_wallet_metrics.sql
+++ b/dbt_subprojects/nft/models/nft_metrics/ethereum/nft_ethereum_wallet_metrics.sql
@@ -10,7 +10,6 @@
     )
 }}
 
--- trigger CI
 with
 --- filtering out wash trades based on definition in this model https://github.com/duneanalytics/spellbook/blob/main/models/nft/nft_wash_trades.sql
 nft_trades_no_wash as

--- a/dbt_subprojects/nft/models/nft_metrics/ethereum/nft_ethereum_wallet_metrics.sql
+++ b/dbt_subprojects/nft/models/nft_metrics/ethereum/nft_ethereum_wallet_metrics.sql
@@ -10,6 +10,7 @@
     )
 }}
 
+-- trigger CI
 with
 --- filtering out wash trades based on definition in this model https://github.com/duneanalytics/spellbook/blob/main/models/nft/nft_wash_trades.sql
 nft_trades_no_wash as

--- a/dbt_subprojects/nft/models/nft_metrics/ethereum/nft_ethereum_wallet_metrics.sql
+++ b/dbt_subprojects/nft/models/nft_metrics/ethereum/nft_ethereum_wallet_metrics.sql
@@ -139,6 +139,7 @@ reservoir_floors as (
     from {{source('reservoir', 'collection_floor_ask_events')}}
     where 1 = 1
     and valid_until_dt > current_date
+    and valid_until < 100000000000 -- overflow protection
 ),
 reservoir_floors_latest_avg as
 (


### PR DESCRIPTION
There are incredibly large timestamps in the `valid_until` and `valid_until_dt` columns of the reservoir `collection_floor_ask_events` dataset. 
This PR will ignore any asks that have an invalid until