### PR TITLE
1inch-U46: changed point of view in oneinch.lop_own_trades for dex.trades

### DIFF
--- a/dbt_subprojects/dex/models/_projects/oneinch/oneinch_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/oneinch_lop_own_trades.sql
@@ -20,8 +20,8 @@ select
     , coalesce(src_token_symbol, '') as token_bought_symbol
     , coalesce(dst_token_symbol, '') as token_sold_symbol
     , case
-        when lower(dst_token_symbol) > lower(src_token_symbol) then concat(src_token_symbol, '-', dst_token_symbol)
-        else concat(dst_token_symbol, '-', src_token_symbol)
+        when lower(src_token_symbol) > lower(dst_token_symbol) then concat(dst_token_symbol, '-', src_token_symbol)
+        else concat(src_token_symbol, '-', dst_token_symbol)
     end as token_pair
     , cast(src_token_amount as double) / pow(10, src_token_decimals) as token_bought_amount
     , cast(dst_token_amount as double) / pow(10, dst_token_decimals) as token_sold_amount

--- a/dbt_subprojects/dex/models/_projects/oneinch/oneinch_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/oneinch_lop_own_trades.sql
@@ -17,19 +17,19 @@ select
     , block_month
     , block_time
     , block_number
-    , coalesce(dst_token_symbol, '') as token_bought_symbol
-    , coalesce(src_token_symbol, '') as token_sold_symbol
+    , coalesce(src_token_symbol, '') as token_bought_symbol
+    , coalesce(dst_token_symbol, '') as token_sold_symbol
     , case
-        when lower(src_token_symbol) > lower(dst_token_symbol) then concat(dst_token_symbol, '-', src_token_symbol)
-        else concat(src_token_symbol, '-', dst_token_symbol)
+        when lower(dst_token_symbol) > lower(src_token_symbol) then concat(src_token_symbol, '-', dst_token_symbol)
+        else concat(dst_token_symbol, '-', src_token_symbol)
     end as token_pair
-    , cast(dst_token_amount as double) / pow(10, dst_token_decimals) as token_bought_amount
-    , cast(src_token_amount as double) / pow(10, src_token_decimals) as token_sold_amount
-    , dst_token_amount as token_bought_amount_raw
-    , src_token_amount as token_sold_amount_raw
+    , cast(src_token_amount as double) / pow(10, src_token_decimals) as token_bought_amount
+    , cast(dst_token_amount as double) / pow(10, dst_token_decimals) as token_sold_amount
+    , src_token_amount as token_bought_amount_raw
+    , dst_token_amount as token_sold_amount_raw
     , amount_usd
-    , dst_token_address as token_bought_address
-    , src_token_address as token_sold_address
+    , src_token_address as token_bought_address
+    , dst_token_address as token_sold_address
     , call_from as taker
     , user as maker
     , call_to as project_contract_address


### PR DESCRIPTION
from liquidity source -> from tx origin

fixing https://github.com/duneanalytics/spellbook/issues/6915