### PR TITLE
Nexus Mutual - Capital Pool rETH/ETH fix

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/capital_pool/nexusmutual_ethereum_capital_pool_totals.sql
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/capital_pool/nexusmutual_ethereum_capital_pool_totals.sql
@@ -273,7 +273,7 @@ daily_reth_eth_prices as (
   select
     date_trunc('day', call_block_time) as block_date,
     avg(output_0 / 1e18) as avg_reth_eth_price
-  from rocketpool_ethereum.RocketTokenRETH_call_getExchangeRate
+  from {{ source('rocketpool_ethereum', 'RocketTokenRETH_call_getExchangeRate') }}
   where call_block_time >= timestamp '2023-04-18'
   group by 1
 ),

--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/capital_pool/nexusmutual_ethereum_capital_pool_totals.sql
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/capital_pool/nexusmutual_ethereum_capital_pool_totals.sql
@@ -269,6 +269,15 @@ daily_avg_cbbtc_prices as (
   group by 1
 ),
 
+daily_reth_eth_prices as (
+  select
+    date_trunc('day', call_block_time) as block_date,
+    avg(output_0 / 1e18) as avg_reth_eth_price
+  from rocketpool_ethereum.RocketTokenRETH_call_getExchangeRate
+  where call_block_time >= timestamp '2023-04-18'
+  group by 1
+),
+
 day_sequence as (
   select cast(d.seq_date as timestamp) as block_date
   from (select sequence(date '2019-05-23', current_date, interval '1' day) as days) as days_s
@@ -337,7 +346,7 @@ daily_running_totals_enriched as (
     -- rETH
     coalesce(drt.reth_total, 0) as reth_total,
     coalesce(drt.reth_total * p_avg_reth.price_usd, 0) as avg_reth_usd_total,
-    coalesce(drt.reth_total * p_avg_reth.price_usd / p_avg_eth.price_usd, 0) as avg_reth_eth_total,
+    coalesce(drt.reth_total * p_reth_eth.avg_reth_eth_price, 0) as avg_reth_eth_total,
     -- USDC
     coalesce(drt.usdc_total, 0) as usdc_total,
     coalesce(drt.usdc_total * p_avg_usdc.price_usd, 0) as avg_usdc_usd_total,
@@ -362,6 +371,7 @@ daily_running_totals_enriched as (
     left join daily_avg_reth_prices p_avg_reth on drt.block_date = p_avg_reth.block_date
     left join daily_avg_usdc_prices p_avg_usdc on drt.block_date = p_avg_usdc.block_date
     left join daily_avg_cbbtc_prices p_avg_cbbtc on drt.block_date = p_avg_cbbtc.block_date
+    left join daily_reth_eth_prices p_reth_eth on drt.block_date = p_reth_eth.block_date
 )
 
 select

--- a/sources/rocketpool/ethereum/rocketpool_ethereum_sources.yml
+++ b/sources/rocketpool/ethereum/rocketpool_ethereum_sources.yml
@@ -1,0 +1,6 @@
+version: 2
+
+sources: 
+  - name: rocketpool_ethereum
+    tables:
+      - name: RocketTokenRETH_call_getExchangeRate


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Current rETH/ETH uses 2 hops through USD (rETH/USD -> USD/ETH), which is not the best approach.. Updating now to use `rocketpool_ethereum.RocketTokenRETH_call_getExchangeRate`


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
