### PR TITLE
Re-add cREAL now that it has more volume

### DIFF
--- a/dbt_subprojects/tokens/models/prices/celo/prices_celo_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/celo/prices_celo_tokens.sql
@@ -19,7 +19,7 @@ FROM
     ('celo-celo', 'celo', 'CELO', 0x471ece3750da237f93b8e339c536989b8978a438, 18), 
     ('cusd-celo-dollar', 'celo', 'cUSD', 0x765de816845861e75a25fca122bb6898b8b1282a, 18),
     ('ceur-celo-euro', 'celo', 'cEUR', 0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73, 18), --requested add to coinPaprika 2023-08-10
-    --('creal-celo-brazilian-real', 'celo', 'cREAL', 0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787, 18), --listed but no much volume
+    ('creal-celo-brazilian-real', 'celo', 'cREAL', 0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787, 18),
     ('ico-axelar', 'celo', 'AXL', 0x23ee2343B892b1BB63503a4FAbc840E0e2C6810f, 6), --requested add to coinPaprika 2023-08-10
     --('mimatic-mimatic', 'celo', 'MAI', 0xb9c8f0d3254007ee4b98970b94544e473cd610ec, 18), --requested add to coinPaprika 2023-08-10
     ('wbtc-wrapped-bitcoin', 'celo', 'WBTC', 0xd629eb00deced2a080b7ec630ef6ac117e614f1b, 18),


### PR DESCRIPTION
Re-adding cREAL, I see it has much more volume than when the low volume comment was written (13 months ago on 31/08/2023). Volume was in the thousands, and now there are some days with 100x more volume. 

Tested the token with its API ID and the Coinpaprika API endpoints 
- `https://api.coinpaprika.com/v1/coins/creal-celo-brazilian-real`
- `https://api.coinpaprika.com/v1/coins/creal-celo-brazilian-real/markets`
- `https://api.coinpaprika.com/v1/coins/creal-celo-brazilian-real/ohlcv/today`