### PR TITLE
Update balancer_cowswap_amm_ethereum_liquidity.sql

### DIFF
--- a/dbt_macros/shared/balancer/balancer_liquidity_macro.sql
+++ b/dbt_macros/shared/balancer/balancer_liquidity_macro.sql
@@ -74,7 +74,8 @@ WITH pool_labels AS (
             DATE_TRUNC('day', minute) as day,
             AVG(price) as eth_price
         FROM {{ source('prices', 'usd') }}
-        WHERE symbol = 'ETH'
+        WHERE blockchain = 'ethereum'
+        AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
         GROUP BY 1
     ),
 

--- a/dbt_macros/shared/balancer/balancer_liquidity_macro.sql
+++ b/dbt_macros/shared/balancer/balancer_liquidity_macro.sql
@@ -18,7 +18,7 @@ WITH pool_labels AS (
             date_trunc('day', minute) AS day,
             contract_address AS token,
             decimals,
-            AVG(price) AS price
+            APPROX_PERCENTILE(price, 0.5) AS price
         FROM {{ source('prices', 'usd') }}
         WHERE blockchain = '{{blockchain}}'
         GROUP BY 1, 2, 3

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/liquidity/ethereum/balancer_v1_ethereum_liquidity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/liquidity/ethereum/balancer_v1_ethereum_liquidity.sql
@@ -31,7 +31,7 @@ WITH pool_labels AS (
             AVG(price) AS eth_price
         FROM {{ source('prices', 'usd') }}
         WHERE blockchain = 'ethereum'
-        AND symbol = 'ETH'
+        AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
         GROUP BY 1
     ),
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/liquidity/ethereum/balancer_v1_ethereum_liquidity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/liquidity/ethereum/balancer_v1_ethereum_liquidity.sql
@@ -28,7 +28,7 @@ WITH pool_labels AS (
     eth_prices AS(
         SELECT
             date_trunc('day', minute) AS day,
-            AVG(price) AS eth_price
+            APPROX_PERCENTILE(price, 0.5) AS eth_price
         FROM {{ source('prices', 'usd') }}
         WHERE blockchain = 'ethereum'
         AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/ethereum/balancer_cowswap_amm_ethereum_liquidity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/ethereum/balancer_cowswap_amm_ethereum_liquidity.sql
@@ -31,10 +31,10 @@ WITH pool_labels AS (
     eth_prices AS(
         SELECT
             date_trunc('day', minute) AS day,
-            AVG(price) AS eth_price
+            APPROX_PERCENTILE(price, 0.5) AS eth_price
         FROM {{ source('prices', 'usd') }}
         WHERE blockchain = '{{blockchain}}'
-        AND symbol = 'ETH'
+        AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
         GROUP BY 1
     ),
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/gnosis/balancer_cowswap_amm_gnosis_liquidity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/gnosis/balancer_cowswap_amm_gnosis_liquidity.sql
@@ -33,8 +33,8 @@ WITH pool_labels AS (
             date_trunc('day', minute) AS day,
             AVG(price) AS eth_price
         FROM {{ source('prices', 'usd') }}
-        WHERE blockchain = '{{blockchain}}'
-        AND symbol = 'ETH'
+        WHERE blockchain = 'ethereum'
+        AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
         GROUP BY 1
     ),
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/gnosis/balancer_cowswap_amm_gnosis_liquidity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/gnosis/balancer_cowswap_amm_gnosis_liquidity.sql
@@ -31,7 +31,7 @@ WITH pool_labels AS (
     eth_prices AS(
         SELECT
             date_trunc('day', minute) AS day,
-            AVG(price) AS eth_price
+            APPROX_PERCENTILE(price, 0.5) AS eth_price
         FROM {{ source('prices', 'usd') }}
         WHERE blockchain = 'ethereum'
         AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Update!
Please build spells in the proper [subproject](../dbt_subprojects/) directory. For more information, please see the main [readme](../README.md), which also links to a GH discussion with the option to ask questions.

### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [x] Adding to existing spell lineage
- [ ] Bug fix

**Note:** You can safely discard any section below which doesn't apply based on selection above

---
Quick update to fix the protocol_liquidity_eth and pool_liquidity_eth fields on the balancer liquidity models as the former syntax (WHERE symbol = 'ETH') was causing undesired results, likely on either one of these results: 
2024-09-03 08:47 | solana | 0x0b931265156395f7491826c94b706e34717e5a9c60e6f668ff9301bbc347b8c1 | 8 | ETH | 0.00000884
-- | -- | -- | -- | -- | --
2024-09-03 08:47 | ethereum | 0x0d505c03d30e65f6e9b4ef88855a47a89e4b7676 | 18 | ETH | 0.00000884


Side note: I've seen that some nexusmutual spells also use this syntax, so tagging @tomfutago here for visibility