### PR TITLE
enrich balancer_v3 trades on dex.trades

### DIFF
--- a/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
+++ b/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
@@ -74,7 +74,6 @@ WITH base_trades as (
             APPROX_PERCENTILE(median_price, 0.5) AS price,
             LEAD(minute, 1, NOW()) OVER (PARTITION BY wrapped_token ORDER BY minute) AS time_of_next_change
         FROM {{ source('balancer_v3', 'erc4626_token_prices') }}
-        WHERE blockchain = 'ethereum'
         GROUP BY 1, 2, 3, 4
 )
 

--- a/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
+++ b/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
@@ -75,7 +75,7 @@ WITH base_trades as (
             LEAD(minute, 1, NOW()) OVER (PARTITION BY wrapped_token ORDER BY minute) AS time_of_next_change
         FROM {{ source('balancer_v3', 'erc4626_token_prices') }}
         WHERE blockchain = 'ethereum'
-        GROUP BY 1, 2, 3
+        GROUP BY 1, 2, 3, 4
 )
 
 SELECT

--- a/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
+++ b/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
@@ -78,7 +78,7 @@ WITH base_trades as (
 )
 
 SELECT
-    blockchain
+    dexs.blockchain
     , project
     , version
     , block_month

--- a/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
+++ b/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
@@ -1,0 +1,123 @@
+{% macro enrich_balancer_v3_dex_trades(
+    base_trades = null
+    , filter = null
+    , tokens_erc20_model = null
+    )
+%}
+
+WITH base_trades as (
+    SELECT
+        *
+    FROM
+        {{ base_trades }}
+    WHERE
+        {{ filter }}
+    {% if is_incremental() %}
+    AND
+        {{ incremental_predicate('block_time') }}
+    {% endif %}
+)
+, enrichments AS (
+    SELECT
+        base_trades.blockchain
+        , base_trades.project
+        , base_trades.version
+        , base_trades.block_month
+        , base_trades.block_date
+        , base_trades.block_time
+        , base_trades.block_number
+        , erc20_bought.symbol AS token_bought_symbol
+        , erc20_sold.symbol AS token_sold_symbol
+        , CASE
+            WHEN lower(erc20_bought.symbol) > lower(erc20_sold.symbol) THEN concat(erc20_sold.symbol, '-', erc20_bought.symbol)
+            ELSE concat(erc20_bought.symbol, '-', erc20_sold.symbol)
+            END AS token_pair
+        , base_trades.token_bought_amount_raw / power(10, erc20_bought.decimals) AS token_bought_amount
+        , base_trades.token_sold_amount_raw / power(10, erc20_sold.decimals) AS token_sold_amount
+        , base_trades.token_bought_amount_raw
+        , base_trades.token_sold_amount_raw
+        , base_trades.token_bought_address
+        , base_trades.token_sold_address
+        , coalesce(base_trades.taker, base_trades.tx_from) AS taker
+        , base_trades.maker
+        , base_trades.project_contract_address
+        , base_trades.tx_hash
+        , base_trades.tx_from
+        , base_trades.tx_to
+        , base_trades.evt_index
+    FROM
+        base_trades
+    LEFT JOIN
+        {{ tokens_erc20_model }} as erc20_bought
+        ON erc20_bought.contract_address = base_trades.token_bought_address
+        AND erc20_bought.blockchain = base_trades.blockchain
+    LEFT JOIN
+        {{ tokens_erc20_model }} as erc20_sold
+        ON erc20_sold.contract_address = base_trades.token_sold_address
+        AND erc20_sold.blockchain = base_trades.blockchain
+)
+
+, enrichments_with_prices AS (
+    {{
+        add_amount_usd(
+            trades_cte = 'enrichments'
+        )
+    }}
+)
+
+,  erc4626_prices AS(
+        SELECT
+            minute,
+            blockchain,
+            wrapped_token,
+            decimals,
+            APPROX_PERCENTILE(median_price, 0.5) AS price,
+            LEAD(minute, 1, NOW()) OVER (PARTITION BY wrapped_token ORDER BY minute) AS time_of_next_change
+        FROM {{ source('balancer_v3', 'erc4626_token_prices') }}
+        WHERE blockchain = 'ethereum'
+        GROUP BY 1, 2, 3
+)
+
+SELECT
+    blockchain
+    , project
+    , version
+    , block_month
+    , block_date
+    , block_time
+    , block_number
+    , token_bought_symbol
+    , token_sold_symbol
+    , token_pair
+    , token_bought_amount
+    , token_sold_amount
+    , token_bought_amount_raw
+    , token_sold_amount_raw
+    , COALESCE(
+        dexs.amount_usd,
+        dexs.token_bought_amount * erc4626a.price,
+        dexs.token_sold_amount * erc4626a.price
+    ) AS amount_usd
+    , token_bought_address
+    , token_sold_address
+    , taker
+    , maker
+    , project_contract_address
+    , tx_hash
+    , tx_from
+    , tx_to
+    , evt_index
+FROM
+    enrichments_with_prices dexs
+LEFT JOIN erc4626_prices erc4626a
+        ON erc4626a.wrapped_token = dexs.token_bought_address
+        AND erc4626a.minute <= dexs.block_time
+        AND dexs.block_time < erc4626a.time_of_next_change
+        AND dexs.blockchain = erc4626a.blockchain
+LEFT JOIN erc4626_prices erc4626b
+        ON erc4626b.wrapped_token = dexs.token_sold_address
+        AND erc4626b.minute <= dexs.block_time
+        AND dexs.block_time < erc4626b.time_of_next_change   
+        AND dexs.blockchain = erc4626b.blockchain
+    
+{% endmacro %}

--- a/dbt_subprojects/dex/models/trades/_schema.yml
+++ b/dbt_subprojects/dex/models/trades/_schema.yml
@@ -7,7 +7,7 @@ models:
       blockchain: arbitrum, avalanche_c, base, bnb, celo, ethereum, fantom, gnosis, kaia, optimism, polygon, scroll, zksync, linea, blast, sei, ronin
       sector: dex
       short_description: The `dex.trades` table captures detailed data on trades executed via decentralized exchanges (DEXs). This table contains a detailed breakdown of trade execution containing one or many trades per transaction. 
-      contributors: 0xRob, hosuke, jeff-dude, tomfutago
+      contributors: 0xRob, hosuke, jeff-dude, tomfutago, viniabussafi
     config:
       tags: [ 'dex', 'trades']
     description: '{{ doc("dex_trades_doc") }}'

--- a/dbt_subprojects/dex/models/trades/dex_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_trades.sql
@@ -46,7 +46,7 @@ WITH curve AS (
     {{
         enrich_curve_dex_trades(
             base_trades = ref('dex_base_trades')
-            , filter = "project = 'curve'"
+            , filter = "project = 'curve' AND block_date = TIMESTAMP '2024-12-17'"
             , curve_ethereum = ref('curve_ethereum_base_trades')
             , curve_optimism = ref('curve_optimism_base_trades')
             , tokens_erc20_model = source('tokens', 'erc20')
@@ -58,7 +58,7 @@ WITH curve AS (
     {{
         enrich_balancer_v3_dex_trades(
             base_trades = ref('dex_base_trades')
-            , filter = "project = 'balancer' AND version = '3'"
+            , filter = "project = 'balancer' AND version = '3' AND block_date = TIMESTAMP '2024-12-17'"
             , tokens_erc20_model = source('tokens', 'erc20')
         )
     }}
@@ -67,7 +67,7 @@ WITH curve AS (
     {{
         enrich_dex_trades(
             base_trades = ref('dex_base_trades')
-            , filter = "project != 'curve' AND (project != 'balancer' AND version != '3')"
+            , filter = "project != 'curve' AND (project != 'balancer' AND version != '3') AND block_date = TIMESTAMP '2024-12-17'"
             , tokens_erc20_model = source('tokens', 'erc20')
         )
     }}

--- a/dbt_subprojects/dex/models/trades/dex_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_trades.sql
@@ -116,6 +116,7 @@ WITH curve AS (
     'curve'
     , 'as_is_dexs'
     , 'dexs'
+    , 'balancer_v3'
     ]
 %}
 

--- a/dbt_subprojects/dex/models/trades/dex_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_trades.sql
@@ -53,11 +53,21 @@ WITH curve AS (
         )
     }}
 )
+,balancer_v3 AS (
+    -- due to Balancer V3 having trades between ERC4626 tokens, which won't be priced on prices.usd, enrich separately
+    {{
+        enrich_balancer_v3_dex_trades(
+            base_trades = ref('dex_base_trades')
+            , filter = "project = 'balancer' AND version = '3'"
+            , tokens_erc20_model = source('tokens', 'erc20')
+        )
+    }}
+)
 , dexs AS (
     {{
         enrich_dex_trades(
             base_trades = ref('dex_base_trades')
-            , filter = "project != 'curve'"
+            , filter = "project != 'curve' AND (project != 'balancer AND version != '3'"
             , tokens_erc20_model = source('tokens', 'erc20')
         )
     }}

--- a/dbt_subprojects/dex/models/trades/dex_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_trades.sql
@@ -67,7 +67,7 @@ WITH curve AS (
     {{
         enrich_dex_trades(
             base_trades = ref('dex_base_trades')
-            , filter = "project != 'curve' AND (project != 'balancer AND version != '3'"
+            , filter = "project != 'curve' AND (project != 'balancer AND version != '3')"
             , tokens_erc20_model = source('tokens', 'erc20')
         )
     }}

--- a/dbt_subprojects/dex/models/trades/dex_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_trades.sql
@@ -32,7 +32,7 @@
                                     ]\',
                                     "sector",
                                     "dex",
-                                    \'["hosuke", "0xrob", "jeff-dude", "tomfutago"]\') }}')
+                                    \'["hosuke", "0xrob", "jeff-dude", "tomfutago", "viniabussafi"]\') }}')
 }}
 
 -- keep existing dbt lineages for the following projects, as the team built themselves and use the spells throughout the entire lineage
@@ -58,7 +58,7 @@ WITH curve AS (
     {{
         enrich_balancer_v3_dex_trades(
             base_trades = ref('dex_base_trades')
-            , filter = "project = 'balancer' AND version = '3' AND block_date = TIMESTAMP '2024-12-17'"
+            , filter = "(project = 'balancer' AND version = '3') AND block_date = TIMESTAMP '2024-12-17'"
             , tokens_erc20_model = source('tokens', 'erc20')
         )
     }}
@@ -67,7 +67,7 @@ WITH curve AS (
     {{
         enrich_dex_trades(
             base_trades = ref('dex_base_trades')
-            , filter = "project != 'curve' AND (project != 'balancer' AND version != '3') AND block_date = TIMESTAMP '2024-12-17'"
+            , filter = "project != 'curve' AND NOT (project = 'balancer' AND version = '3') AND block_date = TIMESTAMP '2024-12-17'"
             , tokens_erc20_model = source('tokens', 'erc20')
         )
     }}

--- a/dbt_subprojects/dex/models/trades/dex_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_trades.sql
@@ -53,7 +53,7 @@ WITH curve AS (
         )
     }}
 )
-,balancer_v3 AS (
+, balancer_v3 AS (
     -- due to Balancer V3 having trades between ERC4626 tokens, which won't be priced on prices.usd, enrich separately
     {{
         enrich_balancer_v3_dex_trades(
@@ -67,7 +67,7 @@ WITH curve AS (
     {{
         enrich_dex_trades(
             base_trades = ref('dex_base_trades')
-            , filter = "project != 'curve' AND (project != 'balancer AND version != '3')"
+            , filter = "project != 'curve' AND (project != 'balancer' AND version != '3')"
             , tokens_erc20_model = source('tokens', 'erc20')
         )
     }}


### PR DESCRIPTION
### Description:

Balancer V3 was launched a week ago and has [100% Boosted Pools](https://docs.balancer.fi/concepts/explore-available-balancer-pools/boosted-pool.html#advantages-of-boosted-pools) as one of it's flagships. The complication we're facing here is, when ERC4626 tokens (see ELI5) are traded against other ERC4626 tokens, the `amount_usd` column in dex.trades is null.
This PR introduces the same logic currently used on [balancer.trades](https://github.com/duneanalytics/spellbook/blob/main/dbt_subprojects/dex/models/_projects/balancer/trades/gnosis/balancer_v3_gnosis_trades.sql) to dex.trades, using a new macro to handle swaps on Balancer V3.
I'd hate to be the one to break dex.trades, so 100% open for suggestions here, this is just an initial idea.

### ELI5 on ERC4626 tokens
the ELI5 is that these tokens are basically receipt tokens from deposits into lending protocols (like aave and morpho). This means that liquidity providers can deposit into a pool with Wrapped AAVE wstETh / Wrapped AAVE WETH. So, the path would be the LP would deposit weth and/or wsteth and get exposed to both the yields on AAVE for both tokens + swap fees on swaps happening on the pool. 
These tokens are priced based on how much Wrapped AAVE WETH you get after depositing WETH (on wrap and unwrap events), multiplied by the price of WETH at that time, like we do [here](https://github.com/duneanalytics/spellbook/blob/cccc1a238a2cfba777db9c11f7664da14bc57440/dbt_subprojects/hourly_spellbook/models/_project/balancer/erc4626_tokens/ethereum/balancer_v3_ethereum_erc4626_token_prices.sql)
That's why these tokens aren't on coinpaprika (and probably will never be).

Example of 100% Boosted Pools: https://balancer.fi/pools/ethereum/v3/0xc4ce391d82d164c166df9c8336ddf84206b2f812
Current trades where amount_usd = 0 on dex.trades: https://dune.com/queries/4445360

tagging @mendesfabio for visibility/comments