### PR TITLE
fix: token22 mint address

### DIFF
--- a/dbt_subprojects/solana/macros/_sector/transfers/solana_token22_spl_transfers_macro.sql
+++ b/dbt_subprojects/solana/macros/_sector/transfers/solana_token22_spl_transfers_macro.sql
@@ -253,7 +253,7 @@ SELECT
     , tr.call_outer_instruction_index as outer_instruction_index
     , COALESCE(tr.call_inner_instruction_index,0) as inner_instruction_index
     , tr.call_outer_executing_account as outer_executing_account
-    , tk_m.base58_address as token_mint_address
+    , COALESCE(tk_s.token_mint_address, tk_d.token_mint_address) as token_mint_address
     , p.price as price_usd
     , CASE 
         WHEN p.decimals is null THEN null


### PR DESCRIPTION
The token_mint_address field in our token22 models requires correction. This necessitates a rerun of the affected models. Given the relatively small data volume involved, the reprocessing should be completed swiftly. Note that this will require triggering backfill operations to ensure data consistency.