### PR TITLE
Improve `cex.flows`

### DIFF
--- a/dbt_subprojects/hourly_spellbook/macros/sector/cex/cex_flows.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/cex/cex_flows.sql
@@ -10,7 +10,7 @@ SELECT DISTINCT '{{blockchain}}' AS blockchain
 , t.symbol AS token_symbol
 , t.token_standard
 , CASE WHEN a.cex_name=c.cex_name AND a.cex_name IS NOT NULL THEN 'Internal'
-    WHEN a.cex_name<>c.cex_name AND a.cex_name IS NOT NULL AND b.cex_name IS NOT NULL THEN 'Cross-CEX'
+    WHEN a.cex_name<>c.cex_name AND a.cex_name IS NOT NULL AND c.cex_name IS NOT NULL THEN 'Cross-CEX'
     WHEN a.cex_name IS NOT NULL THEN 'Outflow'
     WHEN c.cex_name IS NOT NULL THEN 'Inflow'
     WHEN d.cex_name IS NOT NULL THEN 'Executed Contract'

--- a/dbt_subprojects/hourly_spellbook/macros/sector/cex/cex_flows.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/cex/cex_flows.sql
@@ -29,7 +29,7 @@ SELECT DISTINCT '{{blockchain}}' AS blockchain
 FROM {{transfers}} t
 LEFT JOIN cex_ethereum.addresses a ON a.address = t."from" OR a.address=t.tx_from
 LEFT JOIN cex_ethereum.addresses b ON b.address = t.to
-WHERE a.cex_name IS NOT NULL OR b.cex_name IS NOT NULL
+WHERE (a.cex_name IS NOT NULL OR b.cex_name IS NOT NULL)
 {% if is_incremental() %}
 AND {{incremental_predicate('block_time')}}
 {% endif %}

--- a/dbt_subprojects/hourly_spellbook/macros/sector/cex/cex_flows.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/cex/cex_flows.sql
@@ -13,7 +13,7 @@ SELECT DISTINCT '{{blockchain}}' AS blockchain
     WHEN a.address=t."from" AND b.address=t.to THEN 'Cross-CEX'
     WHEN b.address=t.to THEN 'Inflow'
     WHEN a.address=t."from" THEN 'Outflow'
-    ELSE 'Executed'
+    WHEN a.address=t.tx_from THEN 'Executed'
     END AS flow_type
 , CASE WHEN a.address=t."from" AND b.address!=t.to THEN -t.amount ELSE t.amount END AS amount
 , t.amount_raw
@@ -27,7 +27,7 @@ SELECT DISTINCT '{{blockchain}}' AS blockchain
 , t.evt_index
 , t.unique_key
 FROM {{transfers}} t
-INNER JOIN {{addresses}} a ON a.address = t."from" OR OR a.address=t.tx_from
+INNER JOIN {{addresses}} a ON a.address = t."from" OR a.address=t.tx_from
 INNER JOIN {{addresses}} b ON b.address = t.to
 {% if is_incremental() %}
 WHERE {{incremental_predicate('block_time')}}

--- a/dbt_subprojects/hourly_spellbook/macros/sector/cex/cex_flows.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/cex/cex_flows.sql
@@ -4,7 +4,7 @@ SELECT DISTINCT '{{blockchain}}' AS blockchain
 , CAST(date_trunc('month', block_time) AS date) AS block_month
 , block_time
 , block_number
-, a.cex_name
+, COALESCE(c.cex_name, a.cex_name, d.cex_name, b.cex_name) AS cex_name
 , a.distinct_name
 , t.contract_address AS token_address
 , t.symbol AS token_symbol


### PR DESCRIPTION
`cex.flows` currently only has `Inflow` and `Outflow` as potential labels for the `flow_type` column. Here I'm adding:
- `Internal` for transfers internal to one CEX
- `Cross-CEX` for transfers internal to one CEX
- `Inflow` for any token inflows that aren't `Internal` or `Cross-CEX`
- `Outflow` for any token outflows that aren't `Internal` or `Cross-CEX`
- `Executed` which is all the transactions executed by a CEX-tagged address, this is very common now with deposit addresses often being contracts. This is the last tag with the others taking tagging priority

It's worth noting that `Executed` txs aren't in the spell rn and are fundamental to detecting deposit addresses amongst other things