### PR TITLE
bug fix - Update prices_optimism_tokens_curated.sql

### DIFF
--- a/dbt_subprojects/tokens/models/prices/optimism/prices_optimism_tokens_curated.sql
+++ b/dbt_subprojects/tokens/models/prices/optimism/prices_optimism_tokens_curated.sql
@@ -108,7 +108,7 @@ FROM
     ('snx-synthetix-network-token', 'SNX', 0x8700daec35af8ff88c16bdf0418774cb3d7599b4, 18),
     -- ('unlock-unlock', 'UNLOCK', 0x7ae97042a4a0eb4d1eb370c34bfec71042a056b7, 18), --removed for low quality feed
     ('bank-bankless-dao', 'BANK', 0x29FAF5905bfF9Cfcc7CF56a5ed91E0f091F8664B, 18),
-    ('btcb-bitcoin-avalanche-bridged-btcb', 'BTC.b', 0x2297aebd383787a160dd0d9f71508148769342e3,18),
+    ('btcb-bitcoin-avalanche-bridged-btcb', 'BTC.b', 0x2297aebd383787a160dd0d9f71508148769342e3,8),
     ('pickle-pickle-finance', 'PICKLE', 0x0c5b4c92c948691EEBf185C17eeB9c230DC019E9, 18),
     ('bob-bob', 'BOB', 0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b, 18),
     ('bomb-fbomb', 'fBOMB', 0x74ccbe53F77b08632ce0CB91D3A545bF6B8E0979,18),


### PR DESCRIPTION
fixed decimals in BTC.b contract from 18 to 8

## Thank you for contributing to Spellbook 🪄

### Update!
Please build spells in the proper [subproject](../dbt_subprojects/) directory. For more information, please see the main [readme](../README.md), which also links to a GH discussion with the option to ask questions.

### Contribution type
Please check the type of contribution this pull request is for:

- [ ] New spell(s)
- [ ] Adding to existing spell lineage
- [x] Bug fix

**Note:** You can safely discard any section below which doesn't apply based on selection above


---

### For bug fixes
If you are fixing a bug, please provide the following information:

- **Description:** [Found incorrect amount of decimals in BTC.b contract on Optimism - should be 8 instead of 18]
- **Steps to reproduce:** [select row with contract 0x2297aebd383787a160dd0d9f71508148769342e3 from tables prices.tokens or prices.usd_latest]
- **Implementation details:** [Changed decimals to correct value - 8 ]
- **Test instructions:** [select row with contract from tables prices.tokens or prices.usd_latest]

---

### Additional information
Please provide any additional information that might help us review your pull request:

- Link to optimism explorer to BTC.b contract with proof - 8 decimals
https://optimistic.etherscan.io/token/0x2297aebd383787a160dd0d9f71508148769342e3
---

Thank you for your contribution!