### PR TITLE
feat(dex): Add Velodrome v2 Concentrated Liquidity pools support

### DIFF
--- a/dbt_subprojects/dex/models/trades/optimism/platforms/velodrome_optimism_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/optimism/platforms/velodrome_optimism_base_trades.sql
@@ -38,7 +38,7 @@ dexs_v2 AS (
 ),
 
 dexs_v2_cl AS (
-        {{
+    {{
         uniswap_compatible_v3_trades(
             blockchain = 'optimism',
             project = 'velodrome',
@@ -51,58 +51,62 @@ dexs_v2_cl AS (
 )
 
 SELECT
-    dexs_v1.blockchain,
-    dexs_v1.project,
-    dexs_v1.version,
-    dexs_v1.block_month,
-    dexs_v1.block_date,
-    dexs_v1.block_time,
-    dexs_v1.block_number,
-    dexs_v1.token_bought_amount_raw,
-    dexs_v1.token_sold_amount_raw,
-    dexs_v1.token_bought_address,
-    dexs_v1.token_sold_address,
-    dexs_v1.taker,
-    dexs_v1.maker,
-    dexs_v1.project_contract_address,
-    dexs_v1.tx_hash,
-    dexs_v1.evt_index
+    blockchain,
+    project,
+    version,
+    block_month,
+    block_date,
+    block_time,
+    block_number,
+    token_bought_amount_raw,
+    token_sold_amount_raw,
+    token_bought_address,
+    token_sold_address,
+    taker,
+    maker,
+    project_contract_address,
+    tx_hash,
+    evt_index
 FROM dexs_v1
+
 UNION ALL
+
 SELECT
-    dexs_v2.blockchain,
-    dexs_v2.project,
-    dexs_v2.version,
-    dexs_v2.block_month,
-    dexs_v2.block_date,
-    dexs_v2.block_time,
-    dexs_v2.block_number,
-    dexs_v2.token_bought_amount_raw,
-    dexs_v2.token_sold_amount_raw,
-    dexs_v2.token_bought_address,
-    dexs_v2.token_sold_address,
-    dexs_v2.taker,
-    dexs_v2.maker,
-    dexs_v2.project_contract_address,
-    dexs_v2.tx_hash,
-    dexs_v2.evt_index
+    blockchain,
+    project,
+    version,
+    block_month,
+    block_date,
+    block_time,
+    block_number,
+    token_bought_amount_raw,
+    token_sold_amount_raw,
+    token_bought_address,
+    token_sold_address,
+    taker,
+    maker,
+    project_contract_address,
+    tx_hash,
+    evt_index
 FROM dexs_v2
+
 UNION ALL
+
 SELECT
-    dexs_v2_cl.blockchain,
-    dexs_v2_cl.project,
-    dexs_v2_cl.version,
-    dexs_v2_cl.block_month,
-    dexs_v2_cl.block_date,
-    dexs_v2_cl.block_time,
-    dexs_v2_cl.block_number,
-    dexs_v2_cl.token_bought_amount_raw,
-    dexs_v2_cl.token_sold_amount_raw,
-    dexs_v2_cl.token_bought_address,
-    dexs_v2_cl.token_sold_address,
-    dexs_v2_cl.taker,
-    dexs_v2_cl.maker,
-    dexs_v2_cl.project_contract_address,
-    dexs_v2_cl.tx_hash,
-    dexs_v2_cl.evt_index
+    blockchain,
+    project,
+    version,
+    block_month,
+    block_date,
+    block_time,
+    block_number,
+    token_bought_amount_raw,
+    token_sold_amount_raw,
+    token_bought_address,
+    token_sold_address,
+    taker,
+    maker,
+    project_contract_address,
+    tx_hash,
+    evt_index
 FROM dexs_v2_cl

--- a/dbt_subprojects/dex/models/trades/optimism/platforms/velodrome_optimism_base_trades.yml
+++ b/dbt_subprojects/dex/models/trades/optimism/platforms/velodrome_optimism_base_trades.yml
@@ -1,0 +1,75 @@
+version: 2
+
+models:
+  - name: velodrome_optimism_base_trades
+    meta:
+      blockchain: optimism
+      project: velodrome
+      contributors: ['IvyLabs-Analytics', 'crStiv']
+    config:
+      tags: ['optimism','velodrome','dex','trades']
+    description: >
+      Velodrome v1 and v2 trades on Optimism including both regular and concentrated liquidity pools
+    columns:
+      - name: blockchain
+        description: "Blockchain which the DEX is deployed on"
+        tests:
+          - not_null
+      - name: project
+        description: "Project name"
+        tests:
+          - not_null
+      - name: version
+        description: "Version of the contract (1, 2, or 2_cl for concentrated liquidity pools)"
+        tests:
+          - not_null
+      - name: block_month
+        description: "UTC month of the block time"
+        tests:
+          - not_null
+      - name: block_date
+        description: "UTC date of the block time"
+        tests:
+          - not_null
+      - name: block_time
+        description: "UTC timestamp of the block time"
+        tests:
+          - not_null
+      - name: block_number
+        description: "Block number"
+        tests:
+          - not_null
+      - name: token_bought_amount_raw
+        description: "Raw amount of tokens bought (not normalized)"
+        tests:
+          - not_null
+      - name: token_sold_amount_raw
+        description: "Raw amount of tokens sold (not normalized)"
+        tests:
+          - not_null
+      - name: token_bought_address
+        description: "Contract address of the token bought"
+        tests:
+          - not_null
+      - name: token_sold_address
+        description: "Contract address of the token sold"
+        tests:
+          - not_null
+      - name: taker
+        description: "Address of the trader who initiated the trade"
+        tests:
+          - not_null
+      - name: maker
+        description: "Address of the liquidity provider"
+      - name: project_contract_address
+        description: "Contract address of the pool"
+        tests:
+          - not_null
+      - name: tx_hash
+        description: "Transaction hash"
+        tests:
+          - not_null
+      - name: evt_index
+        description: "Event index within the transaction"
+        tests:
+          - not_null


### PR DESCRIPTION
### Description:

This PR adds support for Velodrome v2 Concentrated Liquidity (CL) pools on Optimism to the `dex.trades` table.

Changes made:
- Added processing of CLPool_evt_Swap events using uniswap_compatible_v3_trades macro
- Added CLFactory_evt_PoolCreated events processing
- Added full documentation and tests in YAML schema
- Added myself to contributors list

This will allow tracking trades from CL pools like: 0x478946bcd4a5a22b316470f5486fafb928c0ba25

Closes #6828