### PR TITLE
fix: sol transfer model merge strategy

### DIFF
--- a/dbt_subprojects/solana/macros/_sector/transfers/solana_sol_transfers_macro.sql
+++ b/dbt_subprojects/solana/macros/_sector/transfers/solana_sol_transfers_macro.sql
@@ -60,7 +60,7 @@ SELECT
     , t.block_slot
     , t.tx_id
     , t.tx_index
-    , t.inner_instruction_index
+    , coalesce(t.inner_instruction_index, 0) as inner_instruction_index
     , t.outer_instruction_index
     , t.tx_signer
     , cast(null as varchar) as from_token_account


### PR DESCRIPTION
This PR fixes the issue in the merge strategy of the native SOL transfer model.

This will require a complete backfill as we are now coalescing `inner_instruction_index` to 0.

