### PR TITLE
bebop jam on base chain: exclude failing model

### DIFF
--- a/dbt_subprojects/dex/models/_projects/bebop/base/bebop_jam_base_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/bebop/base/bebop_jam_base_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'bebop_jam_base',
     alias = 'trades',
     partition_by = ['block_month'],


### PR DESCRIPTION
fyi @B1boid 
we are hitting this error on this model query:
```
Error: SQL array indices start at 1 [Execution ID: 01J6WF0D2EBJDZV11MSHB61PF9].
```

i attempted to find the exact issue, but couldn't narrow it down quickly. for now, i am excluding in prod. you can reproduce the error by compiling the raw sql and running on dune