### PR TITLE
fix: temporarily exclude polymarket daily prices model from data explorer

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_prices_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_prices_daily.sql
@@ -3,6 +3,7 @@
     alias = 'market_prices_daily',
     materialized = 'view',
     tags = ['prod_exclude']
+    )
 }}
 
 WITH changed_prices AS (

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_prices_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_prices_daily.sql
@@ -2,11 +2,7 @@
     schema = 'polymarket_polygon',
     alias = 'market_prices_daily',
     materialized = 'view',
-    post_hook = '{{ expose_spells(blockchains = \'["polygon"]\',
-                                  spell_type = "project",
-                                  spell_name = "polymarket",
-                                  contributors = \'["0xboxer, tomfutago"]\') }}'
-  )
+    tags = ['prod_exclude']
 }}
 
 WITH changed_prices AS (


### PR DESCRIPTION
excluding daily prices model because of unknown bug, no time to investigate, hourly and latest models work fine