### PR TITLE
Docs: Fix Broken Links in Seeds and Tests

### DIFF
--- a/docs/seeds/seed_overview.md
+++ b/docs/seeds/seed_overview.md
@@ -6,12 +6,12 @@ Seeds will be required in these sector-level spell additions to ensure proper le
 
 ## Using `dex.trades` as an Example for Sector-Level Spell Design Approach to Seeds:
 
-1. Add new model seed to [the schema file](/seeds/_sector/dex/_schema.yml), to ensure proper data type assignments.
+1. Add new model seed to [the schema file](/dbt_subprojects/dex/seeds/trades/_schema.yml), to ensure proper data type assignments.
 2. Build a seed file in CSV format, which contains:
    - All the unique keys on the model for downstream join conditions in tests.
    - Fields which we want to test the results of the model execution.
-   - Example seed file [here](/seeds/_sector/dex/aerodrome_base_base_trades_seed.csv).
-3. Within the [model schema file](/models/_sector/dex/trades/arbitrum/_schema.yml#L20-L23), call the [generic seed test](/tests/generic/check_dex_base_trades_seed.sql) with parameters necessary:
+   - Example seed file [here](/dbt_subprojects/dex/seeds/trades/aerodrome_base_base_trades_seed.csv).
+3. Within the [model schema file](/dbt_subprojects/dex/models/trades/arbitrum/_schema.yml#23-25), call the [generic seed test](/dbt_subprojects/dex/tests/generic/check_dex_base_trades_seed.sql) with parameters necessary:
    - Seed file name.
    - Filter(s) for project versions, if the spell is split into versions per project.
 4. Ultimately, following the above steps, the test query built and executed against seed files lives in the generic seed macro [here](/dbt_macros/generic-tests/check_seed_macro.sql).

--- a/docs/tests/test_overview.md
+++ b/docs/tests/test_overview.md
@@ -11,7 +11,7 @@ Tests tied to models are highly encouraged & at times required, depending on the
 
 These tests would benefit all sector-level spells, first introduced in `nft.trades`:
 
-- Validate column data types, as built [here](https://github.com/duneanalytics/spellbook/blob/d6b5acc1dbd01e67e6cb23d96da6f3fc3ec7d268/tests/generic/check_column_types.sql#L6) and called like [this](/models/_sector/nft/trades/chains/arbitrum/platforms/_schema.yml#L14).
+- Validate column data types, as built [here](https://github.com/duneanalytics/spellbook/blob/d6b5acc1dbd01e67e6cb23d96da6f3fc3ec7d268/tests/generic/check_column_types.sql#L6) and called like [this](/dbt_subprojects/nft/models/_sector/trades/chains/arbitrum/platforms/_schema.yml#L14).
 
 ## Where to Store Tests?
 


### PR DESCRIPTION
### Description:

This pull request fixes broken links in the documentation for the `Spellbook` repository. The updates ensure that all references point to the correct paths in the project structure. Specifically, the following changes were made:

### Changes
1. Updated links in [/docs/seeds/seed_overview.md](https://github.com/duneanalytics/spellbook/blob/main/docs/seeds/seed_overview.md) to reflect the correct paths to schema files, seed files, and generic tests.
2. Corrected broken links in [docs/tests/test_overview.md](https://github.com/duneanalytics/spellbook/blob/main/docs/tests/test_overview.md) to align with the updated directory structure for model schemas and test files.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
