### PR TITLE
dex: fix quoting on sources which fail on trino

### DIFF
--- a/sources/_sector/dex/trades/avalanche_c/_sources.yml
+++ b/sources/_sector/dex/trades/avalanche_c/_sources.yml
@@ -61,7 +61,11 @@ sources:
   - name: curvefi_avalanche_c
     tables:
       - name: 3pool_evt_TokenExchange
+        quoting:
+          identifier: true # override source defaults
       - name: 3poolV2_evt_TokenExchange
+        quoting:
+          identifier: true # override source defaults
       - name: AavePool_evt_TokenExchange
       - name: AavePool_evt_TokenExchangeUnderlying
       - name: aave_v3_evt_TokenExchangeUnderlying


### PR DESCRIPTION
adds double quotes around table names which start with a number and fail on trino.