### PR TITLE
Add EventLog decoded data (gmx v2) into 4 event models

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_cancelled.sql
@@ -50,6 +50,25 @@ WITH evt_data_1 AS (
     {% endif %}
 )
 
+, evt_data_3 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
 -- unite 2 tables
 , evt_data AS (
     SELECT * 
@@ -57,6 +76,9 @@ WITH evt_data_1 AS (
     UNION ALL
     SELECT *
     FROM evt_data_2
+    UNION ALL
+    SELECT *
+    FROM evt_data_3
 )
 
 , parsed_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_cancelled.sql
@@ -69,7 +69,7 @@ WITH evt_data_1 AS (
     {% endif %}
 )
 
--- unite 2 tables
+-- unite 3 tables
 , evt_data AS (
     SELECT * 
     FROM evt_data_1

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_executed.sql
@@ -50,6 +50,25 @@ WITH evt_data_1 AS (
     {% endif %}
 )
 
+, evt_data_3 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
 -- unite 2 tables
 , evt_data AS (
     SELECT * 
@@ -57,6 +76,9 @@ WITH evt_data_1 AS (
     UNION ALL
     SELECT *
     FROM evt_data_2
+    UNION ALL
+    SELECT *
+    FROM evt_data_3
 )
 
 , parsed_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_executed.sql
@@ -69,7 +69,7 @@ WITH evt_data_1 AS (
     {% endif %}
 )
 
--- unite 2 tables
+-- unite 3 tables
 , evt_data AS (
     SELECT * 
     FROM evt_data_1

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_cancelled.sql
@@ -50,13 +50,35 @@ WITH evt_data_1 AS (
     {% endif %}
 )
 
--- unite 2 tables
+, evt_data_3 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
+-- unite 3 tables
 , evt_data AS (
     SELECT * 
     FROM evt_data_1
     UNION ALL
     SELECT *
     FROM evt_data_2
+    UNION ALL
+    SELECT *
+    FROM evt_data_3
 )
 
 , parsed_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_executed.sql
@@ -50,13 +50,35 @@ WITH evt_data_1 AS (
     {% endif %}
 )
 
--- unite 2 tables
+, evt_data_3 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
+-- unite 3 tables
 , evt_data AS (
     SELECT * 
     FROM evt_data_1
     UNION ALL
     SELECT *
     FROM evt_data_2
+    UNION ALL
+    SELECT *
+    FROM evt_data_3
 )
 
 , parsed_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_cancelled.sql
@@ -69,7 +69,7 @@ WITH evt_data_1 AS (
     {% endif %}
 )
 
--- unite 2 tables
+-- unite 3 tables
 , evt_data AS (
     SELECT * 
     FROM evt_data_1

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_cancelled.sql
@@ -50,6 +50,25 @@ WITH evt_data_1 AS (
     {% endif %}
 )
 
+, evt_data_3 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
 -- unite 2 tables
 , evt_data AS (
     SELECT * 
@@ -57,6 +76,9 @@ WITH evt_data_1 AS (
     UNION ALL
     SELECT *
     FROM evt_data_2
+    UNION ALL
+    SELECT *
+    FROM evt_data_3
 )
 
 , parsed_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_executed.sql
@@ -69,7 +69,7 @@ WITH evt_data_1 AS (
     {% endif %}
 )
 
--- unite 2 tables
+-- unite 3 tables
 , evt_data AS (
     SELECT * 
     FROM evt_data_1

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_executed.sql
@@ -50,6 +50,25 @@ WITH evt_data_1 AS (
     {% endif %}
 )
 
+, evt_data_3 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
 -- unite 2 tables
 , evt_data AS (
     SELECT * 
@@ -57,6 +76,9 @@ WITH evt_data_1 AS (
     UNION ALL
     SELECT *
     FROM evt_data_2
+    UNION ALL
+    SELECT *
+    FROM evt_data_3
 )
 
 , parsed_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_cancelled.sql
@@ -50,13 +50,35 @@ WITH evt_data_1 AS (
     {% endif %}
 )
 
--- unite 2 tables
+, evt_data_3 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
+-- unite 3 tables
 , evt_data AS (
     SELECT * 
     FROM evt_data_1
     UNION ALL
     SELECT *
     FROM evt_data_2
+    UNION ALL
+    SELECT *
+    FROM evt_data_3
 )
 
 , parsed_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_executed.sql
@@ -50,13 +50,35 @@ WITH evt_data_1 AS (
     {% endif %}
 )
 
--- unite 2 tables
+, evt_data_3 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
+-- unite 3 tables
 , evt_data AS (
     SELECT * 
     FROM evt_data_1
     UNION ALL
     SELECT *
     FROM evt_data_2
+    UNION ALL
+    SELECT *
+    FROM evt_data_3
 )
 
 , parsed_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/arbitrum/gmx_v2_arbitrum_glvs_data.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/arbitrum/gmx_v2_arbitrum_glvs_data.sql
@@ -1,7 +1,7 @@
 {{
   config(
     schema = 'gmx_v2_arbitrum',
-    alias = 'glv_markets_data',    
+    alias = 'glvs_data',    
     materialized = 'view'
     )
 }}

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/arbitrum/gmx_v2_arbitrum_glvs_data.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/arbitrum/gmx_v2_arbitrum_glvs_data.sql
@@ -8,9 +8,9 @@
 
 SELECT
     GCE.glv_token AS glv,
-    CONCAT(ERC20_LT.symbol, '-', ERC20_ST.symbol) AS glv_market_name,
-    'GM' AS market_token_symbol,
-    18 AS market_token_decimals,
+    CONCAT(ERC20_LT.symbol, '-', ERC20_ST.symbol) AS glv_name,
+    'GLV' AS glv_token_symbol,
+    18 AS glv_token_decimals,
     GCE.long_token,
     ERC20_LT.symbol AS long_token_symbol,
     ERC20_LT.decimals AS long_token_decimals,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/arbitrum/gmx_v2_arbitrum_tokens_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/arbitrum/gmx_v2_arbitrum_tokens_schema.yml
@@ -145,11 +145,11 @@ models:
       project: gmx
       contributors: ai_data_master, gmx-io
     config:
-      tags: ['arbitrum', 'gmx', 'pool', 'glvs_data']
+      tags: ['arbitrum', 'gmx', 'pools', 'glvs_data']
     description: |
       Processes decoded data for GLV pools on the GMX platform in the Arbitrum blockchain.
       This model extracts key details such as pool names, token symbols, and decimals, enabling
-      comprehensive analysis of GLV pool.
+      comprehensive analysis of GLV pools.
 
     columns:
       - name: glv

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/arbitrum/gmx_v2_arbitrum_tokens_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/arbitrum/gmx_v2_arbitrum_tokens_schema.yml
@@ -145,21 +145,21 @@ models:
       project: gmx
       contributors: ai_data_master, gmx-io
     config:
-      tags: ['arbitrum', 'gmx', 'markets', 'glvs_data']
+      tags: ['arbitrum', 'gmx', 'pool', 'glvs_data']
     description: |
-      Processes decoded market data for GLV markets on the GMX platform in the Arbitrum blockchain.
-      This model extracts key details such as market names, token symbols, and decimals, enabling
-      comprehensive analysis of GLV markets.
+      Processes decoded data for GLV pools on the GMX platform in the Arbitrum blockchain.
+      This model extracts key details such as pool names, token symbols, and decimals, enabling
+      comprehensive analysis of GLV pool.
 
     columns:
       - name: glv
-        description: The identifier of the GLV market.
-      - name: glv_market_name
-        description: The name of the GLV market.
-      - name: market_token_symbol
-        description: The symbol of the market token.
-      - name: market_token_decimals
-        description: The decimal precision of the market token.
+        description: The identifier of the GLV pool.
+      - name: glv_name
+        description: The name of the GLV pool.
+      - name: glv_token_symbol
+        description: The symbol of the glv token.
+      - name: glv_token_decimals
+        description: The decimal precision of the glv token.
       - name: long_token
         description: The contract address of the long token.
       - name: long_token_symbol

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/arbitrum/gmx_v2_arbitrum_tokens_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/arbitrum/gmx_v2_arbitrum_tokens_schema.yml
@@ -138,14 +138,14 @@ models:
           - not_null  
 
 
-  - name: gmx_v2_arbitrum_glv_markets_data
+  - name: gmx_v2_arbitrum_glvs_data
     meta:
       blockchain: arbitrum
       sector: dex
       project: gmx
       contributors: ai_data_master, gmx-io
     config:
-      tags: ['arbitrum', 'gmx', 'markets', 'glv_markets_data']
+      tags: ['arbitrum', 'gmx', 'markets', 'glvs_data']
     description: |
       Processes decoded market data for GLV markets on the GMX platform in the Arbitrum blockchain.
       This model extracts key details such as market names, token symbols, and decimals, enabling

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/avalanche_c/gmx_v2_avalanche_c_glvs_data.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/avalanche_c/gmx_v2_avalanche_c_glvs_data.sql
@@ -1,7 +1,7 @@
 {{
   config(
     schema = 'gmx_v2_avalanche_c',
-    alias = 'glv_markets_data',    
+    alias = 'glvs_data',    
     materialized = 'view'
     )
 }}

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/avalanche_c/gmx_v2_avalanche_c_glvs_data.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/avalanche_c/gmx_v2_avalanche_c_glvs_data.sql
@@ -8,9 +8,9 @@
 
 SELECT
     GCE.glv_token AS glv,
-    CONCAT(ERC20_LT.symbol, '-', ERC20_ST.symbol) AS glv_market_name,
-    'GM' AS market_token_symbol,
-    18 AS market_token_decimals,
+    CONCAT(ERC20_LT.symbol, '-', ERC20_ST.symbol) AS glv_name,
+    'GLV' AS glv_token_symbol,
+    18 AS glv_token_decimals,
     GCE.long_token,
     ERC20_LT.symbol AS long_token_symbol,
     ERC20_LT.decimals AS long_token_decimals,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/avalanche_c/gmx_v2_avalanche_c_tokens_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/avalanche_c/gmx_v2_avalanche_c_tokens_schema.yml
@@ -144,21 +144,21 @@ models:
       project: gmx
       contributors: ai_data_master, gmx-io
     config:
-      tags: ['avalanche_c', 'gmx', 'markets', 'glvs_data']
+      tags: ['avalanche_c', 'gmx', 'pools', 'glvs_data']
     description: |
-      Processes decoded market data for GLV markets on the GMX platform in the Avalanche blockchain.
-      This model extracts key details such as market names, token symbols, and decimals, enabling
-      comprehensive analysis of GLV markets.
+      Processes decoded data for GLV pools on the GMX platform in the Avalanche blockchain.
+      This model extracts key details such as pool names, token symbols, and decimals, enabling
+      comprehensive analysis of GLV pools.
 
     columns:
       - name: glv
-        description: The identifier of the GLV market.
-      - name: glv_market_name
-        description: The name of the GLV market.
-      - name: market_token_symbol
-        description: The symbol of the market token.
-      - name: market_token_decimals
-        description: The decimal precision of the market token.
+        description: The identifier of the GLV pool.
+      - name: glv_name
+        description: The name of the GLV pool.
+      - name: glv_token_symbol
+        description: The symbol of the glv token.
+      - name: glv_token_decimals
+        description: The decimal precision of the glv token.
       - name: long_token
         description: The contract address of the long token.
       - name: long_token_symbol

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/avalanche_c/gmx_v2_avalanche_c_tokens_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/avalanche_c/gmx_v2_avalanche_c_tokens_schema.yml
@@ -137,14 +137,14 @@ models:
           - not_null  
 
 
-  - name: gmx_v2_avalanche_c_glv_markets_data
+  - name: gmx_v2_avalanche_c_glvs_data
     meta:
       blockchain: avalanche_c
       sector: dex
       project: gmx
       contributors: ai_data_master, gmx-io
     config:
-      tags: ['avalanche_c', 'gmx', 'markets', 'glv_markets_data']
+      tags: ['avalanche_c', 'gmx', 'markets', 'glvs_data']
     description: |
       Processes decoded market data for GLV markets on the GMX platform in the Avalanche blockchain.
       This model extracts key details such as market names, token symbols, and decimals, enabling

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/gmx_v2_glvs_data.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/gmx_v2_glvs_data.sql
@@ -1,6 +1,6 @@
 {{ config(
         schema='gmx_v2',
-        alias = 'glv_markets_data',
+        alias = 'glvs_data',
         post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c"]\',
                                     "project",
                                     "gmx",
@@ -26,7 +26,7 @@ SELECT
     short_token,
     short_token_symbol,
     short_token_decimals  
-FROM {{ ref('gmx_v2_' ~ chain ~ '_glv_markets_data') }}
+FROM {{ ref('gmx_v2_' ~ chain ~ '_glvs_data') }}
 {% if not loop.last %}
 UNION ALL
 {% endif %}

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/gmx_v2_glvs_data.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/gmx_v2_glvs_data.sql
@@ -17,9 +17,9 @@
 SELECT
     '{{ chain }}' AS "blockchain",
     glv,
-    glv_market_name,
-    market_token_symbol,
-    market_token_decimals,
+    glv_name,
+    glv_token_symbol,
+    glv_token_decimals,
     long_token,
     long_token_symbol,
     long_token_decimals,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/gmx_v2_tokens_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/gmx_v2_tokens_schema.yml
@@ -138,14 +138,14 @@ models:
           - not_null         
 
 
-  - name: gmx_v2_glv_markets_data
+  - name: gmx_v2_glvs_data
     meta:
       blockchain: arbitrum, avalanche_c
       sector: dex
       project: gmx
       contributors: ai_data_master, gmx-io
     config:
-      tags: ['arbitrum', 'avalanche_c', 'gmx', 'markets', 'glv_markets_data']
+      tags: ['arbitrum', 'avalanche_c', 'gmx', 'markets', 'glvs_data']
     description: |
       Processes decoded market data for GLV markets on the GMX platform in the Arbitrum and Avalanche blockchains.
       This model extracts key details such as market names, token symbols, and decimals, enabling

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/gmx_v2_tokens_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/tokens/gmx_v2_tokens_schema.yml
@@ -145,22 +145,22 @@ models:
       project: gmx
       contributors: ai_data_master, gmx-io
     config:
-      tags: ['arbitrum', 'avalanche_c', 'gmx', 'markets', 'glvs_data']
+      tags: ['arbitrum', 'avalanche_c', 'gmx', 'pools', 'glvs_data']
     description: |
-      Processes decoded market data for GLV markets on the GMX platform in the Arbitrum and Avalanche blockchains.
-      This model extracts key details such as market names, token symbols, and decimals, enabling
-      comprehensive analysis of GLV markets.
+      Processes decoded data for GLV pools on the GMX platform in the Arbitrum and Avalanche blockchains.
+      This model extracts key details such as pool names, token symbols, and decimals, enabling
+      comprehensive analysis of GLV pools.
 
     columns:
       - *blockchain
       - name: glv
-        description: The identifier of the GLV market.
-      - name: glv_market_name
-        description: The name of the GLV market.
-      - name: market_token_symbol
-        description: The symbol of the market token.
-      - name: market_token_decimals
-        description: The decimal precision of the market token.
+        description: The identifier of the GLV pool.
+      - name: glv_name
+        description: The name of the GLV pool.
+      - name: glv_token_symbol
+        description: The symbol of the glv token.
+      - name: glv_token_decimals
+        description: The decimal precision of the glv token.
       - name: long_token
         description: The contract address of the long token.
       - name: long_token_symbol

--- a/sources/gmx/arbitrum/gmx_arbitrum_sources.yml
+++ b/sources/gmx/arbitrum/gmx_arbitrum_sources.yml
@@ -12,5 +12,6 @@ sources:
   - name: gmx_v2_arbitrum
     description: Tables with all decoded events for GMX v2 on the Arbitrum blockchain
     tables:
+      - name: EventEmitter_evt_EventLog
       - name: EventEmitter_evt_EventLog1
       - name: EventEmitter_evt_EventLog2    

--- a/sources/gmx/avalanche_c/gmx_avalanche_c_sources.yml
+++ b/sources/gmx/avalanche_c/gmx_avalanche_c_sources.yml
@@ -12,5 +12,6 @@ sources:
   - name: gmx_v2_avalanche_c
     description: Tables with all decoded events for GMX v2 on the Avalanche blockchain
     tables:
+      - name: EventEmitter_evt_EventLog
       - name: EventEmitter_evt_EventLog1
       - name: EventEmitter_evt_EventLog2    


### PR DESCRIPTION
### Description:

This PRs makes the followings updates on existing GMX event models:
- [x] Add EventEmitter_evt_EventLog decoded data to dbt models:
   - [x] gmx_v2_arbitrum_deposit_cancelled
   - [x] gmx_v2_arbitrum_deposit_executed
   - [x] gmx_v2_arbitrum_withdrawal_cancelled
   - [x] gmx_v2_arbitrum_withdrawal_executed
   - [x] gmx_v2_avalanche_c_deposit_cancelled
   - [x] gmx_v2_avalanche_c_deposit_executed
   - [x] gmx_v2_avalanche_c_withdrawal_cancelled
   - [x] gmx_v2_avalanche_c_withdrawal_executed
 - [x] Rename *glv_markets_data table names to *glvs_data  
 - [x] Rename 3 columns in *glvs_data