### PR TITLE
Add arbitrum chain to balancer_cowswap_amm spells

### DIFF
--- a/dbt_subprojects/dex/models/_projects/balancer_cowswap_amm/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/balancer_cowswap_amm/_schema.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: balancer_cowswap_amm_trades
     meta:
-      blockchain: ethereum, gnosis
+      blockchain: arbitrum, ethereum, gnosis
       sector: trades
       project: balancer_cowswap_amm
       contributors: viniabussafi
@@ -89,7 +89,7 @@ models:
 
   - name: labels_balancer_cowswap_amm_pools
     meta:
-      blockchain: ethereum, gnosis
+      blockchain: arbitrum, ethereum, gnosis
       sector: labels
       project: balancer_cowswap_amm
       contributors: viniabussafi

--- a/dbt_subprojects/dex/models/_projects/balancer_cowswap_amm/arbitrum/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/balancer_cowswap_amm/arbitrum/_schema.yml
@@ -1,0 +1,137 @@
+version: 2
+
+models:
+  - name: balancer_cowswap_amm_arbitrum_trades
+    meta:
+      blockchain: arbitrum
+      sector: trades
+      project: balancer_cowswap_amm
+      contributors: viniabussafi
+    config:
+      tags: ['balancer', 'cowswap', 'arbitrum', 'amm', 'trades']
+    description: "Trades on Balancer CoWSwap AMM pools"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - evt_index
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain"
+      - &project
+        name: project
+        description: "Project name (balancer)"
+      - &version
+        name: version
+        description: "Version of the project"
+      - &block_month
+        name: block_month
+        description: "Block month in UTC"
+      - &block_date
+        name: block_date
+        description: "Block date in UTC"
+      - &block_time
+        name: block_time
+        description: 'Block time in UTC'
+      - &block_number
+        name: block_number
+        description: 'Block number'
+      - &token_bought_symbol
+        name: token_bought_symbol
+        description: "Token symbol for token bought in the trade"
+      - &token_sold_symbol
+        name: token_sold_symbol
+        description: "Token symbol for token sold in the trade"
+      - &token_pair
+        name: token_pair
+        description: "Token symbol pair for each token involved in the trade"
+      - &token_bought_amount
+        name: token_bought_amount
+        description: "Value of the token bought at time of execution in the original currency"
+      - &token_sold_amount
+        name: token_sold_amount
+        description: "Value of the token sold at time of execution in the original currency"
+      - &token_bought_amount_raw
+        name: token_bought_amount_raw
+        description: "Raw value of the token bought at time of execution in the original currency"
+      - &token_sold_amount_raw
+        name: token_sold_amount_raw
+        description: "Raw value of the token sold at time of execution in the original currency"
+      - &amount_usd
+        name: amount_usd
+        description: "USD value of the trade at time of execution"
+      - &token_bought_address
+        name: token_bought_address
+        description: "Contract address of the token bought"
+      - &token_sold_address
+        name: token_sold_address
+        description: "Contract address of the token sold"
+      - &taker
+        name: taker
+        description: "Address of trader who purchased a token"
+      - &maker
+        name: maker
+        description: "Address of trader who sold a token"
+      - &project_contract_address
+        name: project_contract_address
+        description: "Pool address"
+      - &tx_hash
+        name: tx_hash
+        description: "Tx. Hash"
+      - &tx_from
+        name: tx_from
+        description: "transaction.from"
+      - &tx_to
+        name: tx_to
+        description: "transaction.to"
+      - &evt_index
+        name: evt_index
+        description: 'Event index'
+      - name: pool_type
+      - name: pool_symbol
+      - name: swap_fee
+
+  - name: labels_balancer_cowswap_amm_pools_arbitrum
+    meta:
+      blockchain: arbitrum
+      sector: labels
+      project: balancer_cowswap_amm
+      contributors: viniabussafi
+    config:
+      tags: ['labels', 'arbitrum', 'balancer', 'pools']
+    description: "Balancer CoWSwap AMM liquidity pools created on arbitrum."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - *blockchain
+      - &address
+        name: address
+        description: "Address of liquidity pool"
+      - &name
+        name: name
+        description: "Label name of pool containing the token symbols and their respective weights (if applicable)"
+      - name: pool_type
+      - &category
+        name: category
+        description: "Label category"
+      - &contributor
+        name: contributor
+        description: "Wizard(s) contributing to labels"
+      - &source
+        name: source
+        description: "How were labels generated (could be static or query)"
+      - &created_at
+        name: created_at
+        description: "When were labels created"
+      - &updated_at
+        name: updated_at
+        description: "When were labels updated for the last time"
+      - &model_name
+        name: model_name
+        description: "Name of the label model sourced from"
+      - &label_type
+        name: label_type
+        description: "Type of label (see labels overall readme)"

--- a/dbt_subprojects/dex/models/_projects/balancer_cowswap_amm/arbitrum/balancer_cowswap_amm_arbitrum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer_cowswap_amm/arbitrum/balancer_cowswap_amm_arbitrum_trades.sql
@@ -1,0 +1,74 @@
+{% set blockchain = 'arbitrum' %}
+
+{{
+    config(
+        schema = 'balancer_cowswap_amm_' + blockchain,
+        alias = 'trades',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['tx_hash', 'evt_index']
+    )
+}}
+
+    SELECT 
+    '{{blockchain}}' AS blockchain
+    , 'balancer' AS project
+    , '1' AS version
+    , CAST(date_trunc('month', trade.evt_block_time) AS DATE) AS block_month
+    , CAST(date_trunc('day', trade.evt_block_time) AS DATE) AS block_date
+    , trade.evt_block_time AS block_time
+    , trade.evt_block_number block_number
+    , tb.symbol AS token_bought_symbol
+    , tb.symbol AS token_sold_symbol
+    , CONCAT(ts.symbol, '-', tb.symbol) AS token_pair
+    , (trade.buyAmount / POWER(10, COALESCE(pb.decimals, tb.decimals))) AS token_bought_amount
+    , ((trade.sellAmount - trade.feeAmount) / POWER(10, COALESCE(ps.decimals, ts.decimals))) AS token_sold_amount
+    , trade.buyAmount AS token_bought_amount_raw
+    , trade.sellAmount AS token_sold_amount_raw
+    , COALESCE(trade.buyAmount / POWER(10, COALESCE(pb.decimals, tb.decimals)) * pb.price,
+    trade.sellAmount / POWER(10, COALESCE(ps.decimals, ts.decimals)) * ps.price)
+     AS amount_usd
+    ,trade.buyToken AS token_bought_address
+    ,trade.sellToken AS token_sold_address
+    ,CAST(NULL AS VARBINARY) AS taker
+    ,CAST(NULL AS VARBINARY) AS maker
+    , pool.bPool AS project_contract_address
+    , pool.bPool AS pool_id   
+    , trade.evt_tx_hash AS tx_hash
+    , settlement.solver AS tx_from
+    , trade.contract_address AS tx_to
+    , trade.evt_index AS evt_index
+    , p.name AS pool_symbol
+    , p.pool_type
+    , (trade.feeAmount / POWER (10, ts.decimals)) AS swap_fee
+    FROM {{ source('gnosis_protocol_v2_arbitrum', 'GPv2Settlement_evt_Trade') }} trade
+    INNER JOIN {{ source('b_cow_amm_arbitrum', 'BCoWFactory_evt_LOG_NEW_POOL') }} pool
+        ON trade.owner = pool.bPool
+    LEFT JOIN {{ source('prices', 'usd') }} AS ps
+                    ON sellToken = ps.contract_address
+                        AND ps.minute = date_trunc('minute', trade.evt_block_time)
+                        AND ps.blockchain = '{{blockchain}}'
+                        {% if is_incremental() %}
+                        AND {{ incremental_predicate('ps.minute') }}
+                        {% endif %}
+    LEFT JOIN {{ source('prices', 'usd') }} AS pb
+                    ON pb.contract_address = buyToken
+                        AND pb.minute = date_trunc('minute', trade.evt_block_time)
+                        AND pb.blockchain = '{{blockchain}}'
+                        {% if is_incremental() %}
+                        AND {{ incremental_predicate('pb.minute') }}
+                        {% endif %}
+    LEFT JOIN {{ source('tokens', 'erc20') }} AS ts
+                    ON trade.sellToken = ts.contract_address
+                        AND ts.blockchain = '{{blockchain}}'
+    LEFT JOIN {{ source('tokens', 'erc20') }} AS tb
+                    ON trade.buyToken = tb.contract_address
+                        AND tb.blockchain = '{{blockchain}}'   
+    LEFT JOIN {{ source('gnosis_protocol_v2_arbitrum', 'GPv2Settlement_evt_Settlement') }} AS settlement
+                    ON trade.evt_tx_hash = settlement.evt_tx_hash  
+    LEFT JOIN {{ ref('labels_balancer_cowswap_amm_pools_arbitrum') }} p ON p.address = trade.owner                                                                             
+    {% if is_incremental() %}
+    WHERE {{ incremental_predicate('trade.evt_block_time') }}
+    {% endif %}

--- a/dbt_subprojects/dex/models/_projects/balancer_cowswap_amm/arbitrum/labels_balancer_cowswap_amm_pools_arbitrum.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer_cowswap_amm/arbitrum/labels_balancer_cowswap_amm_pools_arbitrum.sql
@@ -1,0 +1,71 @@
+{% set blockchain = 'arbitrum' %}
+
+{{config(
+    schema = 'labels',
+    alias = 'balancer_cowswap_amm_pools_' + blockchain,
+    materialized = 'table',
+    file_format = 'delta'
+    )
+}}
+
+WITH events AS (
+    -- binds
+    SELECT call_block_number AS block_number,
+           contract_address  AS pool,
+           token,
+           denorm
+    FROM {{ source('b_cow_amm_arbitrum', 'BCoWPool_call_bind') }}
+    WHERE call_success
+
+    UNION all
+
+    -- unbinds
+    SELECT call_block_number AS block_number,
+            contract_address AS pool,
+            token,
+            uint256 '0' AS denorm
+    FROM {{ source('b_cow_amm_arbitrum', 'BCoWPool_call_unbind') }}
+    WHERE call_success
+),
+
+state_with_gaps AS (
+    SELECT events.block_number
+           , events.pool
+           , events.token
+           , CAST(events.denorm AS uint256) AS denorm,
+    LEAD(events.block_number, 1, 99999999) OVER (PARTITION BY events.pool, events.token ORDER BY events.block_number) AS next_block_number
+    FROM events
+),
+
+settings AS (
+    SELECT pool,
+        coalesce(t.symbol,'?') AS symbol,
+        denorm,
+        next_block_number
+    FROM state_with_gaps s
+    LEFT JOIN {{ source('tokens', 'erc20') }} t ON s.token = t.contract_address
+        AND t.blockchain = '{{blockchain}}'
+    WHERE next_block_number = 99999999
+        AND denorm > uint256 '0'
+)
+
+    SELECT
+      '{{blockchain}}' AS blockchain,
+      pool AS address,
+      CONCAT('BCowAMM: ', array_join(array_agg(symbol), '/'), ' ', array_join(array_agg(cast(norm_weight AS varchar)), '/')) AS name,
+      'Balancer CoWSwap AMM' AS pool_type,
+      'balancer_cowswap_amm_pool' AS category,
+      'balancerlabs' AS contributor,
+      'query' AS source,
+      timestamp '2024-07-20' AS created_at,
+      now() AS updated_at,
+      'balancer_cowswap_amm_pools_ethereum' AS model_name,
+      'identifier' as label_type
+    FROM   (
+        SELECT s1.pool, symbol, cast(100*denorm/total_denorm AS integer) AS norm_weight FROM settings s1
+        INNER JOIN (SELECT pool, sum(denorm) AS total_denorm FROM settings GROUP BY pool) s2
+        ON s1.pool = s2.pool
+        ORDER BY 1 ASC , 3 DESC, 2 ASC
+    ) s
+    GROUP BY 1, 2
+    

--- a/dbt_subprojects/dex/models/_projects/balancer_cowswap_amm/balancer_cowswap_amm_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer_cowswap_amm/balancer_cowswap_amm_trades.sql
@@ -7,6 +7,7 @@
 }}
 
 {% set b_cow_amm_models = [
+    ref('balancer_cowswap_amm_arbitrum_trades'),
     ref('balancer_cowswap_amm_ethereum_trades'),
     ref('balancer_cowswap_amm_gnosis_trades')
 ] %}

--- a/dbt_subprojects/dex/models/_projects/balancer_cowswap_amm/labels_balancer_cowswap_amm_pools.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer_cowswap_amm/labels_balancer_cowswap_amm_pools.sql
@@ -6,6 +6,7 @@
 }}
 
 {% set b_cow_amm_models = [
+    ref('labels_balancer_cowswap_amm_pools_arbitrum'),
     ref('labels_balancer_cowswap_amm_pools_ethereum'),
     ref('labels_balancer_cowswap_amm_pools_gnosis')
 ] %}

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/_schema.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: balancer_cowswap_amm_balances
     meta:
-      blockchain: ethereum, gnosis
+      blockchain: arbitrum, ethereum, gnosis
       project: balancer_cowswap_amm
       contributors: viniabussafi
     config:
@@ -31,7 +31,7 @@ models:
 
   - name: balancer_cowswap_amm_liquidity
     meta:
-      blockchain: ethereum, gnosis
+      blockchain: arbitrum, ethereum, gnosis
       project: balancer_cowswap_amm
       contributors: viniabussafi
     config:

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/arbitrum/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/arbitrum/_schema.yml
@@ -1,0 +1,80 @@
+version: 2
+
+models:
+  - name: balancer_cowswap_amm_arbitrum_balances
+    meta:
+      blockchain: arbitrum
+      project: balancer_cowswap_amm
+      contributors: viniabussafi
+    config:
+      tags: ['arbitrum', 'balancer', 'balances']
+    description: >
+      ERC20 token rolling sum balances on Balancer, an automated portfolio manager and trading platform.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - pool_address
+            - token_address
+    columns:
+      - &day
+        name: day
+        description: "UTC event block time truncated to the day mark"
+        tests:
+          - not_null
+      - &blockchain
+        name: blockchain
+        description: ""
+      - &pool_address
+        name: pool_address
+        description: "Balancer CoWSwap AMM pool contract address"
+      - &token_address
+        name: token_address
+        description: "Token contract address"
+      - &token_balance_raw
+        name: token_balance_raw
+        description: "Balance of a token"
+
+  - name: balancer_cowswap_amm_arbitrum_liquidity
+    meta:
+      blockchain: arbitrum
+      project: balancer_cowswap_amm
+      contributors: viniabussafi
+    config:
+      tags: ['arbitrum', 'balancer', 'pools', 'liquidity']
+    description: >
+      Balancer CoWSwap AMM pools liquidity by token in arbitrum.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - pool_id
+            - token_address
+    columns:
+      - *day
+      - name: pool_id
+      - *pool_address
+      - name: pool_symbol
+      - name: version
+      - *blockchain
+      - name: pool_type
+      - *token_address
+      - &token_symbol
+        name: token_symbol
+        description: "Token symbol"
+      - *token_balance_raw
+      - &token_balance
+        name: token_balance
+        description: "Balance of the token in the pool"
+      - &protocol_liquidity_usd
+        name: protocol_liquidity_usd
+        description: "Protocol liquidity in USD"
+      - &protocol_liquidity_eth
+        name: protocol_liquidity_eth
+        description: "Protocol liquidity in ETH"
+      - &pool_liquidity_usd
+        name: pool_liquidity_usd
+        description: "Pool liquidity in USD"
+      - &pool_liquidity_eth
+        name: pool_liquidity_eth
+        description: "Pool liquidity in ETH"          

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/arbitrum/balancer_cowswap_amm_arbitrum_balances.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/arbitrum/balancer_cowswap_amm_arbitrum_balances.sql
@@ -1,0 +1,77 @@
+{{
+    config(
+        schema = 'balancer_cowswap_amm_arbitrum',
+        alias = 'balances',
+        materialized = 'table',
+        file_format = 'delta'
+    )
+}}
+
+WITH pools AS (
+    SELECT 
+        bPool AS pools
+    FROM {{ source('b_cow_amm_arbitrum', 'BCoWFactory_evt_LOG_NEW_POOL') }}
+),
+
+joins AS (
+    SELECT 
+        p.pools AS pool, 
+        DATE_TRUNC('day', e.evt_block_time) AS day, 
+        e.contract_address AS token, 
+        SUM(CAST(value AS int256)) AS amount
+    FROM {{ source('erc20_arbitrum', 'evt_transfer') }} e
+    INNER JOIN pools p ON e."to" = p.pools
+    GROUP BY 1, 2, 3
+),
+
+exits AS (
+    SELECT 
+        p.pools AS pool, 
+        DATE_TRUNC('day', e.evt_block_time) AS day, 
+        e.contract_address AS token, 
+        - SUM(CAST(value AS int256)) AS amount
+    FROM {{ source('erc20_arbitrum', 'evt_transfer') }} e
+    INNER JOIN pools p ON e."from" = p.pools   
+    GROUP BY 1, 2, 3
+),
+
+daily_delta_balance_by_token AS (
+    SELECT 
+        pool, 
+        day, 
+        token, 
+        SUM(COALESCE(amount, CAST(0 AS int256))) AS amount 
+    FROM 
+        (SELECT *
+        FROM joins j
+        UNION ALL
+        SELECT * 
+        FROM exits e) foo
+    GROUP BY 1, 2, 3
+),
+
+cumulative_balance_by_token AS (
+    SELECT
+        pool, 
+        token, 
+        day, 
+        LEAD(day, 1, now()) OVER (PARTITION BY pool, token ORDER BY day) AS day_of_next_change,
+        SUM(amount) OVER (PARTITION BY pool, token ORDER BY day ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS cumulative_amount
+    FROM daily_delta_balance_by_token
+),
+
+calendar AS (
+    SELECT 
+        date_sequence AS day
+    FROM unnest(sequence(date('2024-07-01'), date(now()), interval '1' day)) AS t(date_sequence)
+)
+
+SELECT
+    c.day,   
+    'arbitrum' AS blockchain,
+    b.pool AS pool_address, 
+    b.token AS token_address, 
+    b.cumulative_amount AS token_balance_raw
+FROM calendar c
+LEFT JOIN cumulative_balance_by_token b ON b.day <= c.day AND c.day < b.day_of_next_change
+WHERE b.pool IS NOT NULL

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/arbitrum/balancer_cowswap_amm_arbitrum_liquidity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/arbitrum/balancer_cowswap_amm_arbitrum_liquidity.sql
@@ -1,0 +1,85 @@
+{% set blockchain = 'arbitrum' %}
+
+{{
+    config(
+        schema='balancer_cowswap_amm_' + blockchain,
+        alias = 'liquidity',
+        materialized = 'table',
+        file_format = 'delta'
+    )
+}}
+
+WITH pool_labels AS (
+    SELECT
+        address,
+        name
+    FROM {{ source('labels', 'balancer_cowswap_amm_pools') }}
+    WHERE blockchain = '{{blockchain}}'
+    ),
+
+    prices AS (
+        SELECT
+            date_trunc('day', minute) AS day,
+            contract_address AS token,
+            decimals,
+            AVG(price) AS price
+        FROM {{ source('prices', 'usd') }}
+        WHERE blockchain = '{{blockchain}}'
+        GROUP BY 1, 2, 3
+    ),
+
+    eth_prices AS(
+        SELECT
+            date_trunc('day', minute) AS day,
+            AVG(price) AS eth_price
+        FROM {{ source('prices', 'usd') }}
+        WHERE blockchain = 'ethereum'
+        AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+        GROUP BY 1
+    ),
+
+    cumulative_balance AS (
+        SELECT
+            day,
+            pool_address,
+            token_address,
+            token_balance_raw
+        FROM {{ ref('balancer_cowswap_amm_arbitrum_balances') }} b
+    ),
+    
+   cumulative_usd_balance AS (
+        SELECT
+            b.day,
+            b.pool_address,
+            b.token_address,
+            t.symbol,
+            token_balance_raw,
+            token_balance_raw / POWER(10, COALESCE(t.decimals, p1.decimals)) AS token_balance,
+            token_balance_raw / POWER(10, COALESCE(t.decimals, p1.decimals)) * COALESCE(p1.price, 0) AS protocol_liquidity_usd
+        FROM cumulative_balance b
+        LEFT JOIN {{ source('tokens', 'erc20') }} t ON t.contract_address = b.token_address
+        AND t.blockchain = '{{blockchain}}'
+        LEFT JOIN prices p1 ON p1.day = b.day
+        AND p1.token = b.token_address
+    )
+    
+SELECT
+    c.day,
+    c.pool_address AS pool_id,
+    c.pool_address,
+    p.name AS pool_symbol,
+    '1' AS version,
+    '{{blockchain}}' AS blockchain,
+    'balancer_cowswap_amm' AS pool_type,
+    c.token_address,
+    c.symbol AS token_symbol,
+    c.token_balance_raw,
+    c.token_balance,
+    c.protocol_liquidity_usd,
+    (c.protocol_liquidity_usd) / e.eth_price AS protocol_liquidity_eth,
+    c.protocol_liquidity_usd AS pool_liquidity_usd,
+    (c.protocol_liquidity_usd) / e.eth_price AS pool_liquidity_eth
+FROM cumulative_usd_balance c
+LEFT JOIN pool_labels p ON p.address = c.pool_address
+LEFT JOIN eth_prices e ON e.day = c.day
+WHERE c.pool_address IS NOT NULL

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/balancer_cowswap_amm_balances.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/balancer_cowswap_amm_balances.sql
@@ -8,6 +8,7 @@
 
 
 {% set b_cow_amm_models = [
+    ref('balancer_cowswap_amm_arbitrum_balances'),
     ref('balancer_cowswap_amm_ethereum_balances'),
     ref('balancer_cowswap_amm_gnosis_balances')
 ] %}

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/balancer_cowswap_amm_liquidity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer_cowswap_amm/balancer_cowswap_amm_liquidity.sql
@@ -7,6 +7,7 @@
 }}
 
 {% set b_cow_amm_models = [
+    ref('balancer_cowswap_amm_arbitrum_liquidity'),
     ref('balancer_cowswap_amm_ethereum_liquidity'),
     ref('balancer_cowswap_amm_gnosis_liquidity')
 ] %}

--- a/sources/balancer_cowswap_amm/arbitrum/_sources.yml
+++ b/sources/balancer_cowswap_amm/arbitrum/_sources.yml
@@ -1,0 +1,9 @@
+version: 2
+sources:
+  - name: b_cow_amm_arbitrum
+    tables:
+      - name: BCoWFactory_evt_LOG_NEW_POOL
+      - name: BCoWFactory_evt_COWAMMPoolCreated
+      - name: BCoWFactory_call_logBCoWPool
+      - name: BCoWPool_call_bind    
+      - name: BCoWPool_call_unbind


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Update!
Please build spells in the proper [subproject](../dbt_subprojects/) directory. For more information, please see the main [readme](../README.md), which also links to a GH discussion with the option to ask questions.

### Contribution type
Please check the type of contribution this pull request is for:

- [x] New spell(s)
- [x] Adding to existing spell lineage
- [ ] Bug fix

This PR simply replicates the logic for balancer_cowswap_amm spells on ethereum to arbitrum, since we've recently deployed our contracts over there. It also adds the new arbitrum spells to the cross-chain tables