### PR TITLE
kyberswap aggregator: filter out troubled rows

### DIFF
--- a/dbt_subprojects/dex/models/_projects/kyberswap/arbitrum/kyberswap_aggregator_arbitrum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/kyberswap/arbitrum/kyberswap_aggregator_arbitrum_trades.sql
@@ -36,9 +36,11 @@ WITH meta_router AS
             ,ARRAY[-1]              AS trace_address
         FROM
             {{ source('kyber_arbitrum', 'MetaAggregationRouterV2_evt_Swapped') }}
-        {% if is_incremental() %}
-        WHERE evt_block_time >= date_trunc('day', now() - INTERVAL '7' DAY)
-        {% endif %}
+        WHERE
+            dstToken != 0x7d3eedb40fbecd9fba383504e066fdf67382a835 --bug with MTK token
+            {% if is_incremental() %}
+            AND evt_block_time >= date_trunc('day', now() - INTERVAL '7' DAY)
+            {% endif %}
 )
 SELECT
     'arbitrum'                                                          AS blockchain

--- a/dbt_subprojects/dex/models/_projects/kyberswap/base/kyberswap_aggregator_base_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/kyberswap/base/kyberswap_aggregator_base_trades.sql
@@ -32,9 +32,11 @@ WITH meta_router AS
             ,ARRAY[-1]              AS trace_address
         FROM
             {{ source('kyber_base', 'MetaAggregationRouterV2_evt_Swapped') }}
-        {% if is_incremental() %}
-        WHERE {{incremental_predicate('evt_block_time')}}
-        {% endif %}
+        WHERE
+            dstToken != 0xd1e24444591bf0ebea5cfe4e39c885b18129d940 --bug with MTK token
+            {% if is_incremental() %}
+            AND {{incremental_predicate('evt_block_time')}}
+            {% endif %}
 )
 SELECT
     'base'                                                          AS blockchain

--- a/dbt_subprojects/dex/models/_projects/kyberswap/polygon/kyberswap_aggregator_polygon_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/kyberswap/polygon/kyberswap_aggregator_polygon_trades.sql
@@ -36,9 +36,11 @@ WITH meta_router AS
             ,ARRAY[-1]              AS trace_address
         FROM
             {{ source('kyber_polygon', 'MetaAggregationRouterV2_evt_Swapped') }}
-        {% if is_incremental() %}
-        WHERE evt_block_time >= date_trunc('day', now() - INTERVAL '7' DAY)
-        {% endif %}
+        WHERE
+            dstToken != 0xd848db988b477efe60ee2ff99f9898990c6fb0cd --bug with MTK token
+            {% if is_incremental() %}
+            AND evt_block_time >= date_trunc('day', now() - INTERVAL '7' DAY)
+            {% endif %}
 )
 SELECT
     'polygon'                                                          AS blockchain


### PR DESCRIPTION
it looks like either the query is pulling data incorrectly or one particular token is breaking the logic.

troubled bought token address:
- polygon: https://polygonscan.com/token/0xd848db988b477efe60ee2ff99f9898990c6fb0cd
- base: https://basescan.org/token/0xd1e24444591bf0ebea5cfe4e39c885b18129d940
- arbitrum: https://arbiscan.io/token/0x7d3eedb40fbecd9fba383504e066fdf67382a835

issue downstream in `dex_aggregator.trades` where `amount_usd` gets inflated significantly as the token bought address shows as USDC/USDT/etc with 6 decimals, where the explorer shows raw amount is tied to MTK token with 18 decimals. there were 5 total tx across these three chains that involved this token and scenario.
- polygon [here](https://polygonscan.com/tx/0x58023c101eb238719418728c648ce7df31a10e78af2c1be5bb3df9065b9dba03) and [here](https://polygonscan.com/tx/0x08605969aed3d52013b012aaa95c9b7f31b8df07fc5dbe76c2e74d57e5b0e714)
- arbitrum [here](https://arbiscan.io/tx/0xbf28284ac6ca92fe39ab3d18e8fb1079e3c8e13da00922c281dce491863d36e6) and [here](https://arbiscan.io/tx/0xdfcfa48da784460dc74cc56d59c399cadbf38b88f7a7e22a446cfa653c154c9a)
- base [here](https://basescan.org/tx/0x47d404b7cc0837b63ec27ddc46624ef5e10d310ad5a2ec2b5807a165b5d86a16)