### PR TITLE
Fix dex_berachain_base_trades.sql

### DIFF
--- a/dbt_subprojects/dex/models/trades/berachain/dex_berachain_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/berachain/dex_berachain_base_trades.sql
@@ -42,7 +42,7 @@ WITH base_union AS (
 {{
     add_tx_columns(
         model_cte = 'base_union'
-        , blockchain = 'base'
+        , blockchain = 'berachain'
         , columns = ['from', 'to', 'index']
     )
 }}


### PR DESCRIPTION
This pull request includes a small but important change to the SQL file `dex_berachain_base_trades.sql`. The change updates the blockchain name from 'base' to 'berachain' in the `add_tx_columns` function call.

* [`dbt_subprojects/dex/models/trades/berachain/dex_berachain_base_trades.sql`](diffhunk://#diff-95d02bbbef6660b8e70466779d46019fdf6315ce500e77e8c2bda8a2e40128abL45-R45): Updated the `blockchain` parameter from 'base' to 'berachain' in the `add_tx_columns` function call.