### PR TITLE
 Fix Typos in Configuration Files

### DIFF
--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get latest manifest
         run: "aws s3 cp $S3_LOCATION/manifest.json $PROJECT_DIR/manifest.json"
-        continue-on-error: true # Temprorary until all projects have manifest
+        continue-on-error: true # Temporary until all projects have manifest
 
       - name: dbt dependencies
         working-directory: ${{env.PROJECT_DIR}}

--- a/dbt_macros/dune/macros_schema.yml
+++ b/dbt_macros/dune/macros_schema.yml
@@ -23,7 +23,7 @@ macros:
 
   - name: is_incremental
     description: >
-      Overrides the core is_incremental marco to allow the usage of a force-incremental command line variable.
+      Overrides the core is_incremental macro to allow the usage of a force-incremental command line variable.
       This enables us to easily get the compiled incremental models. 
       Example usage: dbt compile --vars '{force-incremental: True}'
 


### PR DESCRIPTION




1. `.github/workflows/dbt_run.yml`
- Fixed typo: "Temprorary" → "Temporary" in comment

2. `dbt_macros/dune/macros_schema.yml`
- Fixed typo: "marco" → "macro" in description

## Why
These corrections improve documentation accuracy and readability. While they don't affect functionality, maintaining correct technical terminology and spelling is important for code maintainability and professionalism.

