### PR TITLE
Build utility timeseries for days, hours and minutes

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/_schema.yml
@@ -1,0 +1,59 @@
+version: 2
+
+models:
+  - name: utils_days
+    meta:
+      contributors: 0xRob
+    config:
+      tags: [ 'utils', 'days' ]
+    description: >
+      Utility model to have a table of days from bitcoin genesis to current date
+  
+  - name: utils_hours
+    meta:
+      contributors: 0xRob
+    config:
+      tags: [ 'utils', 'hours' ]
+    description: >
+      Utility model to have a table of hours from bitcoin genesis to current timestamp
+
+  - name: utils_minutes
+    meta:
+      contributors: 0xRob
+    config:
+      tags: [ 'utils', 'minutes' ]
+    description: >
+      Utility model to have a table of minutes from bitcoin genesis to current timestamp
+
+  - name: utils_days_table
+    description: >
+      materialized model of days, including some days in the future
+    columns:
+      - name: timestamp
+        data_tests:
+          - unique
+          - dbt_utils.sequential_values:
+              interval: 1
+              datepart: 'day'
+
+  - name: utils_hours_table
+    description: >
+      materialized model of hours, including some hours in the future
+    columns:
+      - name: timestamp
+        data_tests:
+          - unique
+          - dbt_utils.sequential_values:
+              interval: 1
+              datepart: 'hour'
+
+  - name: utils_minutes_table
+    description: >
+      materialized model of minutes, including some minutes in the future
+    columns:
+      - name: timestamp
+        data_tests:
+          - unique
+          - dbt_utils.sequential_values:
+              interval: 1
+              datepart: 'minute'

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days.sql
@@ -1,0 +1,9 @@
+{{ config(
+    schema = 'utils',
+    alias = 'days',
+    materialized = 'view'
+}}
+
+
+select * from {{ref('utils_days_table')}}
+where timestamp <= now()

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days.sql
@@ -1,7 +1,11 @@
 {{ config(
     schema = 'utils',
     alias = 'days',
-    materialized = 'view'
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'[]',
+                                    "sector",
+                                    "utils",
+                                    \'["0xRob"]\') }}'
     )
 }}
 

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days.sql
@@ -2,6 +2,7 @@
     schema = 'utils',
     alias = 'days',
     materialized = 'view'
+    )
 }}
 
 

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days.sql
@@ -2,7 +2,7 @@
     schema = 'utils',
     alias = 'days',
     materialized = 'view',
-    post_hook='{{ expose_spells(\'[]',
+    post_hook='{{ expose_spells(\'[]\',
                                     "sector",
                                     "utils",
                                     \'["0xRob"]\') }}'

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
@@ -4,7 +4,8 @@
     materialized = 'incremental',
     file_format = 'delta',
     unique_key = 'timestamp',
-    incremental_strategy = 'merge',
+    incremental_strategy = 'merge'
+    )
 }}
 
 

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
@@ -13,7 +13,7 @@ SELECT timestamp
 FROM unnest(
     sequence(
         {%if is_incremental() %}
-        cast(date_trunc('day', now()) as timestamp)- interval '{{env_var('DBT_ENV_INCREMENTAL_TIME')}}' {{env_var('DBT_ENV_INCREMENTAL_TIME_UNIT')}}
+        cast(date_trunc('day', now()) as timestamp)- interval '{{var("DBT_ENV_INCREMENTAL_TIME")}}' {{var("DBT_ENV_INCREMENTAL_TIME_UNIT")}}
         {% else %}
         timestamp '2009-01-03'
         {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
@@ -21,3 +21,4 @@ FROM unnest(
         , interval '1' day
         )
     ) as foo(timestamp)
+order by timestamp asc

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
@@ -5,7 +5,7 @@
     file_format = 'delta'
     )
 }}
-
+-- these are set up as tables instead of incremental models because this guarantees the ordering and compute is negligable.
 
 SELECT timestamp
 FROM unnest(

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
@@ -1,10 +1,8 @@
 {{ config(
     schema = 'utils',
     alias = 'days_table',
-    materialized = 'incremental',
-    file_format = 'delta',
-    unique_key = 'timestamp',
-    incremental_strategy = 'merge'
+    materialized = 'table',
+    file_format = 'delta'
     )
 }}
 
@@ -12,11 +10,7 @@
 SELECT timestamp
 FROM unnest(
     sequence(
-        {%if is_incremental() %}
-        cast(date_trunc('day', now()) as timestamp)- interval '{{var("DBT_ENV_INCREMENTAL_TIME")}}' {{var("DBT_ENV_INCREMENTAL_TIME_UNIT")}}
-        {% else %}
         timestamp '2009-01-03'
-        {% endif %}
         , cast(date_trunc('day', now()) as timestamp)+ interval '3' day  -- add some padding to account for materialization lag
         , interval '1' day
         )

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
@@ -17,7 +17,7 @@ FROM unnest(
         {% else %}
         timestamp '2009-01-03'
         {% endif %}
-        , cast(date_trunc('day', now()) as timestamp)+ interval '2' day  -- add some padding to account for materialization lag
+        , cast(date_trunc('day', now()) as timestamp)+ interval '3' day  -- add some padding to account for materialization lag
         , interval '1' day
         )
     ) as foo(timestamp)

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_days_table.sql
@@ -1,0 +1,22 @@
+{{ config(
+    schema = 'utils',
+    alias = 'days_table',
+    materialized = 'incremental',
+    file_format = 'delta',
+    unique_key = 'timestamp',
+    incremental_strategy = 'merge',
+}}
+
+
+SELECT timestamp
+FROM unnest(
+    sequence(
+        {%if is_incremental() %}
+        cast(date_trunc('day', now()) as timestamp)- interval '{{env_var('DBT_ENV_INCREMENTAL_TIME')}}' {{env_var('DBT_ENV_INCREMENTAL_TIME_UNIT')}}
+        {% else %}
+        timestamp '2009-01-03'
+        {% endif %}
+        , cast(date_trunc('day', now()) as timestamp)+ interval '2' day  -- add some padding to account for materialization lag
+        , interval '1' day
+        )
+    ) as foo(timestamp)

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours.sql
@@ -2,6 +2,7 @@
     schema = 'utils',
     alias = 'hours',
     materialized = 'view'
+    )
 }}
 
 

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours.sql
@@ -2,7 +2,7 @@
     schema = 'utils',
     alias = 'hours',
     materialized = 'view',
-    post_hook='{{ expose_spells(\'[]',
+    post_hook='{{ expose_spells(\'[]\',
                                     "sector",
                                     "utils",
                                     \'["0xRob"]\') }}'

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours.sql
@@ -1,7 +1,11 @@
 {{ config(
     schema = 'utils',
     alias = 'hours',
-    materialized = 'view'
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'[]',
+                                    "sector",
+                                    "utils",
+                                    \'["0xRob"]\') }}'
     )
 }}
 

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours.sql
@@ -1,0 +1,9 @@
+{{ config(
+    schema = 'utils',
+    alias = 'hours',
+    materialized = 'view'
+}}
+
+
+select * from {{ref('utils_hours_table')}}
+where timestamp <= now()

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours_table.sql
@@ -4,7 +4,8 @@
     materialized = 'incremental',
     file_format = 'delta',
     unique_key = 'timestamp',
-    incremental_strategy = 'merge',
+    incremental_strategy = 'merge'
+    )
 }}
 
 

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours_table.sql
@@ -1,0 +1,25 @@
+{{ config(
+    schema = 'utils',
+    alias = 'hours_table',
+    materialized = 'incremental',
+    file_format = 'delta',
+    unique_key = 'timestamp',
+    incremental_strategy = 'merge',
+}}
+
+
+with days as (
+    select * from {{ref('utils_days_table')}}
+    {%if is_incremental() %}
+    where {{incremental_predicate('timestamp')}}
+    {%endif%}
+)
+
+SELECT * FROM (
+        SELECT date_add('hour', hour, day) as timestamp
+        FROM (
+            SELECT timestamp as day 
+            FROM days
+        )
+        CROSS JOIN unnest(sequence(0, 23)) AS h(hour)
+)

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours_table.sql
@@ -1,19 +1,14 @@
 {{ config(
     schema = 'utils',
     alias = 'hours_table',
-    materialized = 'incremental',
-    file_format = 'delta',
-    unique_key = 'timestamp',
-    incremental_strategy = 'merge'
+    materialized = 'table',
+    file_format = 'delta'
     )
 }}
 
 
 with days as (
     select * from {{ref('utils_days_table')}}
-    {%if is_incremental() %}
-    where {{incremental_predicate('timestamp')}}
-    {%endif%}
 )
 
 SELECT * FROM (

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_hours_table.sql
@@ -24,3 +24,4 @@ SELECT * FROM (
         )
         CROSS JOIN unnest(sequence(0, 23)) AS h(hour)
 )
+order by timestamp asc

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes.sql
@@ -2,7 +2,7 @@
     schema = 'utils',
     alias = 'minutes',
     materialized = 'view',
-    post_hook='{{ expose_spells(\'[]',
+    post_hook='{{ expose_spells(\'[]\',
                                     "sector",
                                     "utils",
                                     \'["0xRob"]\') }}'

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes.sql
@@ -2,6 +2,7 @@
     schema = 'utils',
     alias = 'minutes',
     materialized = 'view'
+    )
 }}
 
 

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes.sql
@@ -1,7 +1,11 @@
 {{ config(
     schema = 'utils',
     alias = 'minutes',
-    materialized = 'view'
+    materialized = 'view',
+    post_hook='{{ expose_spells(\'[]',
+                                    "sector",
+                                    "utils",
+                                    \'["0xRob"]\') }}'
     )
 }}
 

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes.sql
@@ -1,0 +1,9 @@
+{{ config(
+    schema = 'utils',
+    alias = 'minutes',
+    materialized = 'view'
+}}
+
+
+select * from {{ref('utils_minutes_table')}}
+where timestamp <= now()

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes_table.sql
@@ -1,0 +1,25 @@
+{{ config(
+    schema = 'utils',
+    alias = 'hours_table',
+    materialized = 'incremental',
+    file_format = 'delta',
+    unique_key = 'timestamp',
+    incremental_strategy = 'merge',
+}}
+
+
+with hours as (
+    select * from {{ref('utils_hours_table')}}
+    {%if is_incremental() %}
+    where {{incremental_predicate('timestamp')}}
+    {%endif%}
+)
+
+SELECT * FROM (
+        SELECT date_add('minute', minute, hour) as timestamp
+        FROM (
+            SELECT timestamp as hour 
+            FROM hours
+        )
+        CROSS JOIN unnest(sequence(0, 59)) AS m(minute)
+)

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes_table.sql
@@ -24,3 +24,4 @@ SELECT * FROM (
         )
         CROSS JOIN unnest(sequence(0, 59)) AS m(minute)
 )
+order by timestamp asc

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes_table.sql
@@ -1,10 +1,11 @@
 {{ config(
     schema = 'utils',
-    alias = 'hours_table',
+    alias = 'minutes_table',
     materialized = 'incremental',
     file_format = 'delta',
     unique_key = 'timestamp',
-    incremental_strategy = 'merge',
+    incremental_strategy = 'merge'
+    )
 }}
 
 

--- a/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes_table.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/utils/utils_minutes_table.sql
@@ -1,19 +1,14 @@
 {{ config(
     schema = 'utils',
     alias = 'minutes_table',
-    materialized = 'incremental',
-    file_format = 'delta',
-    unique_key = 'timestamp',
-    incremental_strategy = 'merge'
+    materialized = 'table',
+    file_format = 'delta'
     )
 }}
 
 
 with hours as (
     select * from {{ref('utils_hours_table')}}
-    {%if is_incremental() %}
-    where {{incremental_predicate('timestamp')}}
-    {%endif%}
 )
 
 SELECT * FROM (


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

materialized timeseries with that contain timestamps up to 2 days in the future. 
- `utils.days_table`
- `utils.hours_table`
- `utils.minutes_table`

exposed views that are filtered for `timestamp <= now()`
- `utils.days`
- `utils.hours`
- `utils.minutes`


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
