### PR TITLE
feat(tokens): Add ROCI, PYTH, and TOSHI to Ethereum tokens list

### DIFF
--- a/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_erc20.sql
+++ b/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_erc20.sql
@@ -12,6 +12,9 @@ SELECT
     , trim(symbol) as symbol
     , decimals
 FROM (VALUES
+    (0x8e87e65ba24b708f1f458d208cc5537ac120bc17, 'PYTH', 6)
+    , (0x3717d9e9d0921c219674c2b0c0ff3b31519b1f62, 'ROCI', 18)
+    , (0x8544fe9d190fd7ec52860abbf45088e81ee24a8c, 'TOSHI', 18)
     (0x01c0987e88f778df6640787226bc96354e1a9766, 'UAT', 18)
     , (0x080eb7238031f97ff011e273d6cad5ad0c2de532, 'KIT', 18)
     , (0x0efc2390c79c47452898a234a27f2b9c39a7a725, 'EST', 18)


### PR DESCRIPTION
This PR adds three popular ERC20 tokens to the Ethereum tokens list:

1. ROCI (Rocket Pool Insurance) - `0x3717d9e9d0921c219674c2b0c0ff3b31519b1f62`
   - Verification: https://etherscan.io/token/0x3717d9e9d0921c219674c2b0c0ff3b31519b1f62
   - Decimals: 18

2. PYTH (Pyth Network) - `0x8e87e65ba24b708f1f458d208cc5537ac120bc17`
   - Verification: https://etherscan.io/token/0x8e87e65ba24b708f1f458d208cc5537ac120bc17
   - Decimals: 6

3. TOSHI (Toshi Protocol) - `0x8544fe9d190fd7ec52860abbf45088e81ee24a8c`
   - Verification: https://etherscan.io/token/0x8544fe9d190fd7ec52860abbf45088e81ee24a8c
   - Decimals: 18

Checklist:
- [x] Contract addresses verified on Etherscan
- [x] Tokens are not duplicates (checked all networks)
- [x] Added in alphabetical order by symbol
- [x] Correct decimal places specified