### PR TITLE
saddle finance optimism: exclude troubled model

### DIFF
--- a/dbt_subprojects/dex/models/trades/optimism/dex_optimism_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/optimism/dex_optimism_base_trades.sql
@@ -5,6 +5,8 @@
     )
 }}
 
+--exclude, until resolved at model level: , ref('saddle_finance_optimism_base_trades')
+
 {% set base_models = [
     ref('uniswap_v3_optimism_base_trades')
     , ref('woofi_optimism_base_trades')
@@ -35,7 +37,6 @@
     , ref('elk_finance_optimism_base_trades')
     , ref('fraxswap_optimism_base_trades')
     , ref('swaap_v2_optimism_base_trades')
-    , ref('saddle_finance_optimism_base_trades')
     , ref('bridgers_optimism_base_trades')
 ] %}
 

--- a/dbt_subprojects/dex/models/trades/optimism/platforms/saddle_finance_optimism_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/optimism/platforms/saddle_finance_optimism_base_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags=['prod_exclude'],
     schema = 'saddle_finance_optimism',
     alias = 'base_trades',
     partition_by = ['block_month'],


### PR DESCRIPTION
fyi @Hosuke @PatelPrinci 
looks like the mappings here are incorrect, where decimal assignment of USDC / DAI are getting mixed up (6 vs 18), leading to incorrect `amount_usd` calculations downstream. are we sure `0` shouldn't be `usdc`, and dai as `1`?

here is sample tx / event index where you can see raw amounts (smaller value should likely be USDC)
https://optimistic.etherscan.io/tx/0x97d9bbde821ad796da5f70cd02195e0b3be1468ee5ebda5c5e7418a02c58984c#eventlog#38