### PR TITLE
Fix typos in schema descriptions

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_metrics/transfers/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_metrics/transfers/_schema.yml
@@ -8,16 +8,16 @@ models:
     config:
       tags: ['metrics', 'net_transfers']
     description: &net_transfers_description |
-      "The amount returned is the net received amount in a transaction. This gets to the heart of what was really transfered
+      "The amount returned is the net received amount in a transaction. This gets to the heart of what was really transferred
       in a transaction, as the amounts that go from and back to a single address don't actually count as real transfers.
       For example, if I give you a dollar and then you give it back to me in a single transaction that should count as $0 
       because nothing was effectively transferred. If I give you two dollars and you give one back to me that should count as $1
-      because one dollar was effectively transfered.
+      because one dollar was effectively transferred.
 
       The reason we filter where net_received is greater than 0 is because if you sum the negative net received (aka sent)
       with the positive net received (aka received) it adds up to 0 since the net sent should equal the net received. 
       For example, if I give you $1 that's -1 sent (from me) and +1 received (by you) which adds to 0. 
-      This query counts the received to show that $1 was effectively transfered."
+      This query counts the received to show that $1 was effectively transferred."
 
   - name: metrics_transfers_stats
     meta:

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/ethereum/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/ethereum/_schema.yml
@@ -56,7 +56,7 @@ models:
         description: "Date of Eth transfer"
       - &amount_raw
         name: amount_raw
-        description: "Raw amount of transfered Eth"
+        description: "Raw amount of transferred Eth"
       - *tx_hash
       - &trace_address
         name: trace_address

--- a/dbt_subprojects/nft/models/nft_metrics/ethereum/metadata/nft_ethereum_metadata_schema.yml
+++ b/dbt_subprojects/nft/models/nft_metrics/ethereum/metadata/nft_ethereum_metadata_schema.yml
@@ -102,7 +102,7 @@ models:
         description: "Day Zero?"
       - &harmonic
         name: harmonic
-        description: "Harmoninc?"
+        description: "Harmonic?"
 
   - name: nft_ethereum_metadata_terraforms
     meta:


### PR DESCRIPTION
Why:
- Fixed incorrect spelling of "transferred" 
- Fixed typo in "harmonic" description
- Improves documentation clarity and professionalism
- No functional code changes