### PR TITLE
update adapters file

### DIFF
--- a/dbt_macros/dune/adapters.sql
+++ b/dbt_macros/dune/adapters.sql
@@ -10,12 +10,25 @@
   );
 {% endmacro %}
 
+{# temp fix to get latest dbt-trino version 1.8.3 working in dbt cloud #}
+{% macro dune_properties(properties) %}
+  {%- if properties is not none -%}
+      WITH (
+          {%- for key, value in properties.items() -%}
+            {{ key }} = {{ value }}
+            {%- if not loop.last -%}{{ ',\n  ' }}{%- endif -%}
+          {%- endfor -%}
+      )
+  {%- endif -%}
+{%- endmacro -%}
+
 {% macro create_table_properties(_properties, relation) %}
   {%- set modified_identifier = relation.identifier | replace("__dbt_tmp", "") -%}
   {%- set unique_location = modified_identifier ~ '_' ~ time_salted_md5_prefix() -%}
   {%- set location= 's3a://%s/%s/%s' % (s3_bucket(), relation.schema, unique_location) -%}
   {%- do _properties.update({'location': "'" + location + "'"}) -%}
-    {{ properties(_properties) }} {# properties is a macro within the trino adapter #}
+    {# temp fix to get latest dbt-trino version 1.8.3 working in dbt cloud #}
+    {{ dune_properties(_properties) }} {# properties is a macro within the trino adapter #}
 {%- endmacro -%}
 
 {% macro time_salted_md5_prefix(input_string=None) -%}


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

dbt cloud uses `versionless` approach, which means dbt-trino is upgraded behind the scenes without the ability for us to test code prior to upgrading versions. since we override macros in our project, this introduces risk. the latest dbt-trino release / dbt cloud upgrade to v1.8.3 removed arguments for `properties()` macro.

here is dbt-trino PR:
https://github.com/starburstdata/dbt-trino/pull/438/files#diff-011a68c79e1add2ddcf1a38093337163629ddd4962b8b46c91a1e2ee5e677deeR80

here is our override:
https://github.com/duneanalytics/spellbook/pull/3705/files#diff-188b341e8ecaa7f162afce0c804260f3892290bd41067a06fe8683d4bd695366R18

since we pass an arguement, prod is failing on all models materialized as tables:
```
04:53:06    Compilation Error in model uniswap_optimism_pools (models/_projects/uniswap/optimism/uniswap_optimism_pools.sql)
  macro 'dbt_macro__properties' takes not more than 0 argument(s)
  
  > in macro create_table_properties (../../dbt_macros/dune/adapters.sql)
  > called by macro trino__create_table_as (../../dbt_macros/dune/adapters.sql)
  > called by macro create_table_as (macros/relations/table/create.sql)
  > called by macro statement (macros/etc/statement.sql)
  > called by macro on_table_exists_logic (macros/materializations/table.sql)
  > called by macro materialization_table_trino (macros/materializations/table.sql)
  > called by model uniswap_optimism_pools (models/_projects/uniswap/optimism/uniswap_optimism_pools.sql)
```


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
