### PR TITLE
Add addresses for ApeOut 1inch, Helixbox, and Elfomo

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/arbitrum/cow_protocol_arbitrum_solvers.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/arbitrum/cow_protocol_arbitrum_solvers.sql
@@ -79,11 +79,11 @@ known_solver_metadata (address, environment, name) as (
                 (0x8C3f83f6A489cCbA2E3df304034F8C120cEb3527, 'barn', 'GlueX_Protocol'),
                 (0x49E1F55D4a695291533BB0A993aca5D58E90C613, 'prod', 'GlueX_Protocol'),
                 (0x3144a51a7699c629070d6aAEf68256c2d07a6334, 'barn', 'OKX'),
-                (0x7F636D152AB0Cfc68A899d4dF441F2322cd78C6B, 'prod', 'OKX')
+                (0x7F636D152AB0Cfc68A899d4dF441F2322cd78C6B, 'prod', 'OKX'),
                 (0x7199cF10CF16b85fb59170d5c83d114Ac11d3afA, 'barn', 'ApeOut_1inch'),
                 (0xDd8a1F39fFBFB77c488054CB18f53aa9A3c4bD9D, 'prod', 'ApeOut_1inch'),
                 (0x312B5D8AbC6b7C8355B86f5F7803E9cD97AE8D75, 'barn', 'Helixbox'),
-                (0x4CdbA844CEB949567eA18b9EF185515fA626c69D, 'prod', 'Helixbox'),
+                (0x4CdbA844CEB949567eA18b9EF185515fA626c69D, 'prod', 'Helixbox')
     ) as _
 )
 -- Combining the metadata with current activation status for final table

--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/arbitrum/cow_protocol_arbitrum_solvers.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/arbitrum/cow_protocol_arbitrum_solvers.sql
@@ -80,6 +80,10 @@ known_solver_metadata (address, environment, name) as (
                 (0x49E1F55D4a695291533BB0A993aca5D58E90C613, 'prod', 'GlueX_Protocol'),
                 (0x3144a51a7699c629070d6aAEf68256c2d07a6334, 'barn', 'OKX'),
                 (0x7F636D152AB0Cfc68A899d4dF441F2322cd78C6B, 'prod', 'OKX')
+                (0x7199cF10CF16b85fb59170d5c83d114Ac11d3afA, 'barn', 'ApeOut_1inch'),
+                (0xDd8a1F39fFBFB77c488054CB18f53aa9A3c4bD9D, 'prod', 'ApeOut_1inch'),
+                (0x312B5D8AbC6b7C8355B86f5F7803E9cD97AE8D75, 'barn', 'Helixbox'),
+                (0x4CdbA844CEB949567eA18b9EF185515fA626c69D, 'prod', 'Helixbox'),
     ) as _
 )
 -- Combining the metadata with current activation status for final table

--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/ethereum/cow_protocol_ethereum_solvers.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/ethereum/cow_protocol_ethereum_solvers.sql
@@ -123,6 +123,8 @@ known_solver_metadata (address, environment, name) as (
                  (0xbada5552a3e5e2fb57db982e29257821a2cf192d, 'prod', 'Project_Blanc'),
                  (0x34717040928D7fd8154d4612f3228EFf14521023, 'prod', 'Laita'),
                  (0xdcE5B9574C9A18B4f1713C80BfC53623c007e7e1, 'prod', 'OKX'),
+                 (0x42cb97c2695cF6227C3a1323A1942089ABc9716B, 'prod', 'Elfomo'),
+                 (0x6b8Dc2Dd45bBF6A71a987b61cC4Dbbdf7C601c20, 'barn', 'Elfomo'),
                  (0xD2E90778eE3F480d305FF535bE88f5AF9F2ac85c, 'barn', 'OKX'),
                  (0xBab555BaBEe5d867983902bC8db8F707157245Be, 'barn', 'Project_Blanc'),
                  (0x854490ef1d402D4f6fce05aBefE1C676eB0DCD74, 'barn', 'ApeOut_1inch'),


### PR DESCRIPTION
### Description:
This PR adds the barn and production addresses for the Helixbox and ApeOut 1inch solvers on Arbitrum, and the barn and production addresses for the Elfomo solver on mainnet.