### PR TITLE
polygon net transfers per asset: update native token address

### DIFF
--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_net_transfers_daily_asset.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_net_transfers_daily_asset.sql
@@ -14,6 +14,6 @@
 
 {{ evm_net_transfers_daily_asset(
         blockchain=blockchain,
-        native_contract_address='0x0000000000000000000000000000000000001010'
+        native_contract_address=var('ETH_ERC20_ADDRESS')
 ) 
 }}


### PR DESCRIPTION
duplicates were introduced by using this native token address. either:
- address is incorrect and `dune.blockchains` needs updated
- or polygon has a special case, as this `0x0000000000000000000000000000000000001010` address appears in the erc20 transfers table which is unexpected

for now, update to universal native token address until we can understand the usage better.