### PR TITLE
Nexus Mutual - staking rewards & staked history

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/_schema.yml
@@ -147,6 +147,9 @@ models:
       - &block_time
         name: block_time
         description: "UTC event block time"
+      - &block_date
+        name: block_date
+        description: "event block date"
       - *pool_address
       - &token_id
         name: token_id
@@ -182,6 +185,42 @@ models:
         name: tx_hash
         description: "unique transaction hash value"
 
+  - name: nexusmutual_ethereum_staking_deposit_ordered
+    meta:
+      blockchain: ethereum
+      project: nexusmutual
+      contributors: tomfutago
+    config:
+      tags: ["ethereum", "nexusmutual", "staking"]
+    description: "Staking pools deposit ordered for Nexus Mutual on Ethereum"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - flow_type
+            - block_time
+            - evt_index
+            - tx_hash
+    columns:
+      - *block_time
+      - *flow_type
+      - &stake_start_date
+        name: stake_start_date
+      - &stake_end_date
+        name: stake_end_date
+      - *pool_address
+      - *token_id
+      - *tranche_id
+      - *init_tranche_id
+      - *new_tranche_id
+      - *tranche_expiry_date
+      - *is_active
+      - *amount
+      - *topup_amount
+      - *user
+      - *evt_index
+      - *tx_hash
+      - name: deposit_rn
+
   - name: nexusmutual_ethereum_staking_deposit_extensions
     meta:
       blockchain: ethereum
@@ -199,14 +238,16 @@ models:
             - current_tranche_id
     columns:
       - *block_time
+      - *block_date
       - *pool_address
       - *token_id
       - *init_tranche_id
       - name: current_tranche_id
         description: "current staking tranche period (most recent one in the chain of extensions)"
-      - name: total_amount
+      - name: amount
         description: "total staking amount (initial deposit + all top-up amounts)"
-      - *tranche_expiry_date
+      - *stake_start_date
+      - *stake_end_date
       - *is_active
       - name: chain_level
         description: "chain (recursion) level"

--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/_schema.yml
@@ -132,7 +132,7 @@ models:
       contributors: tomfutago
     config:
       tags: ["ethereum", "nexusmutual", "staking"]
-    description: "Staking pools event history for Nexus Mutual on Ethereum"
+    description: "Staking pools event history"
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -192,7 +192,7 @@ models:
       contributors: tomfutago
     config:
       tags: ["ethereum", "nexusmutual", "staking"]
-    description: "Staking pools deposit ordered for Nexus Mutual on Ethereum"
+    description: "Staking pools deposit ordered"
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -228,7 +228,7 @@ models:
       contributors: tomfutago
     config:
       tags: ["ethereum", "nexusmutual", "staking"]
-    description: "Staking pools deposit extensions for Nexus Mutual on Ethereum"
+    description: "Staking pools deposit extensions"
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -255,3 +255,73 @@ models:
         description: "descending row number per pool, token & tranche"
       - *evt_index
       - *tx_hash
+
+  - name: nexusmutual_ethereum_staking_rewards
+    meta:
+      blockchain: ethereum
+      project: nexusmutual
+      contributors: tomfutago
+    config:
+      tags: ["ethereum", "nexusmutual", "staking"]
+    description: "Staking rewards minted at cover buy event - to be streamed over cover period"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - pool_id
+            - cover_id
+    columns:
+      - *block_time
+      - *block_date
+      - *pool_id
+      - *product_id
+      - name: cover_id
+      - name: cover_start_date
+      - name: cover_end_date
+      - name: reward_amount_expected_total
+      - name: reward_amount_per_second
+      - name: reward_amount_per_day
+      - *tx_hash
+
+  - name: nexusmutual_ethereum_staked_per_pool
+    meta:
+      blockchain: ethereum
+      project: nexusmutual
+      contributors: tomfutago
+    config:
+      tags: ["ethereum", "nexusmutual", "staking"]
+    description: "Staking rewards minted at cover buy event - to be streamed over cover period"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - pool_id
+    columns:
+      - *block_date
+      - *pool_id
+      - *pool_address
+      - &total_staked_nxm
+        name: total_staked_nxm
+      - name: pool_date_rn
+
+  - name: nexusmutual_ethereum_staked_per_token
+    meta:
+      blockchain: ethereum
+      project: nexusmutual
+      contributors: tomfutago
+    config:
+      tags: ["ethereum", "nexusmutual", "staking"]
+    description: "Staking rewards minted at cover buy event - to be streamed over cover period"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - pool_id
+            - token_id
+    columns:
+      - *block_date
+      - *pool_id
+      - *pool_address
+      - *token_id
+      - *total_staked_nxm
+      - name: stake_expiry_date
+      - name: token_date_rn

--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/_schema.yml
@@ -236,6 +236,8 @@ models:
             - token_id
             - init_tranche_id
             - current_tranche_id
+            - stake_start_date
+            - stake_end_date
     columns:
       - *block_time
       - *block_date

--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_base_staking_pools.sql
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_base_staking_pools.sql
@@ -202,10 +202,16 @@ products as (
   select
     cast(p.product_id as int) as product_id,
     p.product_name,
-    pt.product_type_id,
+    cast(pt.product_type_id as int) as product_type_id,
     pt.product_type_name as product_type
   from {{ ref('nexusmutual_ethereum_product_types_v2') }} pt
     inner join {{ ref('nexusmutual_ethereum_products_v2') }} p on pt.product_type_id = p.product_type_id
+  union all
+  select
+    -1 as product_id,
+    null as product_name,
+    -1 as product_type_id,
+    null as product_type
 )
 
 select
@@ -247,6 +253,6 @@ select
   ) as tx_hash_updated
 from staking_pools_created_ext sp
   inner join staking_pool_products_combined spc on sp.pool_id = spc.pool_id
-  left join products p on spc.product_id = p.product_id
+  inner join products p on spc.product_id = p.product_id
   left join staking_pool_managers spm on sp.pool_id = spm.pool_id
   left join staking_pool_fee_updates spf on sp.pool_address = spf.pool_address

--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staked_per_pool.sql
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staked_per_pool.sql
@@ -1,0 +1,90 @@
+{{
+  config(
+    schema = 'nexusmutual_ethereum',
+    alias = 'staked_per_pool',
+    materialized = 'view',
+    unique_key = ['block_date', 'pool_id'],
+    post_hook = '{{ expose_spells(blockchains = \'["ethereum"]\',
+                                  spell_type = "project",
+                                  spell_name = "nexusmutual",
+                                  contributors = \'["tomfutago"]\') }}'
+  )
+}}
+
+with
+
+staking_pools as (
+  select distinct
+    sp.pool_id,
+    sp.pool_address,
+    se.first_stake_event_date
+  from {{ ref('nexusmutual_ethereum_staking_pools') }} sp
+    inner join (
+      select
+        pool_address,
+        cast(min(block_time) as date) as first_stake_event_date
+      from {{ ref('nexusmutual_ethereum_staking_events') }}
+      group by 1
+    ) se on sp.pool_address = se.pool_address
+),
+
+staking_pool_day_sequence as (
+  select
+    sp.pool_id,
+    sp.pool_address,
+    s.block_date
+  from staking_pools sp
+    cross join unnest (
+      sequence(
+        cast(date_trunc('day', sp.first_stake_event_date) as timestamp),
+        cast(date_trunc('day', now()) as timestamp),
+        interval '1' day
+      )
+    ) as s(block_date)
+),
+
+staked_nxm_per_pool as (
+  select
+    block_date,
+    pool_id,
+    pool_address,
+    sum(coalesce(total_amount, 0)) as total_staked_nxm,
+    dense_rank() over (partition by pool_id order by block_date desc) as pool_date_rn
+  from (
+      -- deposits & deposit extensions
+      select
+        d.block_date,
+        d.pool_id,
+        d.pool_address,
+        sum(se.amount) as total_amount
+      from staking_pool_day_sequence d
+        left join {{ ref('nexusmutual_ethereum_staking_deposit_extensions') }} se
+          on d.pool_address = se.pool_address
+         and d.block_date >= se.stake_start_date
+         and d.block_date < se.stake_end_date
+      group by 1, 2, 3
+      union all
+      -- withdrawals & burns
+      select
+        d.block_date,
+        d.pool_id,
+        d.pool_address,
+        sum(se.amount) as total_amount
+      from staking_pool_day_sequence d
+        left join {{ ref('nexusmutual_ethereum_staking_events') }} se
+          on d.pool_address = se.pool_address
+         and d.block_date >= date_trunc('day', se.block_time)
+         and d.block_date < coalesce(se.tranche_expiry_date, current_date)
+      where flow_type in ('withdraw', 'stake burn')
+      group by 1, 2, 3
+    ) t
+  group by 1, 2, 3
+)
+
+select
+  block_date,
+  pool_id,
+  pool_address,
+  total_staked_nxm,
+  pool_date_rn
+from staked_nxm_per_pool

--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staked_per_token.sql
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staked_per_token.sql
@@ -1,0 +1,98 @@
+{{
+  config(
+    schema = 'nexusmutual_ethereum',
+    alias = 'staked_per_token',
+    materialized = 'view',
+    unique_key = ['block_date', 'pool_id', 'token_id'],
+    post_hook = '{{ expose_spells(blockchains = \'["ethereum"]\',
+                                  spell_type = "project",
+                                  spell_name = "nexusmutual",
+                                  contributors = \'["tomfutago"]\') }}'
+  )
+}}
+
+with
+
+staking_pools as (
+  select distinct
+    sp.pool_id,
+    sp.pool_address,
+    se.first_stake_event_date
+  from {{ ref('nexusmutual_ethereum_staking_pools') }} sp
+    inner join (
+      select
+        pool_address,
+        cast(min(block_time) as date) as first_stake_event_date
+      from {{ ref('nexusmutual_ethereum_staking_events') }}
+      group by 1
+    ) se on sp.pool_address = se.pool_address
+),
+
+staking_pool_day_sequence as (
+  select
+    sp.pool_id,
+    sp.pool_address,
+    s.block_date
+  from staking_pools sp
+    cross join unnest (
+      sequence(
+        cast(date_trunc('day', sp.first_stake_event_date) as timestamp),
+        cast(date_trunc('day', now()) as timestamp),
+        interval '1' day
+      )
+    ) as s(block_date)
+),
+
+staked_nxm_per_pool_n_token as (
+  select
+    block_date,
+    pool_id,
+    pool_address,
+    token_id,
+    sum(coalesce(total_amount, 0)) as total_staked_nxm,
+    max(stake_expiry_date) as stake_expiry_date,
+    dense_rank() over (partition by pool_id, token_id order by block_date desc) as token_date_rn
+  from (
+      -- deposits & deposit extensions
+      select
+        d.block_date,
+        d.pool_id,
+        d.pool_address,
+        se.token_id,
+        sum(se.amount) as total_amount,
+        max(se.stake_end_date) as stake_expiry_date
+      from staking_pool_day_sequence d
+        left join {{ ref('nexusmutual_ethereum_staking_deposit_extensions') }} se
+          on d.pool_address = se.pool_address
+         and d.block_date >= se.stake_start_date
+         and d.block_date < se.stake_end_date
+      group by 1, 2, 3, 4
+      union all
+      -- withdrawals & burns?
+      select
+        d.block_date,
+        d.pool_id,
+        d.pool_address,
+        se.token_id,
+        sum(se.amount) as total_amount,
+        cast(null as date) as stake_expiry_date -- no point pulling stake_expiry_date for withdrawals
+      from staking_pool_day_sequence d
+        left join {{ ref('nexusmutual_ethereum_staking_events') }} se
+          on d.pool_address = se.pool_address
+         and d.block_date >= date_trunc('day', se.block_time)
+         and d.block_date < coalesce(se.tranche_expiry_date, current_date)
+      where flow_type in ('withdraw', 'stake burn')
+      group by 1, 2, 3, 4
+    ) t
+  group by 1, 2, 3, 4
+)
+
+select
+  block_date,
+  pool_id,
+  pool_address,
+  token_id,
+  total_staked_nxm,
+  stake_expiry_date,
+  token_date_rn
+from staked_nxm_per_pool_n_token

--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staking_deposit_extensions.sql
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staking_deposit_extensions.sql
@@ -3,7 +3,7 @@
     schema = 'nexusmutual_ethereum',
     alias = 'staking_deposit_extensions',
     materialized = 'view',
-    unique_key = ['pool_address', 'token_id', 'init_tranche_id', 'current_tranche_id'],
+    unique_key = ['pool_address', 'token_id', 'init_tranche_id', 'current_tranche_id', 'stake_start_date', 'stake_end_date'],
     post_hook = '{{ expose_spells(blockchains = \'["ethereum"]\',
                                   spell_type = "project",
                                   spell_name = "nexusmutual",

--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staking_deposit_extensions.sql
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staking_deposit_extensions.sql
@@ -11,60 +11,67 @@
   )
 }}
 
-with recursive deposit_chain (pool_address, token_id, tranche_id, new_tranche_id, total_amount, block_time, tranche_expiry_date, is_active, evt_index, tx_hash, chain_level) as (
+with recursive deposit_chain (
+  block_time, pool_address, token_id, tranche_id, new_tranche_id, amount, stake_start_date, stake_end_date, is_active, evt_index, tx_hash, deposit_rn, chain_level
+) as (
   select
+    block_time,
     pool_address,
     token_id,
-    tranche_id as tranche_id,
+    tranche_id,
     tranche_id as new_tranche_id,
-    sum(amount) as total_amount,
-    max(block_time) as block_time,
-    max_by(tranche_expiry_date, block_time) as tranche_expiry_date,
-    max_by(is_active, block_time) as is_active,
-    max_by(evt_index, block_time) as evt_index,
-    max_by(tx_hash, block_time) as tx_hash,
+    amount,
+    stake_start_date,
+    stake_end_date,
+    is_active,
+    evt_index,
+    tx_hash,
+    deposit_rn,
     1 as chain_level
-  from {{ ref('nexusmutual_ethereum_staking_events') }}
+  from {{ ref('nexusmutual_ethereum_staking_deposit_ordered') }}
   where flow_type = 'deposit'
-  group by 1,2,3,4
   
   union all
   
   select 
+    d.block_time,
     d.pool_address,
     d.token_id,
     dc.tranche_id,
-    d.new_tranche_id,
-    dc.total_amount + coalesce(d.topup_amount, 0) as total_amount,
-    d.block_time,
-    d.tranche_expiry_date,
+    coalesce(d.new_tranche_id, dc.tranche_id) as new_tranche_id,
+    dc.amount + coalesce(d.amount, d.topup_amount, 0) as amount,
+    d.stake_start_date,
+    d.stake_end_date,
     d.is_active,
     d.evt_index,
     d.tx_hash,
+    d.deposit_rn,
     dc.chain_level + 1 as chain_level
   from deposit_chain dc
-    inner join {{ ref('nexusmutual_ethereum_staking_events') }} d on dc.pool_address = d.pool_address
-      and dc.token_id = d.token_id
-      and dc.new_tranche_id = d.init_tranche_id
-  where d.flow_type = 'deposit extended'
+    inner join {{ ref('nexusmutual_ethereum_staking_deposit_ordered') }} d on dc.pool_address = d.pool_address and dc.token_id = d.token_id
+  where dc.deposit_rn = d.deposit_rn - 1
+    and ((d.flow_type = 'deposit extended' and dc.new_tranche_id = d.init_tranche_id)
+      or (d.flow_type = 'deposit addon' and dc.new_tranche_id = d.tranche_id))
 )
 
-select 
+select
   block_time,
+  date_trunc('day', block_time) as block_date,
   pool_address,
   token_id,
   tranche_id as init_tranche_id,
   new_tranche_id as current_tranche_id,
-  total_amount,
-  tranche_expiry_date,
+  amount,
+  stake_start_date,
+  stake_end_date,
   is_active,
   chain_level,
-  rn as token_tranche_rn,
+  token_tranche_rn,
   evt_index,
   tx_hash
 from (
     select
       *,
-      row_number() over (partition by pool_address, token_id, tranche_id order by chain_level desc) as rn
+      row_number() over (partition by pool_address, token_id, tranche_id order by chain_level desc) as token_tranche_rn
     from deposit_chain
   ) t

--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staking_deposit_ordered.sql
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staking_deposit_ordered.sql
@@ -1,0 +1,67 @@
+{{
+  config(
+    schema = 'nexusmutual_ethereum',
+    alias = 'staking_deposit_ordered',
+    materialized = 'view',
+    unique_key = ['flow_type', 'block_time', 'evt_index', 'tx_hash']
+  )
+}}
+
+with
+
+deposits as (
+  select
+    flow_type,
+    block_time,
+    block_date,
+    pool_address,
+    token_id,
+    tranche_id,
+    init_tranche_id,
+    new_tranche_id,
+    tranche_expiry_date,
+    is_active,
+    amount,
+    topup_amount,
+    user,
+    evt_index,
+    tx_hash,
+    lead(block_date, 1) over (partition by pool_address, token_id order by coalesce(tranche_id, init_tranche_id), block_time) as next_block_date,
+    lag(flow_type, 1) over (partition by pool_address, token_id order by coalesce(tranche_id, init_tranche_id), block_time) as prev_flow_type,
+    lead(flow_type, 1) over (partition by pool_address, token_id order by coalesce(tranche_id, init_tranche_id), block_time) as next_flow_type,
+    lag(token_id, 1) over (partition by pool_address, token_id order by coalesce(tranche_id, init_tranche_id), block_time) as prev_token_id,
+    lag(tranche_id, 1) over (partition by pool_address, token_id order by coalesce(tranche_id, init_tranche_id), block_time) as prev_tranche_id,
+    lead(tranche_id, 1) over (partition by pool_address, token_id order by coalesce(tranche_id, init_tranche_id), block_time) as next_tranche_id,
+    row_number() over (partition by pool_address, token_id order by coalesce(tranche_id, init_tranche_id), block_time) as deposit_rn
+  from {{ ref('nexusmutual_ethereum_staking_events') }}
+  where flow_type in ('deposit', 'deposit extended')
+)
+
+select
+  block_time,
+  case
+    when token_id = prev_token_id and flow_type = 'deposit' and prev_flow_type = 'deposit' and prev_tranche_id = tranche_id
+    then 'deposit addon'
+    else flow_type
+  end as flow_type,
+  block_date as stake_start_date,
+  case
+    when flow_type = 'deposit' and next_flow_type <> 'deposit extended' and next_tranche_id <> tranche_id then tranche_expiry_date
+    when flow_type = 'deposit extended' and next_flow_type = 'deposit' then tranche_expiry_date
+    when next_block_date > tranche_expiry_date then tranche_expiry_date
+    else coalesce(next_block_date, tranche_expiry_date)
+  end as stake_end_date,
+  pool_address,
+  token_id,
+  tranche_id,
+  init_tranche_id,
+  new_tranche_id,
+  tranche_expiry_date,
+  is_active,
+  amount,
+  topup_amount,
+  user,
+  evt_index,
+  tx_hash,
+  deposit_rn
+from deposits

--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staking_events.sql
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staking_events.sql
@@ -104,6 +104,7 @@ staked_nxm_history as (
 select
   flow_type,
   block_time,
+  date_trunc('day', block_time) as block_date,
   pool_address,
   token_id,
   tranche_id,

--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staking_pools.sql
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staking_pools.sql
@@ -38,7 +38,6 @@ select
   tx_hash_created,
   tx_hash_updated
 from {{ ref('nexusmutual_ethereum_base_staking_pools') }}
-where true
-  {% if is_incremental() %}
-  and {{ incremental_predicate('block_time_updated') }}
-  {% endif %}
+{% if is_incremental() %}
+where {{ incremental_predicate('block_time_updated') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staking_rewards.sql
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/staking/nexusmutual_ethereum_staking_rewards.sql
@@ -1,0 +1,64 @@
+{{
+  config(
+    schema = 'nexusmutual_ethereum',
+    alias = 'staking_rewards',
+    materialized = 'view',
+    unique_key = ['pool_id', 'cover_id'],
+    post_hook = '{{ expose_spells(blockchains = \'["ethereum"]\',
+                                  spell_type = "project",
+                                  spell_name = "nexusmutual",
+                                  contributors = \'["tomfutago"]\') }}'
+  )
+}}
+
+with
+
+covers as (
+  select
+    cover_id,
+    cover_start_date,
+    cover_end_date,
+    floor(date_diff('day', from_unixtime(0), cover_end_date) / 28) as cover_end_bucket_id,
+    from_unixtime(28.0 * 86400.0 * cast(floor(date_diff('day', from_unixtime(0), cover_end_time) / 28) + 1 as double)) as cover_end_bucket_expiry_date,
+    date_diff(
+      'second',
+      cover_start_time,
+      from_unixtime(28.0 * 86400.0 * cast(floor(date_diff('day', from_unixtime(0), cover_end_time) / 28) + 1 as double)) -- cover_end_bucket_expiry_date (rathan than cover_end_time)
+    ) as cover_period_seconds,
+    staking_pool_id,
+    product_id,
+    block_number,
+    trace_address,
+    tx_hash
+  from {{ ref("nexusmutual_ethereum_covers_v2") }}
+)
+
+select
+  mr.call_block_time as block_time,
+  date_trunc('day', mr.call_block_time) as block_date,
+  mr.poolId as pool_id,
+  c.product_id,
+  c.cover_id,
+  c.cover_start_date,
+  c.cover_end_date,
+  mr.amount / 1e18 as reward_amount_expected_total,
+  mr.amount / c.cover_period_seconds / 1e18 as reward_amount_per_second,
+  mr.amount / c.cover_period_seconds * 86400.0 / 1e18 as reward_amount_per_day,
+  mr.call_tx_hash as tx_hash
+from (
+    select call_block_time, call_block_number, poolId, amount, call_trace_address, call_tx_hash
+    from {{ source('nexusmutual_ethereum', 'TokenController_call_mintStakingPoolNXMRewards') }}
+    where call_success
+    union all
+    select call_block_time, call_block_number, poolId, amount, call_trace_address, call_tx_hash
+    from {{ source('nexusmutual_ethereum', 'TokenController2_call_mintStakingPoolNXMRewards') }}
+    where call_success
+    union all
+    select call_block_time, call_block_number, poolId, amount, call_trace_address, call_tx_hash
+    from {{ source('nexusmutual_ethereum', 'TokenController3_call_mintStakingPoolNXMRewards') }}
+    where call_success
+  ) mr
+  inner join covers c on mr.call_tx_hash = c.tx_hash and mr.call_block_number = c.block_number
+where mr.poolId = c.staking_pool_id
+  and (c.trace_address is null
+    or slice(mr.call_trace_address, 1, cardinality(c.trace_address)) = c.trace_address)

--- a/sources/nexusmutual/ethereum/nexusmutual_ethereum_sources.yml
+++ b/sources/nexusmutual/ethereum/nexusmutual_ethereum_sources.yml
@@ -15,6 +15,9 @@ sources:
       - name: TokenController_call_assignStakingPoolManager
       - name: TokenController2_call_assignStakingPoolManager
       - name: TokenController3_call_assignStakingPoolManager
+      - name: TokenController_call_mintStakingPoolNXMRewards
+      - name: TokenController2_call_mintStakingPoolNXMRewards
+      - name: TokenController3_call_mintStakingPoolNXMRewards
       - name: StakingProducts_evt_ProductUpdated
       - name: StakingPool_call_manager
       - name: StakingPool_evt_PoolFeeChanged


### PR DESCRIPTION
### Contribution type
Please check the type of contribution this pull request is for:

- [x] New spell(s)
- [x] Adding to existing spell lineage
- [x] Bug fix

---

### For new spell(s)
If you are building new spell(s), please provide the following information:

- **Description:** :
  - `staking_deposit_ordered` - enriched deposit view (helper to `staking_deposit_extensions`)
  - `staking_rewards` - rewards minted at cover buy event (view)
  - `staked_per_pool` - daily staked NXM total per pool history (view)
  - `staked_per_token` - daily staked NXM total per pool & token history (view)

---

### For adding to existing spell lineage
If you are adding to an existing spell lineage, please provide the following information:

- **Description:**:
  - `staking_events` - added `block_date`
  - `staking_deposit_extensions` - amended logic relying now on `staking_deposit_ordered` spell

---

### For bug fixes
If you are fixing a bug, please provide the following information:

- **Description:**:
  - `base_staking_pools` - amended (hopefully for good this time 😬🤞) `product_id` to non-nullable column to fix incremental load on `staking_pools`
 
---
