### PR TITLE
Add New Event Models for GMX v2 Project

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/arbitrum/gmx_v2_arbitrum_event_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/arbitrum/gmx_v2_arbitrum_event_schema.yml
@@ -910,3 +910,271 @@ models:
       - *acceptable_price
       - *min_output_amount_raw   
       - *updated_at_time
+
+
+  - name: gmx_v2_arbitrum_open_interest_in_tokens_updated
+    meta:
+      blockchain: arbitrum
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['arbitrum', 'gmx', 'event', 'open_interest_in_tokens_updated']
+    description: |
+      Combines and processes decoded event data to produce a normalized dataset of updated orders 
+      on the GMX platform for the Arbitrum blockchain. 
+      This model integrates data from the `open_interest_in_tokens_updated` table, enriching it with market-specific details.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'OpenInterestInTokensUpdated' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: market
+        description: The market in which the order was updated, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: collateral_token
+        description: The token used as collateral for the order, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: is_long
+        description: A boolean flag indicating whether the order is a long position (true) or short position (false).
+      - name: next_value
+        description: |
+          Represents the updated open interest vlaue after the transaction. It is derived by normalizing 
+          the raw value using index token decimals.
+          This ensures consistent scaling of the value across tokens with varying decimals.
+      - name: delta
+        description: |
+          Indicates the change in open interest. It is calculated by normalizing the raw delta value 
+          using index token decimals.
+          This normalization accounts for token decimal differences and provides a standardized measure of change.
+      - name: tx_from
+        description: The address that initiated the transaction
+      - name: tx_to
+        description: The destination address of the transaction
+      - name: tx_index
+        description: Index value related to the transaction
+
+
+  - name: gmx_v2_arbitrum_open_interest_updated
+    meta:
+      blockchain: arbitrum
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['arbitrum', 'gmx', 'event', 'open_interest_updated']
+    description: |
+      Extracts and processes decoded event data for open interest updates on the GMX platform, 
+      specifically on the Arbitrum blockchain. This model normalizes data, including key metrics like 
+      delta and next_value, ensuring consistent scaling based on token decimals.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'OpenInterestUpdated' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: market
+        description: The market associated with the open interest update, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: collateral_token
+        description: The token used as collateral for the open interest, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: is_long
+        description: |
+          A boolean flag indicating whether the open interest update is for a long position (true) or short position (false).
+        data_type: boolean
+      - name: delta
+        description: |
+          Represents the change in open interest value, normalized by dividing the raw delta by `POWER(10, 30)`. 
+          This ensures consistent scaling for values across tokens with varying decimals.
+        data_type: float
+        data_tests:
+          - not_null
+      - name: next_value
+        description: |
+          Indicates the updated open interest value after the transaction, normalized by dividing 
+          the raw value by `POWER(10, 30)` to ensure consistent scaling across tokens.
+        data_type: float
+        data_tests:
+          - not_null
+      - name: tx_from
+        description: The address that initiated the transaction.
+      - name: tx_to
+        description: The destination address of the transaction.
+      - name: tx_index
+        description: The index value related to the transaction.
+
+  
+  - name: gmx_v2_arbitrum_oracle_price_update
+    meta:
+      blockchain: arbitrum
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['arbitrum', 'gmx', 'event', 'oracle_price_update']
+    description: |
+      Processes decoded event data for Oracle Price Updates on the GMX platform in the Arbitrum blockchain. 
+      The model normalizes price data (min_price and max_price) using token-specific decimals and extracts 
+      additional details such as the provider and token involved in the update.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'OraclePriceUpdate' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: token
+        description: The token associated with the oracle price update, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: provider
+        description: The address of the price provider, decoded from a hexadecimal value.
+      - name: min_price
+        description: The minimum price reported by the oracle.
+        data_tests:
+          - not_null
+      - name: max_price
+        description: The maximum price reported by the oracle.
+        data_tests:
+          - not_null
+      - name: timestamp
+        description: The timestamp of the oracle price update.
+        data_type: timestamp
+      - name: tx_from
+        description: The address that initiated the transaction.
+      - name: tx_to
+        description: The destination address of the transaction.
+      - name: tx_index
+        description: The index value related to the transaction, used for unique identification.
+
+
+  - name: gmx_v2_arbitrum_pool_amount_updated
+    meta:
+      blockchain: arbitrum
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['arbitrum', 'gmx', 'event', 'pool_amount_updated']
+    description: |
+      Processes decoded event data for Pool Amount Updates on the GMX platform in the Arbitrum blockchain.
+      This model normalizes token values (next_value and delta) based on token-specific decimals and extracts
+      additional details such as the market and token involved in the pool update.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'PoolAmountUpdated' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: market
+        description: The market associated with the pool update, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: token
+        description: The token involved in the pool update, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: next_value
+        description: |
+          The amount in the pool for the specified token, normalized by dividing the raw value
+          by `POWER(10, token_decimals)`, where `token_decimals` is derived from ERC-20 token metadata.
+        data_tests:
+          - not_null
+      - name: delta
+        description: |
+          The change in the pool amount for the specified token, normalized by dividing the raw value
+          by `POWER(10, token_decimals)`, where `token_decimals` is derived from ERC-20 token metadata.
+        data_tests:
+          - not_null
+      - name: tx_from
+        description: The address that initiated the transaction.
+      - name: tx_to
+        description: The destination address of the transaction.
+      - name: tx_index
+        description: The index value related to the transaction, used for unique identification.
+
+
+  - name: gmx_v2_arbitrum_set_uint
+    meta:
+      blockchain: arbitrum
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['arbitrum', 'gmx', 'event', 'set_uint']
+    description: |
+      Processes decoded event data for `SetUint` events on the GMX platform in the Arbitrum blockchain.
+      This model normalizes the value field and extracts additional details such as the base key and associated data,
+      ensuring compatibility with downstream analyses.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'SetUint' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: base_key
+        description: The base key associated with the event, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: data
+        description: The associated data field, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: value
+        description: |
+          The value associated with the event, normalized by dividing the raw value by `POWER(10, 30)`.
+          This ensures the value is represented in a standard floating-point format for analysis.
+        data_type: float
+        data_tests:
+          - not_null
+      - name: tx_from
+        description: The address that initiated the transaction.
+      - name: tx_to
+        description: The destination address of the transaction.
+      - name: tx_index
+        description: The index value related to the transaction, used for unique identification.

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/arbitrum/gmx_v2_arbitrum_open_interest_in_tokens_updated.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/arbitrum/gmx_v2_arbitrum_open_interest_in_tokens_updated.sql
@@ -1,0 +1,183 @@
+{{
+  config(
+    schema = 'gmx_v2_arbitrum',
+    alias = 'open_interest_in_tokens_updated',
+    materialized = 'table'
+    )
+}}
+
+{%- set event_name = 'OpenInterestInTokensUpdated' -%}
+{%- set blockchain_name = 'arbitrum' -%}
+
+
+WITH evt_data_1 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender,
+        varbinary_substring(topic1, 13, 20) as account
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog1')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+, evt_data_2 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender,
+        varbinary_substring(topic2, 13, 20) as account
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog2')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+-- unite 2 tables
+, evt_data AS (
+    SELECT * 
+    FROM evt_data_1
+    UNION
+    SELECT *
+    FROM evt_data_2
+)
+, parsed_data AS (
+    SELECT
+        tx_hash,
+        index, 
+        json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
+        json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
+        json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
+        json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
+    FROM
+        evt_data
+)
+
+, address_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(address_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, uint_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(uint_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, int_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(int_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, bool_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(bool_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, combined AS (
+    SELECT *
+    FROM address_items_parsed
+    UNION ALL      
+    SELECT *
+    FROM uint_items_parsed
+    UNION ALL    
+    SELECT *
+    FROM int_items_parsed
+    UNION ALL
+    SELECT *
+    FROM bool_items_parsed
+)
+
+, evt_data_parsed AS (
+    SELECT
+        tx_hash,
+        index,
+        MAX(CASE WHEN key_name = 'isLong' THEN value END) AS is_long,
+        MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value,
+        MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
+        MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
+        MAX(CASE WHEN key_name = 'delta' THEN value END) AS delta
+    FROM
+        combined
+    GROUP BY tx_hash, index
+)
+
+-- full data 
+, full_data AS (
+    SELECT 
+        blockchain,
+        block_time,
+        DATE(block_time) AS block_date,
+        block_number,
+        ED.tx_hash,
+        ED.index,
+        contract_address,
+        event_name,
+        msg_sender,
+
+        from_hex(EDP.market) AS market,
+        from_hex(EDP.collateral_token) AS collateral_token,   
+        CAST(EDP.is_long AS BOOLEAN) AS is_long,
+        CAST(EDP.next_value AS DOUBLE) / POWER(10, MD.index_token_decimals) AS next_value,
+        CAST(EDP.delta AS DOUBLE) / POWER(10, MD.index_token_decimals) AS delta
+
+    FROM evt_data AS ED
+    LEFT JOIN evt_data_parsed AS EDP
+        ON ED.tx_hash = EDP.tx_hash
+        AND ED.index = EDP.index
+    LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
+        ON from_hex(EDP.market) = MD.market
+)
+
+--can be removed once decoded tables are fully denormalized
+{{
+    add_tx_columns(
+        model_cte = 'full_data'
+        , blockchain = blockchain_name
+        , columns = ['from', 'to', 'index']
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/arbitrum/gmx_v2_arbitrum_open_interest_updated.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/arbitrum/gmx_v2_arbitrum_open_interest_updated.sql
@@ -1,0 +1,181 @@
+{{
+  config(
+    schema = 'gmx_v2_arbitrum',
+    alias = 'open_interest_updated',
+    materialized = 'table'
+    )
+}}
+
+{%- set event_name = 'OpenInterestUpdated' -%}
+{%- set blockchain_name = 'arbitrum' -%}
+
+
+WITH evt_data_1 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog1')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+, evt_data_2 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog2')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+-- unite 2 tables
+, evt_data AS (
+    SELECT * 
+    FROM evt_data_1
+    UNION
+    SELECT *
+    FROM evt_data_2
+)
+
+, parsed_data AS (
+    SELECT
+        tx_hash,
+        index, 
+        json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
+        json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
+        json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
+        json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
+    FROM
+        evt_data
+)
+
+, address_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(address_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, uint_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(uint_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, int_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(int_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, bool_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(bool_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, combined AS (
+    SELECT *
+    FROM address_items_parsed
+    UNION ALL      
+    SELECT *
+    FROM uint_items_parsed
+    UNION ALL    
+    SELECT *
+    FROM int_items_parsed
+    UNION ALL
+    SELECT *
+    FROM bool_items_parsed
+)
+
+, evt_data_parsed AS (
+    SELECT
+        tx_hash,
+        index,
+        MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
+        MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
+        MAX(CASE WHEN key_name = 'isLong' THEN value END) AS is_long,
+        MAX(CASE WHEN key_name = 'delta' THEN value END) AS delta,
+        MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value
+    FROM
+        combined
+    GROUP BY tx_hash, index
+)
+
+-- full data 
+, full_data AS (
+    SELECT 
+        blockchain,
+        block_time,
+        DATE(block_time) AS block_date,
+        block_number,
+        ED.tx_hash,
+        ED.index,
+        contract_address,
+        event_name,
+        msg_sender,
+
+        from_hex(market) AS market,
+        from_hex(collateral_token) AS collateral_token,
+        TRY_CAST(is_long AS BOOLEAN) AS is_long,
+        TRY_CAST(delta AS DOUBLE) / POWER(10, 30) AS delta,
+        TRY_CAST(next_value AS DOUBLE) / POWER(10, 30) AS next_value
+
+    FROM evt_data AS ED
+    LEFT JOIN evt_data_parsed AS EDP
+        ON ED.tx_hash = EDP.tx_hash
+            AND ED.index = EDP.index
+)
+
+--can be removed once decoded tables are fully denormalized
+{{
+    add_tx_columns(
+        model_cte = 'full_data'
+        , blockchain = blockchain_name
+        , columns = ['from', 'to', 'index']
+    )
+}}
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/arbitrum/gmx_v2_arbitrum_oracle_price_update.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/arbitrum/gmx_v2_arbitrum_oracle_price_update.sql
@@ -1,0 +1,149 @@
+{{
+  config(
+    schema = 'gmx_v2_arbitrum',
+    alias = 'oracle_price_update',
+    materialized = 'table'
+    )
+}}
+
+{%- set event_name = 'OraclePriceUpdate' -%}
+{%- set blockchain_name = 'arbitrum' -%}
+
+
+WITH evt_data_1 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog1')}}
+    WHERE eventName = '{{ event_name }}'
+        AND evt_block_time > DATE '2023-08-01'
+    ORDER BY evt_block_time ASC
+)
+
+, evt_data_2 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog2')}}
+    WHERE eventName = '{{ event_name }}'
+        AND evt_block_time > DATE '2023-08-01'
+    ORDER BY evt_block_time ASC
+)
+
+-- unite 2 tables
+, evt_data AS (
+    SELECT * 
+    FROM evt_data_1
+    UNION
+    SELECT *
+    FROM evt_data_2
+)
+, parsed_data AS (
+    SELECT
+        tx_hash,
+        index, 
+        json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
+        json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
+    FROM
+        evt_data
+)
+, address_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(address_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+, uint_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(uint_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+, combined AS (
+    SELECT *
+    FROM address_items_parsed
+    UNION ALL      
+    SELECT *
+    FROM uint_items_parsed
+)
+, evt_data_parsed AS (
+    SELECT
+        tx_hash,
+        index,
+        MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
+        MAX(CASE WHEN key_name = 'provider' THEN value END) AS provider,
+        MAX(CASE WHEN key_name = 'minPrice' THEN value END) AS min_price,
+        MAX(CASE WHEN key_name = 'maxPrice' THEN value END) AS max_price,
+        MAX(CASE WHEN key_name = 'timestamp' THEN value END) AS "timestamp"    
+    FROM
+        combined
+    GROUP BY tx_hash, index
+)
+
+-- full data 
+, full_data AS (
+    SELECT 
+        blockchain,
+        block_time,
+        DATE(block_time) AS block_date,
+        block_number,
+        ED.tx_hash,
+        ED.index,
+        contract_address,
+        event_name,
+        msg_sender,
+
+        from_hex(token) AS token,
+        from_hex(provider) AS provider,
+        TRY_CAST(min_price AS DOUBLE) / POWER(10, 30 - ERC20.decimals) AS min_price,
+        TRY_CAST(max_price AS DOUBLE) / POWER(10, 30 - ERC20.decimals) AS max_price,
+        CASE 
+            WHEN "timestamp" = 0 THEN NULL
+            ELSE "timestamp"
+        END AS "timestamp"
+
+    FROM evt_data AS ED
+    LEFT JOIN evt_data_parsed AS EDP
+        ON ED.tx_hash = EDP.tx_hash
+        AND ED.index = EDP.index
+    LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
+        ON from_hex(EDP.token) = ERC20.contract_address
+)
+
+--can be removed once decoded tables are fully denormalized
+{{
+    add_tx_columns(
+        model_cte = 'full_data'
+        , blockchain = blockchain_name
+        , columns = ['from', 'to', 'index']
+    )
+}}
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/arbitrum/gmx_v2_arbitrum_pool_amount_updated.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/arbitrum/gmx_v2_arbitrum_pool_amount_updated.sql
@@ -1,0 +1,159 @@
+{{
+  config(
+    schema = 'gmx_v2_arbitrum',
+    alias = 'pool_amount_updated',
+    materialized = 'table'
+    )
+}}
+
+{%- set event_name = 'PoolAmountUpdated' -%}
+{%- set blockchain_name = 'arbitrum' -%}
+
+
+WITH evt_data_1 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog1')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+, evt_data_2 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog2')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+-- unite 2 tables
+, evt_data AS (
+    SELECT * 
+    FROM evt_data_1
+    UNION
+    SELECT *
+    FROM evt_data_2
+)
+
+, parsed_data AS (
+    SELECT
+        tx_hash,
+        index, 
+        json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
+        json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
+        json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items
+    FROM
+        evt_data
+)
+, address_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(address_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+, uint_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(uint_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+, int_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(int_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+, combined AS (
+    SELECT *
+    FROM address_items_parsed
+    UNION ALL      
+    SELECT *
+    FROM uint_items_parsed
+    UNION ALL    
+    SELECT *
+    FROM int_items_parsed
+)
+, evt_data_parsed AS (
+    SELECT
+        tx_hash,
+        index,
+        MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
+        MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
+        MAX(CASE WHEN key_name = 'delta' THEN value END) AS delta,
+        MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value
+    FROM
+        combined
+    GROUP BY tx_hash, index
+)
+
+-- full data 
+, full_data AS (
+    SELECT 
+        blockchain,
+        block_time,
+        DATE(block_time) AS block_date,
+        block_number,
+        ED.tx_hash,
+        ED.index,
+        contract_address,
+        event_name,
+        msg_sender,
+
+        from_hex(market) AS market,
+        from_hex(token) AS token,
+        TRY_CAST(next_value AS DOUBLE) / POWER(10, ERC20.decimals) AS next_value,
+        TRY_CAST(delta AS DOUBLE) / POWER(10, ERC20.decimals) AS delta
+
+    FROM evt_data AS ED
+    LEFT JOIN evt_data_parsed AS EDP
+        ON ED.tx_hash = EDP.tx_hash
+        AND ED.index = EDP.index
+    LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
+        ON from_hex(EDP.token) = ERC20.contract_address
+)
+
+--can be removed once decoded tables are fully denormalized
+{{
+    add_tx_columns(
+        model_cte = 'full_data'
+        , blockchain = blockchain_name
+        , columns = ['from', 'to', 'index']
+    )
+}}
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/arbitrum/gmx_v2_arbitrum_set_uint.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/arbitrum/gmx_v2_arbitrum_set_uint.sql
@@ -1,0 +1,159 @@
+{{
+  config(
+    schema = 'gmx_v2_arbitrum',
+    alias = 'set_uint',
+    materialized = 'table'
+    )
+}}
+
+{%- set event_name = 'SetUint' -%}
+{%- set blockchain_name = 'arbitrum' -%}
+
+
+WITH evt_data_1 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog1')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+, evt_data_2 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog2')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+-- unite 2 tables
+, evt_data AS (
+    SELECT * 
+    FROM evt_data_1
+    UNION
+    SELECT *
+    FROM evt_data_2
+)
+
+, parsed_data AS (
+    SELECT
+        tx_hash,
+        index, 
+        json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
+        json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
+        json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
+    FROM
+        evt_data
+)
+
+, bytes32_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(bytes32_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, bytes_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(bytes_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, uint_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(uint_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, combined AS (
+    SELECT *
+    FROM bytes32_items_parsed
+    UNION ALL      
+    SELECT *
+    FROM bytes_items_parsed
+    UNION ALL    
+    SELECT *
+    FROM uint_items_parsed
+)
+
+, evt_data_parsed AS (
+    SELECT
+        tx_hash,
+        index,
+        MAX(CASE WHEN key_name = 'baseKey' THEN value END) AS base_key,
+        MAX(CASE WHEN key_name = 'data' THEN value END) AS "data",
+        MAX(CASE WHEN key_name = 'value' THEN value END) AS "value"
+    FROM
+        combined
+    GROUP BY tx_hash, index
+)
+
+-- full data 
+, full_data AS (
+    SELECT 
+        blockchain,
+        block_time,
+        DATE(block_time) AS block_date,
+        block_number,
+        ED.tx_hash,
+        ED.index,
+        contract_address,
+        event_name,
+        msg_sender,
+
+        from_hex(base_key) AS base_key,
+        from_hex("data") AS "data",
+        TRY_CAST("value" AS DOUBLE) / POWER(10, 30) AS "value"
+    FROM evt_data AS ED
+    LEFT JOIN evt_data_parsed AS EDP
+        ON ED.tx_hash = EDP.tx_hash
+            AND ED.index = EDP.index
+)
+
+--can be removed once decoded tables are fully denormalized
+{{
+    add_tx_columns(
+        model_cte = 'full_data'
+        , blockchain = blockchain_name
+        , columns = ['from', 'to', 'index']
+    )
+}}
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/avalanche_c/gmx_v2_avalanche_c_event_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/avalanche_c/gmx_v2_avalanche_c_event_schema.yml
@@ -910,3 +910,271 @@ models:
       - *acceptable_price
       - *min_output_amount_raw   
       - *updated_at_time
+
+
+  - name: gmx_v2_avalanche_c_open_interest_in_tokens_updated
+    meta:
+      blockchain: avalanche_c
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['avalanche_c', 'gmx', 'event', 'open_interest_in_tokens_updated']
+    description: |
+      Combines and processes decoded event data to produce a normalized dataset of updated orders 
+      on the GMX platform for the Avalanche blockchain. 
+      This model integrates data from the `open_interest_in_tokens_updated` table, enriching it with market-specific details.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'OpenInterestInTokensUpdated' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: market
+        description: The market in which the order was updated, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: collateral_token
+        description: The token used as collateral for the order, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: is_long
+        description: A boolean flag indicating whether the order is a long position (true) or short position (false).
+      - name: next_value
+        description: |
+          Represents the updated open interest vlaue after the transaction. It is derived by normalizing 
+          the raw value using index token decimals.
+          This ensures consistent scaling of the value across tokens with varying decimals.
+      - name: delta
+        description: |
+          Indicates the change in open interest. It is calculated by normalizing the raw delta value 
+          using index token decimals.
+          This normalization accounts for token decimal differences and provides a standardized measure of change.
+      - name: tx_from
+        description: The address that initiated the transaction
+      - name: tx_to
+        description: The destination address of the transaction
+      - name: tx_index
+        description: Index value related to the transaction
+
+
+  - name: gmx_v2_avalanche_c_open_interest_updated
+    meta:
+      blockchain: avalanche_c
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['avalanche_c', 'gmx', 'event', 'open_interest_updated']
+    description: |
+      Extracts and processes decoded event data for open interest updates on the GMX platform, 
+      specifically on the Avalanche blockchain. This model normalizes data, including key metrics like 
+      delta and next_value, ensuring consistent scaling based on token decimals.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'OpenInterestUpdated' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: market
+        description: The market associated with the open interest update, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: collateral_token
+        description: The token used as collateral for the open interest, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: is_long
+        description: |
+          A boolean flag indicating whether the open interest update is for a long position (true) or short position (false).
+        data_type: boolean
+      - name: delta
+        description: |
+          Represents the change in open interest value, normalized by dividing the raw delta by `POWER(10, 30)`. 
+          This ensures consistent scaling for values across tokens with varying decimals.
+        data_type: float
+        data_tests:
+          - not_null
+      - name: next_value
+        description: |
+          Indicates the updated open interest value after the transaction, normalized by dividing 
+          the raw value by `POWER(10, 30)` to ensure consistent scaling across tokens.
+        data_type: float
+        data_tests:
+          - not_null
+      - name: tx_from
+        description: The address that initiated the transaction.
+      - name: tx_to
+        description: The destination address of the transaction.
+      - name: tx_index
+        description: The index value related to the transaction.
+
+
+  - name: gmx_v2_avalanche_c_oracle_price_update
+    meta:
+      blockchain: avalanche_c
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['avalanche_c', 'gmx', 'event', 'oracle_price_update']
+    description: |
+      Processes decoded event data for Oracle Price Updates on the GMX platform in the Avalanche blockchain. 
+      The model normalizes price data (min_price and max_price) using token-specific decimals and extracts 
+      additional details such as the provider and token involved in the update.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'OraclePriceUpdate' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: token
+        description: The token associated with the oracle price update, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: provider
+        description: The address of the price provider, decoded from a hexadecimal value.
+      - name: min_price
+        description: The minimum price reported by the oracle.
+        data_tests:
+          - not_null
+      - name: max_price
+        description: The maximum price reported by the oracle.
+        data_tests:
+          - not_null
+      - name: timestamp
+        description: The timestamp of the oracle price update.
+        data_type: timestamp
+      - name: tx_from
+        description: The address that initiated the transaction.
+      - name: tx_to
+        description: The destination address of the transaction.
+      - name: tx_index
+        description: The index value related to the transaction, used for unique identification.
+
+
+  - name: gmx_v2_avalanche_c_pool_amount_updated
+    meta:
+      blockchain: avalanche_c
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['avalanche_c', 'gmx', 'event', 'pool_amount_updated']
+    description: |
+      Processes decoded event data for Pool Amount Updates on the GMX platform in the Avalanche blockchain.
+      This model normalizes token values (next_value and delta) based on token-specific decimals and extracts
+      additional details such as the market and token involved in the pool update.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'PoolAmountUpdated' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: market
+        description: The market associated with the pool update, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: token
+        description: The token involved in the pool update, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: next_value
+        description: |
+          The amount in the pool for the specified token, normalized by dividing the raw value
+          by `POWER(10, token_decimals)`, where `token_decimals` is derived from ERC-20 token metadata.
+        data_tests:
+          - not_null
+      - name: delta
+        description: |
+          The change in the pool amount for the specified token, normalized by dividing the raw value
+          by `POWER(10, token_decimals)`, where `token_decimals` is derived from ERC-20 token metadata.
+        data_tests:
+          - not_null
+      - name: tx_from
+        description: The address that initiated the transaction.
+      - name: tx_to
+        description: The destination address of the transaction.
+      - name: tx_index
+        description: The index value related to the transaction, used for unique identification.
+
+
+  - name: gmx_v2_avalanche_c_set_uint
+    meta:
+      blockchain: avalanche_c
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['avalanche_c', 'gmx', 'event', 'set_uint']
+    description: |
+      Processes decoded event data for `SetUint` events on the GMX platform in the Avalanche blockchain.
+      This model normalizes the value field and extracts additional details such as the base key and associated data,
+      ensuring compatibility with downstream analyses.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'SetUint' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: base_key
+        description: The base key associated with the event, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: data
+        description: The associated data field, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: value
+        description: |
+          The value associated with the event, normalized by dividing the raw value by `POWER(10, 30)`.
+          This ensures the value is represented in a standard floating-point format for analysis.
+        data_type: float
+        data_tests:
+          - not_null
+      - name: tx_from
+        description: The address that initiated the transaction.
+      - name: tx_to
+        description: The destination address of the transaction.
+      - name: tx_index
+        description: The index value related to the transaction, used for unique identification.

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/avalanche_c/gmx_v2_avalanche_c_open_interest_in_tokens_updated.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/avalanche_c/gmx_v2_avalanche_c_open_interest_in_tokens_updated.sql
@@ -1,0 +1,183 @@
+{{
+  config(
+    schema = 'gmx_v2_avalanche_c',
+    alias = 'open_interest_in_tokens_updated',
+    materialized = 'table'
+    )
+}}
+
+{%- set event_name = 'OpenInterestInTokensUpdated' -%}
+{%- set blockchain_name = 'avalanche_c' -%}
+
+
+WITH evt_data_1 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender,
+        varbinary_substring(topic1, 13, 20) as account
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog1')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+, evt_data_2 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender,
+        varbinary_substring(topic2, 13, 20) as account
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog2')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+-- unite 2 tables
+, evt_data AS (
+    SELECT * 
+    FROM evt_data_1
+    UNION
+    SELECT *
+    FROM evt_data_2
+)
+, parsed_data AS (
+    SELECT
+        tx_hash,
+        index, 
+        json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
+        json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
+        json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
+        json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
+    FROM
+        evt_data
+)
+
+, address_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(address_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, uint_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(uint_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, int_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(int_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, bool_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(bool_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, combined AS (
+    SELECT *
+    FROM address_items_parsed
+    UNION ALL      
+    SELECT *
+    FROM uint_items_parsed
+    UNION ALL    
+    SELECT *
+    FROM int_items_parsed
+    UNION ALL
+    SELECT *
+    FROM bool_items_parsed
+)
+
+, evt_data_parsed AS (
+    SELECT
+        tx_hash,
+        index,
+        MAX(CASE WHEN key_name = 'isLong' THEN value END) AS is_long,
+        MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value,
+        MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
+        MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
+        MAX(CASE WHEN key_name = 'delta' THEN value END) AS delta
+    FROM
+        combined
+    GROUP BY tx_hash, index
+)
+
+-- full data 
+, full_data AS (
+    SELECT 
+        blockchain,
+        block_time,
+        DATE(block_time) AS block_date,
+        block_number,
+        ED.tx_hash,
+        ED.index,
+        contract_address,
+        event_name,
+        msg_sender,
+
+        from_hex(EDP.market) AS market,
+        from_hex(EDP.collateral_token) AS collateral_token,   
+        CAST(EDP.is_long AS BOOLEAN) AS is_long,
+        CAST(EDP.next_value AS DOUBLE) / POWER(10, MD.index_token_decimals) AS next_value,
+        CAST(EDP.delta AS DOUBLE) / POWER(10, MD.index_token_decimals) AS delta
+
+    FROM evt_data AS ED
+    LEFT JOIN evt_data_parsed AS EDP
+        ON ED.tx_hash = EDP.tx_hash
+        AND ED.index = EDP.index
+    LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
+        ON from_hex(EDP.market) = MD.market
+)
+
+--can be removed once decoded tables are fully denormalized
+{{
+    add_tx_columns(
+        model_cte = 'full_data'
+        , blockchain = blockchain_name
+        , columns = ['from', 'to', 'index']
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/avalanche_c/gmx_v2_avalanche_c_open_interest_updated.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/avalanche_c/gmx_v2_avalanche_c_open_interest_updated.sql
@@ -1,0 +1,181 @@
+{{
+  config(
+    schema = 'gmx_v2_avalanche_c',
+    alias = 'open_interest_updated',
+    materialized = 'table'
+    )
+}}
+
+{%- set event_name = 'OpenInterestUpdated' -%}
+{%- set blockchain_name = 'avalanche_c' -%}
+
+
+WITH evt_data_1 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog1')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+, evt_data_2 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog2')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+-- unite 2 tables
+, evt_data AS (
+    SELECT * 
+    FROM evt_data_1
+    UNION
+    SELECT *
+    FROM evt_data_2
+)
+
+, parsed_data AS (
+    SELECT
+        tx_hash,
+        index, 
+        json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
+        json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
+        json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
+        json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
+    FROM
+        evt_data
+)
+
+, address_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(address_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, uint_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(uint_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, int_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(int_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, bool_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(bool_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, combined AS (
+    SELECT *
+    FROM address_items_parsed
+    UNION ALL      
+    SELECT *
+    FROM uint_items_parsed
+    UNION ALL    
+    SELECT *
+    FROM int_items_parsed
+    UNION ALL
+    SELECT *
+    FROM bool_items_parsed
+)
+
+, evt_data_parsed AS (
+    SELECT
+        tx_hash,
+        index,
+        MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
+        MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
+        MAX(CASE WHEN key_name = 'isLong' THEN value END) AS is_long,
+        MAX(CASE WHEN key_name = 'delta' THEN value END) AS delta,
+        MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value
+    FROM
+        combined
+    GROUP BY tx_hash, index
+)
+
+-- full data 
+, full_data AS (
+    SELECT 
+        blockchain,
+        block_time,
+        DATE(block_time) AS block_date,
+        block_number,
+        ED.tx_hash,
+        ED.index,
+        contract_address,
+        event_name,
+        msg_sender,
+
+        from_hex(market) AS market,
+        from_hex(collateral_token) AS collateral_token,
+        TRY_CAST(is_long AS BOOLEAN) AS is_long,
+        TRY_CAST(delta AS DOUBLE) / POWER(10, 30) AS delta,
+        TRY_CAST(next_value AS DOUBLE) / POWER(10, 30) AS next_value
+
+    FROM evt_data AS ED
+    LEFT JOIN evt_data_parsed AS EDP
+        ON ED.tx_hash = EDP.tx_hash
+            AND ED.index = EDP.index
+)
+
+--can be removed once decoded tables are fully denormalized
+{{
+    add_tx_columns(
+        model_cte = 'full_data'
+        , blockchain = blockchain_name
+        , columns = ['from', 'to', 'index']
+    )
+}}
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/avalanche_c/gmx_v2_avalanche_c_oracle_price_update.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/avalanche_c/gmx_v2_avalanche_c_oracle_price_update.sql
@@ -1,0 +1,149 @@
+{{
+  config(
+    schema = 'gmx_v2_avalanche_c',
+    alias = 'oracle_price_update',
+    materialized = 'table'
+    )
+}}
+
+{%- set event_name = 'OraclePriceUpdate' -%}
+{%- set blockchain_name = 'avalanche_c' -%}
+
+
+WITH evt_data_1 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog1')}}
+    WHERE eventName = '{{ event_name }}'
+        AND evt_block_time > DATE '2023-08-01'
+    ORDER BY evt_block_time ASC
+)
+
+, evt_data_2 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog2')}}
+    WHERE eventName = '{{ event_name }}'
+        AND evt_block_time > DATE '2023-08-01'
+    ORDER BY evt_block_time ASC
+)
+
+-- unite 2 tables
+, evt_data AS (
+    SELECT * 
+    FROM evt_data_1
+    UNION
+    SELECT *
+    FROM evt_data_2
+)
+, parsed_data AS (
+    SELECT
+        tx_hash,
+        index, 
+        json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
+        json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
+    FROM
+        evt_data
+)
+, address_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(address_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+, uint_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(uint_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+, combined AS (
+    SELECT *
+    FROM address_items_parsed
+    UNION ALL      
+    SELECT *
+    FROM uint_items_parsed
+)
+, evt_data_parsed AS (
+    SELECT
+        tx_hash,
+        index,
+        MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
+        MAX(CASE WHEN key_name = 'provider' THEN value END) AS provider,
+        MAX(CASE WHEN key_name = 'minPrice' THEN value END) AS min_price,
+        MAX(CASE WHEN key_name = 'maxPrice' THEN value END) AS max_price,
+        MAX(CASE WHEN key_name = 'timestamp' THEN value END) AS "timestamp"    
+    FROM
+        combined
+    GROUP BY tx_hash, index
+)
+
+-- full data 
+, full_data AS (
+    SELECT 
+        blockchain,
+        block_time,
+        DATE(block_time) AS block_date,
+        block_number,
+        ED.tx_hash,
+        ED.index,
+        contract_address,
+        event_name,
+        msg_sender,
+
+        from_hex(token) AS token,
+        from_hex(provider) AS provider,
+        TRY_CAST(min_price AS DOUBLE) / POWER(10, 30 - ERC20.decimals) AS min_price,
+        TRY_CAST(max_price AS DOUBLE) / POWER(10, 30 - ERC20.decimals) AS max_price,
+        CASE 
+            WHEN "timestamp" = 0 THEN NULL
+            ELSE "timestamp"
+        END AS "timestamp"
+
+    FROM evt_data AS ED
+    LEFT JOIN evt_data_parsed AS EDP
+        ON ED.tx_hash = EDP.tx_hash
+        AND ED.index = EDP.index
+    LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
+        ON from_hex(EDP.token) = ERC20.contract_address
+)
+
+--can be removed once decoded tables are fully denormalized
+{{
+    add_tx_columns(
+        model_cte = 'full_data'
+        , blockchain = blockchain_name
+        , columns = ['from', 'to', 'index']
+    )
+}}
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/avalanche_c/gmx_v2_avalanche_c_pool_amount_updated.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/avalanche_c/gmx_v2_avalanche_c_pool_amount_updated.sql
@@ -1,0 +1,159 @@
+{{
+  config(
+    schema = 'gmx_v2_avalanche_c',
+    alias = 'pool_amount_updated',
+    materialized = 'table'
+    )
+}}
+
+{%- set event_name = 'PoolAmountUpdated' -%}
+{%- set blockchain_name = 'avalanche_c' -%}
+
+
+WITH evt_data_1 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog1')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+, evt_data_2 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog2')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+-- unite 2 tables
+, evt_data AS (
+    SELECT * 
+    FROM evt_data_1
+    UNION
+    SELECT *
+    FROM evt_data_2
+)
+
+, parsed_data AS (
+    SELECT
+        tx_hash,
+        index, 
+        json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
+        json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
+        json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items
+    FROM
+        evt_data
+)
+, address_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(address_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+, uint_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(uint_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+, int_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(int_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+, combined AS (
+    SELECT *
+    FROM address_items_parsed
+    UNION ALL      
+    SELECT *
+    FROM uint_items_parsed
+    UNION ALL    
+    SELECT *
+    FROM int_items_parsed
+)
+, evt_data_parsed AS (
+    SELECT
+        tx_hash,
+        index,
+        MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
+        MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
+        MAX(CASE WHEN key_name = 'delta' THEN value END) AS delta,
+        MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value
+    FROM
+        combined
+    GROUP BY tx_hash, index
+)
+
+-- full data 
+, full_data AS (
+    SELECT 
+        blockchain,
+        block_time,
+        DATE(block_time) AS block_date,
+        block_number,
+        ED.tx_hash,
+        ED.index,
+        contract_address,
+        event_name,
+        msg_sender,
+
+        from_hex(market) AS market,
+        from_hex(token) AS token,
+        TRY_CAST(next_value AS DOUBLE) / POWER(10, ERC20.decimals) AS next_value,
+        TRY_CAST(delta AS DOUBLE) / POWER(10, ERC20.decimals) AS delta
+
+    FROM evt_data AS ED
+    LEFT JOIN evt_data_parsed AS EDP
+        ON ED.tx_hash = EDP.tx_hash
+        AND ED.index = EDP.index
+    LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
+        ON from_hex(EDP.token) = ERC20.contract_address
+)
+
+--can be removed once decoded tables are fully denormalized
+{{
+    add_tx_columns(
+        model_cte = 'full_data'
+        , blockchain = blockchain_name
+        , columns = ['from', 'to', 'index']
+    )
+}}
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_uint.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_uint.sql
@@ -1,0 +1,159 @@
+{{
+  config(
+    schema = 'gmx_v2_avalanche_c',
+    alias = 'set_uint',
+    materialized = 'table'
+    )
+}}
+
+{%- set event_name = 'SetUint' -%}
+{%- set blockchain_name = 'avalanche_c' -%}
+
+
+WITH evt_data_1 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog1')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+, evt_data_2 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog2')}}
+    WHERE eventName = '{{ event_name }}'
+    ORDER BY evt_block_time ASC
+)
+
+-- unite 2 tables
+, evt_data AS (
+    SELECT * 
+    FROM evt_data_1
+    UNION
+    SELECT *
+    FROM evt_data_2
+)
+
+, parsed_data AS (
+    SELECT
+        tx_hash,
+        index, 
+        json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
+        json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
+        json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
+    FROM
+        evt_data
+)
+
+, bytes32_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(bytes32_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, bytes_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(bytes_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, uint_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(uint_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, combined AS (
+    SELECT *
+    FROM bytes32_items_parsed
+    UNION ALL      
+    SELECT *
+    FROM bytes_items_parsed
+    UNION ALL    
+    SELECT *
+    FROM uint_items_parsed
+)
+
+, evt_data_parsed AS (
+    SELECT
+        tx_hash,
+        index,
+        MAX(CASE WHEN key_name = 'baseKey' THEN value END) AS base_key,
+        MAX(CASE WHEN key_name = 'data' THEN value END) AS "data",
+        MAX(CASE WHEN key_name = 'value' THEN value END) AS "value"
+    FROM
+        combined
+    GROUP BY tx_hash, index
+)
+
+-- full data 
+, full_data AS (
+    SELECT 
+        blockchain,
+        block_time,
+        DATE(block_time) AS block_date,
+        block_number,
+        ED.tx_hash,
+        ED.index,
+        contract_address,
+        event_name,
+        msg_sender,
+
+        from_hex(base_key) AS base_key,
+        from_hex("data") AS "data",
+        TRY_CAST("value" AS DOUBLE) / POWER(10, 30) AS "value"
+    FROM evt_data AS ED
+    LEFT JOIN evt_data_parsed AS EDP
+        ON ED.tx_hash = EDP.tx_hash
+            AND ED.index = EDP.index
+)
+
+--can be removed once decoded tables are fully denormalized
+{{
+    add_tx_columns(
+        model_cte = 'full_data'
+        , blockchain = blockchain_name
+        , columns = ['from', 'to', 'index']
+    )
+}}
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/gmx_v2_event_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/gmx_v2_event_schema.yml
@@ -910,3 +910,272 @@ models:
       - *acceptable_price
       - *min_output_amount_raw   
       - *updated_at_time
+
+
+  - name: gmx_v2_open_interest_in_tokens_updated
+    meta:
+      blockchain: arbitrum, avalanche_c
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['arbitrum', 'avalanche_c', 'gmx', 'event', 'open_interest_in_tokens_updated']
+    description: |
+      Combines and processes decoded event data to produce a normalized dataset of updated orders 
+      on the GMX platform for the Arbitrum and Avalanche blockchains. 
+      This model integrates data from the `open_interest_in_tokens_updated` table, enriching it with market-specific details.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'OpenInterestInTokensUpdated' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: market
+        description: The market in which the order was updated, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: collateral_token
+        description: The token used as collateral for the order, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: is_long
+        description: A boolean flag indicating whether the order is a long position (true) or short position (false).
+      - name: next_value
+        description: |
+          Represents the updated open interest vlaue after the transaction. It is derived by normalizing 
+          the raw value using index token decimals.
+          This ensures consistent scaling of the value across tokens with varying decimals.
+      - name: delta
+        description: |
+          Indicates the change in open interest. It is calculated by normalizing the raw delta value 
+          using index token decimals.
+          This normalization accounts for token decimal differences and provides a standardized measure of change.
+      - name: tx_from
+        description: The address that initiated the transaction
+      - name: tx_to
+        description: The destination address of the transaction
+      - name: tx_index
+        description: Index value related to the transaction
+
+
+  - name: gmx_v2_open_interest_updated
+    meta:
+      blockchain: arbitrum, avalanche_c
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['arbitrum', 'avalanche_c', 'gmx', 'event', 'open_interest_updated']
+    description: |
+      Extracts and processes decoded event data for open interest updates on the GMX platform, 
+      specifically on the Arbitrum and Avalanche blockchains. This model normalizes data, including key metrics like 
+      delta and next_value, ensuring consistent scaling based on token decimals.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'OpentInterestUpdated' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: market
+        description: The market associated with the open interest update, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: collateral_token
+        description: The token used as collateral for the open interest, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: is_long
+        description: |
+          A boolean flag indicating whether the open interest update is for a long position (true) or short position (false).
+        data_type: boolean
+      - name: delta
+        description: |
+          Represents the change in open interest value, normalized by dividing the raw delta by `POWER(10, 30)`. 
+          This ensures consistent scaling for values across tokens with varying decimals.
+        data_type: float
+        data_tests:
+          - not_null
+      - name: next_value
+        description: |
+          Indicates the updated open interest value after the transaction, normalized by dividing 
+          the raw value by `POWER(10, 30)` to ensure consistent scaling across tokens.
+        data_type: float
+        data_tests:
+          - not_null
+      - name: tx_from
+        description: The address that initiated the transaction.
+      - name: tx_to
+        description: The destination address of the transaction.
+      - name: tx_index
+        description: The index value related to the transaction.
+
+
+  - name: gmx_v2_oracle_price_update
+    meta:
+      blockchain: arbitrum, avalanche_c
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['arbitrum', 'avalanche_c', 'gmx', 'event', 'oracle_price_update']
+    description: |
+      Processes decoded event data for Oracle Price Updates on the GMX platform in the Arbitrum and Avalanche blockchains. 
+      The model normalizes price data (min_price and max_price) using token-specific decimals and extracts 
+      additional details such as the provider and token involved in the update.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'OraclePriceUpdate' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: token
+        description: The token associated with the oracle price update, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: provider
+        description: The address of the price provider, decoded from a hexadecimal value.
+      - name: min_price
+        description: The minimum price reported by the oracle.
+        data_tests:
+          - not_null
+      - name: max_price
+        description: The maximum price reported by the oracle.
+        data_tests:
+          - not_null
+      - name: timestamp
+        description: The timestamp of the oracle price update.
+        data_type: timestamp
+      - name: tx_from
+        description: The address that initiated the transaction.
+      - name: tx_to
+        description: The destination address of the transaction.
+      - name: tx_index
+        description: The index value related to the transaction, used for unique identification.
+
+
+  - name: gmx_v2_pool_amount_updated
+    meta:
+      blockchain: arbitrum, avalanche_c
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['arbitrum', 'avalanche_c', 'gmx', 'event', 'pool_amount_updated']
+    description: |
+      Processes decoded event data for Pool Amount Updates on the GMX platform in the Arbitrum and Avalanche blockchains.
+      This model normalizes token values (next_value and delta) based on token-specific decimals and extracts
+      additional details such as the market and token involved in the pool update.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'PoolAmountUpdated' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: market
+        description: The market associated with the pool update, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: token
+        description: The token involved in the pool update, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: next_value
+        description: |
+          The amount in the pool for the specified token, normalized by dividing the raw value
+          by `POWER(10, token_decimals)`, where `token_decimals` is derived from ERC-20 token metadata.
+        data_tests:
+          - not_null
+      - name: delta
+        description: |
+          The change in the pool amount for the specified token, normalized by dividing the raw value
+          by `POWER(10, token_decimals)`, where `token_decimals` is derived from ERC-20 token metadata.
+        data_tests:
+          - not_null
+      - name: tx_from
+        description: The address that initiated the transaction.
+      - name: tx_to
+        description: The destination address of the transaction.
+      - name: tx_index
+        description: The index value related to the transaction, used for unique identification.
+
+
+  - name: gmx_v2_set_uint
+    meta:
+      blockchain: arbitrum, avalanche_c
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['arbitrum', 'avalanche_c', 'gmx', 'event', 'set_uint']
+    description: |
+      Processes decoded event data for `SetUint` events on the GMX platform in the Arbitrum and Avalanche blockchains.
+      This model normalizes the value field and extracts additional details such as the base key and associated data,
+      ensuring compatibility with downstream analyses.
+
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - name: event_name
+        description: The type of event recorded, always 'SetUint' for this model
+        data_tests:
+          - not_null 
+      - *msg_sender
+      - name: base_key
+        description: The base key associated with the event, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: data
+        description: The associated data field, decoded from a hexadecimal value.
+        data_tests:
+          - not_null
+      - name: value
+        description: |
+          The value associated with the event, normalized by dividing the raw value by `POWER(10, 30)`.
+          This ensures the value is represented in a standard floating-point format for analysis.
+        data_type: float
+        data_tests:
+          - not_null
+      - name: tx_from
+        description: The address that initiated the transaction.
+      - name: tx_to
+        description: The destination address of the transaction.
+      - name: tx_index
+        description: The index value related to the transaction, used for unique identification.
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/gmx_v2_open_interest_in_tokens_updated.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/gmx_v2_open_interest_in_tokens_updated.sql
@@ -1,0 +1,40 @@
+{{ config(
+        schema='gmx_v2',
+        alias = 'open_interest_in_tokens_updated',
+        post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c"]\',
+                                    "project",
+                                    "gmx",
+                                    \'["ai_data_master","gmx-io"]\') }}'
+        )
+}}
+
+{%- set chains = [
+    'arbitrum',
+    'avalanche_c',
+] -%}
+
+{%- for chain in chains -%}
+SELECT 
+    blockchain,
+    block_time,
+    block_date,
+    block_number,
+    tx_hash,
+    index,
+    contract_address,
+    tx_index,
+    tx_from,
+    tx_to,
+    event_name,
+    msg_sender,
+    market,
+    collateral_token,
+    is_long,
+    next_value,
+    delta
+FROM {{ ref('gmx_v2_' ~ chain ~ '_open_interest_in_tokens_updated') }}
+{% if not loop.last %}
+UNION ALL
+{% endif %}
+{%- endfor -%}
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/gmx_v2_open_interest_updated.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/gmx_v2_open_interest_updated.sql
@@ -1,0 +1,41 @@
+{{ config(
+        schema='gmx_v2',
+        alias = 'open_interest_updated',
+        post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c"]\',
+                                    "project",
+                                    "gmx",
+                                    \'["ai_data_master","gmx-io"]\') }}'
+        )
+}}
+
+{%- set chains = [
+    'arbitrum',
+    'avalanche_c',
+] -%}
+
+{%- for chain in chains -%}
+SELECT 
+    blockchain,
+    block_time,
+    block_date,
+    block_number,
+    tx_hash,
+    index,
+    contract_address,
+    tx_index,
+    tx_from,
+    tx_to,
+    event_name,
+    msg_sender,
+    market,
+    collateral_token,
+    is_long,
+    next_value,
+    delta
+FROM {{ ref('gmx_v2_' ~ chain ~ '_open_interest_updated') }}
+{% if not loop.last %}
+UNION ALL
+{% endif %}
+{%- endfor -%}
+
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/gmx_v2_oracle_price_update.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/gmx_v2_oracle_price_update.sql
@@ -1,0 +1,40 @@
+{{ config(
+        schema='gmx_v2',
+        alias = 'oracle_price_update',
+        post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c"]\',
+                                    "project",
+                                    "gmx",
+                                    \'["ai_data_master","gmx-io"]\') }}'
+        )
+}}
+
+{%- set chains = [
+    'arbitrum',
+    'avalanche_c',
+] -%}
+
+{%- for chain in chains -%}
+SELECT 
+    blockchain,
+    block_time,
+    block_date,
+    block_number,
+    tx_hash,
+    index,
+    contract_address,
+    tx_index,
+    tx_from,
+    tx_to,
+    event_name,
+    msg_sender,
+    token,
+    "provider",
+    min_price,
+    max_price,
+    "timestamp"
+FROM {{ ref('gmx_v2_' ~ chain ~ '_oracle_price_update') }}
+{% if not loop.last %}
+UNION ALL
+{% endif %}
+{%- endfor -%}
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/gmx_v2_pool_amount_updated.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/gmx_v2_pool_amount_updated.sql
@@ -1,0 +1,39 @@
+{{ config(
+        schema='gmx_v2',
+        alias = 'pool_amount_updated',
+        post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c"]\',
+                                    "project",
+                                    "gmx",
+                                    \'["ai_data_master","gmx-io"]\') }}'
+        )
+}}
+
+{%- set chains = [
+    'arbitrum',
+    'avalanche_c',
+] -%}
+
+{%- for chain in chains -%}
+SELECT 
+    blockchain,
+    block_time,
+    block_date,
+    block_number,
+    tx_hash,
+    index,
+    contract_address,
+    tx_index,
+    tx_from,
+    tx_to,
+    event_name,
+    msg_sender,
+    market,
+    token,
+    next_value,
+    delta
+FROM {{ ref('gmx_v2_' ~ chain ~ '_pool_amount_updated') }}
+{% if not loop.last %}
+UNION ALL
+{% endif %}
+{%- endfor -%}
+

--- a/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/gmx_v2_set_uint.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/gmx/event/gmx_v2_set_uint.sql
@@ -1,0 +1,38 @@
+{{ config(
+        schema='gmx_v2',
+        alias = 'set_uint',
+        post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c"]\',
+                                    "project",
+                                    "gmx",
+                                    \'["ai_data_master","gmx-io"]\') }}'
+        )
+}}
+
+{%- set chains = [
+    'arbitrum',
+    'avalanche_c',
+] -%}
+
+{%- for chain in chains -%}
+SELECT 
+    blockchain,
+    block_time,
+    block_date,
+    block_number,
+    tx_hash,
+    index,
+    contract_address,
+    tx_index,
+    tx_from,
+    tx_to,
+    event_name,
+    msg_sender,
+    base_key,
+    "data",
+    "value"
+FROM {{ ref('gmx_v2_' ~ chain ~ '_set_uint') }}
+{% if not loop.last %}
+UNION ALL
+{% endif %}
+{%- endfor -%}
+


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Updated five event models (`OpenInterestUpdated`, `OraclePriceUpdate`, `PoolAmountUpdated`, `SetUint`, and `OpenInterestInTokensUpdated`) for `Arbitrum` and `Avalanche` blockchains to enhance data normalization and accuracy.
