### PR TITLE
fix: add missing amms for jupiter tracking

### DIFF
--- a/dbt_subprojects/solana/models/jupiter/jupiter_solana_aggregator_swaps.sql
+++ b/dbt_subprojects/solana/models/jupiter/jupiter_solana_aggregator_swaps.sql
@@ -71,7 +71,11 @@ with
                 ('1DEX', 'DEXYosS6oEGvk8uCDayvwEZz4qEyDJRf9nFgYCaqPMTm'),
                 ('Obric V2', 'obriQD1zbpyLz95G5n7nJe6a4DPjpFwa5XYPoNm113y'),
                 ('Mooshot', 'MoonCVVNZFSYkqNXP6bxHLPL6QQJiMagDL3qcqUQTrG'),
-                ('Fox', 'HyhpEq587ANShDdbx1mP4dTmDZC44CXWft29oYQXDb53')
+                ('Fox', 'HyhpEq587ANShDdbx1mP4dTmDZC44CXWft29oYQXDb53'),
+                ('Solayer', 'endoLNCKTqDn8gSVnN2hDdpgACUPWHZTwoYnnMybpAT'),
+                ('Token Mill', 'JoeaRXgtME3jAoz5WuFXGEndfv4NPH9nBxsLq44hk9J'),
+                ('Daos.fun', '5jnapfrAN47UYkLkEf7HnprPPBCQLvkYWGZDeKkaP5hv'),
+                ('ZeroFi', 'ZERor4xhbUycZ6gb9ntrhqscUcZmAbQDjEAtCf4hbZY')
             ) as v(amm_name, amm)
     )
 


### PR DESCRIPTION
### Description

The jupiter tracking table contains a list of amms updated from the list available via jupiter api: https://station.jup.ag/api-v6/get-program-id-to-label .

I made sure all amms that were reported by the api are present in the query's list.

The list was previously updated this way in #7131