### PR TITLE
Add ALB token to base price tokens

### DIFF
--- a/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
@@ -189,6 +189,7 @@ FROM
     ('meta-based-meta', 'base', 'META',0x3efd97aeb3d2451bbec0e4dfebc8b66ebb33f552, 18),
     ('alf-alf', 'base', 'ALF',0x26f1bb40ea88b46ceb21557dc0ffac7b7c0ad40f, 18), 
     ('tad1-tadpole', 'base', 'TAD',0x55027a5b06f4340cc4c82dcc74c90ca93dcb173e, 18),
-    ('blue-blue-guy', 'base', 'BLUE',0x891502ba08132653151f822a3a430198f1844115, 18)
+    ('blue-blue-guy', 'base', 'BLUE',0x891502ba08132653151f822a3a430198f1844115, 18),
+    ('alb-alienbase', 'base', 'ALB',0x1dd2d631c92b1acdfcdd51a0f7145a50130050c4, 18)
 
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)


### PR DESCRIPTION
ALB on Base was added today to Coinpaprika.

Tested coinpaprika endpoints:

https://api.coinpaprika.com/v1/coins/alb-alienbase
https://api.coinpaprika.com/v1/coins/alb-alienbase/markets
https://api.coinpaprika.com/v1/coins/alb-alienbase/ohlcv/today

Coinpaprika token page: https://coinpaprika.com/coin/alb-alienbase/
Base explorer: https://basescan.org/token/0x1dd2d631c92b1acdfcdd51a0f7145a50130050c4