### PR TITLE
feat: add wstETH to trusted tokens

### DIFF
--- a/dbt_subprojects/tokens/models/prices/_schema.yml
+++ b/dbt_subprojects/tokens/models/prices/_schema.yml
@@ -195,6 +195,11 @@ models:
     config:
       tags: [ 'prices', 'stability' ]
     description: "List of trusted tokens across blockchains"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - contract_address
 
   - name: prices_usd_trusted_tokens
     meta:

--- a/dbt_subprojects/tokens/models/prices/prices_trusted_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_trusted_tokens.sql
@@ -67,6 +67,7 @@ WITH trusted_tokens AS (
                 , ('ethereum', 0x6b175474e89094c44da98b954eedeac495271d0f)
                 , ('ethereum', 0x2260fac5e5542a773aa44fbcfedf7c193bc2c599)
                 , ('ethereum', 0xf939e0a03fb07f59a73314e73794be0e57ac1b4e)
+                , ('ethereum', 0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0) -- wstETH
                 , ('fantom', 0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83)
                 , ('flare', 0x1D80c49BbBCd1C0911346656B529DF9E5c2F783d)
                 , ('fantom', 0x04068da6c83afcfa0e13ba15a6696662335d5b75)


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

wstETH (Wrapped liquid staked Ether) by Lido has a market cap of over 16 billion (ref 1). It is commonly used as a quote token on Curve, particularly in pools involving LSTs or LRTs.
Enabling wstETH to be included as a trusted token would facilitate the development of price feeds for tokens currently only 
 available on Curve, such as ynETH

References:
1. [Etherscan](https://etherscan.io/token/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0)
2. [Curve](https://curve.fi/#/ethereum/pools?search=0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0)

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
