### PR TITLE
Enable maverick v2 on zksync

### DIFF
--- a/dbt_subprojects/dex/models/trades/zksync/platforms/maverick_v2_zksync_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/zksync/platforms/maverick_v2_zksync_base_trades.sql
@@ -1,6 +1,5 @@
 {{
     config(
-        tags = ['prod_exclude'],
         schema = 'maverick_v2_zksync',
         alias = 'base_trades',
         materialized = 'incremental',


### PR DESCRIPTION
Enabling maverick v2 on zksync.  
fixes https://github.com/duneanalytics/spellbook/pull/6454 (cc @jeff-dude)

The wrong address was mapped to `maverick_v2_zksync.V2Factory` before.   Data is there now:

<img width="998" alt="image" src="https://github.com/user-attachments/assets/03bc9d58-f425-498d-9b92-9939606bac8d">
