### PR TITLE
`ethereum_blobs` exclude from prod

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/blobs/ethereum/ethereum_blobs.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/blobs/ethereum/ethereum_blobs.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'ethereum',
     alias = 'blobs',
     materialized = 'incremental',


### PR DESCRIPTION
fyi @lorenz234 @0xRobin @hildobby @MSilb7 @Jam516 
tagging as history shows all involved
this has started to fail in prod on the following error:
```
19:54:30    Database Error in model ethereum_blobs (models/_sector/blobs/ethereum/ethereum_blobs.sql)
  TrinoUserError(type=USER_ERROR, name=GENERIC_USER_ERROR, message="Task 20240911_193845_06449_mhikh.5.1.0 is failed, due to containing long running stuck splits.", query_id=20240911_193845_06449_mhikh)
```

i raised to the platform team to see if it's query engine related, but looks like it's new data coming through which is breaking the query planning.
first thought revolves around:
> The blobs table contains lots of fun UTF8ish data, right? And that file in particular has a very fun blob that appears to contain a single blob with 300,000 null characters

seems like lots of nulls coming through unexpectedly somewhere?

if we want this spell re-enabled, feel free to open PR to remove prod exclude tag and apply fixes as necessary (or continue the conversation on how to fix).