### PR TITLE
Update metrics spells with first iteration of feedback

### DIFF
--- a/dbt_subprojects/hourly_spellbook/macros/blockchain_transaction_metrics.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/blockchain_transaction_metrics.sql
@@ -10,8 +10,9 @@ from (
     time
     ,lag(time) over (order by "time" asc) as lag_time
     from {{source(blockchain,'blocks')}}
+    where number > 0 --some chains have a genesis block with number 0 and dummy timestamp
     {% if is_incremental() %}
-    where {{ incremental_predicate('time') }}
+    and {{ incremental_predicate('time') }}
     {% endif %}
 )
 group by 1,2

--- a/dbt_subprojects/hourly_spellbook/models/_metrics/fees/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_metrics/fees/_schema.yml
@@ -12,7 +12,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - blockchain
-            - day
+            - block_date
   - name: metrics_gas_fees_stats
     meta:
       sector: metrics

--- a/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_daily.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_daily.sql
@@ -12,7 +12,7 @@
 select
     blockchain
     , block_date
-    , sum(tx_fee_usd) as gas_spent_usd
+    , sum(tx_fee_usd) as gas_fees_usd
 from
     {{ ref('gas_fees') }}
 {% if is_incremental() %}

--- a/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_daily.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_daily.sql
@@ -4,14 +4,14 @@
         , materialized = 'incremental'
         , file_format = 'delta'
         , incremental_strategy = 'merge'
-        , unique_key = ['blockchain', 'day']
-        , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
+        , unique_key = ['blockchain', 'block_date']
+        , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
         )
 }}
 
 select
     blockchain
-    , block_date as day
+    , block_date
     , sum(tx_fee_usd) as gas_spent_usd
 from
     {{ ref('gas_fees') }}

--- a/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_stats.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_stats.sql
@@ -30,9 +30,9 @@ with source as (
     where
         block_date >= date_trunc('day', now()) - interval '2' day
         and block_date < date_trunc('day', now()) - interval '1' day
-), total_current_day_fees as (
+), total_current_day_gas_fees as (
     select
-        sum(current_day_gas_fees_usd) AS total_current_day_fees
+        sum(current_day_gas_fees_usd) AS total_current_day_gas_fees
     from
         current_day
 ), daily_stats as (
@@ -41,13 +41,13 @@ with source as (
         , c.current_day_gas_fees_usd
         , p.previous_day_gas_fees_usd
         , ((c.current_day_gas_fees_usd - coalesce(p.previous_day_gas_fees_usd, 0)) / coalesce(p.previous_day_gas_fees_usd, 1)) * 100 AS daily_percent_change
-        , t.total_current_day_fees
-        , (c.current_day_gas_fees_usd / t.total_current_day_fees) * 100 AS percent_of_total_current_day_fees
+        , t.total_current_day_gas_fees
+        , (c.current_day_gas_fees_usd / t.total_current_day_gas_fees) * 100 AS percent_of_total_current_day_fees
     from
         current_day as c
     left join previous_day as p
         on c.blockchain = p.blockchain
-    inner join total_current_day_fees as t
+    inner join total_current_day_gas_fees as t
         on 1 = 1
 ), current_week as (
     select
@@ -71,9 +71,9 @@ with source as (
         and block_date < date_trunc('day', now()) - interval '7' day
     group by
         blockchain
-), total_current_week_fees as (
+), total_current_week_gas_fees as (
     select
-        sum(current_week_gas_fees_usd) AS total_current_week_fees
+        sum(current_week_gas_fees_usd) AS total_current_week_gas_fees
     from
         current_week
 ), weekly_stats as (
@@ -82,13 +82,13 @@ with source as (
         , c.current_week_gas_fees_usd
         , p.previous_week_gas_fees_usd
         , ((c.current_week_gas_fees_usd - coalesce(p.previous_week_gas_fees_usd, 0)) / coalesce(p.previous_week_gas_fees_usd, 1)) * 100 AS weekly_percent_change
-        , t.total_current_week_fees
-        , (c.current_week_gas_fees_usd / t.total_current_week_fees) * 100 AS percent_of_total_current_week_fees
+        , t.total_current_week_gas_fees
+        , (c.current_week_gas_fees_usd / t.total_current_week_gas_fees) * 100 AS percent_of_total_current_week_gas_fees
     from
         current_week as c
     left join previous_week as p
         on c.blockchain = p.blockchain
-    inner join total_current_week_fees as t
+    inner join total_current_week_gas_fees as t
         on 1 = 1
 ), current_month as (
     select
@@ -112,9 +112,9 @@ with source as (
         and block_date < date_trunc('day', now()) - interval '30' day
     group by
         blockchain
-), total_current_month_fees as (
+), total_current_month_gas_fees as (
     select
-        sum(current_month_gas_fees_usd) AS total_current_month_fees
+        sum(current_month_gas_fees_usd) AS total_current_month_gas_fees
     from
         current_month
 ), monthly_stats as (
@@ -123,13 +123,13 @@ with source as (
         , c.current_month_gas_fees_usd
         , p.previous_month_gas_fees_usd
         , ((c.current_month_gas_fees_usd - coalesce(p.previous_month_gas_fees_usd, 0)) / coalesce(p.previous_month_gas_fees_usd, 1)) * 100 AS monthly_percent_change
-        , t.total_current_month_fees
-        , (c.current_month_gas_fees_usd / t.total_current_month_fees) * 100 AS percent_of_total_current_month_fees
+        , t.total_current_month_gas_fees
+        , (c.current_month_gas_fees_usd / t.total_current_month_gas_fees) * 100 AS percent_of_total_current_month_gas_fees
     from
         current_month as c
     left join previous_month as p
         on c.blockchain = p.blockchain
-    inner join total_current_month_fees as t
+    inner join total_current_month_gas_fees as t
         on 1 = 1
 )
 select
@@ -137,19 +137,19 @@ select
     , d.current_day_gas_fees_usd
     , d.previous_day_gas_fees_usd
     , d.daily_percent_change
-    , d.total_current_day_fees
-    , d.percent_of_total_current_day_fees
+    , d.total_current_day_gas_fees
+    , d.percent_of_total_current_day_gas_fees
     , w.current_week_gas_fees_usd
     , w.previous_week_gas_fees_usd
     , w.weekly_percent_change
-    , w.total_current_week_fees
-    , w.percent_of_total_current_week_fees
+    , w.total_current_week_gas_fees
+    , w.percent_of_total_current_week_gas_fees
     , m.current_month_gas_fees_usd
     , m.previous_month_gas_fees_usd
     , m.monthly_percent_change
-    , m.total_current_month_fees
-    , m.percent_of_total_current_month_fees
-    , m.total_current_month_fees * 12 as gas_fees_usd_run_rate
+    , m.total_current_month_gas_fees
+    , m.percent_of_total_current_month_gas_fees
+    , m.total_current_month_gas_fees * 12 as gas_fees_usd_run_rate
 from
     daily_stats as d
 inner join weekly_stats as w

--- a/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_stats.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_stats.sql
@@ -124,7 +124,7 @@ with source as (
         , p.previous_30_days_gas_fees_usd
         , ((c.last_30_days_gas_fees_usd - coalesce(p.previous_30_days_gas_fees_usd, 0)) / coalesce(p.previous_30_days_gas_fees_usd, 1)) * 100 AS monthly_percent_change
         , t.total_cross_chain_last_30_days_gas_fees_usd
-        , (c.last_30_days_gas_fees_usd / t.total_cross_chain_last_30_days_gas_fees_usd) * 100 AS percent_total_last_30_days_gas_fees
+        , (c.last_30_days_gas_fees_usd / t.total_cross_chain_last_30_days_gas_fees_usd) * 100 AS percent_total_last_30_days_gas_fees_usd
     from
         current_month as c
     left join previous_month as p
@@ -148,7 +148,7 @@ select
     , m.previous_30_days_gas_fees_usd
     , m.monthly_percent_change
     , m.total_cross_chain_last_30_days_gas_fees_usd
-    , m.percent_total_last_30_days_gas_fees
+    , m.percent_total_last_30_days_gas_fees_usd
     , m.last_30_days_gas_fees_usd * 12 as gas_fees_usd_run_rate
 from
     daily_stats as d

--- a/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_stats.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_stats.sql
@@ -8,7 +8,7 @@ with source as (
     -- daily aggregation of gas fees per blockchain
     select
         blockchain
-        , day
+        , block_date
         , gas_spent_usd
     from
         {{ ref('metrics_gas_fees_daily') }}
@@ -19,8 +19,8 @@ with source as (
     from
         source
     where
-        day >= date_trunc('day', now()) - interval '1' day
-        and day < date_trunc('day', now())
+        block_date >= date_trunc('day', now()) - interval '1' day
+        and block_date < date_trunc('day', now())
 ), previous_day as (
     select
         blockchain
@@ -28,8 +28,8 @@ with source as (
     from
         source
     where
-        day >= date_trunc('day', now()) - interval '2' day
-        and day < date_trunc('day', now()) - interval '1' day
+        block_date >= date_trunc('day', now()) - interval '2' day
+        and block_date < date_trunc('day', now()) - interval '1' day
 ), total_current_day_fees as (
     select
         sum(current_day_gas_spent_usd) AS total_current_day_fees
@@ -56,8 +56,8 @@ with source as (
     from
         source
     where
-        day >= date_trunc('day', now()) - interval '7' day
-        and day < date_trunc('day', now())
+        block_date >= date_trunc('day', now()) - interval '7' day
+        and block_date < date_trunc('day', now())
     group by
         blockchain
 ), previous_week as (
@@ -67,8 +67,8 @@ with source as (
     from
         source
     where
-        day >= date_trunc('day', now()) - interval '14' day
-        and day < date_trunc('day', now()) - interval '7' day
+        block_date >= date_trunc('day', now()) - interval '14' day
+        and block_date < date_trunc('day', now()) - interval '7' day
     group by
         blockchain
 ), total_current_week_fees as (
@@ -97,8 +97,8 @@ with source as (
     from
         source
     where
-        day >= date_trunc('day', now()) - interval '30' day
-        and day < date_trunc('day', now())
+        block_date >= date_trunc('day', now()) - interval '30' day
+        and block_date < date_trunc('day', now())
     group by
         blockchain
 ), previous_month as (
@@ -108,8 +108,8 @@ with source as (
     from
         source
     where
-        day >= date_trunc('day', now()) - interval '60' day
-        and day < date_trunc('day', now()) - interval '30' day
+        block_date >= date_trunc('day', now()) - interval '60' day
+        and block_date < date_trunc('day', now()) - interval '30' day
     group by
         blockchain
 ), total_current_month_fees as (

--- a/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_stats.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_stats.sql
@@ -9,13 +9,13 @@ with source as (
     select
         blockchain
         , block_date
-        , gas_spent_usd
+        , gas_fees_usd
     from
         {{ ref('metrics_gas_fees_daily') }}
 ), current_day as (
     select
         blockchain
-        , gas_spent_usd as current_day_gas_spent_usd
+        , gas_fees_usd as current_day_gas_fees_usd
     from
         source
     where
@@ -24,7 +24,7 @@ with source as (
 ), previous_day as (
     select
         blockchain
-        , gas_spent_usd as previous_day_gas_spent_usd
+        , gas_fees_usd as previous_day_gas_fees_usd
     from
         source
     where
@@ -32,17 +32,17 @@ with source as (
         and block_date < date_trunc('day', now()) - interval '1' day
 ), total_current_day_fees as (
     select
-        sum(current_day_gas_spent_usd) AS total_current_day_fees
+        sum(current_day_gas_fees_usd) AS total_current_day_fees
     from
         current_day
 ), daily_stats as (
     select
         c.blockchain
-        , c.current_day_gas_spent_usd
-        , p.previous_day_gas_spent_usd
-        , ((c.current_day_gas_spent_usd - coalesce(p.previous_day_gas_spent_usd, 0)) / coalesce(p.previous_day_gas_spent_usd, 1)) * 100 AS daily_percent_change
+        , c.current_day_gas_fees_usd
+        , p.previous_day_gas_fees_usd
+        , ((c.current_day_gas_fees_usd - coalesce(p.previous_day_gas_fees_usd, 0)) / coalesce(p.previous_day_gas_fees_usd, 1)) * 100 AS daily_percent_change
         , t.total_current_day_fees
-        , (c.current_day_gas_spent_usd / t.total_current_day_fees) * 100 AS percent_of_total_current_day_fees
+        , (c.current_day_gas_fees_usd / t.total_current_day_fees) * 100 AS percent_of_total_current_day_fees
     from
         current_day as c
     left join previous_day as p
@@ -52,7 +52,7 @@ with source as (
 ), current_week as (
     select
         blockchain
-        , sum(gas_spent_usd) as current_week_gas_spent_usd
+        , sum(gas_fees_usd) as current_week_gas_fees_usd
     from
         source
     where
@@ -63,7 +63,7 @@ with source as (
 ), previous_week as (
     select
         blockchain
-        , sum(gas_spent_usd) as previous_week_gas_spent_usd
+        , sum(gas_fees_usd) as previous_week_gas_fees_usd
     from
         source
     where
@@ -73,17 +73,17 @@ with source as (
         blockchain
 ), total_current_week_fees as (
     select
-        sum(current_week_gas_spent_usd) AS total_current_week_fees
+        sum(current_week_gas_fees_usd) AS total_current_week_fees
     from
         current_week
 ), weekly_stats as (
     select
         c.blockchain
-        , c.current_week_gas_spent_usd
-        , p.previous_week_gas_spent_usd
-        , ((c.current_week_gas_spent_usd - coalesce(p.previous_week_gas_spent_usd, 0)) / coalesce(p.previous_week_gas_spent_usd, 1)) * 100 AS weekly_percent_change
+        , c.current_week_gas_fees_usd
+        , p.previous_week_gas_fees_usd
+        , ((c.current_week_gas_fees_usd - coalesce(p.previous_week_gas_fees_usd, 0)) / coalesce(p.previous_week_gas_fees_usd, 1)) * 100 AS weekly_percent_change
         , t.total_current_week_fees
-        , (c.current_week_gas_spent_usd / t.total_current_week_fees) * 100 AS percent_of_total_current_week_fees
+        , (c.current_week_gas_fees_usd / t.total_current_week_fees) * 100 AS percent_of_total_current_week_fees
     from
         current_week as c
     left join previous_week as p
@@ -93,7 +93,7 @@ with source as (
 ), current_month as (
     select
         blockchain
-        , sum(gas_spent_usd) as current_month_gas_spent_usd
+        , sum(gas_fees_usd) as current_month_gas_fees_usd
     from
         source
     where
@@ -104,7 +104,7 @@ with source as (
 ), previous_month as (
     select
         blockchain
-        , sum(gas_spent_usd) as previous_month_gas_spent_usd
+        , sum(gas_fees_usd) as previous_month_gas_fees_usd
     from
         source
     where
@@ -114,17 +114,17 @@ with source as (
         blockchain
 ), total_current_month_fees as (
     select
-        sum(current_month_gas_spent_usd) AS total_current_month_fees
+        sum(current_month_gas_fees_usd) AS total_current_month_fees
     from
         current_month
 ), monthly_stats as (
     select
         c.blockchain
-        , c.current_month_gas_spent_usd
-        , p.previous_month_gas_spent_usd
-        , ((c.current_month_gas_spent_usd - coalesce(p.previous_month_gas_spent_usd, 0)) / coalesce(p.previous_month_gas_spent_usd, 1)) * 100 AS monthly_percent_change
+        , c.current_month_gas_fees_usd
+        , p.previous_month_gas_fees_usd
+        , ((c.current_month_gas_fees_usd - coalesce(p.previous_month_gas_fees_usd, 0)) / coalesce(p.previous_month_gas_fees_usd, 1)) * 100 AS monthly_percent_change
         , t.total_current_month_fees
-        , (c.current_month_gas_spent_usd / t.total_current_month_fees) * 100 AS percent_of_total_current_month_fees
+        , (c.current_month_gas_fees_usd / t.total_current_month_fees) * 100 AS percent_of_total_current_month_fees
     from
         current_month as c
     left join previous_month as p
@@ -134,22 +134,22 @@ with source as (
 )
 select
     d.blockchain
-    , d.current_day_gas_spent_usd
-    , d.previous_day_gas_spent_usd
+    , d.current_day_gas_fees_usd
+    , d.previous_day_gas_fees_usd
     , d.daily_percent_change
     , d.total_current_day_fees
     , d.percent_of_total_current_day_fees
-    , w.current_week_gas_spent_usd
-    , w.previous_week_gas_spent_usd
+    , w.current_week_gas_fees_usd
+    , w.previous_week_gas_fees_usd
     , w.weekly_percent_change
     , w.total_current_week_fees
     , w.percent_of_total_current_week_fees
-    , m.current_month_gas_spent_usd
-    , m.previous_month_gas_spent_usd
+    , m.current_month_gas_fees_usd
+    , m.previous_month_gas_fees_usd
     , m.monthly_percent_change
     , m.total_current_month_fees
     , m.percent_of_total_current_month_fees
-    , m.total_current_month_fees * 12 as gas_spent_usd_run_rate
+    , m.total_current_month_fees * 12 as gas_fees_usd_run_rate
 from
     daily_stats as d
 inner join weekly_stats as w

--- a/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_stats.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_metrics/fees/metrics_gas_fees_stats.sql
@@ -15,7 +15,7 @@ with source as (
 ), current_day as (
     select
         blockchain
-        , gas_fees_usd as current_day_gas_fees_usd
+        , gas_fees_usd as last_1_days_gas_fees_usd
     from
         source
     where
@@ -24,7 +24,7 @@ with source as (
 ), previous_day as (
     select
         blockchain
-        , gas_fees_usd as previous_day_gas_fees_usd
+        , gas_fees_usd as previous_1_days_gas_fees_usd
     from
         source
     where
@@ -32,17 +32,17 @@ with source as (
         and block_date < date_trunc('day', now()) - interval '1' day
 ), total_current_day_gas_fees as (
     select
-        sum(current_day_gas_fees_usd) AS total_current_day_gas_fees
+        sum(last_1_days_gas_fees_usd) AS total_cross_chain_last_1_days_gas_fees_usd
     from
         current_day
 ), daily_stats as (
     select
         c.blockchain
-        , c.current_day_gas_fees_usd
-        , p.previous_day_gas_fees_usd
-        , ((c.current_day_gas_fees_usd - coalesce(p.previous_day_gas_fees_usd, 0)) / coalesce(p.previous_day_gas_fees_usd, 1)) * 100 AS daily_percent_change
-        , t.total_current_day_gas_fees
-        , (c.current_day_gas_fees_usd / t.total_current_day_gas_fees) * 100 AS percent_of_total_current_day_fees
+        , c.last_1_days_gas_fees_usd
+        , p.previous_1_days_gas_fees_usd
+        , ((c.last_1_days_gas_fees_usd - coalesce(p.previous_1_days_gas_fees_usd, 0)) / coalesce(p.previous_1_days_gas_fees_usd, 1)) * 100 AS daily_percent_change
+        , t.total_cross_chain_last_1_days_gas_fees_usd
+        , (c.last_1_days_gas_fees_usd / t.total_cross_chain_last_1_days_gas_fees_usd) * 100 AS percent_total_last_1_days_fees_usd
     from
         current_day as c
     left join previous_day as p
@@ -52,7 +52,7 @@ with source as (
 ), current_week as (
     select
         blockchain
-        , sum(gas_fees_usd) as current_week_gas_fees_usd
+        , sum(gas_fees_usd) as last_7_days_gas_fees_usd
     from
         source
     where
@@ -63,7 +63,7 @@ with source as (
 ), previous_week as (
     select
         blockchain
-        , sum(gas_fees_usd) as previous_week_gas_fees_usd
+        , sum(gas_fees_usd) as previous_7_days_gas_fees_usd
     from
         source
     where
@@ -73,17 +73,17 @@ with source as (
         blockchain
 ), total_current_week_gas_fees as (
     select
-        sum(current_week_gas_fees_usd) AS total_current_week_gas_fees
+        sum(last_7_days_gas_fees_usd) AS total_cross_chain_last_7_days_gas_fees_usd
     from
         current_week
 ), weekly_stats as (
     select
         c.blockchain
-        , c.current_week_gas_fees_usd
-        , p.previous_week_gas_fees_usd
-        , ((c.current_week_gas_fees_usd - coalesce(p.previous_week_gas_fees_usd, 0)) / coalesce(p.previous_week_gas_fees_usd, 1)) * 100 AS weekly_percent_change
-        , t.total_current_week_gas_fees
-        , (c.current_week_gas_fees_usd / t.total_current_week_gas_fees) * 100 AS percent_of_total_current_week_gas_fees
+        , c.last_7_days_gas_fees_usd
+        , p.previous_7_days_gas_fees_usd
+        , ((c.last_7_days_gas_fees_usd - coalesce(p.previous_7_days_gas_fees_usd, 0)) / coalesce(p.previous_7_days_gas_fees_usd, 1)) * 100 AS weekly_percent_change
+        , t.total_cross_chain_last_7_days_gas_fees_usd
+        , (c.last_7_days_gas_fees_usd / t.total_cross_chain_last_7_days_gas_fees_usd) * 100 AS percent_total_last_7_days_gas_fees_usd
     from
         current_week as c
     left join previous_week as p
@@ -93,7 +93,7 @@ with source as (
 ), current_month as (
     select
         blockchain
-        , sum(gas_fees_usd) as current_month_gas_fees_usd
+        , sum(gas_fees_usd) as last_30_days_gas_fees_usd
     from
         source
     where
@@ -104,7 +104,7 @@ with source as (
 ), previous_month as (
     select
         blockchain
-        , sum(gas_fees_usd) as previous_month_gas_fees_usd
+        , sum(gas_fees_usd) as previous_30_days_gas_fees_usd
     from
         source
     where
@@ -114,17 +114,17 @@ with source as (
         blockchain
 ), total_current_month_gas_fees as (
     select
-        sum(current_month_gas_fees_usd) AS total_current_month_gas_fees
+        sum(last_30_days_gas_fees_usd) AS total_cross_chain_last_30_days_gas_fees_usd
     from
         current_month
 ), monthly_stats as (
     select
         c.blockchain
-        , c.current_month_gas_fees_usd
-        , p.previous_month_gas_fees_usd
-        , ((c.current_month_gas_fees_usd - coalesce(p.previous_month_gas_fees_usd, 0)) / coalesce(p.previous_month_gas_fees_usd, 1)) * 100 AS monthly_percent_change
-        , t.total_current_month_gas_fees
-        , (c.current_month_gas_fees_usd / t.total_current_month_gas_fees) * 100 AS percent_of_total_current_month_gas_fees
+        , c.last_30_days_gas_fees_usd
+        , p.previous_30_days_gas_fees_usd
+        , ((c.last_30_days_gas_fees_usd - coalesce(p.previous_30_days_gas_fees_usd, 0)) / coalesce(p.previous_30_days_gas_fees_usd, 1)) * 100 AS monthly_percent_change
+        , t.total_cross_chain_last_30_days_gas_fees_usd
+        , (c.last_30_days_gas_fees_usd / t.total_cross_chain_last_30_days_gas_fees_usd) * 100 AS percent_total_last_30_days_gas_fees
     from
         current_month as c
     left join previous_month as p
@@ -134,22 +134,22 @@ with source as (
 )
 select
     d.blockchain
-    , d.current_day_gas_fees_usd
-    , d.previous_day_gas_fees_usd
+    , d.last_1_days_gas_fees_usd
+    , d.previous_1_days_gas_fees_usd
     , d.daily_percent_change
-    , d.total_current_day_gas_fees
-    , d.percent_of_total_current_day_gas_fees
-    , w.current_week_gas_fees_usd
-    , w.previous_week_gas_fees_usd
+    , d.total_cross_chain_last_1_days_gas_fees_usd
+    , d.percent_total_last_1_days_fees_usd
+    , w.last_7_days_gas_fees_usd
+    , w.previous_7_days_gas_fees_usd
     , w.weekly_percent_change
-    , w.total_current_week_gas_fees
-    , w.percent_of_total_current_week_gas_fees
-    , m.current_month_gas_fees_usd
-    , m.previous_month_gas_fees_usd
+    , w.total_cross_chain_last_7_days_gas_fees_usd
+    , w.percent_total_last_7_days_gas_fees_usd
+    , m.last_30_days_gas_fees_usd
+    , m.previous_30_days_gas_fees_usd
     , m.monthly_percent_change
-    , m.total_current_month_gas_fees
-    , m.percent_of_total_current_month_gas_fees
-    , m.total_current_month_gas_fees * 12 as gas_fees_usd_run_rate
+    , m.total_cross_chain_last_30_days_gas_fees_usd
+    , m.percent_total_last_30_days_gas_fees
+    , m.last_30_days_gas_fees_usd * 12 as gas_fees_usd_run_rate
 from
     daily_stats as d
 inner join weekly_stats as w

--- a/dbt_subprojects/hourly_spellbook/models/_metrics/transactions/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_metrics/transactions/_schema.yml
@@ -12,7 +12,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - blockchain
-            - day
+            - block_date
   - name: metrics_transactions_stats
     meta:
       sector: metrics

--- a/dbt_subprojects/hourly_spellbook/models/_metrics/transactions/metrics_transactions_daily.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_metrics/transactions/metrics_transactions_daily.sql
@@ -4,14 +4,14 @@
         , materialized = 'incremental'
         , file_format = 'delta'
         , incremental_strategy = 'merge'
-        , unique_key = ['blockchain', 'day']
-        , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
+        , unique_key = ['blockchain', 'block_date']
+        , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
         )
 }}
 
 select
     blockchain
-    , date_trunc('day', block_hour) as day
+    , date_trunc('day', block_hour) as block_date
     , sum(tx_count) as tx_count
 from
     {{ ref('evms_transaction_metrics') }}

--- a/dbt_subprojects/hourly_spellbook/models/_metrics/transactions/metrics_transactions_stats.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_metrics/transactions/metrics_transactions_stats.sql
@@ -8,7 +8,7 @@ with source as (
     -- daily aggregation of tx's per blockchain
     select
         blockchain
-        , day
+        , block_date
         , tx_count
     from
         {{ ref('metrics_transactions_daily') }}
@@ -19,8 +19,8 @@ with source as (
     from
         source
     where
-        day >= date_trunc('day', now()) - interval '1' day
-        and day < date_trunc('day', now())
+        block_date >= date_trunc('day', now()) - interval '1' day
+        and block_date < date_trunc('day', now())
 ), previous_day as (
     select
         blockchain
@@ -28,8 +28,8 @@ with source as (
     from
         source
     where
-        day >= date_trunc('day', now()) - interval '2' day
-        and day < date_trunc('day', now()) - interval '1' day
+        block_date >= date_trunc('day', now()) - interval '2' day
+        and block_date < date_trunc('day', now()) - interval '1' day
 ), total_current_day_txs as (
     select
         sum(current_day_tx_count) AS total_current_day_txs
@@ -56,8 +56,8 @@ with source as (
     from
         source
     where
-        day >= date_trunc('day', now()) - interval '7' day
-        and day < date_trunc('day', now())
+        block_date >= date_trunc('day', now()) - interval '7' day
+        and block_date < date_trunc('day', now())
     group by
         blockchain
 ), previous_week as (
@@ -67,8 +67,8 @@ with source as (
     from
         source
     where
-        day >= date_trunc('day', now()) - interval '14' day
-        and day < date_trunc('day', now()) - interval '7' day
+        block_date >= date_trunc('day', now()) - interval '14' day
+        and block_date < date_trunc('day', now()) - interval '7' day
     group by
         blockchain
 ), total_current_week_txs as (
@@ -97,8 +97,8 @@ with source as (
     from
         source
     where
-        day >= date_trunc('day', now()) - interval '30' day
-        and day < date_trunc('day', now())
+        block_date >= date_trunc('day', now()) - interval '30' day
+        and block_date < date_trunc('day', now())
     group by
         blockchain
 ), previous_month as (
@@ -108,8 +108,8 @@ with source as (
     from
         source
     where
-        day >= date_trunc('day', now()) - interval '60' day
-        and day < date_trunc('day', now()) - interval '30' day
+        block_date >= date_trunc('day', now()) - interval '60' day
+        and block_date < date_trunc('day', now()) - interval '30' day
     group by
         blockchain
 ), total_current_month_txs as (

--- a/dbt_subprojects/hourly_spellbook/models/_metrics/transactions/metrics_transactions_stats.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_metrics/transactions/metrics_transactions_stats.sql
@@ -15,7 +15,7 @@ with source as (
 ), current_day as (
     select
         blockchain
-        , tx_count as current_day_tx_count
+        , tx_count as last_1_days_tx_count
     from
         source
     where
@@ -24,7 +24,7 @@ with source as (
 ), previous_day as (
     select
         blockchain
-        , tx_count as previous_day_tx_count
+        , tx_count as previous_1_days_tx_count
     from
         source
     where
@@ -32,17 +32,17 @@ with source as (
         and block_date < date_trunc('day', now()) - interval '1' day
 ), total_current_day_txs as (
     select
-        sum(current_day_tx_count) AS total_current_day_txs
+        sum(last_1_days_tx_count) AS total_cross_chain_last_1_days_tx_count
     from
         current_day
 ), daily_stats as (
     select
         c.blockchain
-        , c.current_day_tx_count
-        , p.previous_day_tx_count
-        , ((cast(c.current_day_tx_count as double) - coalesce(cast(p.previous_day_tx_count as double), 0)) / coalesce(cast(p.previous_day_tx_count as double), 1)) * 100 AS daily_percent_change
-        , t.total_current_day_txs
-        , (cast(c.current_day_tx_count as double) / cast(t.total_current_day_txs as double)) * 100 AS percent_of_total_current_day_txs
+        , c.last_1_days_tx_count
+        , p.previous_1_days_tx_count
+        , ((cast(c.last_1_days_tx_count as double) - coalesce(cast(p.previous_1_days_tx_count as double), 0)) / coalesce(cast(p.previous_1_days_tx_count as double), 1)) * 100 AS daily_percent_change
+        , t.total_cross_chain_last_1_days_tx_count
+        , (cast(c.last_1_days_tx_count as double) / cast(t.total_cross_chain_last_1_days_tx_count as double)) * 100 AS percent_total_last_1_days_tx_count
     from
         current_day as c
     left join previous_day as p
@@ -52,7 +52,7 @@ with source as (
 ), current_week as (
     select
         blockchain
-        , sum(tx_count) as current_week_tx_count
+        , sum(tx_count) as last_7_days_tx_count
     from
         source
     where
@@ -63,7 +63,7 @@ with source as (
 ), previous_week as (
     select
         blockchain
-        , sum(tx_count) as previous_week_tx_count
+        , sum(tx_count) as previous_7_days_tx_count
     from
         source
     where
@@ -73,17 +73,17 @@ with source as (
         blockchain
 ), total_current_week_txs as (
     select
-        sum(current_week_tx_count) AS total_current_week_txs
+        sum(last_7_days_tx_count) AS total_cross_chain_last_7_days_tx_count
     from
         current_week
 ), weekly_stats as (
     select
         c.blockchain
-        , c.current_week_tx_count
-        , p.previous_week_tx_count
-        , ((cast(c.current_week_tx_count as double) - coalesce(cast(p.previous_week_tx_count as double), 0)) / coalesce(cast(p.previous_week_tx_count as double), 1)) * 100 AS weekly_percent_change
-        , t.total_current_week_txs
-        , (cast(c.current_week_tx_count as double) / cast(t.total_current_week_txs as double)) * 100 AS percent_of_total_current_week_txs
+        , c.last_7_days_tx_count
+        , p.previous_7_days_tx_count
+        , ((cast(c.last_7_days_tx_count as double) - coalesce(cast(p.previous_7_days_tx_count as double), 0)) / coalesce(cast(p.previous_7_days_tx_count as double), 1)) * 100 AS weekly_percent_change
+        , t.total_cross_chain_last_7_days_tx_count
+        , (cast(c.last_7_days_tx_count as double) / cast(t.total_cross_chain_last_7_days_tx_count as double)) * 100 AS percent_total_last_7_days_tx_count
     from
         current_week as c
     left join previous_week as p
@@ -93,7 +93,7 @@ with source as (
 ), current_month as (
     select
         blockchain
-        , sum(tx_count) as current_month_tx_count
+        , sum(tx_count) as last_30_days_tx_count
     from
         source
     where
@@ -104,7 +104,7 @@ with source as (
 ), previous_month as (
     select
         blockchain
-        , sum(tx_count) as previous_month_tx_count
+        , sum(tx_count) as previous_30_days_tx_count
     from
         source
     where
@@ -114,17 +114,17 @@ with source as (
         blockchain
 ), total_current_month_txs as (
     select
-        sum(current_month_tx_count) AS total_current_month_txs
+        sum(last_30_days_tx_count) AS total_cross_chain_last_30_days_tx_count
     from
         current_month
 ), monthly_stats as (
     select
         c.blockchain
-        , c.current_month_tx_count
-        , p.previous_month_tx_count
-        , ((cast(c.current_month_tx_count as double) - coalesce(cast(p.previous_month_tx_count as double), 0)) / coalesce(cast(p.previous_month_tx_count as double), 1)) * 100 AS monthly_percent_change
-        , t.total_current_month_txs
-        , (cast(c.current_month_tx_count as double) / cast(t.total_current_month_txs as double)) * 100 AS percent_of_total_current_month_txs
+        , c.last_30_days_tx_count
+        , p.previous_30_days_tx_count
+        , ((cast(c.last_30_days_tx_count as double) - coalesce(cast(p.previous_30_days_tx_count as double), 0)) / coalesce(cast(p.previous_30_days_tx_count as double), 1)) * 100 AS monthly_percent_change
+        , t.total_cross_chain_last_30_days_tx_count
+        , (cast(c.last_30_days_tx_count as double) / cast(t.total_cross_chain_last_30_days_tx_count as double)) * 100 AS percent_total_last_30_days_tx_count
     from
         current_month as c
     left join previous_month as p
@@ -134,22 +134,22 @@ with source as (
 )
 select
     d.blockchain
-    , d.current_day_tx_count
-    , d.previous_day_tx_count
+    , d.last_1_days_tx_count
+    , d.previous_1_days_tx_count
     , d.daily_percent_change
-    , d.total_current_day_txs
-    , d.percent_of_total_current_day_txs
-    , w.current_week_tx_count
-    , w.previous_week_tx_count
+    , d.total_cross_chain_last_1_days_tx_count
+    , d.percent_total_last_1_days_tx_count
+    , w.last_7_days_tx_count
+    , w.previous_7_days_tx_count
     , w.weekly_percent_change
-    , w.total_current_week_txs
-    , w.percent_of_total_current_week_txs
-    , m.current_month_tx_count
-    , m.previous_month_tx_count
+    , w.total_cross_chain_last_7_days_tx_count
+    , w.percent_total_last_7_days_tx_count
+    , m.last_30_days_tx_count
+    , m.previous_30_days_tx_count
     , m.monthly_percent_change
-    , m.total_current_month_txs
-    , m.percent_of_total_current_month_txs
-    , m.total_current_month_txs * 12 as tx_count_run_rate
+    , m.total_cross_chain_last_30_days_tx_count
+    , m.percent_total_last_30_days_tx_count
+    , m.last_30_days_tx_count * 12 as tx_count_run_rate
 from
     daily_stats as d
 inner join weekly_stats as w


### PR DESCRIPTION
- column naming standards (last_x_days vs. current period, block_date vs. day, gas_fees vs. fees, etc)
- fix run rate calc to be chain specific
- add `cross_chain` on totals to be clear