### PR TITLE
Add addresses for the Enso and OKX solvers

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/arbitrum/cow_protocol_arbitrum_solvers.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/arbitrum/cow_protocol_arbitrum_solvers.sql
@@ -56,6 +56,7 @@ known_solver_metadata (address, environment, name) as (
                 (0x1FA2FF499b327f53cD9a82BcAFE36093563E32e4, 'prod', 'Apollo'),
                 (0x0148538e6cA813D41eA5988008Cdc9B72d4e65A7, 'prod', 'Laita'),
                 (0x9C75aae1Bd2f96D7B4E67e8C5344f3304382276E, 'prod', 'Enso'),
+                (0x5156808c3f9440191ef600587a73c87bb23c92b2, 'barn', 'Enso'),
                 (0x034F6Aca83F1900b0157b0123F514A29456eeA59, 'barn', 'Laita'),
                 (0x6bf97aFe2D2C790999cDEd2a8523009eB8a0823f, 'prod', 'Portus'),
                 (0xBB765c920f86e2A2654c4B82deB5BC2E092fF93b, 'barn', 'Portus'),
@@ -77,6 +78,8 @@ known_solver_metadata (address, environment, name) as (
                 (0x26B5e3bF135D3Dd05A220508dD61f25BF1A47cBD, 'barn', 'Rizzolver'),
                 (0x8C3f83f6A489cCbA2E3df304034F8C120cEb3527, 'barn', 'GlueX_Protocol'),
                 (0x49E1F55D4a695291533BB0A993aca5D58E90C613, 'prod', 'GlueX_Protocol')
+                (0x3144a51a7699c629070d6aAEf68256c2d07a6334, 'barn', 'OKX'),
+                (0x7F636D152AB0Cfc68A899d4dF441F2322cd78C6B, 'prod', 'OKX'),
     ) as _
 )
 -- Combining the metadata with current activation status for final table

--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/arbitrum/cow_protocol_arbitrum_solvers.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/arbitrum/cow_protocol_arbitrum_solvers.sql
@@ -77,9 +77,9 @@ known_solver_metadata (address, environment, name) as (
                 (0x2aeC288B42C99D2e8e984c5C324FB069f7705186, 'barn', 'Rizzolver'),
                 (0x26B5e3bF135D3Dd05A220508dD61f25BF1A47cBD, 'barn', 'Rizzolver'),
                 (0x8C3f83f6A489cCbA2E3df304034F8C120cEb3527, 'barn', 'GlueX_Protocol'),
-                (0x49E1F55D4a695291533BB0A993aca5D58E90C613, 'prod', 'GlueX_Protocol')
+                (0x49E1F55D4a695291533BB0A993aca5D58E90C613, 'prod', 'GlueX_Protocol'),
                 (0x3144a51a7699c629070d6aAEf68256c2d07a6334, 'barn', 'OKX'),
-                (0x7F636D152AB0Cfc68A899d4dF441F2322cd78C6B, 'prod', 'OKX'),
+                (0x7F636D152AB0Cfc68A899d4dF441F2322cd78C6B, 'prod', 'OKX')
     ) as _
 )
 -- Combining the metadata with current activation status for final table

--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/base/cow_protocol_base_solvers.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/base/cow_protocol_base_solvers.sql
@@ -51,6 +51,8 @@ known_solver_metadata (address, environment, name) as (
                 (0x9775be2Bb0B72d4eA98Bfd38024EF733dc048a30, 'barn', 'Apollo'),
                 (0xe0b25FA3EA727Dc34708D026ba122625B98A94FB, 'barn', 'GlueX_Protocol'),
                 (0x707Dfa95835542A6528fD077c351446f497276CF, 'barn', 'Rizzolver'),
+                (0x4eAD087d78C21Fd95D30411928A2Ade7456f56F4, 'barn', 'OKX'),
+                (0xd875cd50B179a046512C80edF6CB2C1Fc3F3072D, 'prod', 'OKX'),
                 (0x914db7338ACAe3f3866B79DcEfFcFBCC554F18ed, 'prod', 'Rizzolver'),
                 (0xc1b0bB599c578a846b51EE5dcE3d9FAD69528613, 'prod', 'GlueX_Protocol'),
                 (0x41f387db8470c99b7f376212075e2E289f085Ce9, 'prod', 'Apollo'),

--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/ethereum/cow_protocol_ethereum_solvers.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/ethereum/cow_protocol_ethereum_solvers.sql
@@ -122,6 +122,8 @@ known_solver_metadata (address, environment, name) as (
                  (0x04B89dBce06e7Aa2F4BBA78969ADD4576eB94788, 'prod', 'ApeOut_1inch'),
                  (0xbada5552a3e5e2fb57db982e29257821a2cf192d, 'prod', 'Project_Blanc'),
                  (0x34717040928D7fd8154d4612f3228EFf14521023, 'prod', 'Laita'),
+                 (0xdcE5B9574C9A18B4f1713C80BfC53623c007e7e1, 'prod', 'OKX'),
+                 (0xD2E90778eE3F480d305FF535bE88f5AF9F2ac85c, 'barn', 'OKX'),
                  (0xBab555BaBEe5d867983902bC8db8F707157245Be, 'barn', 'Project_Blanc'),
                  (0x854490ef1d402D4f6fce05aBefE1C676eB0DCD74, 'barn', 'ApeOut_1inch'),
                  (0xBB765c920f86e2A2654c4B82deB5BC2E092fF93b, 'barn', 'Portus'),


### PR DESCRIPTION
### Description:
This PR adds the address for the Enso solver on Arbitrum barn. It also adds the the barn and prod addresses for the OKX solver on Arbitrum, Base, and Ethereum.