### PR TITLE
Update lifinity_v1_base_trades.sql

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/lifinity/lifinity_v1_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/lifinity/lifinity_v1_base_trades.sql
@@ -45,7 +45,7 @@ WITH
                                 order by COALESCE(tr_2.inner_instruction_index, 0) asc) as first_transfer_out
         FROM {{ source('lifinity_amm_solana', 'lifinity_amm_call_swap') }} sp
         INNER JOIN {{ ref('tokens_solana_transfers') }} tr_1
-            ON tr_1.tx_id = sp.call_tx_id
+            ON tr_1.tx_id = sp.call_tx_id AND tr_1.action = 'transfer'
             AND tr_1.outer_instruction_index = sp.call_outer_instruction_index
             AND ((sp.call_is_inner = false AND tr_1.inner_instruction_index = 1)
                 OR (sp.call_is_inner = true AND tr_1.inner_instruction_index = sp.call_inner_instruction_index + 1))
@@ -57,7 +57,7 @@ WITH
             {% endif %}
         --swap out can be either 2nd or 3rd transfer.
         INNER JOIN {{ ref('tokens_solana_transfers') }} tr_2
-            ON tr_2.tx_id = sp.call_tx_id
+            ON tr_2.tx_id = sp.call_tx_id AND tr_2.action = 'transfer'
             AND tr_2.outer_instruction_index = sp.call_outer_instruction_index
             AND ((sp.call_is_inner = false AND (tr_2.inner_instruction_index = 2 OR tr_2.inner_instruction_index = 3))
                 OR (sp.call_is_inner = true AND (tr_2.inner_instruction_index = sp.call_inner_instruction_index + 2 OR tr_2.inner_instruction_index = sp.call_inner_instruction_index + 3))


### PR DESCRIPTION
there are instances where the token amounts are incorrectly attributing a mint instruction to the transfer instruction

to get an idea of the issue you can see an example trade here:
```
SELECT 
    *
FROM dex_solana.trades
WHERE 
    date_trunc('week', block_time) = TIMESTAMP '2023-11-06'
    AND project = 'lifinity' and token_pair is null AND token_bought_mint_address = '8gz8AFF1w6DDvhpdmq6SRqUydNGju94CEtrty4Fnu6Qa'
LIMIT 10 
```

also see: https://github.com/duneanalytics/spellbook/pull/7266

it seems the mint action is getting picked up because of the way the joins are done. We can filter for transfer actions to get rid of the possibility of picking up the mint amounts by accident