### PR TITLE
cow protocol: exclude failing model

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/cow_protocol_tx_hash_labels_all.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/cow_protocol_tx_hash_labels_all.sql
@@ -1,5 +1,5 @@
 {{ config(
-    
+    tags = ['prod_exclude'],
     alias = 'tx_hash_labels_all',
     materialized = 'table',
     file_format = 'delta',


### PR DESCRIPTION
```
22:39:03  Failure in model cow_protocol_tx_hash_labels_all (models/_project/cow_protocol/tx_hash_labels/cow_protocol_tx_hash_labels_all.sql)
22:39:03
22:39:03    Database Error in model cow_protocol_tx_hash_labels_all (models/_project/cow_protocol/tx_hash_labels/cow_protocol_tx_hash_labels_all.sql)
  TrinoUserError(type=USER_ERROR, name=INVALID_CAST_ARGUMENT, message="Negative cast to UINT256: -1", query_id=20250221_215832_17243_fqhxu)
```