### PR TITLE
add flETH as base trusted token so amount_usd on dex.trades can show up

### DIFF
--- a/dbt_subprojects/tokens/models/prices/prices_trusted_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_trusted_tokens.sql
@@ -41,6 +41,7 @@ WITH trusted_tokens AS (
                 , ('base', 0xeb466342c4d449bc9f53a865d5cb90586f405215)
                 , ('base', 0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22)
                 , ('base', 0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452)
+                , ('base', 0x000000000d564d5be76f7f0d28fe52605afc7cf8)
                 , ('berachain', 0x6969696969696969696969696969696969696969)
                 , ('berachain', 0x549943e04f40284185054145c6E4e9568C1D3241)
                 , ('berachain', 0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590)


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

select * from prices.usd
where symbol = 'flETH'
limit 2 --> prices is available already 

https://basescan.org/address/0x000000000d564d5be76f7f0d28fe52605afc7cf8 --> this is the flETH address 

all Flaunch pairs are anchored on flETH instead of ETH or WETH, so we need this added as trusted tokens for base


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
