### PR TITLE
Fix for kyberswap aggregator: ignore 1 specific token

### DIFF
--- a/dbt_subprojects/dex/models/_projects/kyberswap/avalanche_c/kyberswap_aggregator_avalanche_c_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/kyberswap/avalanche_c/kyberswap_aggregator_avalanche_c_trades.sql
@@ -1,6 +1,6 @@
 {{ config
 (
-    
+
     schema = 'kyberswap_aggregator_avalanche_c',
     alias = 'trades',
     partition_by = ['block_month'],
@@ -36,6 +36,9 @@ WITH meta_router AS
             ,ARRAY[-1]              AS trace_address
         FROM
             {{ source('kyber_avalanche_c', 'MetaAggregationRouterV2_evt_Swapped') }}
+        WHERE 0x250f8f7750735e3ab5dc9db3a542f6b71999ed38 not in (dstToken, srcToken)
+        -- There are 2 weird transactions with this token where the return and spent amounts in the event are not correct
+        -- these result in inflated volume, so we'll ignore this token in any trades.
         {% if is_incremental() %}
         WHERE evt_block_time >= date_trunc('day', now() - INTERVAL '7' DAY)
         {% endif %}

--- a/dbt_subprojects/dex/models/_projects/kyberswap/avalanche_c/kyberswap_aggregator_avalanche_c_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/kyberswap/avalanche_c/kyberswap_aggregator_avalanche_c_trades.sql
@@ -40,7 +40,7 @@ WITH meta_router AS
         -- There are 2 weird transactions with this token where the return and spent amounts in the event are not correct
         -- these result in inflated volume, so we'll ignore this token in any trades.
         {% if is_incremental() %}
-        WHERE evt_block_time >= date_trunc('day', now() - INTERVAL '7' DAY)
+        AND evt_block_time >= date_trunc('day', now() - INTERVAL '7' DAY)
         {% endif %}
 )
 SELECT


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:
       
 -- There are 2 weird transactions with this token where the return and spent amounts in the event are not correct
  -- these result in inflated volume, so we'll ignore this token in any trades.
tx hashes:
0x63c631b8bb2fd076e7593bd0a0f9221ca3dadd635198e7f65c4971d5e22d6e1e
0x9e716a5ce8aaa89d0f9ff864bb5223cf48d2cd9af08c50ba852e82469e829e26


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
