### PR TITLE
flokibot bnb: exclude due to long running incremental

### DIFF
--- a/dbt_subprojects/dex/models/bot_trades/flokibot/bnb/flokibot_bnb_bot_trades.sql
+++ b/dbt_subprojects/dex/models/bot_trades/flokibot/bnb/flokibot_bnb_bot_trades.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags=['prod_exclude'],
         alias='bot_trades',
         schema='flokibot_bnb',
         partition_by=['block_month'],


### PR DESCRIPTION
fyi @whalehunting 
the bnb model is blowing up our DEX job in prod, running >1 hour, much longer than any other model in the job. plz see below for reference. we should look into what could be causing this and fix prior to re-enabling in prod.
![image](https://github.com/user-attachments/assets/a83edc2b-014d-4a85-91be-6940c170964a)
