### PR TITLE
Fix Documentation Typos and Formatting

### DIFF
--- a/dbt_subprojects/daily_spellbook/README.md
+++ b/dbt_subprojects/daily_spellbook/README.md
@@ -1,3 +1,3 @@
 ## Daily Spellbook
 
-This is a DBT sub project for the the main models of Spellbook that runs on a daily candence.
+This is a DBT sub project for the main models of Spellbook that runs on a daily cadence.

--- a/docs/general/faq_and_common_issues.md
+++ b/docs/general/faq_and_common_issues.md
@@ -3,7 +3,7 @@
 - Why is my PR running more models than included in the CI test runs?
     - Steps within the CI test workflow depend on DBT manifest file to be up-to-date on the main branch
     - When other PRs are merged, main is updated, therefore a new manifest file needs uploaded to storage for CI to read
-    - The GH workflow to do this lives here: https://github.com/duneanalytics/spellbook/actions/workflows/commit_manifest.yml
+    - The GH workflow to do this lives [here](https://github.com/duneanalytics/spellbook/actions/workflows/commit_manifest.yml)
     - If the latest run failed and/or is in progress, then it’s possible manifest files are out of date and your PR will run more than it should
     - Wait for it to complete or Dune team to fix any failures
 - I’m modifying an existing spell within my PR that contains a seed test on it via the schema YML file. CI is failing on the seed test, as it can’t find the seed. How do I get around this?

--- a/sources/_base_sources/evm/kaia_docs_block.md
+++ b/sources/_base_sources/evm/kaia_docs_block.md
@@ -85,7 +85,7 @@ The `kaia.contracts` table tracks all contracts that have been submitted to Dune
 
 {% docs kaia_creation_traces_doc %}
 
-The `kaiam.creation_traces` table contains data about contract creation events on the kaia blockchain. It includes:
+The `kaia.creation_traces` table contains data about contract creation events on the kaia blockchain. It includes:
 
 - Block number and timestamp
 - Transaction hash


### PR DESCRIPTION


## Changes:

1. sources/_base_sources/evm/kaia_docs_block.md:
- kaiam.creation_traces -> kaia.creation_traces
Why: Fixed incorrect table name by removing extra 'm'

2. dbt_subprojects/daily_spellbook/README.md:
- for the the main models -> for the main models
- daily candence -> daily cadence
Why: Fixed duplicate word and spelling error

3. docs/general/faq_and_common_issues.md:
- lives here: https://github.com/... -> lives [here](https://github.com/...)
Why: Updated to proper Markdown link format

These changes improve documentation accuracy, readability and formatting consistency.