### PR TITLE
feat(tokens): Add MODE chain to native tokens post_hook

### DIFF
--- a/dbt_subprojects/tokens/models/tokens/tokens_native.sql
+++ b/dbt_subprojects/tokens/models/tokens/tokens_native.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias='native',
         tags=['static'],
-        post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","bnb","ethereum","optimism", "gnosis", "fantom", "polygon","solana", "celo", "zksync", "mantle","blast","scroll","linea"]\',
+        post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","bnb","ethereum","optimism", "gnosis", "fantom", "polygon","solana", "celo", "zksync", "mantle","blast","scroll","linea","mode"]\',
                                     "sector",
                                     "tokens",
                                     \'["0xManny","hildobby","soispoke","dot2dotseurat","mtitus6","wuligy","lgingerich","angus_1","Henrystats","rantum"]\') }}')}}


### PR DESCRIPTION
Add MODE chain to the list of supported chains in tokens_native.sql post_hook configuration. This ensures proper handling of MODE native token in the system.

The MODE chain and its native token were already present in the token list but were not included in the post_hook expose_spells configuration, which could lead to incomplete processing. This commit fixes this oversight by adding MODE to the list of supported chains.
