### PR TITLE
Lifinity v2 transfers fix

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/lifinity/lifinity_v2_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/lifinity/lifinity_v2_base_trades.sql
@@ -45,7 +45,7 @@ WITH
                                 order by COALESCE(tr_2.inner_instruction_index, 0) asc) as first_transfer_out
         FROM {{ source('lifinity_amm_v2_solana', 'lifinity_amm_v2_call_swap') }} sp
         INNER JOIN {{ ref('tokens_solana_transfers') }} tr_1
-            ON tr_1.tx_id = sp.call_tx_id
+            ON tr_1.tx_id = sp.call_tx_id AND tr_1.action = 'transfer'
             AND tr_1.outer_instruction_index = sp.call_outer_instruction_index
             AND ((sp.call_is_inner = false AND tr_1.inner_instruction_index = 1)
                 OR (sp.call_is_inner = true AND tr_1.inner_instruction_index = sp.call_inner_instruction_index + 1))
@@ -57,7 +57,7 @@ WITH
             {% endif %}
         --swap out can be either 2nd or 3rd transfer.
         INNER JOIN {{ ref('tokens_solana_transfers') }} tr_2
-            ON tr_2.tx_id = sp.call_tx_id
+            ON tr_2.tx_id = sp.call_tx_id AND tr_2.action = 'transfer'
             AND tr_2.outer_instruction_index = sp.call_outer_instruction_index
             AND ((sp.call_is_inner = false AND (tr_2.inner_instruction_index = 2 OR tr_2.inner_instruction_index = 3))
                 OR (sp.call_is_inner = true AND (tr_2.inner_instruction_index = sp.call_inner_instruction_index + 2 OR tr_2.inner_instruction_index = sp.call_inner_instruction_index + 3))


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

there are instances where the token amounts are incorrectly attributing a mint instruction to the transfer instruction


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
