### PR TITLE
add zeroex linea trades to downstream spells

### DIFF
--- a/dbt_subprojects/dex/models/_projects/zeroex/zeroex_api_fills_deduped.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/zeroex_api_fills_deduped.sql
@@ -1,7 +1,7 @@
 {{ config(
      schema = 'zeroex'
         , alias = 'api_fills_deduped'
-        , post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "base", "bnb", "celo", "ethereum", "fantom", "optimism", "polygon","scroll"]\',
+        , post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "base", "bnb", "celo", "ethereum", "fantom", "optimism", "polygon","scroll", "linea"]\',
                                 "project",
                                 "zeroex",
                                 \'["rantum","bakabhai993"]\') }}'

--- a/dbt_subprojects/dex/models/_projects/zeroex/zeroex_api_fills_deduped.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/zeroex_api_fills_deduped.sql
@@ -30,6 +30,7 @@
   ,ref('zeroex_avalanche_c_settler_trades')
   ,ref('zeroex_arbitrum_settler_trades')
   ,ref('zeroex_scroll_settler_trades')
+  ,ref('zeroex_linea_settler_trades')
 ] %}
 
 

--- a/dbt_subprojects/dex/models/_projects/zeroex/zeroex_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/zeroex_schema.yml
@@ -7,7 +7,7 @@ models:
       project: zeroex
       contributors: rantum, danning.sui, bakabhai993
     config:
-      tags: ['ethereum','0x','dex_aggregator','dex','aggregator','optimism','polygon','arbitrum','fantom','avalanche','bnb','scroll']
+      tags: ['ethereum','0x','dex_aggregator','dex','aggregator','optimism','polygon','arbitrum','fantom','avalanche','bnb']
     description: >
         0x API erc20 swaps raw fills (including multihops) and also native swaps thru 0x exchange contracts (without using 0x API) on Ethereum
     tests:
@@ -105,7 +105,7 @@ models:
 
   - name: zeroex_api_fills_deduped
     meta: 
-      blockchain: ethereum, optimism, polygon, arbitrum, fantom, avalanche, bnb
+      blockchain: ethereum, optimism, polygon, arbitrum, fantom, avalanche, bnb, base, scroll, linea
       sector: dex
       project: zeroex
       contributors: rantum, bakabhai993
@@ -158,7 +158,7 @@ models:
 
   - name: zeroex_trades
     meta:
-      blockchain: ethereum, optimism, polygon, arbitrum, fantom, avalanche, bnb
+      blockchain: ethereum, optimism, polygon, arbitrum, fantom, avalanche, bnb, base, linea, scroll
       project: zeroex
       contributors: rantum, danning.sui, bakabhai993 
     config:

--- a/dbt_subprojects/dex/models/_projects/zeroex/zeroex_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/zeroex_trades.sql
@@ -1,7 +1,7 @@
 {{ config(
     schema = 'zeroex'
         ,alias = 'trades'
-        ,post_hook='{{ expose_spells(\'["ethereum","arbitrum", "optimism", "polygon","fantom","avalanche_c","bnb"]\',
+        ,post_hook='{{ expose_spells(\'["ethereum","arbitrum", "optimism", "polygon","fantom","avalanche_c","bnb","base","scroll","linea"]\',
                                 "project",
                                 "zeroex",
                                 \'["rantum","bakabhai993"]\') }}'

--- a/dbt_subprojects/dex/models/aggregator_trades/_schema.yml
+++ b/dbt_subprojects/dex/models/aggregator_trades/_schema.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: dex_aggregator_trades
     meta:
-      blockchain: ethereum, gnosis, avalanche_c, fantom, optimism, arbitrum, bnb
+      blockchain: ethereum, gnosis, avalanche_c, fantom, optimism, arbitrum, bnb, base, scroll, linea, polygon 
       sector: dex_aggregator
       contributors: bh2smith, Henrystats, jeff-dude, rantum
       docs_slug: /curated/trading/DEX/dex-aggregator-trades

--- a/dbt_subprojects/dex/models/aggregator_trades/dex_aggregator_trades.sql
+++ b/dbt_subprojects/dex/models/aggregator_trades/dex_aggregator_trades.sql
@@ -6,7 +6,7 @@
         incremental_strategy = 'merge',
         unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address'],
         incremental_predicates = ['DBT_INTERNAL_DEST.block_date >= date_trunc(\'day\', now() - interval \'7\' day)'],
-        post_hook='{{ expose_spells(\'["ethereum", "gnosis", "avalanche_c", "fantom", "bnb", "optimism", "arbitrum"]\',
+        post_hook='{{ expose_spells(\'["ethereum", "gnosis", "avalanche_c", "fantom", "bnb", "optimism", "arbitrum", "base", "linea", "scroll", "polygon"]\',
                                 "sector",
                                 "dex_aggregator",
                                 \'["bh2smith", "Henrystats", "jeff-dude", "rantum", "hosuke"]\') }}'


### PR DESCRIPTION
### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [x] Adding to existing spell lineage
- [ ] Bug fix


---

### For adding to existing spell lineage
If you are adding to an existing spell lineage, please provide the following information:

- **Description:** [Description of the changes made]
- add linea trades to `zeroex.api_fills_deduped` (+ downstream inclusion in `dex_aggregator.trades`) 
---
