### PR TITLE
Fix Typos and Add Clarity to Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Spellbook is built for and by the community, you are welcome to close any gaps t
 
 ## Docs
 
-Spellbook has a lot of moving parts & specific design principles for contributing to Dune's interpretation layer of data. In order to prepare contributors to participate most efficiently, the [docs](docs/) directory contains a wide ranging set of topics to answer common questions & provide info on why the repo is setup as it is. Please read & refer to this section when developing in Spellbook and questions arise. The Dune team will also link back to these docs to answer questions often, to help grow awareness and keep communications clean.
+Spellbook has a lot of moving parts & specific design principles for contributing to Dune's interpretation layer of data. In order to prepare contributors to participate most efficiently, the [docs](docs/) directory contains a wide-ranging set of topics to answer common questions & provide info on why the repo is setup as it is. Please read & refer to this section when developing in Spellbook and questions arise. The Dune team will also link back to these docs to answer questions often, to help grow awareness and keep communications clean.
 
 ## Sub-projects
 

--- a/docs/general/best_practices.md
+++ b/docs/general/best_practices.md
@@ -15,7 +15,7 @@
 ## Incremental model setup
 - Make sure your unique key columns are *exactly* the same in the model config block, schema yml file, and seed match columns (where applicable)
 - There cannot be nulls in the unique key columns
-    - Be sure to double check key columns are correct or `COALESCE()` as needed on key column(s), otherwise the tests may fail on duplicates
+    - Be sure to double-check key columns are correct or `COALESCE()` as needed on key column(s), otherwise the tests may fail on duplicates
 
 ## 🪄 Use the built CI tables for testing 🪄
 

--- a/docs/macros/macro_overview.md
+++ b/docs/macros/macro_overview.md
@@ -55,7 +55,7 @@ Within models, such as uniswap v2, call macro code with [this approach](/dbt_sub
    - Macros with lists for for-loops in models, like [`all_evm_chains`](/dbt_macros/shared/all_evm_chains.sql).
 3. **Dune Team Specific Cases** (`dbt_macros/dune`)
    - Overriding dbt-trino core macros for Spellbook-specific scenarios.
-   - Backend database specific code in pre or post hooks for spell optimization.
+   - Backend database specific code in pre- or post-hooks for spell optimization.
 
 ## Future Developments
 


### PR DESCRIPTION
This pull request addresses several documentation improvements:

1. **`README.md`**: Corrected "wide ranging" to "wide-ranging" for grammatical accuracy.  
2. **`best_practices.md`**: Updated "double check" to "double-check" to follow standard verb usage.  
3. **`macro_overview.md`**: Adjusted "pre or post hooks" to "pre- or post-hooks" for clarity and proper formatting.  
