### PR TITLE
Fix: Typos in Documentation 

### DIFF
--- a/dbt_subprojects/solana/dbt_project.yml
+++ b/dbt_subprojects/solana/dbt_project.yml
@@ -46,7 +46,7 @@ seeds:
   solana:
     +schema: test_data
 
-# defining search order of macro invokation
+# defining search order of macro invocation
 dispatch:
   - macro_namespace: dbt_utils
     search_order: ['trino_utils', 'dbt_utils']
@@ -65,5 +65,5 @@ models:
       - sql: "{{ mark_as_spell(this, model.config.materialized) }}"
         transaction: true
     +materialized: view
-    +schema: no_schema    # this should be overriden in model specific configs
+    +schema: no_schema    # this should be overridden in model specific configs
     +view_security: invoker

--- a/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v4_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v4_base_trades.sql
@@ -76,7 +76,7 @@
             AND tk_2.account_type = 'fungible'
         WHERE 1=1
         and trs_1.token_mint_address != trs_2.token_mint_address --gets rid of dupes from the OR statement in transfer joins
-        and tk_2.token_balance_owner = '5Q544fKrFoe6tsEbD7S8EmxGTJYAKtTVhAW5Q5pge4j1' --raydium pool v4 authority. makes sure we don't accidently catch some fee transfer or something after the swap. should add for lifinity too later.
+        and tk_2.token_balance_owner = '5Q544fKrFoe6tsEbD7S8EmxGTJYAKtTVhAW5Q5pge4j1' --raydium pool v4 authority. makes sure we don't accidentally catch some fee transfer or something after the swap. should add for lifinity too later.
         {% if is_incremental() %}
         AND {{incremental_predicate('sp.call_block_time')}}
         {% else %}

--- a/dbt_subprojects/solana/models/tokens/solana/_schema.yml
+++ b/dbt_subprojects/solana/models/tokens/solana/_schema.yml
@@ -77,7 +77,7 @@ models:
       - name: minter
         description: "the account_payer or account_leafOwner that minted the NFT"
       - name: version
-        description: "version of the NFT - Token Metdata, cNFT, etc"
+        description: "version of the NFT - Token Metadata, cNFT, etc"
       - name: token_standard
       - name: token_name
       - name: token_symbol

--- a/sources/_base_sources/evm/nova_base_sources.yml
+++ b/sources/_base_sources/evm/nova_base_sources.yml
@@ -171,7 +171,7 @@ sources:
           - name: name
             description: "Name of the decoded contract"
           - name: namespace
-            description: "Namesapce of the decoded contract"
+            description: "Namespace of the decoded contract"
           - name: dynamic
             description: "Boolean indicating whether the contract is dynamic or not"
           - name: base

--- a/sources/woofi/optimism/woofi_optimism_sources.yml
+++ b/sources/woofi/optimism/woofi_optimism_sources.yml
@@ -20,7 +20,7 @@ sources:
 
       - name: WooRouterV2_evt_WooRouterSwap
         description: >
-          'Decoded table related to swap events from  the router contract that routes to 3rd party DEXs incase there is less liquidity in liquidity reserves'
+          'Decoded table related to swap events from  the router contract that routes to 3rd party DEXs in case there is less liquidity in liquidity reserves'
         columns:
           - name: contract_address
             description: 'optimism address for the router contract'


### PR DESCRIPTION
### Description:
Hi there! This PR focuses on fixing a series of typos across multiple files in the repository. The changes are minor but enhance readability and maintain consistency in the project's documentation and code comments. Below is a summary of the updates:

1. **`nova_base_sources.yml`:** Corrected "Namesapce" to "Namespace".
2. **`woofi_optimism_sources.yml`:** Fixed "incase" to "in case".
3. **`dbt_project.yml`:** Resolved typos in comments, such as "invokation" to "invocation" and "overriden" to "overridden".
4. **`raydium_v4_base_trades.sql`:** Adjusted "accidently" to "accidentally" in inline comments.
5. **`_schema.yml`:** Fixed "Token Metdata" to "Token Metadata".