### PR TITLE
improvement for balancer erc4626 tokens

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/erc4626_tokens/ethereum/balancer_v3_ethereum_erc4626_token_mapping.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/erc4626_tokens/ethereum/balancer_v3_ethereum_erc4626_token_mapping.sql
@@ -70,6 +70,20 @@ FROM {{ source('metamorpho_factory_ethereum', 'MetaMorphoV1_1Factory_evt_CreateM
 JOIN {{ source('tokens', 'erc20') }} t
 ON t.blockchain = 'ethereum'
 AND a.asset = t.contract_address
+AND a.metaMorpho != 0xbeefc011e94f43b8b7b455ebab290c7ab4e216f1
+
+UNION 
+
+SELECT 
+    erc4626_token,
+    erc4626_token_name,
+    erc4626_token_symbol,
+    underlying_token,
+    underlying_token_symbol,
+    decimals
+FROM (VALUES 
+    (0xbeefc011e94f43b8b7b455ebab290c7ab4e216f1, 'Coinshift USDL', 'csUDL', 0xbdC7c08592Ee4aa51D06C27Ee23D5087D65aDbcD, 'USDL', 18)
+    ) AS temp_table (erc4626_token, erc4626_token_name, erc4626_token_symbol, underlying_token, underlying_token_symbol, decimals)
 )
 
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/erc4626_tokens/ethereum/balancer_v3_ethereum_erc4626_token_prices.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/erc4626_tokens/ethereum/balancer_v3_ethereum_erc4626_token_prices.sql
@@ -41,7 +41,7 @@ WITH wrap_unwrap AS(
         m.erc4626_token_symbol,
         m.underlying_token_symbol,
         m.decimals,
-        ratio * price AS adjusted_price
+        ratio * price * POWER(10, (m.decimals - p.decimals)) AS adjusted_price
     FROM wrap_unwrap w
     JOIN {{ref('balancer_v3_ethereum_erc4626_token_mapping')}} m ON m.erc4626_token = w.wrappedToken
     JOIN {{ source('prices', 'usd') }} p ON m.underlying_token = p.contract_address

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/erc4626_tokens/gnosis/balancer_v3_gnosis_erc4626_token_prices.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/erc4626_tokens/gnosis/balancer_v3_gnosis_erc4626_token_prices.sql
@@ -41,7 +41,7 @@ WITH wrap_unwrap AS(
         m.erc4626_token_symbol,
         m.underlying_token_symbol,
         m.decimals,
-        ratio * price AS adjusted_price
+        ratio * price * POWER(10, (m.decimals - p.decimals)) AS adjusted_price
     FROM wrap_unwrap w
     JOIN {{ref('balancer_v3_gnosis_erc4626_token_mapping')}} m ON m.erc4626_token = w.wrappedToken
     JOIN {{ source('prices', 'usd') }} p ON m.underlying_token = p.contract_address

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/erc4626_tokens/sonic/balancer_v3_sonic_erc4626_token_prices.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/erc4626_tokens/sonic/balancer_v3_sonic_erc4626_token_prices.sql
@@ -41,7 +41,7 @@ WITH wrap_unwrap AS(
         m.erc4626_token_symbol,
         m.underlying_token_symbol,
         m.decimals,
-        ratio * price AS adjusted_price
+        ratio * price * POWER(10, (m.decimals - p.decimals)) AS adjusted_price
     FROM wrap_unwrap w
     JOIN {{ref('balancer_v3_sonic_erc4626_token_mapping')}} m ON m.erc4626_token = w.wrappedToken
     JOIN {{ source('prices', 'usd') }} p ON m.underlying_token = p.contract_address


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

This PR helps account for right price of ERC4626 tokens, given that some have different decimals from their underlying tokens, which was impacting the correct ratio between deposits and shares.
It also manually tracks csUSDL to USDL instead of wUSDL, given that wUSDL isn't tracked on coinpaprika


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
