### PR TITLE
Use `block_slot` for `dex_prices_block_solana` + schema file

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/prices/dex_prices_block_solana.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/prices/dex_prices_block_solana.sql
@@ -160,5 +160,6 @@ from
         , dp.contract_address
         , dp.symbol
         , dp.decimals
+        , dp.block_time
         , dp.block_slot
 )

--- a/dbt_subprojects/solana/models/_sector/dex/prices/schema.yml
+++ b/dbt_subprojects/solana/models/_sector/dex/prices/schema.yml
@@ -1,0 +1,25 @@
+version: 2
+
+models:
+  - name: dex_prices_block_solana
+    meta:
+      blockchain: |
+        solana
+      sector: prices
+      short_description: |
+          The dex.prices_block_solana table provides aggregated token price data at the block level, derived from decentralized exchange (DEX) trades in dex.trades_solana.
+          It filters out tokens with less than $10,000 USD in overall trading volume.
+          The final price for each token per block is determined by taking the median (50th percentile) of all qualifying trades, ensuring a robust representation of token prices across different DEX platforms.
+      contributors: couralex, jeff-dude, 0xRob
+    config:
+      tags: [ 'dex', 'prices', 'solana']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_month
+            - blockchain
+            - contract_address
+            - symbol
+            - decimals
+            - block_number
+            - block_time

--- a/dbt_subprojects/solana/models/_sector/dex/prices/schema.yml
+++ b/dbt_subprojects/solana/models/_sector/dex/prices/schema.yml
@@ -16,7 +16,6 @@ models:
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - block_month
             - blockchain
             - contract_address
             - symbol

--- a/dbt_subprojects/solana/models/_sector/dex/prices/schema.yml
+++ b/dbt_subprojects/solana/models/_sector/dex/prices/schema.yml
@@ -21,5 +21,5 @@ models:
             - contract_address
             - symbol
             - decimals
-            - block_number
+            - block_slot
             - block_time


### PR DESCRIPTION
Groupiing by `block_slot` instead of `blocktime`
Forgot to add the schema definition for dex_prices_block_solana in pr #7037  
