### PR TITLE
feat(tokens): Add Solayer (LAYER) token to Solana tokens list

### DIFF
--- a/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
@@ -735,5 +735,6 @@ FROM
         ('chillguy-just-a-chill-guy', 'solana', 'CHILLGUY', 'Df6yfrKC8kZE3KNkrHERKzAetSxbrWeniQfyJY4Jpump', 6),
         ('kmno-kamino-finance', 'solana', 'KMNO', 'KMNo3nJsBXfcpJTVhZcXLW7RmTwTt4GVFE7suUBo9sS', 6),
         ('pyusd-paypal-usd', 'solana', 'PyUSD', '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo', 6),
-        ('prcl-parcl', 'solana', 'PRCL', '4LLbsb5ReP3yEtYzmXewyGjcir5uXtKFURtaEUVC2AHs', 6)
+        ('prcl-parcl', 'solana', 'PRCL', '4LLbsb5ReP3yEtYzmXewyGjcir5uXtKFURtaEUVC2AHs', 6),
+        ('layer-solayer', 'solana', 'LAYER', 'LAYER4xPpTCb3QL8S9u41EAhAX7mhBn8Q6xMTwY2Yzc', 9)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Description:

Added new Solayer (LAYER) token to the Solana tokens list.

Token details:
- Token ID: `layer-solayer`
- Blockchain: `solana`
- Symbol: `LAYER`
- Contract address: `LAYER4xPpTCb3QL8S9u41EAhAX7mhBn8Q6xMTwY2Yzc`
- Decimals: `9`

Changes:
- Added new entry to `dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql`
- Token data verified via [Solscan](https://solscan.io/token/LAYER4xPpTCb3QL8S9u41EAhAX7mhBn8Q6xMTwY2Yzc)

Pull request is opened in **draft** status and will be ready for review after changes verification.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)