### PR TITLE
fix: add missing amms for jupiter tracking

### DIFF
--- a/dbt_subprojects/solana/models/jupiter/jupiter_solana_aggregator_swaps.sql
+++ b/dbt_subprojects/solana/models/jupiter/jupiter_solana_aggregator_swaps.sql
@@ -64,7 +64,14 @@ with
                 ('Cropper', 'H8W3ctz92svYg6mkn1UtGfu2aQr2fnUFHM1RhScEtQDt'),
                 ('Sanctum Infinity', '5ocnV1qiCgaQR8Jb8xWnVbApfaygJ8tNoZfgPwsgx9kx'),
                 ('Token Swap', 'SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8'),
-                ('Jupiter Perps', 'PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu')
+                ('Jupiter Perps', 'PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu'),
+                ('Guacswap', 'Gswppe6ERWKpUTXvRPfXdzHhiCyJvLadVvXGfdpBqcE1'),
+                ('SolFi', 'SoLFiHG9TfgtdUXUjWAxi3LtvYuFyDLVhBWxdMZxyCe'),
+                ('Pump.fun', '6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P'),
+                ('1DEX', 'DEXYosS6oEGvk8uCDayvwEZz4qEyDJRf9nFgYCaqPMTm'),
+                ('Obric V2', 'obriQD1zbpyLz95G5n7nJe6a4DPjpFwa5XYPoNm113y'),
+                ('Mooshot', 'MoonCVVNZFSYkqNXP6bxHLPL6QQJiMagDL3qcqUQTrG'),
+                ('Fox', 'HyhpEq587ANShDdbx1mP4dTmDZC44CXWft29oYQXDb53')
             ) as v(amm_name, amm)
     )
 


### PR DESCRIPTION
### Description:

There are DEXes being routed to through Jupiter which have significant volume (SolFi, Obric V2) that are not currently being tracked. The newly added DEX labels/program ids comes from `https://station.jup.ag/api-v6/get-program-id-to-label` as per existing comments.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
