### PR TITLE
Fix typo in variable name "defintions" to "definitions" Update valida…

### DIFF
--- a/scripts/validate_source_freshness_checks.py
+++ b/scripts/validate_source_freshness_checks.py
@@ -35,8 +35,8 @@ class Sources:
 
 def missing_freshness_checks(sources, manifest, check_type='warn'):
     sources = list(set(sources))
-    source_defintions = {source: manifest['sources'][source] for source in sources}
-    empty_checks = [key for key, value in source_defintions.items() if
+    source_definitions = {source: manifest['sources'][source] for source in sources}
+    empty_checks = [key for key, value in source_definitions.items() if
                     value['freshness'][f'{check_type}_after']['count'] is None]
     return empty_checks
 


### PR DESCRIPTION
### Description:

This pull request fixes a typo in the code. The variable name `defintions` in the following line:

```python
source_defintions = {source: manifest['sources'][source] for source in sources}
```

was misspelled. The correct spelling is **"definitions"**, so the corrected line should be:

```python
source_definitions = {source: manifest['sources'][source] for source in sources}
```

**Importance of this fix:**

- The typo could cause confusion and may lead to potential misunderstandings when reviewing the code.
- Although Python would not raise an error due to the typo, using the correct spelling ensures better readability and consistency with common coding standards.
  
This fix improves code clarity and follows the principle of using correctly spelled variable names.