### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/general/sector_spell_design.md
+++ b/docs/general/sector_spell_design.md
@@ -4,7 +4,7 @@ Within Spellbook, there are two main spells which are considered the most popula
 
 **Note**: not all sectors are up-to-date in the new structure, but will be considered moving forward
 
-Since these sector-level spells will have their own dedicated `readme` within their directory with specifics, this will remain a high-level overview. Example dex readme [here](/models/_sector/dex/readme.md).
+Since these sector-level spells will have their own dedicated `readme` within their directory with specifics, this will remain a high-level overview. Example dex readme [here](/dbt_subprojects/dex/README.md).
 
 ## Model level of granularity
 

--- a/docs/macros/macro_overview.md
+++ b/docs/macros/macro_overview.md
@@ -28,7 +28,7 @@ Following [this](/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_
 - **Multiple Macros in One File**
   - It's common to have multiple macros within a single file, such as various versions of the uniswap contract code. Group similar macros together logically.
 
-Within models, such as uniswap v2, call macro code with [this approach](/dbt_subprojects/dex/target/compiled/dex/models/trades/ethereum/platforms/uniswap_v2_ethereum_base_trades.sql).
+Within models, such as uniswap v2, call macro code with [this approach](/dbt_subprojects/dex/models/trades/ethereum/platforms/uniswap_v2_ethereum_base_trades.sql).
 
 ## When to Use a Macro
 


### PR DESCRIPTION
While going through the docs I found one broken link in the document "sector_spell_design.md".

- [ ] New spell(s)
- [ ] Adding to existing spell lineage
- [x] Bug fix

---

### For bug fixes
If you are fixing a bug, please provide the following information:

- **Description:** The link in the doc "sector_spell_design.md" is broken due rto restructure. The old link doesn't exit anymore
- **Test instructions:** no test needed as this is only a doc modification
