### PR TITLE
Implements meta pools support in dex_raw_pool_creations.sql by adding meta pool data to pool_created_logs CTE.

### DIFF
--- a/dbt_subprojects/dex/models/pools/dex_raw_pool_creations.sql
+++ b/dbt_subprojects/dex/models/pools/dex_raw_pool_creations.sql
@@ -311,6 +311,23 @@ uniswap_pool_created_logs as (
         , contract_address
         , tx_hash
     from curve_base_pool_created_calls
+
+    union all
+
+    select 
+        blockchain
+        , type
+        , version
+        , pool
+        , coin as token0
+        , base_pool as token1
+        , array[coin, base_pool] as tokens
+        , cast(null as uint256) as fee
+        , block_time
+        , block_number
+        , contract_address
+        , tx_hash
+    from curve_meta_pool_created_calls
 )
 
 


### PR DESCRIPTION
Changes:
- Added curve_meta_pool_created_calls data to main union
- Mapped meta pool structure: coin -> token0, base_pool -> token1
- Set fee as null for meta pools

Resolves TODO: "implement meta pools logic"