### PR TITLE
balancer protocol fees: fix column name, propogate downstream

### DIFF
--- a/dbt_macros/shared/balancer/balancer_protocol_fee_macro.sql
+++ b/dbt_macros/shared/balancer/balancer_protocol_fee_macro.sql
@@ -364,7 +364,7 @@ WITH pool_labels AS (
         SUM(f.token_amount) as token_amount,
         SUM(f.protocol_fee_collected_usd) as protocol_fee_collected_usd, 
         r.treasury_share,
-        SUM(f.protocol_fee_collected_usd) * r.treasury_share as treasury_feee_usd,
+        SUM(f.protocol_fee_collected_usd) * r.treasury_share as treasury_fee_usd,
         SUM(CASE WHEN f.fee_type = 'swap_fee' THEN f.protocol_fee_collected_usd
         WHEN f.fee_type = 'yield_fee' THEN f.protocol_fee_collected_usd * 9 END) 
             AS lp_fee_collected_usd

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/protocol_fee/balancer_protocol_fee.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/protocol_fee/balancer_protocol_fee.sql
@@ -39,7 +39,8 @@ FROM (
         token_amount,
         protocol_fee_collected_usd, 
         treasury_share,
-        treasury_revenue_usd
+        treasury_fee_usd,
+        lp_fee_collected_usd
     FROM {{ protocol_fee }}
     {% if not loop.last %}
     UNION ALL


### PR DESCRIPTION
fyi @viniabussafi 
looks like a typo in a column, then we forgot to propagate downstream. i believe this should account for it all. until we implement a solution to check downstream automatically (without introducing too much running without need), we should manually check our lineage downstream. extensions like dbt power user in local IDE are helpful.