### PR TITLE
initiate prices usd trusted tokens

### DIFF
--- a/dbt_subprojects/tokens/models/prices/_schema.yml
+++ b/dbt_subprojects/tokens/models/prices/_schema.yml
@@ -56,3 +56,15 @@ models:
     config:
       tags: [ 'prices', 'stability' ]
     description: "List of trusted tokens across blockchains"
+
+  - name: prices_usd_trusted_tokens
+    meta:
+      sector: prices
+      contributors: jeff-dude
+    description: "Subset of minute-level prices from CoinPaprika API, only containing the list of trusted tokens across blockchains"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - contract_address
+            - minute

--- a/dbt_subprojects/tokens/models/prices/prices_usd_trusted_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_usd_trusted_tokens.sql
@@ -1,7 +1,7 @@
 {{ config(
         schema = 'prices'
         , alias = 'usd_trusted_tokens'
-        , partition_by = ['blockchain']
+        , partition_by = ['month']
         , materialized = 'incremental'
         , file_format = 'delta'
         , incremental_strategy = 'merge'
@@ -15,6 +15,7 @@ select
     , ptt.contract_address
     , ptt.symbol
     , ptt.decimals
+    , date_trunc('month', p.minute) as month
     , p.minute
     , p.price
 from

--- a/dbt_subprojects/tokens/models/prices/prices_usd_trusted_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_usd_trusted_tokens.sql
@@ -1,0 +1,28 @@
+{{ config(
+        schema = 'prices'
+        , alias = 'usd_trusted_tokens'
+        , partition_by = ['blockchain']
+        , materialized = 'incremental'
+        , file_format = 'delta'
+        , incremental_strategy = 'merge'
+        , unique_key = ['blockchain', 'contract_address', 'minute']
+        , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.minute')]
+        )
+}}
+
+select
+    p.minute
+    , ptt.blockchain
+    , ptt.contract_address
+    , ptt.symbol
+    , ptt.decimals
+    , p.price
+from
+    {{ source('prices','usd_0003') }} as p
+inner join
+    {{ ref('prices_trusted_tokens') }} as ptt
+    on p.token_id = ptt.token_id
+{% if is_incremental() %}
+where
+    {{ incremental_predicate('p.minute') }}
+{% endif %}

--- a/dbt_subprojects/tokens/models/prices/prices_usd_trusted_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_usd_trusted_tokens.sql
@@ -11,11 +11,11 @@
 }}
 
 select
-    p.minute
-    , ptt.blockchain
+    ptt.blockchain
     , ptt.contract_address
     , ptt.symbol
     , ptt.decimals
+    , p.minute
     , p.price
 from
     {{ source('prices','usd_0003') }} as p

--- a/sources/prices/prices_sources.yml
+++ b/sources/prices/prices_sources.yml
@@ -5,6 +5,8 @@ sources:
   - name: prices
     description: "Prices tables across blockchains"
     tables:
+      - name: usd_0003
+        description: "raw, versioned USD prices table"
       - name: usd
         description: "USD prices across blockchains"
         meta:


### PR DESCRIPTION
subset of `prices.usd` containing only list of trusted tokens across chains.
at this time, sole intention is to be used in new prices pipeline downstream, we should not expect to modify for other use cases at this time.