### PR TITLE
Fix bebop bug

### DIFF
--- a/dbt_subprojects/dex/models/_projects/bebop/arbitrum/bebop_rfq_arbitrum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/bebop/arbitrum/bebop_rfq_arbitrum_trades.sql
@@ -1,7 +1,6 @@
 {{ config(
     schema = 'bebop_rfq_arbitrum',
     alias = 'trades',
-    tags = ['prod_exclude'],
     partition_by = ['block_month'],
     materialized = 'incremental',
     file_format = 'delta',
@@ -58,6 +57,8 @@ bebop_raw_data AS (
     {% if is_incremental() %}
     AND {{ incremental_predicate('evt.evt_block_time') }}
     {% endif %}
+    AND json_array_length(json_extract((JSON_EXTRACT(ex."order", '$.maker_tokens')), '$[0]')) > 0
+    AND json_array_length(json_extract((JSON_EXTRACT(ex."order", '$.taker_tokens')), '$[0]')) > 0
 ),
 
 unnested_array_taker AS (

--- a/dbt_subprojects/dex/models/_projects/bebop/ethereum/bebop_rfq_ethereum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/bebop/ethereum/bebop_rfq_ethereum_trades.sql
@@ -57,6 +57,8 @@ bebop_raw_data AS (
     {% if is_incremental() %}
     AND {{ incremental_predicate('evt.evt_block_time') }}
     {% endif %}
+    AND json_array_length(json_extract((JSON_EXTRACT(ex."order", '$.maker_tokens')), '$[0]')) > 0
+    AND json_array_length(json_extract((JSON_EXTRACT(ex."order", '$.taker_tokens')), '$[0]')) > 0
 ),
 
 unnested_array_taker AS (

--- a/dbt_subprojects/dex/models/_projects/bebop/optimism/bebop_rfq_optimism_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/bebop/optimism/bebop_rfq_optimism_trades.sql
@@ -50,6 +50,8 @@ bebop_raw_data AS (
     {% if is_incremental() %}
     AND {{ incremental_predicate('evt.evt_block_time') }}
     {% endif %}
+    AND json_array_length(json_extract((JSON_EXTRACT(ex."order", '$.maker_tokens')), '$[0]')) > 0
+    AND json_array_length(json_extract((JSON_EXTRACT(ex."order", '$.taker_tokens')), '$[0]')) > 0
 ),
 
 unnested_array_taker AS (

--- a/dbt_subprojects/dex/models/_projects/bebop/polygon/bebop_rfq_polygon_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/bebop/polygon/bebop_rfq_polygon_trades.sql
@@ -57,6 +57,8 @@ bebop_raw_data AS (
     {% if is_incremental() %}
     AND {{ incremental_predicate('evt.evt_block_time') }}
     {% endif %}
+    AND json_array_length(json_extract((JSON_EXTRACT(ex."order", '$.maker_tokens')), '$[0]')) > 0
+    AND json_array_length(json_extract((JSON_EXTRACT(ex."order", '$.taker_tokens')), '$[0]')) > 0
 ),
 
 unnested_array_taker AS (


### PR DESCRIPTION
Added sanity check to exclude empty arrays, mentioned in https://github.com/duneanalytics/spellbook/pull/7456#issue-2783654743 and returned model back to prod

