### PR TITLE
Update ethereum_blobs.sql

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/blobs/ethereum/ethereum_blobs.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/blobs/ethereum/ethereum_blobs.sql
@@ -21,7 +21,7 @@ SELECT
     , b.index AS blob_index
     , b.proposer_index AS beacon_proposer_index
     , b.kzg_commitment AS blob_kzg_commitment
-    ,bytearray_length(varbinary_ltrim(varbinary_rtrim(blob))) as used_blob_byte_count
+    ,bytearray_length(varbinary_rtrim(blob)) as used_blob_byte_count
     ,bytearray_length(blob) AS blob_byte_count
     ,bytearray_length(blob) AS blob_gas_used
     -- GPT to the rescue


### PR DESCRIPTION
Removed 'ltrim' while retaining 'rtrim'.

In blob raw data, padding with 0 bytes occurs only on the right side, while left-side 0 bytes are part of the actual data and included in the compression algorithm. Therefore, only 'rtrim' should be applied, without using 'ltrim'.

## Thank you for contributing to Spellbook 🪄

### Update!
Please build spells in the proper [subproject](../dbt_subprojects/) directory. For more information, please see the main [readme](../README.md), which also links to a GH discussion with the option to ask questions.

### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [ ] Adding to existing spell lineage
- [v ] Bug fix

**Note:** You can safely discard any section below which doesn't apply based on selection above

### For bug fixes
If you are fixing a bug, please provide the following information:

- **Description:** [Description of the bug fix]
The issue was that both ltrim and rtrim were used to remove 0 bytes from blob raw data, but only right-side 0s are padding. Left-side 0 bytes are part of the actual data, so applying ltrim was incorrect.

- **Steps to reproduce:** [How to reproduce the bug]
.

- **Implementation details:** [Information on how the bug was fixed]
I removed the use of ltrim and kept rtrim to ensure that only right-side padding is removed, while preserving left-side 0 bytes as part of the actual data.


- **Test instructions:** [How to test the fix]
1. Apply the fix and process blob raw data.
2. Check that only right-side padding is removed and left-side 0 bytes are retained.
3. Verify that the compression algorithm includes left-side 0 bytes.

- **Related issue(s):** [Link to related issues, if any]

---

### Additional information
Please provide any additional information that might help us review your pull request:

- [Any additional information]
None
---

Thank you for your contribution!