### PR TITLE
fix: Column rename in gyroscope_arbitrum.gyro2clppoolfactory_call_create

### DIFF
--- a/dbt_subprojects/dex/models/_projects/balancer/labels/arbitrum/labels_balancer_v2_pools_arbitrum.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/arbitrum/labels_balancer_v2_pools_arbitrum.sql
@@ -237,7 +237,7 @@ WITH pools AS (
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
   CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-/*
+
   UNION ALL
 
   SELECT
@@ -250,8 +250,9 @@ WITH pools AS (
   INNER JOIN {{ source('gyroscope_arbitrum', 'Gyro2CLPPoolFactory_call_create') }} cc
     ON c.evt_tx_hash = cc.call_tx_hash
     AND bytearray_substring(c.poolId, 1, 20) = cc.output_0
-  CROSS JOIN UNNEST(cc.tokens) AS t(tokens)
-*/
+  CROSS JOIN UNNEST(cc.tokens_array_binary) AS t(tokens)
+  WHERE cc.tokens_array_binary IS NOT NULL
+
   UNION ALL
   
   SELECT


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

The column name changed from 'tokens' to 'tokens_array_binary'


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
