### PR TITLE
Update GitHub Actions checkout version from v2 to v3

### DIFF
--- a/.github/workflows/prices_check.yml
+++ b/.github/workflows/prices_check.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
 
       - name: Fetch base commit

--- a/.github/workflows/spellbook_metadata.yml
+++ b/.github/workflows/spellbook_metadata.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v3
       - name: Checkout main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: main
           fetch-depth: 0


### PR DESCRIPTION
Reason for Changes
actions/checkout@v2 is being phased out
v3 provides better performance and security
Recommended to keep GitHub Actions up to date
Better integration with GitHub's newer features
Improved token handling
Impact

This maintenance update improves workflow security and reliability without changing functionality. The change is backward compatible and poses no risk to existing processes.
