### PR TITLE
Typos Correction **draft**

### DIFF
--- a/docs/general/faq_and_common_issues.md
+++ b/docs/general/faq_and_common_issues.md
@@ -2,12 +2,12 @@
 
 - Why is my PR running more models than included in the CI test runs?
     - Steps within the CI test workflow depend on DBT manifest file to be up-to-date on the main branch
-    - When other PRs are merged, main is updated, therefore a new manifest file needs uploaded to storage for CI to read
+    - When other PRs are merged, main is updated, therefore a new manifest file needs to be uploaded to storage for CI to read
     - The GH workflow to do this lives here: https://github.com/duneanalytics/spellbook/actions/workflows/commit_manifest.yml
     - If the latest run failed and/or is in progress, then it’s possible manifest files are out of date and your PR will run more than it should
     - Wait for it to complete or Dune team to fix any failures
 - I’m modifying an existing spell within my PR that contains a seed test on it via the schema YML file. CI is failing on the seed test, as it can’t find the seed. How do I get around this?
-    - We’ve recently setup seeds to run in prod, since CI defaults to prod if spells not in PR
+    - We’ve recently setup seeds to run in prod, since CI defaults to prod if spells are not in PR
     - Sometimes the seed doesn’t exist in prod (due to failure or other reason)
     - If the seed also isn’t in the PR, then CI test runs out of places to check
     - The workflow will fail on ‘metadata not found’ or ‘missing seed’

--- a/docs/general/repo_navigation.md
+++ b/docs/general/repo_navigation.md
@@ -3,7 +3,7 @@
 There are a few main use cases for opening GH issues in spellbook:
 
 1. **Report a bug** found on an existing spell.
-2. **Suggest enhancements** on existing spells.
+2. **Suggest enhancements** for existing spells.
 3. **Share an idea for a new spell** & have upfront discussions on the design prior to developing.
     - **Note**: This is especially important for new sector spells, that contain multiple projects across multiple blockchains.
 


### PR DESCRIPTION
### Description:

Added typo corrections to documentation for the following files:

- docs/general/faq_and_common_issues.md

"a new manifest file needs uploaded to storage" — The construction is incorrect. Correct version: "**a new manifest file needs to be uploaded to storage**".

"if spells not in PR" — Missing "are" before "not". Correct version: "**if spells are not in PR**".

- docs/general/repo_navigation.md

"suggest enhancements on existing spells" — It would be more grammatically correct to use "for" instead of "on". Correct version: "**Suggest enhancements for existing spells**."

### Goals

Correct errors and improve readability of the documentation.
