### PR TITLE
Add dex CI testing pipeline for base_trades modifications

### DIFF
--- a/.github/workflows/dex.yml
+++ b/.github/workflows/dex.yml
@@ -9,11 +9,58 @@ on:
       - .github/workflows/dbt_run.yml
 
 concurrency:
-  group:  ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check-base-trades:
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: check
+        name: Check for base_trades changes
+        run: |
+          CHANGES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -E "dbt_subprojects/dex/models/.*/.*_base_trades\.sql$" || true)
+          if [ ! -z "$CHANGES" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Found changes in base_trades files:"
+            echo "$CHANGES"
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No base_trades changes found"
+          fi
+
+  test-base-trades:
+    needs: check-base-trades
+    if: needs.check-base-trades.outputs.has_changes == 'true'
+    runs-on: [ self-hosted, linux, spellbook-trino-ci ]
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Setup variables
+        run: |
+          echo "PROFILE=--profiles-dir $HOME/.dbt --profile dunesql" >> $GITHUB_ENV
+          echo "PROJECT_DIR=dbt_subprojects/dex" >> $GITHUB_ENV
+          
+      - name: dbt dependencies
+        working-directory: ${{env.PROJECT_DIR}}
+        run: "dbt deps"
+        
+      - name: Run CI Test Models
+        working-directory: ${{env.PROJECT_DIR}}
+        run: |
+          dbt run $PROFILE --select dex_ci_trades_test --project-dir ${PROJECT_DIR}
+          
+      - name: Test Results
+        working-directory: ${{env.PROJECT_DIR}}
+        run: |
+          dbt test $PROFILE --select dex_ci_trades_test --project-dir ${PROJECT_DIR}
+
   dbt-run:
+    needs: [check-base-trades, test-base-trades]
+    if: always() && (needs.check-base-trades.outputs.has_changes == 'false' || needs.test-base-trades.result == 'success')
     uses: ./.github/workflows/dbt_run.yml
     with:
       project: 'dex'

--- a/dbt_subprojects/dex/macros/models/add_tx_columns_dynamic.sql
+++ b/dbt_subprojects/dex/macros/models/add_tx_columns_dynamic.sql
@@ -1,0 +1,47 @@
+{% macro add_tx_columns_dynamic(
+    model_cte
+    , columns = []
+    )
+%}
+
+WITH blockchain_list AS (
+    SELECT DISTINCT blockchain
+    FROM {{ model_cte }}
+)
+
+, tx_data AS (
+    {% raw %}
+    {%- set blockchain_query %}
+    SELECT DISTINCT blockchain FROM blockchain_list
+    {%- endset %}
+    
+    {%- set results = run_query(blockchain_query) %}
+    
+    {%- if execute %}
+    {%- set blockchains = results.columns[0].values() %}
+    {%- else %}
+    {%- set blockchains = [] %}
+    {%- endif %}
+
+    {% for blockchain in blockchains %}
+    SELECT
+        model.*
+        {% for column in columns %}
+        , tx."{{column}}" as tx_{{column}}
+        {% endfor %}
+    FROM {{model_cte}} model
+    INNER JOIN {{source(blockchain, 'transactions')}} tx
+        ON model.block_date = tx.block_date
+        AND model.block_number = tx.block_number
+        AND model.tx_hash = tx.hash
+        AND model.blockchain = '{{blockchain}}'
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+    {% endraw %}
+)
+
+SELECT * FROM tx_data
+
+{% endmacro %}

--- a/dbt_subprojects/dex/models/trades/test/_schema.yml
+++ b/dbt_subprojects/dex/models/trades/test/_schema.yml
@@ -1,0 +1,52 @@
+version: 2
+
+models:
+  - name: dex_ci_trades_test
+    meta:
+      blockchain: arbitrum, avalanche_c, base, bnb, celo, ethereum, fantom, gnosis, kaia, optimism, polygon, scroll, zksync, linea, blast, sei, ronin
+      sector: dex
+      contributors: hosuke
+    config:
+      tags: ['dex', 'trades', 'ci_test']
+    description: "CI test view that processes modified base_trades models to verify their integration with the dex.trades pipeline"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - project
+            - version
+            - tx_hash
+            - evt_index
+    columns:
+      - *blockchain
+      - *project
+      - name: project
+        data_tests:
+          - relationships:
+              to: ref('dex_info')
+              field: project
+      - *version
+      - *block_month
+      - *block_date
+      - *block_time
+      - *block_number
+      - *token_bought_symbol
+      - *token_sold_symbol
+      - *token_pair
+      - *token_bought_amount
+      - *token_sold_amount
+      - *token_bought_amount_raw
+      - *token_sold_amount_raw
+      - name: amount_usd
+        data_tests:
+          - dbt_utils.accepted_range:
+              max_value: 1000000000
+      - *token_bought_address
+      - *token_sold_address
+      - *taker
+      - *maker
+      - *project_contract_address
+      - *tx_hash
+      - *tx_from
+      - *tx_to
+      - *evt_index

--- a/dbt_subprojects/dex/models/trades/test/dex_ci_trades_test.sql
+++ b/dbt_subprojects/dex/models/trades/test/dex_ci_trades_test.sql
@@ -1,0 +1,56 @@
+{{ config(
+    schema = 'dex'
+    , alias = 'ci_trades_test'
+    , materialized = 'view'
+    , tags = ['prod_exclude']
+    )
+}}
+
+-- This view is only for CI testing purpose
+-- It directly processes modified base_trades models and enriches them with transaction and token information
+
+{% set modified_base_trades = dbt_utils.get_modified_models('base_trades') %}
+
+WITH base_union AS (
+    {% for model in modified_base_trades %}
+    SELECT
+        blockchain
+        , project
+        , version
+        , block_month
+        , block_date
+        , block_time
+        , block_number
+        , token_bought_amount_raw
+        , token_sold_amount_raw
+        , token_bought_address
+        , token_sold_address
+        , taker
+        , maker
+        , project_contract_address
+        , tx_hash
+        , evt_index
+    FROM {{ model }}
+    WHERE block_date = current_date - interval '1' day
+    {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+    {% endfor %}
+)
+
+, with_tx AS (
+    {{
+        add_tx_columns_dynamic(
+            model_cte = 'base_union'
+            , columns = ['from', 'to', 'index']
+        )
+    }}
+)
+
+{{
+    enrich_dex_trades(
+        base_trades = 'with_tx'
+        , filter = "1=1"  -- Date filter already applied in base_union
+        , tokens_erc20_model = source('tokens', 'erc20')
+    )
+}}


### PR DESCRIPTION
- Add dynamic transaction columns macro for multi-chain support
- Create CI test view to validate base_trades changes
- Add comprehensive schema and tests matching dex.trades
- Optimize workflow to efficiently test base_trades modifications

Ideally, this change improves the CI process by:
1. Only testing modified base_trades
2. Processing one day of data for quick validation
3. Using the same data quality checks as production
4. Preventing full dex build until tests pass

