### PR TITLE
chainswap fix: remove cast to varchar

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/chainswap/avalanche_c/chain_swap_avalanche_c_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/avalanche_c/chain_swap_avalanche_c_trades.sql
@@ -130,7 +130,7 @@ select distinct
     fee_token_amount / power(10, decimals) * price as fee_usd,
     fee_token_amount / power(10, decimals) as fee_token_amount,
     symbol as fee_token_symbol,
-    cast(coalesce(fee_token_address, {{wavax_contract_address}}) as varchar) as fee_token_address,
+    coalesce(fee_token_address, {{wavax_contract_address}}) as fee_token_address,
     -- Dex
     project,
     version,


### PR DESCRIPTION
fyi @whalehunting 
got an error from merge in #6909 where it appears avax model left the data type conversion on an address fields, while other chains did not