### PR TITLE
 Fix typos in blockchain documentation

### DIFF
--- a/sources/_base_sources/evm/polygon_base_sources.yml
+++ b/sources/_base_sources/evm/polygon_base_sources.yml
@@ -262,7 +262,7 @@ sources:
           - name: polygon
             description: "Boolean indicating if this is a manual individual submission of a contract."
           - name: factory
-            description: "Boolean indicating if this submission was submitted to Dune with the 'factory' flag enabled. If yes, our decoder will search for contract's deployed by the same factory and decode them into the same namespace as the initial contract." 
+            description: "Boolean indicating if this submission was submitted to Dune with the 'factory' flag enabled. If yes, our decoder will search for contracts deployed by the same factory and decode them into the same namespace as the initial contract." 
           - name: detection_source
             description: "Method used to detect and decode this contract: 'factory', 'polygon', or 'dynamic'. "
           - name: created_at

--- a/sources/_base_sources/evm/ronin_docs_block.md
+++ b/sources/_base_sources/evm/ronin_docs_block.md
@@ -85,7 +85,7 @@ The `ronin.contracts` table tracks all contracts that have been submitted to Dun
 
 {% docs ronin_creation_traces_doc %}
 
-The `roninm.creation_traces` table contains data about contract creation events on the ronin blockchain. It includes:
+The `ronin.creation_traces` table contains data about contract creation events on the ronin blockchain. It includes:
 
 - Block number and timestamp
 - Transaction hash


### PR DESCRIPTION


## Changes Made

1. Fixed table name reference in ronin_docs_block.md:
- `roninm.creation_traces` → `ronin.creation_traces`

2. Fixed grammar in polygon_base_sources.yml:
- "contract's deployed" → "contracts deployed"

## Why These Changes Are Needed

These corrections improve documentation accuracy by:
- Fixing incorrect table name reference
- Correcting grammatical error in contract deployment description

The changes ensure proper table references and maintain professional documentation quality.

## Files Changed
- sources/_base_sources/evm/ronin_docs_block.md
- sources/_base_sources/evm/polygon_base_sources.yml
