### PR TITLE
`tokens.erc20` manually map correct SEI network id value

### DIFF
--- a/dbt_subprojects/tokens/models/tokens/tokens_erc20.sql
+++ b/dbt_subprojects/tokens/models/tokens/tokens_erc20.sql
@@ -41,9 +41,17 @@
     ,'tokens_worldchain': {'blockchain': 'worldchain', 'model': ref('tokens_worldchain_erc20')}
 } %}
 
-with
-  automated_source as (
-    with raw_source as (
+with automated_source as (
+    with evms_info as (
+        select
+            blockchain
+            , case
+                when blockchain = 'sei' then 531 -- the automated erc20 source below (definedfi) has a bug on networkid value for SEI EVM chain
+                else chain_id
+            end as chain_id
+        from
+            {{ source('evms', 'info') }}
+    ), raw_source as (
         select
             i.blockchain
             , t.address as contract_address
@@ -58,7 +66,7 @@ with
             ) as rn
         from
             {{ source("definedfi", "dataset_tokens", database="dune") }} as t
-            join {{ source('evms', 'info') }} as i on t.networkid = i.chain_id
+            join evms_info as i on t.networkid = i.chain_id
     )
     select
         blockchain


### PR DESCRIPTION
this incorrect value has led to no rows in `tokens.erc20` outside of our manually mapped ones in initial PR to bring the chain into spellbook. this has impact on all spells using this metadata, especially the decimals for amount calculations.