### PR TITLE
scroll chain: exclude failing models due to incident on decoded tables

### DIFF
--- a/dbt_subprojects/dex/models/trades/scroll/platforms/iziswap_scroll_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/scroll/platforms/iziswap_scroll_base_trades.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'iziswap_scroll',
         alias = 'base_trades',
         materialized = 'incremental',

--- a/dbt_subprojects/dex/models/trades/scroll/platforms/maverick_v2_scroll_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/scroll/platforms/maverick_v2_scroll_base_trades.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'maverick_v2_scroll',
         alias = 'base_trades',
         materialized = 'incremental',

--- a/dbt_subprojects/dex/models/trades/scroll/platforms/nuri_scroll_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/scroll/platforms/nuri_scroll_base_trades.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'nuri_scroll',
         alias = 'base_trades',
         materialized = 'incremental',

--- a/dbt_subprojects/dex/models/trades/scroll/platforms/sushiswap_v2_scroll_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/scroll/platforms/sushiswap_v2_scroll_base_trades.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'sushiswap_v2_scroll',
         alias = 'base_trades',
         materialized = 'incremental',

--- a/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/scroll/platforms/aave_v3_scroll_base_supply.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/scroll/platforms/aave_v3_scroll_base_supply.sql
@@ -1,5 +1,6 @@
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'aave_v3_scroll',
     alias = 'base_supply',
     materialized = 'incremental',

--- a/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/scroll/platforms/layer_bank_scroll_base_supply.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/scroll/platforms/layer_bank_scroll_base_supply.sql
@@ -1,5 +1,6 @@
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'layer_bank_scroll',
     alias = 'base_supply',
     materialized = 'incremental',

--- a/dbt_subprojects/nft/models/_sector/transfers/chains/nft_scroll_transfers.sql
+++ b/dbt_subprojects/nft/models/_sector/transfers/chains/nft_scroll_transfers.sql
@@ -1,4 +1,5 @@
 {{ config(
+        tags = ['prod_exclude'],
         schema = 'nft_scroll',
         alias ='transfers',
         partition_by=['block_month'],

--- a/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_base_transfers.sql
@@ -1,4 +1,5 @@
 {{config(
+    tags = ['prod_exclude'],
     schema = 'tokens_scroll',
     alias = 'base_transfers',
     partition_by = ['block_month'],


### PR DESCRIPTION
temporary exclusion of models due to a bug in decoded layer where source tables are outputting duplicate rows, causing spellbook to fail downstream. the fix at decoded layer is intended to happen today at a later time.