### PR TITLE
zeroex - exclude nft spells 

### DIFF
--- a/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_ethereum_nft_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_ethereum_nft_fills.sql
@@ -1,4 +1,5 @@
 {{  config(
+        tags=['prod_exclude'],
         schema = 'zeroex_ethereum',
         alias = 'nft_fills',
         materialized='incremental',


### PR DESCRIPTION

### Description:

zeroex - add tag prod_exclude to nft spells 

