### PR TITLE
Remove timestamp filters in dex.trades enrichment

### DIFF
--- a/dbt_subprojects/dex/models/trades/dex_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_trades.sql
@@ -46,7 +46,7 @@ WITH curve AS (
     {{
         enrich_curve_dex_trades(
             base_trades = ref('dex_base_trades')
-            , filter = "project = 'curve' AND block_date = TIMESTAMP '2024-12-17'"
+            , filter = "project = 'curve'"
             , curve_ethereum = ref('curve_ethereum_base_trades')
             , curve_optimism = ref('curve_optimism_base_trades')
             , tokens_erc20_model = source('tokens', 'erc20')
@@ -58,7 +58,7 @@ WITH curve AS (
     {{
         enrich_balancer_v3_dex_trades(
             base_trades = ref('dex_base_trades')
-            , filter = "(project = 'balancer' AND version = '3') AND block_date = TIMESTAMP '2024-12-17'"
+            , filter = "(project = 'balancer' AND version = '3')"
             , tokens_erc20_model = source('tokens', 'erc20')
         )
     }}
@@ -67,7 +67,7 @@ WITH curve AS (
     {{
         enrich_dex_trades(
             base_trades = ref('dex_base_trades')
-            , filter = "project != 'curve' AND NOT (project = 'balancer' AND version = '3') AND block_date = TIMESTAMP '2024-12-17'"
+            , filter = "project != 'curve' AND NOT (project = 'balancer' AND version = '3')"
             , tokens_erc20_model = source('tokens', 'erc20')
         )
     }}


### PR DESCRIPTION
A bug was introduced in https://github.com/duneanalytics/spellbook/pull/7350 where we forgot to remove the timestamp filters used during testing.