### PR TITLE
dao spells: exclude due to dupes failing prod

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/dao/balances/dao_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/dao/balances/dao_balances.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'dao',
     alias = 'balances',
     materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/dao/balances/dao_balances_steth.sql
+++ b/dbt_subprojects/daily_spellbook/models/dao/balances/dao_balances_steth.sql
@@ -1,5 +1,5 @@
 {{ config(
-    
+    tags = ['prod_exclude'],    
     alias = 'balances_steth',
     materialized = 'table',
     file_format = 'delta',

--- a/dbt_subprojects/daily_spellbook/models/dao/transactions/ethereum/dao_transactions_ethereum_erc20.sql
+++ b/dbt_subprojects/daily_spellbook/models/dao/transactions/ethereum/dao_transactions_ethereum_erc20.sql
@@ -1,5 +1,5 @@
 {{ config(
-    
+    tags = ['prod_exclude'],    
     alias = 'transactions_ethereum_erc20',
     partition_by = ['block_month'],
     materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/dao/transactions/ethereum/dao_transactions_ethereum_eth.sql
+++ b/dbt_subprojects/daily_spellbook/models/dao/transactions/ethereum/dao_transactions_ethereum_eth.sql
@@ -1,5 +1,5 @@
 {{ config(
-    
+    tags = ['prod_exclude'],
     alias = 'transactions_ethereum_eth',
     partition_by = ['block_month'],
     materialized = 'incremental',


### PR DESCRIPTION
fyi @henrystats 
the two ethereum models are failing on dupes. the other two are being skipped due to these failures.