### PR TITLE
feat: add chain specific logic for zksync shared bridge

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/rollup_economics/ethereum/l1_data_fees/chains/rollup_economics_zksync_l1_data_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/rollup_economics/ethereum/l1_data_fees/chains/rollup_economics_zksync_l1_data_fees.sql
@@ -8,35 +8,65 @@
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
 )}}
 
+WITH data AS (
+    SELECT
+        cast(date_trunc('month', t.block_time) AS date) AS block_month
+        , cast(date_trunc('day', t.block_time) AS date) AS block_date
+        , t.block_time
+        , t.block_number
+        , t.hash AS tx_hash
+        , t.index AS tx_index
+        , t.gas_price
+        , t.gas_used
+        , (t.gas_price / 1e18) * t.gas_used AS data_fee_native
+        , {{ evm_get_calldata_gas_from_data('t.data') }} AS calldata_gas_used
+        , (length(t.data)) AS data_length
+        , CASE -- If prior to shared bridge, chain_id is always equal to 324 for zksync era. If on shared bridge, fetch chain_id.
+            WHEN bytearray_substring(t.data, 1, 4) IN (
+                0x0c4dd810 -- Commit Block, pre-Boojum
+                , 0x701f58c5 -- Commit Batches, post-Boojum
+                , 0xce9dcf16 -- Execute Block, pre-Boojum
+                , 0xc3d93e7c -- Execute Batches, post-Boojum
+            ) THEN 324
+            WHEN bytearray_substring(t.data, 1, 4) IN (
+                0x6edd4f12 -- Commit Batches Shared Bridge, post-v24
+                , 0x6f497ac6 -- Execute Batches Shared Bridge, post-v24
+            ) THEN varbinary_to_uint256(varbinary_substring(t.data, 5, 32))
+            ELSE 324
+        END AS chain_id        
+    FROM {{ source('ethereum', 'transactions') }} t
+    WHERE t.to IN (
+        0x3dB52cE065f728011Ac6732222270b3F2360d919 -- L1 transactions settle here pre-Boojum
+        , 0xa0425d71cB1D6fb80E65a5361a04096E0672De03 -- L1 transactions settle here post-Boojum
+        , 0xa8CB082A5a689E0d594d7da1E2d72A3D63aDc1bD -- L1 transactions settle here post-EIP4844
+        , 0x5D8ba173Dc6C3c90C8f7C04C9288BeF5FDbAd06E -- L1 transactions settle here post v24 upgrade (shared bridge)
+    )
+    AND bytearray_substring(t.data, 1, 4) IN (
+        0x0c4dd810 -- Commit Block, pre-Boojum
+        , 0xce9dcf16 -- Execute Block, pre-Boojum
+        , 0x701f58c5 -- Commit Batches, post-Boojum
+        , 0xc3d93e7c -- Execute Batches, post-Boojum
+        , 0x6edd4f12 -- Commit Batches, post v24 upgrade (shared bridge)
+        , 0x6f497ac6 -- Execute Batches, post v24 upgrade (shared bridge)
+    )
+    AND t.block_time >= TIMESTAMP '2023-02-14'
+    {% if is_incremental() %}
+    AND {{incremental_predicate('t.block_time')}}
+    {% endif %}
+)
+
 SELECT
     'zksync era' AS name
-    , cast(date_trunc('month', t.block_time) AS date) AS block_month
-    , cast(date_trunc('day', t.block_time) AS date) AS block_date
-    , t.block_time
-    , t.block_number
-    , t.hash AS tx_hash
-    , t.index AS tx_index
-    , t.gas_price
-    , t.gas_used
-    , (t.gas_price / 1e18) * t.gas_used AS data_fee_native
-    , {{ evm_get_calldata_gas_from_data('t.data') }} AS calldata_gas_used
-    , (length(t.data)) AS data_length
-FROM {{ source('ethereum', 'transactions') }} t
-WHERE t.to IN (
-    0x3dB52cE065f728011Ac6732222270b3F2360d919 -- L1 transactions settle here pre-Boojum
-    , 0xa0425d71cB1D6fb80E65a5361a04096E0672De03 -- L1 transactions settle here post-Boojum
-    , 0xa8CB082A5a689E0d594d7da1E2d72A3D63aDc1bD -- L1 transactions settle here post-EIP4844
-    , 0x5D8ba173Dc6C3c90C8f7C04C9288BeF5FDbAd06E -- L1 transactions settle here post v24 upgrade (shared bridge)
-)
-AND bytearray_substring(t.data, 1, 4) IN (
-    0x0c4dd810 -- Commit Block, pre-Boojum
-    , 0xce9dcf16 -- Execute Block, pre-Boojum
-    , 0x701f58c5 -- Commit Batches, post-Boojum
-    , 0xc3d93e7c -- Execute Batches, post-Boojum
-    , 0x6edd4f12 -- Commit Batches, post v24 upgrade (shared bridge)
-    , 0x6f497ac6 -- Execute Batches, post v24 upgrade (shared bridge)
-)
-AND t.block_time >= TIMESTAMP '2023-02-14'
-{% if is_incremental() %}
-AND {{incremental_predicate('t.block_time')}}
-{% endif %}
+    , block_month
+    , block_date
+    , block_time
+    , block_number
+    , tx_hash
+    , tx_index
+    , gas_price
+    , gas_used
+    , data_fee_native
+    , calldata_gas_used
+    , data_length
+FROM data
+WHERE chain_id = 324 -- zksync era

--- a/dbt_subprojects/hourly_spellbook/models/_sector/rollup_economics/ethereum/l1_verification_fees/chains/rollup_economics_zksync_l1_verification_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/rollup_economics/ethereum/l1_verification_fees/chains/rollup_economics_zksync_l1_verification_fees.sql
@@ -8,32 +8,59 @@
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
 )}}
 
+WITH data AS (
+    SELECT
+        cast(date_trunc('month', t.block_time) AS date) AS block_month
+        , cast(date_trunc('day', t.block_time) AS date) AS block_date
+        , t.block_time
+        , t.block_number
+        , t.hash AS tx_hash
+        , t.index AS tx_index
+        , t.gas_price
+        , t.gas_used
+        , (t.gas_price / 1e18) * t.gas_used AS verification_fee_native
+        , {{ evm_get_calldata_gas_from_data('t.data') }} AS calldata_gas_used
+        , 44*32 / cast(1024 AS double) / cast(1024 AS double) AS proof_size_mb
+        , CASE -- If prior to shared bridge, chain_id is always equal to 324 for zksync era. If on shared bridge, fetch chain_id.
+            WHEN bytearray_substring(t.data, 1, 4) IN (
+                0x7739cbe7 -- Prove Block, pre-Boojum
+                , 0x7f61885c -- Prove Batches, post-Boojum
+            ) THEN 324
+            WHEN bytearray_substring(t.data, 1, 4) IN (
+                0xc37533bb -- Prove Batches Shared Bridge, post-v24
+            ) THEN varbinary_to_uint256(varbinary_substring(t.data, 5, 32))
+            ELSE 324
+        END AS chain_id           
+    FROM {{ source('ethereum', 'transactions') }} AS t
+    WHERE t.to IN (
+        0x3dB52cE065f728011Ac6732222270b3F2360d919 -- L1 transactions settle here pre-Boojum
+        , 0xa0425d71cB1D6fb80E65a5361a04096E0672De03 -- L1 transactions settle here post-Boojum
+        , 0xa8CB082A5a689E0d594d7da1E2d72A3D63aDc1bD -- L1 transactions settle here post-EIP4844
+        , 0x5D8ba173Dc6C3c90C8f7C04C9288BeF5FDbAd06E -- L1 transactions settle here post v24 upgrade (shared bridge)
+    )
+    AND bytearray_substring(t.data, 1, 4) IN (
+        0x7739cbe7 -- Prove Block, pre-Boojum
+        , 0x7f61885c -- Prove Batches, post-Boojum
+        , 0xc37533bb -- Prove Batches, post v24 upgrade (shared bridge)
+    )
+    AND t.block_time >= TIMESTAMP '2023-02-14'
+    {% if is_incremental() %}
+    AND {{incremental_predicate('t.block_time')}}
+    {% endif %}
+)
+
 SELECT
     'zksync era' AS name
-    , cast(date_trunc('month', t.block_time) AS date) AS block_month
-    , cast(date_trunc('day', t.block_time) AS date) AS block_date
-    , t.block_time
-    , t.block_number
-    , t.hash AS tx_hash
-    , t.index AS tx_index
-    , t.gas_price
-    , t.gas_used
-    , (t.gas_price / 1e18) * t.gas_used AS verification_fee_native
-    , {{ evm_get_calldata_gas_from_data('t.data') }} AS calldata_gas_used
-    , 44*32 / cast(1024 AS double) / cast(1024 AS double) AS proof_size_mb
-FROM {{ source('ethereum', 'transactions') }} AS t
-WHERE t.to IN (
-    0x3dB52cE065f728011Ac6732222270b3F2360d919 -- L1 transactions settle here pre-Boojum
-    , 0xa0425d71cB1D6fb80E65a5361a04096E0672De03 -- L1 transactions settle here post-Boojum
-    , 0xa8CB082A5a689E0d594d7da1E2d72A3D63aDc1bD -- L1 transactions settle here post-EIP4844
-    , 0x5D8ba173Dc6C3c90C8f7C04C9288BeF5FDbAd06E -- L1 transactions settle here post v24 upgrade (shared bridge)
-)
-AND bytearray_substring(t.data, 1, 4) IN (
-    0x7739cbe7 -- Prove Block, pre-Boojum
-    , 0x7f61885c -- Prove Batches, post-Boojum
-    , 0xc37533bb -- Prove Batches, post v24 upgrade (shared bridge)
-)
-AND t.block_time >= TIMESTAMP '2023-02-14'
-{% if is_incremental() %}
-AND {{incremental_predicate('t.block_time')}}
-{% endif %}
+    , block_month
+    , block_date
+    , block_time
+    , block_number
+    , tx_hash
+    , tx_index
+    , gas_price
+    , gas_used
+    , verification_fee_native
+    , calldata_gas_used
+    , proof_size_mb
+FROM data
+WHERE chain_id = 324 -- zksync era


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

The shared bridge upgrade for zksync added the capability for multiple zk chains to settle to the same L1 bridge. This also added `chain_id` in the transaction data which is used here to filter out chains which aren't zksync era.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
