### PR TITLE
`dex.prices_beta` initial build

### DIFF
--- a/dbt_subprojects/dex/models/prices/_schema.yml
+++ b/dbt_subprojects/dex/models/prices/_schema.yml
@@ -1,6 +1,17 @@
 version: 2
 
 models:
+  - name: dex_prices_beta
+    description: >
+      obtain pricing info from dex.trades to feed into prices pipeline
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_month
+            - blockchain
+            - contract_address
+            - block_time
+  
   - name: dex_prices
     meta:
       blockchain: ethereum, bnb, avalanche_c, gnosis, optimism, arbitrum, fantom

--- a/dbt_subprojects/dex/models/prices/_schema.yml
+++ b/dbt_subprojects/dex/models/prices/_schema.yml
@@ -4,13 +4,6 @@ models:
   - name: dex_prices_beta
     description: >
       obtain pricing info from dex.trades to feed into prices pipeline
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - block_month
-            - blockchain
-            - contract_address
-            - block_time
   
   - name: dex_prices
     meta:

--- a/dbt_subprojects/dex/models/prices/dex_prices_beta.sql
+++ b/dbt_subprojects/dex/models/prices/dex_prices_beta.sql
@@ -1,0 +1,92 @@
+{{ config(
+    schema = 'dex'
+    , alias = 'prices_beta'
+    , partition_by = ['block_month', 'blockchain']
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_month', 'blockchain', 'contract_address', 'block_time']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+)
+}}
+
+with dex_trades as (
+    select distinct
+        blockchain
+        , block_time
+        , token_bought_address
+        , token_bought_amount_raw
+        , token_bought_amount
+        , token_sold_address
+        , token_sold_amount_raw
+        , token_sold_amount
+        , amount_usd
+    from
+        {{ ref('dex_trades') }}
+    where
+        1 = 1
+        and amount_usd > 0
+        {% if is_incremental() %}
+        and {{ incremental_predicate('block_time') }}
+        {% else %}
+        and block_date >= date '2024-08-01'
+        {% endif %}
+),
+dex_bought as (
+    select
+        d.blockchain
+        , d.token_bought_address as contract_address
+        , t.symbol as symbol
+        , t.decimals as decimals
+        , d.block_time as block_time
+        , d.token_bought_amount as amount
+        , coalesce(d.amount_usd/d.token_bought_amount, d.amount_usd/(d.token_bought_amount_raw/POW(10, t.decimals))) as price
+    from
+        dex_trades as d
+    inner join {{ source('tokens', 'erc20') }} as t
+        on d.blockchain = t.blockchain
+        and d.token_bought_address = t.contract_address
+    where
+        1 = 1
+        and d.token_bought_amount_raw > UINT256 '0'
+), 
+dex_sold as (
+    select
+        d.blockchain
+        , d.token_sold_address as contract_address
+        , t.symbol as symbol
+        , t.decimals as decimals
+        , d.block_time as block_time
+        , d.token_sold_amount as amount
+        , coalesce(d.amount_usd/d.token_sold_amount, d.amount_usd/(d.token_sold_amount_raw/POW(10, t.decimals))) as price
+    from
+        dex_trades as d
+    inner join {{ source('tokens', 'erc20') }} as t
+        on d.blockchain = t.blockchain
+        and d.token_sold_address = t.contract_address
+    where
+        1 = 1
+        and d.token_sold_amount_raw > UINT256 '0'
+),
+dex_prices as (
+    select
+        *
+    from
+        dex_bought
+    union
+    select
+        *
+    from
+        dex_sold
+)
+select
+    blockchain
+    , contract_address
+    , symbol
+    , decimals
+    , cast(date_trunc('month', block_time) as date) as block_month, -- for partitioning
+    , block_time
+    , amount
+    , price
+from
+    dex_prices

--- a/dbt_subprojects/dex/models/prices/dex_prices_beta.sql
+++ b/dbt_subprojects/dex/models/prices/dex_prices_beta.sql
@@ -84,7 +84,7 @@ select
     , contract_address
     , symbol
     , decimals
-    , cast(date_trunc('month', block_time) as date) as block_month, -- for partitioning
+    , cast(date_trunc('month', block_time) as date) as block_month -- for partitioning
     , block_time
     , amount
     , price

--- a/dbt_subprojects/dex/models/prices/dex_prices_beta.sql
+++ b/dbt_subprojects/dex/models/prices/dex_prices_beta.sql
@@ -46,7 +46,9 @@ dex_bought as (
         and d.token_bought_address = t.contract_address
     where
         1 = 1
+        and d.token_bought_amount > 0
         and d.token_bought_amount_raw > UINT256 '0'
+        and t.symbol is not null
 ), 
 dex_sold as (
     select
@@ -64,7 +66,9 @@ dex_sold as (
         and d.token_sold_address = t.contract_address
     where
         1 = 1
+        and d.token_sold_amount > 0
         and d.token_sold_amount_raw > UINT256 '0'
+        and t.symbol is not null
 ),
 dex_prices as (
     select
@@ -88,6 +92,3 @@ select
     , price
 from
     dex_prices
-where
-    symbol is not null
-    and amount is not null

--- a/dbt_subprojects/dex/models/prices/dex_prices_beta.sql
+++ b/dbt_subprojects/dex/models/prices/dex_prices_beta.sql
@@ -4,9 +4,7 @@
     , partition_by = ['block_month', 'blockchain']
     , materialized = 'incremental'
     , file_format = 'delta'
-    , incremental_strategy = 'merge'
-    , unique_key = ['block_month', 'blockchain', 'contract_address', 'block_time']
-    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    , incremental_strategy = 'append'
 )
 }}
 
@@ -27,7 +25,7 @@ with dex_trades as (
         1 = 1
         and amount_usd > 0
         {% if is_incremental() %}
-        and {{ incremental_predicate('block_time') }}
+        and block_time > (select max(block_time) from {{ this }})
         {% else %}
         and block_date >= date '2024-08-01'
         {% endif %}

--- a/dbt_subprojects/dex/models/prices/dex_prices_beta.sql
+++ b/dbt_subprojects/dex/models/prices/dex_prices_beta.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'dex'
     , alias = 'prices_beta'
-    , partition_by = ['block_month', 'blockchain']
+    , partition_by = ['block_month']
     , materialized = 'incremental'
     , file_format = 'delta'
     , incremental_strategy = 'append'

--- a/dbt_subprojects/dex/models/prices/dex_prices_beta.sql
+++ b/dbt_subprojects/dex/models/prices/dex_prices_beta.sql
@@ -88,3 +88,6 @@ select
     , price
 from
     dex_prices
+where
+    symbol is not null
+    and amount is not null


### PR DESCRIPTION
few callouts:
- added `distinct` on pull from `dex.trades` to reduce row count written
- switched join to erc20 metadata to `inner join` to ensure we have decimal value to divide by (hardcoding 18 decimals may be inaccurate, as tokens can be various decimals)
- `union` rather than `union all` on bought / sold, in order to reduce rows written (adds some runtime on dbt side)