### PR TITLE
Fix directory paths in test documentation

### DIFF
--- a/docs/tests/test_overview.md
+++ b/docs/tests/test_overview.md
@@ -15,5 +15,5 @@ These tests would benefit all sector-level spells, first introduced in `nft.trad
 
 ## Where to Store Tests?
 
-- Project-specific tests can live in their own directory, following ‘spellbook/test/<project>/’.
-- Generic tests, which are applied universally and typically call a macro, must live in ‘spellbook/test/generic/’.
+- Project-specific tests can live in their own directory, following ‘spellbook/tests/<project>/’.
+- Generic tests, which are applied universally and typically call a macro, must live in ‘spellbook/tests/generic/’.


### PR DESCRIPTION

Changed directory references from `test/` to `tests/` in docs/tests/test_overview.md:

Old:
spellbook/test/<project>/
spellbook/test/generic/

New: 
spellbook/tests/<project>/
spellbook/tests/generic/

Rationale:
- Aligns with actual directory structure
- Ensures documentation accuracy
- Prevents confusion for developers
