### PR TITLE
Aave v2/v3 `lending.supply` macro fix - add WrappedTokenGateway lookup

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/ethereum/platforms/aave_lido_v3_ethereum_base_supply.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/ethereum/platforms/aave_lido_v3_ethereum_base_supply.sql
@@ -15,6 +15,7 @@
     blockchain = 'ethereum',
     project = 'aave_lido',
     version = '3',
-    decoded_contract_name = 'LidoPool'
+    decoded_contract_name = 'LidoPool',
+    decoded_wrapped_token_gateway_name = 'LidoWrappedTokenGatewayV3'
   )
 }}

--- a/sources/_sector/lending/supply/arbitrum/_sources.yml
+++ b/sources/_sector/lending/supply/arbitrum/_sources.yml
@@ -5,6 +5,7 @@ sources:
     tables:
       - name: L2Pool_evt_Supply
       - name: L2Pool_evt_Withdraw
+      - name: WrappedTokenGatewayV3_call_withdrawETH
 
   - name: compound_v3_arbitrum
     tables:

--- a/sources/_sector/lending/supply/avalanche_c/_sources.yml
+++ b/sources/_sector/lending/supply/avalanche_c/_sources.yml
@@ -6,12 +6,14 @@ sources:
       - name: LendingPool_evt_Deposit
       - name: LendingPool_evt_Withdraw
       - name: LendingPool_evt_RedeemUnderlying
+      - name: WrappedTokenGatewayV2_call_withdrawETH
 
   - name: aave_v3_avalanche_c
     tables:
       - name: Pool_evt_Supply
       - name: Pool_evt_Withdraw
       - name: Pool_evt_RedeemUnderlying
+      - name: WrappedTokenGatewayV3_call_withdrawETH
 
   - name: benqi_finance_avalanche_c
     tables:

--- a/sources/_sector/lending/supply/base/_sources.yml
+++ b/sources/_sector/lending/supply/base/_sources.yml
@@ -6,6 +6,7 @@ sources:
       - name: L2Pool_evt_Supply
       - name: L2Pool_evt_Withdraw
       - name: L2Pool_evt_RedeemUnderlying
+      - name: WrappedTokenGatewayV3_call_withdrawETH
 
   - name: compound_v3_base
     tables:

--- a/sources/_sector/lending/supply/bnb/_sources.yml
+++ b/sources/_sector/lending/supply/bnb/_sources.yml
@@ -10,6 +10,7 @@ sources:
     tables:
       - name: Pool_evt_Supply
       - name: Pool_evt_Withdraw
+      - name: WrappedTokenGatewayV3_call_withdrawETH
 
   - name: the_granary_bnb
     tables:

--- a/sources/_sector/lending/supply/ethereum/_sources.yml
+++ b/sources/_sector/lending/supply/ethereum/_sources.yml
@@ -11,21 +11,25 @@ sources:
     tables:
       - name: LendingPool_evt_Deposit
       - name: LendingPool_evt_Withdraw
+      - name: WrappedTokenGatewayV2_call_withdrawETH
 
   - name: aave_v3_ethereum
     tables:
       - name: Pool_evt_Supply
       - name: Pool_evt_Withdraw
       - name: Pool_evt_ReserveDataUpdated
+      - name: WrappedTokenGatewayV3_call_withdrawETH
       - name: LidoPool_evt_Supply
       - name: LidoPool_evt_Withdraw
       - name: LidoPool_evt_ReserveDataUpdated
+      - name: LidoWrappedTokenGatewayV3_call_withdrawETH
 
   - name: aave_v3_etherfi_ethereum
     tables:
       - name: PoolInstance_evt_Supply
       - name: PoolInstance_evt_Withdraw
       - name: PoolInstance_evt_ReserveDataUpdated
+      - name: WrappedTokenGatewayV3_call_withdrawETH
 
   - name: compound_v2_ethereum
     tables:

--- a/sources/_sector/lending/supply/fantom/_sources.yml
+++ b/sources/_sector/lending/supply/fantom/_sources.yml
@@ -6,6 +6,7 @@ sources:
       - name: Pool_evt_Supply
       - name: Pool_evt_Withdraw
       - name: Pool_evt_RedeemUnderlying
+      - name: WrappedTokenGatewayV3_call_withdrawETH
 
   - name: the_granary_fantom
     tables:

--- a/sources/_sector/lending/supply/gnosis/_sources.yml
+++ b/sources/_sector/lending/supply/gnosis/_sources.yml
@@ -10,6 +10,7 @@ sources:
     tables:
       - name: Pool_evt_Supply
       - name: Pool_evt_Withdraw
+      - name: WrappedTokenGatewayV3_call_withdrawETH
 
   - name: real_rmm_v1_gnosis
     tables:

--- a/sources/_sector/lending/supply/optimism/_sources.yml
+++ b/sources/_sector/lending/supply/optimism/_sources.yml
@@ -6,6 +6,7 @@ sources:
       - name: Pool_evt_Supply
       - name: Pool_evt_Withdraw
       - name: Pool_evt_RedeemUnderlying
+      - name: WrappedTokenGatewayV3_call_withdrawETH
 
   - name: sonne_finance_optimism
     tables:

--- a/sources/_sector/lending/supply/polygon/_sources.yml
+++ b/sources/_sector/lending/supply/polygon/_sources.yml
@@ -6,12 +6,14 @@ sources:
       - name: LendingPool_evt_Deposit
       - name: LendingPool_evt_Withdraw
       - name: LendingPool_evt_RedeemUnderlying
+      - name: WrappedTokenGatewayV2_call_withdrawETH
 
   - name: aave_v3_polygon
     tables:
       - name: Pool_evt_Supply
       - name: Pool_evt_Withdraw
       - name: Pool_evt_RedeemUnderlying
+      - name: WrappedTokenGatewayV3_call_withdrawETH
 
   - name: compound_v3_polygon
     tables:

--- a/sources/_sector/lending/supply/scroll/_sources.yml
+++ b/sources/_sector/lending/supply/scroll/_sources.yml
@@ -5,6 +5,7 @@ sources:
     tables:
       - name: L2Pool_evt_Supply
       - name: L2Pool_evt_Withdraw
+      - name: WrappedTokenGatewayV3_call_withdrawETH
 
   - name: layer_bank_scroll
     tables:


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Current logic for withdrawals on Aave v2/v3 defaults `withdrawn_to` to `WrappedTokenGateway` contract address, but doesn't show lender's address. This PR aims to fix this and output lender's address in `on_behalf_of` column (currently `null`).

Note: not all Aave forks use `WrappedTokenGateway` contract address in their implementation of the protocol, so this fix is applied only to Aave for the time being. Forks can be revisited later on.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
