### PR TITLE
Add transfers into boba sources

### DIFF
--- a/sources/_base_sources/evm/boba_base_sources.yml
+++ b/sources/_base_sources/evm/boba_base_sources.yml
@@ -333,3 +333,112 @@ sources:
             description: "Excess blob gas in this block"
           - name: parent_beacon_block_root
             description: "Root hash of the parent beacon block"
+
+  - name: erc20_boba
+    description: "Transfer events for ERC20 tokens on Boba blockchain"
+    tables:
+      - name: evt_transfer
+        meta:
+          docs_slug: /evm/boba/raw/erc20_transfers
+          short_description: The evt_transfer table contains all ERC20 token transfer events on the Boba blockchain.
+        description: '{{ doc("erc20_boba_evt_transfer_doc") }}'
+        columns:
+          - name: contract_address
+            description: "The address of the ERC20 token contract"
+          - name: from
+            description: "The address sending the tokens"
+          - name: to
+            description: "The address receiving the tokens"
+          - name: value
+            description: "The amount of tokens transferred"
+          - name: evt_tx_hash
+            description: "The transaction hash of the transfer event"
+          - name: evt_index
+            description: "The index of this event within the transaction"
+          - name: evt_block_time
+            description: "The timestamp of the block containing this transfer"
+          - name: evt_block_number
+            description: "The block number containing this transfer"
+
+  - name: erc721_boba
+    description: "Transfer events for ERC721 tokens on Boba blockchain"
+    tables:
+      - name: evt_transfer
+        meta:
+          docs_slug: /evm/boba/raw/erc721_transfers
+          short_description: The evt_transfer table contains all ERC721 token transfer events on the Boba blockchain.
+        description: '{{ doc("erc721_boba_evt_transfer_doc") }}'
+        columns:
+          - name: contract_address
+            description: "The address of the ERC721 token contract"
+          - name: from
+            description: "The address sending the NFT"
+          - name: to
+            description: "The address receiving the NFT"
+          - name: tokenId
+            description: "The unique identifier of the NFT being transferred"
+          - name: evt_tx_hash
+            description: "The transaction hash of the transfer event"
+          - name: evt_index
+            description: "The index of this event within the transaction"
+          - name: evt_block_time
+            description: "The timestamp of the block containing this transfer"
+          - name: evt_block_number
+            description: "The block number containing this transfer"
+
+  - name: erc1155_boba
+    description: "Transfer events for ERC1155 tokens on Boba blockchain"
+    tables:
+      - name: evt_transfersingle
+        meta:
+          docs_slug: /evm/boba/raw/erc1155_transfers_single
+          short_description: The evt_transfersingle table contains single token transfer events from ERC1155 contracts on the Boba blockchain.
+        description: '{{ doc("erc1155_boba_evt_transfer_doc") }}'
+        columns:
+          - name: contract_address
+            description: "The address of the ERC1155 token contract"
+          - name: operator
+            description: "The address authorized to make the transfer"
+          - name: from
+            description: "The address sending the tokens"
+          - name: to
+            description: "The address receiving the tokens"
+          - name: id
+            description: "The identifier for the token being transferred"
+          - name: value
+            description: "The amount of tokens being transferred"
+          - name: evt_tx_hash
+            description: "The transaction hash of the transfer event"
+          - name: evt_index
+            description: "The index of this event within the transaction"
+          - name: evt_block_time
+            description: "The timestamp of the block containing this transfer"
+          - name: evt_block_number
+            description: "The block number containing this transfer"
+
+      - name: evt_transferbatch
+        meta:
+          docs_slug: /evm/boba/raw/erc1155_transfers_batch
+          short_description: The evt_transferbatch table contains batch token transfer events from ERC1155 contracts on the Boba blockchain.
+        description: '{{ doc("erc1155_boba_evt_transfer_doc") }}'
+        columns:
+          - name: contract_address
+            description: "The address of the ERC1155 token contract"
+          - name: operator
+            description: "The address authorized to make the transfer"
+          - name: from
+            description: "The address sending the tokens"
+          - name: to
+            description: "The address receiving the tokens"
+          - name: ids
+            description: "The array of token identifiers being transferred"
+          - name: values
+            description: "The array of amounts being transferred for each token id"
+          - name: evt_tx_hash
+            description: "The transaction hash of the transfer event"
+          - name: evt_index
+            description: "The index of this event within the transaction"
+          - name: evt_block_time
+            description: "The timestamp of the block containing this transfer"
+          - name: evt_block_number
+            description: "The block number containing this transfer"

--- a/sources/_base_sources/evm/boba_docs_block.md
+++ b/sources/_base_sources/evm/boba_docs_block.md
@@ -160,3 +160,61 @@ This table is used for:
 It's essentially a filtered version of the `boba.traces` table where `type = create`.
 
 {% enddocs %}
+
+{% docs erc20_boba_evt_transfer_doc %}
+
+The `erc20_boba.evt_transfer` table contains Transfer events from ERC20 token contracts on the Boba blockchain. Each record represents a token transfer and includes:
+
+- Token contract address
+- Sender and recipient addresses
+- Amount of tokens transferred
+- Block and transaction information
+- Event log details
+
+This table is essential for:
+- Tracking token transfers and holder activity
+- Analyzing token distribution patterns
+- Monitoring token holder behavior
+- Calculating token balances
+- Understanding token velocity and liquidity
+
+{% enddocs %}
+
+{% docs erc721_boba_evt_transfer_doc %}
+
+The `erc721_boba.evt_transfer` table contains Transfer events from ERC721 (NFT) token contracts on the Boba blockchain. Each record represents an NFT transfer and includes:
+
+- NFT contract address
+- Token ID
+- Sender and recipient addresses
+- Block and transaction information
+- Event log details
+
+This table is used for:
+- Tracking NFT ownership changes
+- Analyzing NFT trading patterns
+- Monitoring NFT collection activity
+- Building NFT holder histories
+- Understanding NFT market dynamics
+
+{% enddocs %}
+
+{% docs erc1155_boba_evt_transfer_doc %}
+
+The `erc1155_boba.evt_transfersingle` and `erc1155_boba.evt_transferbatch` tables contain Transfer events from ERC1155 token contracts on the Boba blockchain. These tables track both fungible and non-fungible token transfers within the same contract. They include:
+
+- Token contract address
+- Token IDs
+- Amounts transferred
+- Sender, operator, and recipient addresses
+- Block and transaction information
+- Event log details
+
+These tables are essential for:
+- Tracking multi-token transfers
+- Analyzing gaming asset movements
+- Monitoring hybrid token systems
+- Understanding complex token ecosystems
+- Building token holder analytics
+
+{% enddocs %}


### PR DESCRIPTION
This pull request adds support for tracking ERC20, ERC721, and ERC1155 token transfer events on the Boba blockchain. The changes include updates to the source files and documentation to incorporate the new tables and their descriptions.

New tables for token transfers:

* [`sources/_base_sources/evm/boba_base_sources.yml`](diffhunk://#diff-ffff40478a1902012f4e5fea70b6216ac3c43c42ea62bd145e4b497061048ca3R336-R444): Added tables for `erc20_boba`, `erc721_boba`, and `erc1155_boba` to track transfer events of ERC20, ERC721, and ERC1155 tokens on the Boba blockchain. Each table includes detailed columns for contract address, sender, recipient, token details, and event metadata.

Documentation updates:

* [`sources/_base_sources/evm/boba_docs_block.md`](diffhunk://#diff-f852a0e20bb7bfb294da0233828430d157f7693bcde6877a17da606554a4fab6R163-R220): Added detailed documentation for the new `erc20_boba.evt_transfer`, `erc721_boba.evt_transfer`, and `erc1155_boba.evt_transfersingle` and `erc1155_boba.evt_transferbatch` tables. Each documentation section describes the table's purpose, the data it contains, and its use cases.