### PR TITLE
`safe_optimism_balances` exlcude failing model

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/optimism/safe_optimism_balances.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/optimism/safe_optimism_balances.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'safe_optimism',
         alias = 'balances',
         partition_by = ['day'],


### PR DESCRIPTION
fyi @safeintern 
this model has started failing on what we believe to be a bug in dbt-trino (or a bug on our side that we haven't identified).

the error message in prod:
```
 TrinoExternalError(type=EXTERNAL, name=HIVE_CANNOT_OPEN_SPLIT, message="Error opening Hive split s3a://safe_optimism/balances_19b068f9da964c02b5e3f346d547c574/day=2024-08-09 00%3A00%3A00/20241018_080131_04238_3kkwa_94f12cc9-6ca0-44ed-884a-191b70e57869 (offset=134217728, length=67108864)
```

it has something to do with partitioning and can't find that particular day. we will need to exclude from prod for now until we can get this rebuilt.