### PR TITLE
Query and doc fixes for first_funded_by + add a few columns

### DIFF
--- a/dbt_subprojects/hourly_spellbook/macros/sector/addresses_events/addresses_events_first_funded_by.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/addresses_events/addresses_events_first_funded_by.sql
@@ -20,6 +20,7 @@ AND tt.token_standard = 'native'
 AND tt.to NOT IN (SELECT address FROM {{this}})
 {% else %}
 WHERE tt.token_standard = 'native'
+  and tt.block_time >= timestamp '2024-10-01'
 {% endif %}
 GROUP BY tt.to
 

--- a/dbt_subprojects/hourly_spellbook/macros/sector/addresses_events/addresses_events_first_funded_by.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/addresses_events/addresses_events_first_funded_by.sql
@@ -3,16 +3,16 @@
 
 SELECT '{{blockchain}}' as blockchain
 , tt.to AS address
-, MIN_BY(tt."from", (tt.block_number, tt.tx_index, tt.evt_index)) AS first_funded_by
+, MIN_BY(tt."from", (tt.block_number, tt.tx_index, tt.trace_address)) AS first_funded_by
 , MIN_BY(tt.tx_from, (tt.block_number, tt.tx_index)) AS first_funding_executed_by
-, MIN_BY(tt.amount, (tt.block_number, tt.tx_index, tt.evt_index)) AS amount
-, MIN_BY(tt.amount_usd, (tt.block_number, tt.tx_index, tt.evt_index)) AS amount_usd
+, MIN_BY(tt.amount, (tt.block_number, tt.tx_index, tt.trace_address)) AS amount
+, MIN_BY(tt.amount_usd, (tt.block_number, tt.tx_index, tt.trace_address)) AS amount_usd
 , MIN(tt.block_time) AS block_time
 , MIN(tt.block_number) AS block_number
 , MIN_BY(tt.tx_hash, (tt.block_number, tt.tx_index)) AS tx_hash
 , MIN_BY(tt.tx_index, (tt.block_number, tt.tx_index)) AS tx_index
-, MIN_BY(tt.evt_index, (tt.block_number, tt.tx_index, tt.evt_index)) AS evt_index
-, MIN_BY(tt.unique_key, (tt.block_number, tt.tx_index, tt.evt_index)) AS unique_key
+, MIN_BY(tt.trace_address, (tt.block_number, tt.tx_index, tt.trace_address)) AS trace_address
+, MIN_BY(tt.unique_key, (tt.block_number, tt.tx_index, tt.trace_address)) AS unique_key
 FROM {{token_transfers}} tt
 {% if is_incremental() %}
 WHERE {{ incremental_predicate('tt.block_time') }}

--- a/dbt_subprojects/hourly_spellbook/macros/sector/addresses_events/addresses_events_first_funded_by.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/addresses_events/addresses_events_first_funded_by.sql
@@ -20,7 +20,6 @@ AND tt.token_standard = 'native'
 AND tt.to NOT IN (SELECT address FROM {{this}})
 {% else %}
 WHERE tt.token_standard = 'native'
-  and tt.block_time >= timestamp '2024-10-01'
 {% endif %}
 GROUP BY tt.to
 

--- a/dbt_subprojects/hourly_spellbook/macros/sector/addresses_events/addresses_events_first_funded_by.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/addresses_events/addresses_events_first_funded_by.sql
@@ -3,13 +3,16 @@
 
 SELECT '{{blockchain}}' as blockchain
 , tt.to AS address
-, MIN_BY(tt."from", (tt.block_number, tt.tx_index)) AS first_funded_by
+, MIN_BY(tt."from", (tt.block_number, tt.tx_index, tt.evt_index)) AS first_funded_by
 , MIN_BY(tt.tx_from, (tt.block_number, tt.tx_index)) AS first_funding_executed_by
+, MIN_BY(tt.amount, (tt.block_number, tt.tx_index, tt.evt_index)) AS amount
+, MIN_BY(tt.amount_usd, (tt.block_number, tt.tx_index, tt.evt_index)) AS amount_usd
 , MIN(tt.block_time) AS block_time
 , MIN(tt.block_number) AS block_number
 , MIN_BY(tt.tx_hash, (tt.block_number, tt.tx_index)) AS tx_hash
-, MIN_BY(tt.tx_index, tt.block_number) AS tx_index
-, MIN_BY(tt.unique_key, (tt.block_number, tt.tx_index)) AS unique_key
+, MIN_BY(tt.tx_index, (tt.block_number, tt.tx_index)) AS tx_index
+, MIN_BY(tt.evt_index, (tt.block_number, tt.tx_index, tt.evt_index)) AS evt_index
+, MIN_BY(tt.unique_key, (tt.block_number, tt.tx_index, tt.evt_index)) AS unique_key
 FROM {{token_transfers}} tt
 {% if is_incremental() %}
 WHERE {{ incremental_predicate('tt.block_time') }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/addresses_events_first_funded_by.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/addresses_events_first_funded_by.sql
@@ -41,7 +41,7 @@ WITH joined_data AS (
         , block_number
         , tx_hash
         , tx_index
-        , evt_index
+        , trace_address
         FROM {{ addresses_events_model[0] }}
         {% if not loop.last %}
         UNION ALL
@@ -62,6 +62,6 @@ SELECT MIN_BY(blockchain, block_time) AS blockchain
 , MIN(block_number) AS block_number
 , MIN_BY(tx_hash, block_time) AS tx_hash
 , MIN_BY(tx_index, block_time) AS tx_index
-, MIN_BY(evt_index, block_time) AS evt_index
+, MIN_BY(trace_address, block_time) AS trace_address
 FROM joined_data
 GROUP BY address

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/addresses_events_first_funded_by.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/addresses_events_first_funded_by.sql
@@ -10,20 +10,20 @@
 }}
 
 {% set addresses_events_models = [
-ref('addresses_events_arbitrum_first_funded_by')
-, ref('addresses_events_avalanche_c_first_funded_by')
-, ref('addresses_events_bnb_first_funded_by')
-, ref('addresses_events_ethereum_first_funded_by')
-, ref('addresses_events_fantom_first_funded_by')
-, ref('addresses_events_gnosis_first_funded_by')
-, ref('addresses_events_optimism_first_funded_by')
-, ref('addresses_events_polygon_first_funded_by')
-, ref('addresses_events_celo_first_funded_by')
-, ref('addresses_events_zora_first_funded_by')
-, ref('addresses_events_base_first_funded_by')
-, ref('addresses_events_scroll_first_funded_by')
-, ref('addresses_events_zkevm_first_funded_by')
-, ref('addresses_events_linea_first_funded_by')
+(ref('addresses_events_arbitrum_first_funded_by'), 'ETH')
+, (ref('addresses_events_avalanche_c_first_funded_by'), 'AVAX')
+, (ref('addresses_events_bnb_first_funded_by'), 'BNB')
+, (ref('addresses_events_ethereum_first_funded_by'), 'ETH')
+, (ref('addresses_events_fantom_first_funded_by'), 'FTM')
+, (ref('addresses_events_gnosis_first_funded_by'), 'xDAI')
+, (ref('addresses_events_optimism_first_funded_by'), 'ETH')
+, (ref('addresses_events_polygon_first_funded_by'), 'MATIC')
+, (ref('addresses_events_celo_first_funded_by'), 'CELO')
+, (ref('addresses_events_zora_first_funded_by'), 'ETH')
+, (ref('addresses_events_base_first_funded_by'), 'ETH')
+, (ref('addresses_events_scroll_first_funded_by'), 'ETH')
+, (ref('addresses_events_zkevm_first_funded_by'), 'ETH')
+, (ref('addresses_events_linea_first_funded_by'), 'ETH')
 ] %}
 
 WITH joined_data AS (
@@ -32,13 +32,14 @@ WITH joined_data AS (
         {% for addresses_events_model in addresses_events_models %}
         SELECT blockchain
         , address
+        , '{{ addresses_events_model[1] }}' AS token_symbol
         , first_funded_by
         , first_funding_executed_by
         , block_time
         , block_number
         , tx_hash
         , tx_index
-        FROM {{ addresses_events_model }}
+        FROM {{ addresses_events_model[0] }}
         {% if not loop.last %}
         UNION ALL
         {% endif %}
@@ -51,9 +52,13 @@ SELECT MIN_BY(blockchain, block_time) AS blockchain
 , MIN_BY(first_funded_by, block_time) AS first_funded_by
 , array_distinct(array_agg(blockchain)) AS chains_funded_on
 , MIN_BY(first_funding_executed_by, block_time) AS first_funding_executed_by
+, MIN_BY(amount, block_time) AS amount
+, MIN_BY(amount_usd, block_time) AS amount_usd
+, MIN_BY(token_symbol, block_time) AS token_symbol
 , MIN(block_time) AS block_time
 , MIN(block_number) AS block_number
 , MIN_BY(tx_hash, block_time) AS tx_hash
 , MIN_BY(tx_index, block_time) AS tx_index
+, MIN_BY(evt_index, block_time) AS evt_index
 FROM joined_data
 GROUP BY address

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/addresses_events_first_funded_by.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/addresses_events_first_funded_by.sql
@@ -35,10 +35,13 @@ WITH joined_data AS (
         , '{{ addresses_events_model[1] }}' AS token_symbol
         , first_funded_by
         , first_funding_executed_by
+        , amount
+        , amount_usd
         , block_time
         , block_number
         , tx_hash
         , tx_index
+        , evt_index
         FROM {{ addresses_events_model[0] }}
         {% if not loop.last %}
         UNION ALL

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/addresses_events_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/addresses_events_schema.yml
@@ -52,9 +52,9 @@ models:
       - &tx_index
         name: tx_index
         description: "The transaction index within its block on which the address was first funded with the native asset on that chain"
-      - &evt_index
-        name: evt_index
-        description: "The event index within its transaction on which the address was first funded with the native asset on that chain"
+      - &trace_address
+        name: trace_address
+        description: "The trace_address within its transaction on which the address was first funded with the native asset on that chain"
 
   - name: addresses_events_first_activity
     meta:

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/addresses_events_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/addresses_events_schema.yml
@@ -18,7 +18,7 @@ models:
     columns:
       - &blockchain
         name: blockchain
-        description: "Name of the blockchain"
+        description: "Name of the blockchain where the address was first funded"
       - &address
         name: address
         description: "Concerned address"
@@ -31,6 +31,15 @@ models:
       - &first_funding_executed_by
         name: first_funding_executed_by
         description: "Which address executed the first funding tx"
+      - &amount
+        name: amount
+        description: "The amount of the native currency sent in the funding transfer"
+      - &amount_usd
+        name: amount_usd
+        description: "The USD value of the native currency the wallet was funded with in this funding transfer"
+      - &token_symbol
+        name: token_symbol
+        description: "The token symbol of the native currency the wallet was funded with in this funding transfer"
       - &block_time
         name: block_time
         description: "The block time on which the address was first funded with the native asset on that chain"
@@ -43,6 +52,9 @@ models:
       - &tx_index
         name: tx_index
         description: "The transaction index within its block on which the address was first funded with the native asset on that chain"
+      - &evt_index
+        name: evt_index
+        description: "The event index within its transaction on which the address was first funded with the native asset on that chain"
 
   - name: addresses_events_first_activity
     meta:

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/arbitrum/addresses_events_arbitrum_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/arbitrum/addresses_events_arbitrum_schema.yml
@@ -45,8 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with ETH"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/arbitrum/addresses_events_arbitrum_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/arbitrum/addresses_events_arbitrum_schema.yml
@@ -33,6 +33,10 @@ models:
         description: "Which address executed the first funding tx"
       - name: first_funded_by
         description: "Which Arbitrum address first funded the address with ETH"
+      - name: amount
+        description: "The amount of ETH the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the ETH the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with ETH"
       - name: block_number
@@ -41,6 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/avalanche_c/addresses_events_avalanche_c_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/avalanche_c/addresses_events_avalanche_c_schema.yml
@@ -45,8 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with AVAX"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with AVAX"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with AVAX"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with AVAX"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/avalanche_c/addresses_events_avalanche_c_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/avalanche_c/addresses_events_avalanche_c_schema.yml
@@ -32,13 +32,23 @@ models:
       - name: first_funding_executed_by
         description: "Which address executed the first funding tx"
       - name: first_funded_by
-        description: "Which Avalanche address first funded the address with AVAX"
+        description: "Which base address first funded the address with AVAX"
+      - name: amount
+        description: "The amount of AVAX the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the AVAX the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with AVAX"
       - name: block_number
         description: "The block number on which the address was first funded with AVAX"
       - name: tx_hash
         description: "The transaction hash on which the address was first funded with AVAX"
+      - name: tx_index
+        description: "The transaction index within the block on which the address was first funded with AVAX"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with AVAX"
+      - name: unique_key
+        description: "Unique transfer identifier key"
 
   - name: addresses_events_avalanche_c_first_activity
     meta:

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/base/addresses_events_base_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/base/addresses_events_base_schema.yml
@@ -45,8 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with ETH"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/base/addresses_events_base_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/base/addresses_events_base_schema.yml
@@ -33,6 +33,10 @@ models:
         description: "Which address executed the first funding tx"
       - name: first_funded_by
         description: "Which base address first funded the address with ETH"
+      - name: amount
+        description: "The amount of ETH the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the ETH the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with ETH"
       - name: block_number
@@ -41,6 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/bnb/addresses_events_bnb_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/bnb/addresses_events_bnb_schema.yml
@@ -32,13 +32,23 @@ models:
       - name: first_funding_executed_by
         description: "Which address executed the first funding tx"
       - name: first_funded_by
-        description: "Which BNB address first funded the address with BNB"
+        description: "Which base address first funded the address with BNB"
+      - name: amount
+        description: "The amount of BNB the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the BNB the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with BNB"
       - name: block_number
         description: "The block number on which the address was first funded with BNB"
       - name: tx_hash
         description: "The transaction hash on which the address was first funded with BNB"
+      - name: tx_index
+        description: "The transaction index within the block on which the address was first funded with BNB"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with BNB"
+      - name: unique_key
+        description: "Unique transfer identifier key"
 
   - name: addresses_events_bnb_first_activity
     meta:

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/bnb/addresses_events_bnb_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/bnb/addresses_events_bnb_schema.yml
@@ -45,8 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with BNB"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with BNB"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with BNB"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with BNB"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/celo/addresses_events_celo_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/celo/addresses_events_celo_schema.yml
@@ -45,7 +45,7 @@ models:
         description: "The transaction hash on which the address was first funded with CELO"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with CELO"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with CELO"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with CELO"
       - name: unique_key
         description: "Unique transfer identifier key"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/celo/addresses_events_celo_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/celo/addresses_events_celo_schema.yml
@@ -32,10 +32,20 @@ models:
       - name: first_funding_executed_by
         description: "Which address executed the first funding tx"
       - name: first_funded_by
-        description: "Which Celo address first funded the address with CELO"
+        description: "Which base address first funded the address with CELO"
+      - name: amount
+        description: "The amount of CELO the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the CELO the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with CELO"
       - name: block_number
         description: "The block number on which the address was first funded with CELO"
       - name: tx_hash
         description: "The transaction hash on which the address was first funded with CELO"
+      - name: tx_index
+        description: "The transaction index within the block on which the address was first funded with CELO"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with CELO"
+      - name: unique_key
+        description: "Unique transfer identifier key"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/ethereum/addresses_events_ethereum_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/ethereum/addresses_events_ethereum_schema.yml
@@ -45,8 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with ETH"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/ethereum/addresses_events_ethereum_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/ethereum/addresses_events_ethereum_schema.yml
@@ -32,7 +32,11 @@ models:
       - name: first_funding_executed_by
         description: "Which address executed the first funding tx"
       - name: first_funded_by
-        description: "Which Ethereum address first funded the address with ETH"
+        description: "Which base address first funded the address with ETH"
+      - name: amount
+        description: "The amount of ETH the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the ETH the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with ETH"
       - name: block_number
@@ -41,6 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/fantom/addresses_events_fantom_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/fantom/addresses_events_fantom_schema.yml
@@ -45,8 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with FTM"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with FTM"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with FTM"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with FTM"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/fantom/addresses_events_fantom_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/fantom/addresses_events_fantom_schema.yml
@@ -32,13 +32,23 @@ models:
       - name: first_funding_executed_by
         description: "Which address executed the first funding tx"
       - name: first_funded_by
-        description: "Which Fantom address first funded the address with FTM"
+        description: "Which base address first funded the address with FTM"
+      - name: amount
+        description: "The amount of FTM the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the FTM the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with FTM"
       - name: block_number
         description: "The block number on which the address was first funded with FTM"
       - name: tx_hash
         description: "The transaction hash on which the address was first funded with FTM"
+      - name: tx_index
+        description: "The transaction index within the block on which the address was first funded with FTM"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with FTM"
+      - name: unique_key
+        description: "Unique transfer identifier key"
 
   - name: addresses_events_fantom_first_activity
     meta:

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/gnosis/addresses_events_gnosis_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/gnosis/addresses_events_gnosis_schema.yml
@@ -32,13 +32,23 @@ models:
       - name: first_funding_executed_by
         description: "Which address executed the first funding tx"
       - name: first_funded_by
-        description: "Which Gnosis address first funded the address with xDAI"
+        description: "Which base address first funded the address with xDAI"
+      - name: amount
+        description: "The amount of xDAI the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the xDAI the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with xDAI"
       - name: block_number
         description: "The block number on which the address was first funded with xDAI"
       - name: tx_hash
         description: "The transaction hash on which the address was first funded with xDAI"
+      - name: tx_index
+        description: "The transaction index within the block on which the address was first funded with xDAI"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with xDAI"
+      - name: unique_key
+        description: "Unique transfer identifier key"
 
   - name: addresses_events_gnosis_first_activity
     meta:

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/gnosis/addresses_events_gnosis_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/gnosis/addresses_events_gnosis_schema.yml
@@ -45,8 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with xDAI"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with xDAI"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with xDAI"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with xDAI"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/linea/addresses_events_linea_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/linea/addresses_events_linea_schema.yml
@@ -45,8 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with ETH"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
   - name: addresses_events_linea_first_activity

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/linea/addresses_events_linea_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/linea/addresses_events_linea_schema.yml
@@ -32,7 +32,11 @@ models:
       - name: first_funding_executed_by
         description: "Which address executed the first funding tx"
       - name: first_funded_by
-        description: "Which linea address first funded the address with ETH"
+        description: "Which base address first funded the address with ETH"
+      - name: amount
+        description: "The amount of ETH the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the ETH the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with ETH"
       - name: block_number
@@ -41,9 +45,10 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
-
   - name: addresses_events_linea_first_activity
     meta:
       blockchain: linea

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/optimism/addresses_events_optimism_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/optimism/addresses_events_optimism_schema.yml
@@ -44,8 +44,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with ETH"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/optimism/addresses_events_optimism_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/optimism/addresses_events_optimism_schema.yml
@@ -31,7 +31,11 @@ models:
       - name: first_funding_executed_by
         description: "Which address executed the first funding tx"
       - name: first_funded_by
-        description: "Which Optimism address first funded the address with ETH"
+        description: "Which base address first funded the address with ETH"
+      - name: amount
+        description: "The amount of ETH the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the ETH the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with ETH"
       - name: block_number
@@ -40,6 +44,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/polygon/addresses_events_polygon_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/polygon/addresses_events_polygon_schema.yml
@@ -32,13 +32,23 @@ models:
       - name: first_funding_executed_by
         description: "Which address executed the first funding tx"
       - name: first_funded_by
-        description: "Which Polygon address first funded the address with MATIC"
+        description: "Which base address first funded the address with MATIC"
+      - name: amount
+        description: "The amount of MATIC the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the MATIC the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with MATIC"
       - name: block_number
         description: "The block number on which the address was first funded with MATIC"
       - name: tx_hash
         description: "The transaction hash on which the address was first funded with MATIC"
+      - name: tx_index
+        description: "The transaction index within the block on which the address was first funded with MATIC"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with MATIC"
+      - name: unique_key
+        description: "Unique transfer identifier key"
 
   - name: addresses_events_polygon_first_activity
     meta:

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/polygon/addresses_events_polygon_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/polygon/addresses_events_polygon_schema.yml
@@ -45,8 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with MATIC"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with MATIC"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with MATIC"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with MATIC"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/scroll/addresses_events_scroll_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/scroll/addresses_events_scroll_schema.yml
@@ -45,8 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with ETH"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/scroll/addresses_events_scroll_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/scroll/addresses_events_scroll_schema.yml
@@ -32,15 +32,21 @@ models:
       - name: first_funding_executed_by
         description: "Which address executed the first funding tx"
       - name: first_funded_by
-        description: "Which scroll address first funded the address with ETH"
+        description: "Which base address first funded the address with ETH"
+      - name: amount
+        description: "The amount of ETH the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the ETH the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with ETH"
-      - name: block_numbers
+      - name: block_number
         description: "The block number on which the address was first funded with ETH"
       - name: tx_hash
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zkevm/addresses_events_zkevm_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zkevm/addresses_events_zkevm_schema.yml
@@ -45,8 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with ETH"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zkevm/addresses_events_zkevm_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zkevm/addresses_events_zkevm_schema.yml
@@ -32,7 +32,11 @@ models:
       - name: first_funding_executed_by
         description: "Which address executed the first funding tx"
       - name: first_funded_by
-        description: "Which zkevm address first funded the address with ETH"
+        description: "Which base address first funded the address with ETH"
+      - name: amount
+        description: "The amount of ETH the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the ETH the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with ETH"
       - name: block_number
@@ -41,6 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zksync/addresses_events_zksync_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zksync/addresses_events_zksync_schema.yml
@@ -45,8 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
-      - name: evt_index
-        description: "The event index within the transaction on which the address was first funded with ETH"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zksync/addresses_events_zksync_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zksync/addresses_events_zksync_schema.yml
@@ -32,7 +32,11 @@ models:
       - name: first_funding_executed_by
         description: "Which address executed the first funding tx"
       - name: first_funded_by
-        description: "Which zksync address first funded the address with ETH"
+        description: "Which base address first funded the address with ETH"
+      - name: amount
+        description: "The amount of ETH the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the ETH the wallet was funded with in this first transfer"
       - name: block_time
         description: "The block time on which the address was first funded with ETH"
       - name: block_number
@@ -41,6 +45,8 @@ models:
         description: "The transaction hash on which the address was first funded with ETH"
       - name: tx_index
         description: "The transaction index within the block on which the address was first funded with ETH"
+      - name: evt_index
+        description: "The event index within the transaction on which the address was first funded with ETH"
       - name: unique_key
         description: "Unique transfer identifier key"
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zora/addresses_events_zora_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zora/addresses_events_zora_schema.yml
@@ -26,21 +26,29 @@ models:
       - name: blockchain
         description: "Blockchain"
       - name: address
-        description: "Concerned zksync Mainnet address"
+        description: "Concerned zksync address"
         tests:
           - unique
-      - name: first_activity_to
-        description: "First transaction activity to address"
-      - name: first_block_time
-        description: "The block time on which the address made it's first activity"
-      - name: first_block_number
-        description: "The block number on which the address made it's first activity"
-      - name: first_tx_hash
-        description: "The transaction hash on which the address made it's first activity"
-      - name: first_function
-        description: "first function called by address"
-      - name: first_eth_transferred
-        description: "ETH transferred in transaction"
+      - name: first_funding_executed_by
+        description: "Which address executed the first funding tx"
+      - name: first_funded_by
+        description: "Which base address first funded the address with ETH"
+      - name: amount
+        description: "The amount of ETH the wallet was funded with in this first transfer"
+      - name: amount_usd
+        description: "The USD value of the ETH the wallet was funded with in this first transfer"
+      - name: block_time
+        description: "The block time on which the address was first funded with ETH"
+      - name: block_number
+        description: "The block number on which the address was first funded with ETH"
+      - name: tx_hash
+        description: "The transaction hash on which the address was first funded with ETH"
+      - name: tx_index
+        description: "The transaction index within the block on which the address was first funded with ETH"
+      - name: trace_address
+        description: "The trace_address within the transaction on which the address was first funded with ETH"
+      - name: unique_key
+        description: "Unique transfer identifier key"
 
   - name: addresses_events_zora_first_activity
     meta:

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zora/addresses_events_zora_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zora/addresses_events_zora_schema.yml
@@ -26,23 +26,21 @@ models:
       - name: blockchain
         description: "Blockchain"
       - name: address
-        description: "Concerned zora address"
+        description: "Concerned zksync Mainnet address"
         tests:
           - unique
-      - name: first_funding_executed_by
-        description: "Which address executed the first funding tx"
-      - name: first_funded_by
-        description: "Which zora address first funded the address with ETH"
-      - name: block_time
-        description: "The block time on which the address was first funded with ETH"
-      - name: block_number
-        description: "The block number on which the address was first funded with ETH"
-      - name: tx_hash
-        description: "The transaction hash on which the address was first funded with ETH"
-      - name: tx_index
-        description: "The transaction index within the block on which the address was first funded with ETH"
-      - name: unique_key
-        description: "Unique transfer identifier key"
+      - name: first_activity_to
+        description: "First transaction activity to address"
+      - name: first_block_time
+        description: "The block time on which the address made it's first activity"
+      - name: first_block_number
+        description: "The block number on which the address made it's first activity"
+      - name: first_tx_hash
+        description: "The transaction hash on which the address made it's first activity"
+      - name: first_function
+        description: "first function called by address"
+      - name: first_eth_transferred
+        description: "ETH transferred in transaction"
 
   - name: addresses_events_zora_first_activity
     meta:


### PR DESCRIPTION
This PR:
- fixes some documentation issues given that not all native tokens are ETH
- fixes some query issues not factoring in `trace_address`, an essential inclusion for txs funding multiple addresses
- added `token_symbol`, `trace_address`, `amount` and `amount_usd` to the crosschain spell:
  - `token_symbol` is necessary given not all EVM chains use ETH as their native currency
  - `trace_address` is must to easily and efficiently join this spell onto other spells and remain accurate
  - `amount` & `amount_usd` are very useful for sleuthing stuff like CEX deposit addresses (they're usually funded in tiny amounts of native token)