### PR TITLE
exclude failing boost model

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/boost/boost_deployed.sql
+++ b/dbt_subprojects/daily_spellbook/models/boost/boost_deployed.sql
@@ -1,6 +1,7 @@
 {{
     config(
         schema='boost',
+        tags = ['prod_exclude'],
         alias='deployed',
         materialized='incremental',
         file_format='delta',
@@ -49,7 +50,7 @@ from
     {% endif %}
     {% endfor %}
 )
-where 
+where
     creator <> 0xa4c8bb4658bc44bac430699c8b7b13dab28e0f4e
     and start_time > 0
     and end_time < 1e11


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:
exclude failing boost model
this model fails with:
```
TrinoUserError(type=USER_ERROR, name=INVALID_CAST_ARGUMENT, message="Overflow when converting UINT256 to Integer")
```



---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
