### PR TITLE
prices_v2: exclude minute sparse on dupe failure

### DIFF
--- a/dbt_subprojects/tokens/models/prices_v2/sparse_prices/prices_v2_minute_sparse.sql
+++ b/dbt_subprojects/tokens/models/prices_v2/sparse_prices/prices_v2_minute_sparse.sql
@@ -1,4 +1,5 @@
 {{ config(
+        tags = ['prod_exclude'],
         schema='prices_v2',
         alias = 'minute_sparse',
         file_format = 'delta',


### PR DESCRIPTION
here is the scenario:
- updated berachain prices and trusted tokens in #7679 
- prod ran modified step and updated modified models in PR
- regular incremental run failed on duplicates for a token on berachain which was *_removed_* from trusted tokens (not sure how often we remove one there)

looks like maybe this process broke the logic in this pipeline?
it's a bit too late for me to dig into this much deeper, so excluding for now.