### PR TITLE
chore: add new chainswap deployers across all chains

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/chainswap/arbitrum/chain_swap_arbitrum_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/arbitrum/chain_swap_arbitrum_trades.sql
@@ -23,6 +23,7 @@
 {% set deployer_6 = '0xb252f0ab7bdf1be4d5bbf607eb5c220b2d902a2c' %}
 {% set deployer_7 = '0xa24e8cE77D4A7Ce869DA3730e6560BfB66553F94' %}
 {% set deployer_8 = '0xc8378819fbB95130c34D62f520167F745B13C305' %}
+{% set deployer_9 = '0xde7Cb3d58D4004ff0De70995C0604089cc945EAF' %}
 {% set weth_contract_address = '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1' %}
 {% set usdc_contract_address = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' %}
 {% set fee_recipient_1 = '0x415EEc63c95e944D544b3088bc682B759edB8548' %}
@@ -42,6 +43,7 @@ with
                 or "from" = {{ deployer_6 }}
                 or "from" = {{ deployer_7 }}
                 or "from" = {{ deployer_8 }}
+                or "from" = {{ deployer_9 }}
             )
             and block_time >= timestamp '{{project_start_date}}'
     ),

--- a/dbt_subprojects/daily_spellbook/models/chainswap/avalanche_c/chain_swap_avalanche_c_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/avalanche_c/chain_swap_avalanche_c_trades.sql
@@ -20,6 +20,7 @@
 {% set deployer_3 = '0xc1cc1a300Dcfe5359eBe37f2007A77d1F91533ba' %}
 {% set deployer_4 = '0xa24e8cE77D4A7Ce869DA3730e6560BfB66553F94' %}
 {% set deployer_5 = '0xc8378819fbB95130c34D62f520167F745B13C305' %}
+{% set deployer_6 = '0xde7Cb3d58D4004ff0De70995C0604089cc945EAF' %}
 {% set wavax_contract_address = '0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7' %}
 {% set usdc_contract_address = '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E' %}
 {% set fee_recipient_1 = '0x415EEc63c95e944D544b3088bc682B759edB8548' %}
@@ -36,6 +37,7 @@ with
                 or "from" = {{ deployer_3 }}
                 or "from" = {{ deployer_4 }}
                 or "from" = {{ deployer_5 }}
+                or "from" = {{ deployer_6 }}
             )
             and block_time >= timestamp '{{project_start_date}}'
     ),

--- a/dbt_subprojects/daily_spellbook/models/chainswap/base/chain_swap_base_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/base/chain_swap_base_trades.sql
@@ -22,6 +22,7 @@
 {% set deployer_5 = '0xb252f0ab7bdf1be4d5bbf607eb5c220b2d902a2c' %}
 {% set deployer_6 = '0xa24e8cE77D4A7Ce869DA3730e6560BfB66553F94' %}
 {% set deployer_7 = "0xc8378819fbB95130c34D62f520167F745B13C305" %}
+{% set deployer_8 = "0xde7Cb3d58D4004ff0De70995C0604089cc945EAF" %}
 {% set weth_contract_address = '0x4200000000000000000000000000000000000006' %}
 {% set usdc_contract_address = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' %}
 {% set fee_recipient_1 = '0x415EEc63c95e944D544b3088bc682B759edB8548' %}
@@ -40,6 +41,7 @@ with
                 or "from" = {{ deployer_5 }}
                 or "from" = {{ deployer_6 }}
                 or "from" = {{ deployer_7 }}
+                or "from" = {{ deployer_8 }}
             )
             and block_time >= timestamp '{{project_start_date}}'
     ),

--- a/dbt_subprojects/daily_spellbook/models/chainswap/bnb/chain_swap_bnb_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/bnb/chain_swap_bnb_trades.sql
@@ -19,6 +19,7 @@
 {% set deployer_2 = '0x3A510C5a32bCb381c53704AED9c02b0c70041F7A' %}
 {% set deployer_3 = '0xa24e8cE77D4A7Ce869DA3730e6560BfB66553F94' %}
 {% set deployer_4 = '0xc8378819fbB95130c34D62f520167F745B13C305' %}
+{% set deployer_5 = '0xde7Cb3d58D4004ff0De70995C0604089cc945EAF' %}
 {% set wbnb_contract_address = '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c' %}
 {% set usdc_contract_address = '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d' %}
 {% set fee_recipient_1 = '0x415EEc63c95e944D544b3088bc682B759edB8548' %}
@@ -34,6 +35,7 @@ with
                 or "from" = {{ deployer_2 }}
                 or "from" = {{ deployer_3 }}
                 or "from" = {{ deployer_4 }}
+                or "from" = {{ deployer_5 }}
             
             )
             and block_time >= timestamp '{{project_start_date}}'

--- a/dbt_subprojects/daily_spellbook/models/chainswap/ethereum/chain_swap_ethereum_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/ethereum/chain_swap_ethereum_trades.sql
@@ -22,6 +22,7 @@
 {% set deployer_5 = "0xa24e8cE77D4A7Ce869DA3730e6560BfB66553F94" %}
 {% set deployer_6 = "0x686c0072dF3Df7A13ef666a3b661803a48558A90" %}
 {% set deployer_7 = "0xc8378819fbB95130c34D62f520167F745B13C305" %}
+{% set deployer_8 = "0xde7Cb3d58D4004ff0De70995C0604089cc945EAF" %}
 {% set weth_contract_address = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2" %}
 {% set usdc_contract_address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" %}
 {% set usdt_contract_address = "0xdac17f958d2ee523a2206206994597c13d831ec7" %}
@@ -41,6 +42,7 @@ with
                 or "from" = {{ deployer_5 }}
                 or "from" = {{ deployer_6 }}
                 or "from" = {{ deployer_7 }}
+                or "from" = {{ deployer_8 }}
             )
             and block_time >= timestamp '{{project_start_date}}'
     ),

--- a/dbt_subprojects/daily_spellbook/models/chainswap/optimism/chain_swap_optimism_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/optimism/chain_swap_optimism_trades.sql
@@ -23,6 +23,7 @@
 {% set deployer_6 = '0x415EEc63c95e944D544b3088bc682B759edB8548' %}
 {% set deployer_7 = '0xa24e8cE77D4A7Ce869DA3730e6560BfB66553F94' %}
 {% set deployer_8 = '0xc8378819fbB95130c34D62f520167F745B13C305' %}
+{% set deployer_9 = '0xde7Cb3d58D4004ff0De70995C0604089cc945EAF' %}
 {% set weth_contract_address = '0x4200000000000000000000000000000000000006' %}
 {% set usdc_contract_address = '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85' %}
 {% set fee_recipient_1 = '0x415EEc63c95e944D544b3088bc682B759edB8548' %}
@@ -42,6 +43,7 @@ with
                 or "from" = {{ deployer_6 }}
                 or "from" = {{ deployer_7 }}
                 or "from" = {{ deployer_8 }}
+                or "from" = {{ deployer_9 }}
             )
             and block_time >= timestamp '{{project_start_date}}'
     ),

--- a/dbt_subprojects/daily_spellbook/models/chainswap/polygon/chain_swap_polygon_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/polygon/chain_swap_polygon_trades.sql
@@ -22,6 +22,7 @@
 {% set deployer_5 = '0xB7B953e81612c57256fF0aebD62B6a2F0546F7dA' %}
 {% set deployer_6 = '0xa24e8cE77D4A7Ce869DA3730e6560BfB66553F94' %}
 {% set deployer_7 = "0xc8378819fbB95130c34D62f520167F745B13C305" %}
+{% set deployer_8 = "0xde7Cb3d58D4004ff0De70995C0604089cc945EAF" %}
 {% set wmatic_contract_address = '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270' %}
 {% set usdc_contract_address = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359' %}
 {% set usdt_contract_address = '0xc2132d05d31c914a87c6611c10748aeb04b58e8f' %}
@@ -41,6 +42,7 @@ with
                 or "from" = {{ deployer_5 }}
                 or "from" = {{ deployer_6 }}
                 or "from" = {{ deployer_7 }}
+                or "from" = {{ deployer_8 }}
             )
             and block_time >= timestamp '{{project_start_date}}'
     ),


### PR DESCRIPTION
Adds missing deployer `0xde7Cb3d58D4004ff0De70995C0604089cc945EAF` for all chainswap router deployments

https://dune.com/whale_hunter/chainswap