### PR TITLE
remove freshness checks on safe models

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/arbitrum/safe_arbitrum_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/arbitrum/safe_arbitrum_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: arbitrum
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'arbitrum']
     description: "Singletons addresses used with Safes"
@@ -25,9 +22,6 @@ models:
       blockchain: arbitrum
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'arbitrum']
     description: "Safe addresses"
@@ -54,9 +48,6 @@ models:
       blockchain: arbitrum
       project: safe
       contributors: tschubotz, danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'arbitrum']
     description: "Safe transactions"
@@ -118,9 +109,6 @@ models:
       blockchain: arbitrum
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'arbitrum']
     description: "ETH transfers into or out of Safes"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/avalanche_c/safe_avalanche_c_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/avalanche_c/safe_avalanche_c_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: avalanche_c
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'avalanche_c']
     description: "Singletons addresses used with Safes"
@@ -25,9 +22,6 @@ models:
       blockchain: avalanche_c
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'avalanche_c']
     description: "Safe addresses"
@@ -54,9 +48,6 @@ models:
       blockchain: avalanche_c
       project: safe
       contributors: tschubotz, danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'avalanche_c']
     description: "Safe transactions"
@@ -118,9 +109,6 @@ models:
       blockchain: avalanche_c
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'avalanche_c']
     description: "AVAX transfers into or out of Safes"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/base/safe_base_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/base/safe_base_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: base
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'base']
     description: "Safe addresses"
@@ -37,9 +34,6 @@ models:
       blockchain: base
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'base']
     description: "Eth transfers for safes"
@@ -69,9 +63,6 @@ models:
       blockchain: base
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'base']
     description: "Singletons addresses used with Safes"
@@ -87,9 +78,6 @@ models:
       blockchain: base
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'base']
     description: "Safe transactions"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/bnb/safe_bnb_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/bnb/safe_bnb_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: bnb
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'bnb']
     description: "Singletons addresses used with Safes"
@@ -25,9 +22,6 @@ models:
       blockchain: bnb
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'bnb']
     description: "Safe addresses"
@@ -54,9 +48,6 @@ models:
       blockchain: bnb
       project: safe
       contributors: tschubotz, danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'bnb']
     description: "Safe transactions"
@@ -118,9 +109,6 @@ models:
       blockchain: bnb
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'bnb']
     description: "BNB transfers into or out of Safes"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/celo/safe_celo_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/celo/safe_celo_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: celo
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'celo']
     description: "Singletons addresses used with Safes"
@@ -25,9 +22,6 @@ models:
       blockchain: celo
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'celo']
     description: "Safe addresses"
@@ -54,9 +48,6 @@ models:
       blockchain: celo
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'celo']
     description: "Safe transactions"
@@ -118,9 +109,6 @@ models:
       blockchain: celo
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'celo']
     description: "CELO transfers into or out of Safes"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/fantom/safe_fantom_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/fantom/safe_fantom_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: fantom
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'fantom']
     description: "Singletons addresses used with Safes"
@@ -25,9 +22,6 @@ models:
       blockchain: fantom
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'fantom']
     description: "Safe addresses"
@@ -54,9 +48,6 @@ models:
       blockchain: fantom
       project: safe
       contributors: tschubotz, danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'fantom']
     description: "Safe transactions"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/gnosis/safe_gnosis_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/gnosis/safe_gnosis_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: gnosis
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'gnosis']
     description: "Singletons addresses used with Safes"
@@ -25,9 +22,6 @@ models:
       blockchain: gnosis
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'gnosis']
     description: "Safe addresses"
@@ -54,9 +48,6 @@ models:
       blockchain: gnosis
       project: safe
       contributors: tschubotz, danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'gnosis']
     description: "Safe transactions"
@@ -118,9 +109,6 @@ models:
       blockchain: gnosis
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'gnosis']
     description: "xDAI transfers into or out of Safes"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/goerli/safe_goerli_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/goerli/safe_goerli_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: goerli
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'goerli']
     description: "Singletons addresses used with Safes"
@@ -25,9 +22,6 @@ models:
       blockchain: goerli
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'goerli']
     description: "Safe addresses"
@@ -54,9 +48,6 @@ models:
       blockchain: goerli
       project: safe
       contributors: tschubotz, danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'goerli']
     description: "Safe transactions"
@@ -118,9 +109,6 @@ models:
       blockchain: goerli
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'goerli']
     description: "ETH transfers into or out of Safes"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/mantle/safe_mantle_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/mantle/safe_mantle_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: mantle
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'mantle']
     description: "Safe addresses"
@@ -42,9 +39,6 @@ models:
       blockchain: mantle
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'mantle']
     description: "MNT transfers for safes"
@@ -81,9 +75,6 @@ models:
       blockchain: mantle
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'mantle']
     description: "Singletons addresses used with Safes"
@@ -96,9 +87,6 @@ models:
       blockchain: mantle
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'mantle']
     description: "Safe transactions"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/optimism/safe_optimism_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/optimism/safe_optimism_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: optimism
       project: safe
       contributors: frankmaseo
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'optimism']
     description: "Safe addresses on Optimism"
@@ -36,9 +33,6 @@ models:
       blockchain: optimism
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'optimism']
     description: "Singletons addresses used with Safes"
@@ -54,9 +48,6 @@ models:
       blockchain: optimism
       project: safe
       contributors: tschubotz, danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'optimism']
     description: "Safe transactions"
@@ -118,9 +109,6 @@ models:
       blockchain: optimism
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'optimism']
     description: "ETH transfers into or out of Safes"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/polygon/safe_polygon_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/polygon/safe_polygon_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: polygon
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'polygon']
     description: "Singletons addresses used with Safes"
@@ -25,9 +22,6 @@ models:
       blockchain: polygon
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'polygon']
     description: "Safe addresses"
@@ -54,9 +48,6 @@ models:
       blockchain: polygon
       project: safe
       contributors: tschubotz
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'polygon']
     description: "MATIC transfers into or out of Safes"
@@ -93,9 +84,6 @@ models:
       blockchain: polygon
       project: safe
       contributors: tschubotz, danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'polygon']
     description: "Safe transactions"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/ronin/safe_ronin_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/ronin/safe_ronin_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: ronin
       project: safe
       contributors: petertherock
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'ronin']
     description: "Safe addresses"
@@ -42,9 +39,6 @@ models:
       blockchain: ronin
       project: safe
       contributors: petertherock
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'ronin']
     description: "ETH transfers for safes"
@@ -81,9 +75,6 @@ models:
       blockchain: ronin
       project: safe
       contributors: petertherock
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'ronin']
     description: "Singletons addresses used with Safes"
@@ -96,9 +87,6 @@ models:
       blockchain: ronin
       project: safe
       contributors: petertherock
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'ronin']
     description: "Safe transactions"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/safe_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/safe_schema.yml
@@ -35,9 +35,6 @@ models:
       blockchain: arbitrum, avalanche_c, base, blast, bnb, celo, ethereum, fantom, gnosis, goerli, linea, mantle, optimism, polygon, scroll, worldchain, zkevm, zksync
       project: safe
       contributors: kryptaki, danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['arbitrum', 'avalanche_c', 'base', 'blast', 'bnb', 'celo','ethereum', 'fantom', 'gnosis', 'goerli', 'linea', 'mantle', 'optimism', 'polygon', 'safe', 'scroll', 'worldchain', 'zkevm', 'zksync']
     description: "Safe transactions"
@@ -97,9 +94,6 @@ models:
       blockchain: arbitrum, avalanche_c, base, blast, bnb, celo, ethereum, gnosis, goerli, linea, mantle, optimism, polygon, scroll, worldchain, zkevm, zksync
       project: safe
       contributors: kryptaki, tschubotz, danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['arbitrum', 'avalanche_c', 'base', 'blast', 'bnb', 'celo','ethereum', 'gnosis', 'goerli', 'linea', 'mantle', 'optimism', 'polygon', 'safe', 'scroll', 'worldchain', 'zkevm', 'zksync']
     description: "Native gas token transfers into or out of Safes"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/scroll/safe_scroll_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/scroll/safe_scroll_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: scroll
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'scroll']
     description: "Safe addresses"
@@ -42,9 +39,6 @@ models:
       blockchain: scroll
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'scroll']
     description: "ETH transfers for safes"
@@ -81,9 +75,6 @@ models:
       blockchain: scroll
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'scroll']
     description: "Singletons addresses used with Safes"
@@ -96,9 +87,6 @@ models:
       blockchain: scroll
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'scroll']
     description: "Safe transactions"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/worldchain/safe_worldchain_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/worldchain/safe_worldchain_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: worldchain
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'worldchain']
     description: "Safe addresses"
@@ -42,9 +39,6 @@ models:
       blockchain: worldchain
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'worldchain']
     description: "ETH transfers for safes"
@@ -81,9 +75,6 @@ models:
       blockchain: worldchain
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'worldchain']
     description: "Singletons addresses used with Safes"
@@ -96,9 +87,6 @@ models:
       blockchain: worldchain
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'worldchain']
     description: "Safe transactions"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/zkevm/safe_zkevm_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/zkevm/safe_zkevm_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: zkevm
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'zkevm']
     description: "Safe addresses"
@@ -42,9 +39,6 @@ models:
       blockchain: zkevm
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'zkevm']
     description: "MATIC transfers for safes"
@@ -81,9 +75,6 @@ models:
       blockchain: zkevm
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'zkevm']
     description: "Singletons addresses used with Safes"
@@ -96,9 +87,6 @@ models:
       blockchain: zkevm
       project: safe
       contributors: danielpartida
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'zkevm']
     description: "Safe transactions"

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/zksync/safe_zksync_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/zksync/safe_zksync_schema.yml
@@ -6,9 +6,6 @@ models:
       blockchain: zksync
       project: safe
       contributors: ['danielpartida' , 'kryptaki']
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'zksync']
     description: "Safe addresses"
@@ -42,9 +39,6 @@ models:
       blockchain: zksync
       project: safe
       contributors: ['danielpartida' , 'kryptaki']
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'transfers', 'zksync']
     description: "Eth transfers for safes"
@@ -82,9 +76,6 @@ models:
       blockchain: zksync
       project: safe
       contributors: ['danielpartida' , 'kryptaki']
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'singletons', 'zksync']
     description: "Singletons addresses used with Safes"
@@ -100,9 +91,6 @@ models:
       blockchain: zksync
       project: safe
       contributors: kryptaki
-    freshness:
-      warn_after: { count: 12, period: hour }
-      error_after: { count: 24, period: hour }
     config:
       tags: ['safe', 'zksync']
     description: "Safe transactions"


### PR DESCRIPTION
looks like an auto upgrade of dbt versions in prod started to fail on compile for freshness checks on models in yml files. we usually only apply these checks on sources, not models. this is only instance found in hourly project for schema files.