### PR TITLE
Update staking_solana_validator_stake_account_epochs_raw.sql

### DIFF
--- a/dbt_subprojects/solana/models/_sector/staking/solana/staking_solana_validator_stake_account_epochs_raw.sql
+++ b/dbt_subprojects/solana/models/_sector/staking/solana/staking_solana_validator_stake_account_epochs_raw.sql
@@ -1,9 +1,8 @@
 {{ config(
     schema = 'staking_solana'
     , alias = 'validator_stake_account_epochs_raw'
-    , materialized = 'incremental'
+    , materialized = 'table'
     , file_format = 'delta'
-    , incremental_strategy = 'merge'
     , unique_key = ['epoch', 'epoch_time', 'stake_account', 'vote_account']
 )
 }}
@@ -21,9 +20,6 @@ with
         FROM {{ ref('staking_solana_stake_account_delegations') }} vote
         LEFT JOIN {{ ref('solana_utils_epochs') }} epoch
             ON first_block_epoch = true --cross join
-            {% if is_incremental() %}
-            AND epoch.block_time >= date_trunc('day', now() - interval '7' day)
-            {% endif %}
         WHERE vote.block_slot < epoch.block_slot --only get changes to accounts before start of epoch
         GROUP BY 1,2,3,4,5
     )


### PR DESCRIPTION
I noticed the lookback was bumped from 2 to 7 days, but it seems the same issue is still occurring where it does not recognize a new epoch has began and thus does not run the incremental model. I think this needs a full refresh every time in that case

## Thank you for contributing to Spellbook 🪄

### Update!
Please build spells in the proper [subproject](../dbt_subprojects/) directory. For more information, please see the main [readme](../README.md), which also links to a GH discussion with the option to ask questions.

### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [ ] Adding to existing spell lineage
- [x ] Bug fix

I noticed the lookback was bumped from 2 to 7 days, but it seems the same issue is still occurring where it does not recognize a new epoch has began and thus does not run the incremental model. I think this needs a full refresh every time in that case