### PR TITLE
Revert "re-enable solana fees (#6982)"

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/solana/gas_solana_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/solana/gas_solana_fees.sql
@@ -1,10 +1,12 @@
 {{ config(
     schema = 'gas_solana',
     alias = 'fees',
+    tags = ['prod_exclude'],
     partition_by = ['block_date'],
     materialized = 'incremental',
     file_format = 'delta',
-    incremental_strategy = 'delete+insert',
+    incremental_strategy = 'merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     unique_key = ['block_date', 'block_slot', 'tx_index']
 ) }}
 
@@ -24,8 +26,8 @@ WITH compute_limit_cte AS (
     WHERE executing_account = 'ComputeBudget111111111111111111111111111111'
     AND bytearray_substring(data,1,1) = 0x02
     AND inner_instruction_index is null -- compute budget and price are inherited on cross program invocation
-    {% if is_incremental() %}
-            AND {{ incremental_predicate('block_date') }}
+    {% if is_incremental() or true %}
+            AND {{ incremental_predicate('block_time') }}
     {% endif %}
 ),
 
@@ -45,8 +47,8 @@ unit_price_cte AS (
     WHERE executing_account = 'ComputeBudget111111111111111111111111111111'
     AND bytearray_substring(data,1,1) = 0x03
     AND inner_instruction_index is null -- compute budget and price are inherited on cross program invocation
-    {% if is_incremental() %}
-            AND {{ incremental_predicate('block_date') }}
+    {% if is_incremental() or true %}
+            AND {{ incremental_predicate('block_time') }}
     {% endif %}
 ),
 
@@ -75,11 +77,11 @@ base_model AS (
     LEFT JOIN {{ source('solana_utils', 'block_leaders') }} b
         ON t.block_slot = b.slot
         AND t.block_date = b.date
-        {% if is_incremental() %}
-            AND {{ incremental_predicate('b.date') }}
+        {% if is_incremental() or true %}
+            AND {{ incremental_predicate('b.time') }}
         {% endif %}
-    {% if is_incremental() %}
-            WHERE {{ incremental_predicate('t.block_date') }}
+    {% if is_incremental() or true %}
+            WHERE {{ incremental_predicate('t.block_time') }}
     {% endif %}
     UNION ALL
     SELECT
@@ -100,11 +102,11 @@ base_model AS (
     LEFT JOIN {{ source('solana_utils', 'block_leaders') }} b
         ON vt.block_slot = b.slot
         AND vt.block_date = b.date
-        {% if is_incremental() %}
-            AND {{ incremental_predicate('b.date') }}
+        {% if is_incremental() or true %}
+            AND {{ incremental_predicate('b.time') }}
         {% endif %}
-    {% if is_incremental() %}
-    WHERE {{ incremental_predicate('vt.block_date') }}
+    {% if is_incremental() or true %}
+    WHERE {{ incremental_predicate('vt.block_time') }}
     {% endif %}
 )
 
@@ -142,6 +144,6 @@ LEFT JOIN {{ source('prices','usd_forward_fill') }} p
     --AND to_base58(p.contract_address) = tx_fee_currency  -- this would the right way to do it but slow af
     AND p.contract_address = 0x069b8857feab8184fb687f634618c035dac439dc1aeb3b5598a0f00000000001 --from base58 converted wsol address
     AND p.minute = date_trunc('minute', block_time)
-    {% if is_incremental() %}
-        AND {{ incremental_predicate("date_trunc('day',p.minute)")}}
+    {% if is_incremental() or true %}
+        AND {{ incremental_predicate('p.minute') }}
     {% endif %}


### PR DESCRIPTION
consecutive failures of:
```
20:28:37    Database Error in model gas_solana_fees (models/_sector/gas/fees/solana/gas_solana_fees.sql)
  TrinoQueryError(type=INTERNAL_ERROR, name=OUT_OF_SPILL_SPACE, message="No free or healthy space available for spill", query_id=20241021_191945_00607_yesr6)
  compiled Code at [target/run/hourly_spellbook/models/_sector/gas/fees/solana/gas_solana_fees.sql](https://cloud.getdbt.com/api/v2/accounts/58579/runs/336362171/artifacts/run/hourly_spellbook/models/_sector/gas/fees/solana/gas_solana_fees.sql)
```

need to revert for now.
for reference, cluster sizing:
- r7g.16xlarge
- 16 nodes