### PR TITLE
bonkbot solana: failing on duplicates

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/bonkbot_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/bonkbot_solana_bot_trades.sql
@@ -1,6 +1,7 @@
 {{ config(
     alias = 'bot_trades',
     schema = 'bonkbot_solana',
+    tags = ['prod_exclude'],
     partition_by = ['block_month'],
     materialized = 'incremental',
     file_format = 'delta',


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

fyi @whalehunting -- looks like this one started failing again
the `bonkbot_solana.bot_trades` model started to fail in prod on duplicates.
```
Database Error in model bonkbot_solana_bot_trades (models/_sector/dex/bot_trades/solana/platforms/bonkbot_solana_bot_trades.sql)
  TrinoUserError(type=USER_ERROR, name=MERGE_TARGET_ROW_MULTIPLE_MATCHES, message="One MERGE target table row matched more than one source row", query_id=20241029_014427_01057_ca6re)
```


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
