### PR TITLE
create `tokens_{chain}.info`

### DIFF
--- a/dbt_subprojects/daily_spellbook/macros/sector/tokens/tokens_info.sql
+++ b/dbt_subprojects/daily_spellbook/macros/sector/tokens/tokens_info.sql
@@ -1,0 +1,66 @@
+{% macro tokens_info(blockchain) %}
+
+WITH transfers AS (
+    SELECT contract_address AS address
+    , symbol AS token_symbol
+    , token_standard
+    , MIN(block_time) AS first_block_time
+    , MIN(block_number) AS first_block_number
+    , MAX(block_time) AS last_block_time
+    , MAX(block_number) AS last_block_number
+    , COUNT(DISTINCT tx_hash) AS transactions
+    , COUNT(*) AS transfers
+    FROM {{ source('tokens_'~blockchain, 'transfers')}}
+    GROUP BY 1, 2, 3
+    LIMIT 1000000
+    )
+
+, dexs AS (
+    SELECT token_sold_address AS address
+    , SUM(trades) AS trades
+    , SUM(volume) AS volume
+    , array_distinct(array_union_agg(found_on_dexs)) AS found_on_dexs
+    FROM (
+        SELECT token_sold_address AS address
+        , COUNT(*) AS trades
+        , SUM(amount_usd) AS volume
+        , array_distinct(array_agg(project)) AS found_on_dexs
+        FROM {{ source('dex', 'trades')}}
+        WHERE blockchain = '{{blockchain}}'
+        GROUP BY 1
+
+        UNION ALL
+
+        SELECT token_bought_address AS address
+        , COUNT(*) AS trades
+        , SUM(amount_usd) AS volume
+        , array_distinct(array_agg(project)) AS found_on_dexs
+        FROM {{ source('dex', 'trades')}}
+        WHERE blockchain = '{{blockchain}}'
+        GROUP BY 1
+        )
+    GROUP BY 1
+    )
+
+SELECT address AS token_address
+, t.token_symbol
+, ct."from" AS creator
+, i.namespace
+, i.name
+, t.token_standard
+, trades
+, d.volume
+, d.found_on_dexs
+, t.transactions
+, t.transfers
+, t.first_block_time
+, t.first_block_number
+, t.last_block_time
+, t.last_block_number
+FROM transfers t
+INNER JOIN {{ ref('addresses_'~blockchain~'_info')}} i USING (address)
+INNER JOIN {{ source(blockchain, 'creation_traces')}} ct USING (address)
+LEFT JOIN dexs d USING (address)
+LIMIT 100000
+
+{% endmacro %}

--- a/dbt_subprojects/daily_spellbook/macros/sector/tokens/tokens_info.sql
+++ b/dbt_subprojects/daily_spellbook/macros/sector/tokens/tokens_info.sql
@@ -16,15 +16,15 @@ WITH transfers AS (
     )
 
 , dexs AS (
-    SELECT token_sold_address AS address
+    SELECT address
     , SUM(trades) AS trades
     , SUM(volume) AS volume
-    , array_distinct(array_union_agg(found_on_dexs)) AS found_on_dexs
+    --, array_distinct(array_union_agg(found_on_dexs)) AS found_on_dexs
     FROM (
         SELECT token_sold_address AS address
         , COUNT(*) AS trades
         , SUM(amount_usd) AS volume
-        , array_distinct(array_agg(project)) AS found_on_dexs
+        --, array_distinct(array_agg(project)) AS found_on_dexs
         FROM {{ source('dex', 'trades')}}
         WHERE blockchain = '{{blockchain}}'
         GROUP BY 1
@@ -34,7 +34,7 @@ WITH transfers AS (
         SELECT token_bought_address AS address
         , COUNT(*) AS trades
         , SUM(amount_usd) AS volume
-        , array_distinct(array_agg(project)) AS found_on_dexs
+        --, array_distinct(array_agg(project)) AS found_on_dexs
         FROM {{ source('dex', 'trades')}}
         WHERE blockchain = '{{blockchain}}'
         GROUP BY 1
@@ -50,7 +50,7 @@ SELECT address AS token_address
 , t.token_standard
 , trades
 , d.volume
-, d.found_on_dexs
+--, d.found_on_dexs
 , t.transactions
 , t.transfers
 , t.first_block_time

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/_schema.yml
@@ -1,0 +1,380 @@
+version: 2
+
+models:
+  - name: tokens_ethereum_info
+    meta:
+      blockchain: ethereum
+      sector: addresses
+      contributors: hildobby
+    config:
+      tags: ['table', 'address', 'info']
+    description: "High level information about every address on Ethereum"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - &token_address
+        name: token_address
+        description: "Address of the token"
+      - &token_symbol
+        name: token_symbol
+        description: "Token symbol associated with the the token"
+      - &creator
+        name: creator
+        description: "Address that created the token contract"
+      - &namespace
+        name: namespace
+        description: "Namespace given on dune for this token's decoded tables"
+      - &name
+        name: name
+        description: "Contract name"
+      - &token_standard
+        name: token_standard
+        description: "Token standard"
+      - &trades
+        name: trades
+        description: "Amount of trades on DEXs"
+      - &volume
+        name: volume
+        description: "Total volume across all DEXs"
+      - &found_on_dexs
+        name: found_on_dexs
+        description: "List of DEXs where the token was traded"
+      - &transactions
+        name: transactions
+        description: "The amount of transactions involving a transfer of this token"
+      - &transfers
+        name: transfers
+        description: "The amount of transfers involving a transfer of this token"
+      - &first_block_time
+        name: first_block_time
+        description: "The first block where this token saw a transfer"
+      - &first_block_number
+        name: first_block_number
+        description: "The first block number where this token saw a transfer"
+      - &last_block_time
+        name: last_block_time
+        description: "The last block where this token saw a transfer"
+      - &last_block_number
+        name: last_block_number
+        description: "The last block number where this token saw a transfer"
+
+  - name: tokens_arbitrum_info
+    meta:
+      blockchain: arbitrum
+      sector: addresses
+      contributors: hildobby
+    config:
+      tags: ['table', 'address', 'info']
+    description: "High level information about every address on Arbitrum"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - *token_address
+      - *token_symbol
+      - *creator
+      - *namespace
+      - *name
+      - *token_standard
+      - *trades
+      - *volume
+      - *found_on_dexs
+      - *transactions
+      - *transfers
+      - *first_block_time
+      - *first_block_number
+      - *last_block_time
+      - *last_block_number
+
+  - name: tokens_avalanche_c_info
+    meta:
+      blockchain: avalanche_c
+      sector: addresses
+      contributors: hildobby
+    config:
+      tags: ['table', 'address', 'info']
+    description: "High level information about every address on Avalanche"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - *token_address
+      - *token_symbol
+      - *creator
+      - *namespace
+      - *name
+      - *token_standard
+      - *trades
+      - *volume
+      - *found_on_dexs
+      - *transactions
+      - *transfers
+      - *first_block_time
+      - *first_block_number
+      - *last_block_time
+      - *last_block_number
+
+  - name: tokens_base_info
+    meta:
+      blockchain: base
+      sector: addresses
+      contributors: hildobby
+    config:
+      tags: ['table', 'address', 'info']
+    description: "High level information about every address on Base"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - *token_address
+      - *token_symbol
+      - *creator
+      - *namespace
+      - *name
+      - *token_standard
+      - *trades
+      - *volume
+      - *found_on_dexs
+      - *transactions
+      - *transfers
+      - *first_block_time
+      - *first_block_number
+      - *last_block_time
+      - *last_block_number
+
+  - name: tokens_blast_info
+    meta:
+      blockchain: blast
+      sector: addresses
+      contributors: hildobby
+    config:
+      tags: ['table', 'address', 'info']
+    description: "High level information about every address on Blast"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - *token_address
+      - *token_symbol
+      - *creator
+      - *namespace
+      - *name
+      - *token_standard
+      - *trades
+      - *volume
+      - *found_on_dexs
+      - *transactions
+      - *transfers
+      - *first_block_time
+      - *first_block_number
+      - *last_block_time
+      - *last_block_number
+
+  - name: tokens_bnb_info
+    meta:
+      blockchain: bnb
+      sector: addresses
+      contributors: hildobby
+    config:
+      tags: ['table', 'address', 'info']
+    description: "High level information about every address on BNB"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - *token_address
+      - *token_symbol
+      - *creator
+      - *namespace
+      - *name
+      - *token_standard
+      - *trades
+      - *volume
+      - *found_on_dexs
+      - *transactions
+      - *transfers
+      - *first_block_time
+      - *first_block_number
+      - *last_block_time
+      - *last_block_number
+
+  - name: tokens_celo_info
+    meta:
+      blockchain: celo
+      sector: addresses
+      contributors: hildobby
+    config:
+      tags: ['table', 'address', 'info']
+    description: "High level information about every address on Celo"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - *token_address
+      - *token_symbol
+      - *creator
+      - *namespace
+      - *name
+      - *token_standard
+      - *trades
+      - *volume
+      - *found_on_dexs
+      - *transactions
+      - *transfers
+      - *first_block_time
+      - *first_block_number
+      - *last_block_time
+      - *last_block_number
+      
+  - name: tokens_gnosis_info
+    meta:
+      blockchain: gnosis
+      sector: addresses
+      contributors: hildobby
+    config:
+      tags: ['table', 'address', 'info']
+    description: "High level information about every address on Gnosis"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - *token_address
+      - *token_symbol
+      - *creator
+      - *namespace
+      - *name
+      - *token_standard
+      - *trades
+      - *volume
+      - *found_on_dexs
+      - *transactions
+      - *transfers
+      - *first_block_time
+      - *first_block_number
+      - *last_block_time
+      - *last_block_number
+
+  - name: tokens_optimism_info
+    meta:
+      blockchain: optimism
+      sector: addresses
+      contributors: hildobby
+    config:
+      tags: ['table', 'address', 'info']
+    description: "High level information about every address on Optimism"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - *token_address
+      - *token_symbol
+      - *creator
+      - *namespace
+      - *name
+      - *token_standard
+      - *trades
+      - *volume
+      - *found_on_dexs
+      - *transactions
+      - *transfers
+      - *first_block_time
+      - *first_block_number
+      - *last_block_time
+      - *last_block_number
+
+  - name: tokens_polygon_info
+    meta:
+      blockchain: polygon
+      sector: addresses
+      contributors: hildobby
+    config:
+      tags: ['table', 'address', 'info']
+    description: "High level information about every address on Polygon"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - *token_address
+      - *token_symbol
+      - *creator
+      - *namespace
+      - *name
+      - *token_standard
+      - *trades
+      - *volume
+      - *found_on_dexs
+      - *transactions
+      - *transfers
+      - *first_block_time
+      - *first_block_number
+      - *last_block_time
+      - *last_block_number
+
+  - name: tokens_scroll_info
+    meta:
+      blockchain: scroll
+      sector: addresses
+      contributors: hildobby
+    config:
+      tags: ['table', 'address', 'info']
+    description: "High level information about every address on Scroll"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - *token_address
+      - *token_symbol
+      - *creator
+      - *namespace
+      - *name
+      - *token_standard
+      - *trades
+      - *volume
+      - *found_on_dexs
+      - *transactions
+      - *transfers
+      - *first_block_time
+      - *first_block_number
+      - *last_block_time
+      - *last_block_number
+
+  - name: tokens_zora_info
+    meta:
+      blockchain: zora
+      sector: addresses
+      contributors: hildobby
+    config:
+      tags: ['table', 'address', 'info']
+    description: "High level information about every address on Zora"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - address
+    columns:
+      - *token_address
+      - *token_symbol
+      - *creator
+      - *namespace
+      - *name
+      - *token_standard
+      - *trades
+      - *volume
+      - *found_on_dexs
+      - *transactions
+      - *transfers
+      - *first_block_time
+      - *first_block_number
+      - *last_block_time
+      - *last_block_number

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_arbitrum_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_arbitrum_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'arbitrum' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_arbitrum_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_arbitrum_info.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'tokens_' + blockchain,
         alias = 'info',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_avalanche_c_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_avalanche_c_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'avalanche_c' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_avalanche_c_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_avalanche_c_info.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'tokens_' + blockchain,
         alias = 'info',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_base_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_base_info.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'tokens_' + blockchain,
         alias = 'info',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_base_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_base_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'base' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_blast_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_blast_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'blast' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_blast_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_blast_info.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'tokens_' + blockchain,
         alias = 'info',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_bnb_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_bnb_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'bnb' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_bnb_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_bnb_info.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'tokens_' + blockchain,
         alias = 'info',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_celo_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_celo_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'celo' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_ethereum_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_ethereum_info.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'tokens_' + blockchain,
         alias = 'info',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_ethereum_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_ethereum_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'ethereum' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_fantom_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_fantom_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'fantom' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_fantom_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_fantom_info.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'tokens_' + blockchain,
         alias = 'info',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_gnosis_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_gnosis_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'gnosis' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_linea_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_linea_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'linea' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_linea_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_linea_info.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'tokens_' + blockchain,
         alias = 'info',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_optimism_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_optimism_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'optimism' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_optimism_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_optimism_info.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'tokens_' + blockchain,
         alias = 'info',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_polygon_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_polygon_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'polygon' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_polygon_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_polygon_info.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'tokens_' + blockchain,
         alias = 'info',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_scroll_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_scroll_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'scroll' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_zkevm_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_zkevm_info.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'tokens_' + blockchain,
         alias = 'info',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_zkevm_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_zkevm_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'zkevm' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_zksync_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_zksync_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'zksync' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_zksync_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_zksync_info.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags=['prod_exclude'],
         schema = 'tokens_' + blockchain,
         alias = 'info',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_zora_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/tokens/chains/tokens_zora_info.sql
@@ -1,0 +1,18 @@
+{% set blockchain = 'zora' %}
+
+{{
+    config(
+        schema = 'tokens_' + blockchain,
+        alias = 'info',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['token_address']
+    )
+}}
+
+{{
+    addresses_info(
+        blockchain = blockchain
+    )
+}}


### PR DESCRIPTION
This can be considered as an improved version to `tokens_{chain}.erc20` which imo is poorly named, lacks native tokens and a lot of other columns.

A crosschain spell doesn't make sense for now I will eventually work on a spell that maps tokens across different chains (ie all USDC addresses across chains). Once that's in place, we can combine it with the results from this spell to get a great crosschain spell.

For downstream usage, this will come in handy to rank tokens based on heuristics to filter out spam tokens from the rest for example. That will in turn be useful for spells like: `attacks.address_poisonning`