### PR TITLE
Exclude king_of_destiny_nova_base_trades

### DIFF
--- a/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/king_of_destiny_nova_base_trades.sql
+++ b/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/king_of_destiny_nova_base_trades.sql
@@ -52,7 +52,7 @@ left join  {{source('king_of_destiny_nova','MarketplaceV3_call_GetRoyalty')}}  r
     {% endif %}
 WHERE
     tx_hash != 0xde7696b64c41bc6ffe2834ba51da7f04121f49c08fc89de724413bf81e6e16be
-    and (sub_tx_trade_id not in [13, 19]
+    and (sub_tx_trade_id not in (13, 19))
 {% if is_incremental() %}
  and {{incremental_predicate('s.evt_block_time')}}
 {% endif %}

--- a/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/king_of_destiny_nova_base_trades.sql
+++ b/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/king_of_destiny_nova_base_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'king_of_destiny_nova',
     alias = 'base_trades',
     materialized = 'incremental',

--- a/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/king_of_destiny_nova_base_trades.sql
+++ b/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/king_of_destiny_nova_base_trades.sql
@@ -51,7 +51,7 @@ left join  {{source('king_of_destiny_nova','MarketplaceV3_call_GetRoyalty')}}  r
     and {{incremental_predicate('r.call_block_time')}}
     {% endif %}
 WHERE
-    tx_hash != 0xde7696b64c41bc6ffe2834ba51da7f04121f49c08fc89de724413bf81e6e16be
+    s.evt_tx_hash != 0xde7696b64c41bc6ffe2834ba51da7f04121f49c08fc89de724413bf81e6e16be
     and (sub_tx_trade_id not in (13, 19))
 {% if is_incremental() %}
  and {{incremental_predicate('s.evt_block_time')}}

--- a/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/king_of_destiny_nova_base_trades.sql
+++ b/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/king_of_destiny_nova_base_trades.sql
@@ -52,7 +52,7 @@ left join  {{source('king_of_destiny_nova','MarketplaceV3_call_GetRoyalty')}}  r
     {% endif %}
 WHERE
     s.evt_tx_hash != 0xde7696b64c41bc6ffe2834ba51da7f04121f49c08fc89de724413bf81e6e16be
-    and (sub_tx_trade_id not in (13, 19))
+    and (s.evt_index not in (13, 19))
 {% if is_incremental() %}
  and {{incremental_predicate('s.evt_block_time')}}
 {% endif %}

--- a/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/king_of_destiny_nova_base_trades.sql
+++ b/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/king_of_destiny_nova_base_trades.sql
@@ -1,5 +1,4 @@
 {{ config(
-    tags = ['prod_exclude'],
     schema = 'king_of_destiny_nova',
     alias = 'base_trades',
     materialized = 'incremental',
@@ -51,6 +50,9 @@ left join  {{source('king_of_destiny_nova','MarketplaceV3_call_GetRoyalty')}}  r
     {% if is_incremental() %}
     and {{incremental_predicate('r.call_block_time')}}
     {% endif %}
+WHERE
+    tx_hash != 0xde7696b64c41bc6ffe2834ba51da7f04121f49c08fc89de724413bf81e6e16be
+    and (sub_tx_trade_id not in [13, 19]
 {% if is_incremental() %}
-WHERE {{incremental_predicate('s.evt_block_time')}}
+ and {{incremental_predicate('s.evt_block_time')}}
 {% endif %}


### PR DESCRIPTION
This model started throwing this error:

```Database Error in model king_of_destiny_nova_base_trades (models/_sector/trades/chains/nova/platforms/king_of_destiny_nova_base_trades.sql)
  TrinoUserError(type=USER_ERROR, name=MERGE_TARGET_ROW_MULTIPLE_MATCHES, message="One MERGE target table row matched more than one source row", query_id=20241114_050457_00603_k74h4)```

