### PR TITLE
feat: Add wrap action to native sol transfers

### DIFF
--- a/dbt_subprojects/solana/macros/_sector/transfers/solana_sol_transfers_macro.sql
+++ b/dbt_subprojects/solana/macros/_sector/transfers/solana_sol_transfers_macro.sql
@@ -12,40 +12,10 @@ WITH transfers AS (
         call_inner_instruction_index as inner_instruction_index,
         call_outer_instruction_index as outer_instruction_index,
         call_tx_signer as tx_signer,
-        call_account_arguments[1] AS from_owner,
-        call_account_arguments[2] AS to_owner,
-        'native' as token_version,
-        'SOL' as symbol,
-        lamports as amount,
-        lamports / 1e9 as amount_display,
-        'So11111111111111111111111111111111111111112' as token_mint_address,
-        call_outer_executing_account as outer_executing_account,
-        call_inner_executing_account as inner_executing_account,
-        'transfer' as action
-    FROM 
-        {{ source('system_program_solana', 'system_program_call_Transfer') }}
-    WHERE
-        1=1
-        {% if is_incremental() %}
-        AND {{incremental_predicate('call_block_time')}}
-        {% else %}
-        AND call_block_time >= {{start_date}}
-        AND call_block_time < {{end_date}}
-        {% endif %}
-    UNION ALL
-    SELECT
-        'solana' as blockchain,
-        call_block_time as block_time,
-        cast(date_trunc('day', call_block_time) AS date) AS block_date,
-        cast(date_trunc('month', call_block_time) AS date) AS block_month,
-        call_block_slot as block_slot,
-        call_tx_id as tx_id,
-        call_tx_index as tx_index,
-        call_inner_instruction_index as inner_instruction_index,
-        call_outer_instruction_index as outer_instruction_index,
-        call_tx_signer as tx_signer,
-        COALESCE(tk_from.token_balance_owner, call_account_arguments[1]) AS from_owner,
+        COALESCE(tk_from.token_balance_owner, call_account_arguments[1]) AS from_owner, -- if the token account exists, use the owner of that, otherwise if should be an account
         COALESCE(tk_to.token_balance_owner, call_account_arguments[2]) AS to_owner,
+        CASE WHEN tk_from.address IS NOT NULL THEN tk_from.address ELSE null END as from_token_account, -- if the token account exists, use the address of that, otherwise no token accounts are involved
+        CASE WHEN tk_to.address IS NOT NULL THEN tk_to.address ELSE null END as to_token_account,
         'native' as token_version,
         'SOL' as symbol,
         lamports as amount,
@@ -53,7 +23,7 @@ WITH transfers AS (
         'So11111111111111111111111111111111111111112' as token_mint_address,
         call_outer_executing_account as outer_executing_account,
         call_inner_executing_account as inner_executing_account,
-        'wrap' as action
+        CASE WHEN tk_to.address IS NOT NULL THEN 'wrap' ELSE 'transfer' END as action -- if the token account exists, it's a wrap, otherwise it's a transfer
     FROM 
         {{ source('spl_token_solana', 'spl_token_call_Transfer') }} t
     LEFT JOIN 
@@ -101,10 +71,10 @@ SELECT
     , coalesce(t.inner_instruction_index, 0) as inner_instruction_index
     , t.outer_instruction_index
     , t.tx_signer
-    , cast(null as varchar) as from_token_account
-    , cast(null as varchar) as to_token_account
     , t.from_owner
     , t.to_owner
+    , t.from_token_account
+    , t.to_token_account
     , t.token_mint_address
     , t.symbol
     , t.amount_display

--- a/dbt_subprojects/solana/macros/_sector/transfers/solana_sol_transfers_macro.sql
+++ b/dbt_subprojects/solana/macros/_sector/transfers/solana_sol_transfers_macro.sql
@@ -25,7 +25,7 @@ WITH transfers AS (
         call_inner_executing_account as inner_executing_account,
         CASE WHEN tk_to.address IS NOT NULL THEN 'wrap' ELSE 'transfer' END as action -- if the token account exists, it's a wrap, otherwise it's a transfer
     FROM 
-        {{ source('spl_token_solana', 'spl_token_call_Transfer') }} t
+        {{ source('system_program_solana', 'system_program_call_Transfer') }} t
     LEFT JOIN 
         {{ ref('solana_utils_token_accounts') }} tk_from 
         ON tk_from.address = t.call_account_arguments[1]

--- a/dbt_subprojects/solana/macros/_sector/transfers/solana_sol_transfers_macro.sql
+++ b/dbt_subprojects/solana/macros/_sector/transfers/solana_sol_transfers_macro.sql
@@ -68,7 +68,8 @@ SELECT
     , t.block_slot
     , t.tx_id
     , t.tx_index
-    , coalesce(t.inner_instruction_index, 0) as inner_instruction_index
+    , t.inner_instruction_index
+    , coalesce(t.inner_instruction_index, 0) as key_inner_instruction_index
     , t.outer_instruction_index
     , t.tx_signer
     , t.from_owner


### PR DESCRIPTION
This PR includes a change to native sol transfer that will enable to differentiate between transfer and wrap. Action: 'Wrap' can be used to exclude in downstream metrics spells