### PR TITLE
Unmaterialise `blobs.based_submitters`

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/blobs/ethereum/blobs_based_submitters.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/blobs/ethereum/blobs_based_submitters.sql
@@ -1,8 +1,6 @@
 {{ config(
     schema = 'blobs',
-    alias = 'based_submitters',
-    materialized = 'table',
-    file_format = 'delta'
+    alias = 'based_submitters'
 )}}
 
 SELECT evt_tx_hash AS tx_hash, evt_block_number AS block_number, 'Taiko' AS entity FROM {{ source('taikoxyz_ethereum', 'TaikoL1_evt_BlockProposed')}}


### PR DESCRIPTION
With `blobs.based_submitters` not always up to date prior to `ethereum.blobs` runs, it leads to some accidentally untagged blobs when they should be tagged, like here you can see all those untagged from nov 7th onwards showing up when they should be tagged as taiko:

![PixelSnap 2024-11-09 at 17 57 36@2x](https://github.com/user-attachments/assets/a9717d02-97bc-4d1b-a236-9bbd11bcc19f)


It's also misleading people who think those are new blob submitters: https://x.com/trent_vanepps/status/1855170775915065474

And regardless, blobs.based_submitters currently runs in ~2 seconds so this should be no big deal in terms of compute/runtime