### PR TITLE
Fix for TON Transfer volume: add upper bound based on the token TVL

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_metrics/transfers/chains/ton/metrics_ton_transfers_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/_metrics/transfers/chains/ton/metrics_ton_transfers_daily.sql
@@ -19,12 +19,20 @@ with ton_prices as ( -- get price of TON for each day to estimate USD value
         and symbol = 'TON' and blockchain is null
         group by 1
 ), jetton_prices as (
-   select jp.token_address as jetton_master, jp.timestamp as block_date, avg(price_usd) as price_usd
+   select jp.token_address as jetton_master,
+   case
+     when
+        jp.token_address = '0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE' -- USDT
+        or jp.token_address = '0:BDF3FA8098D129B54B4F73B5BAC5D1E1FD91EB054169C3916DFC8CCD536D1000' -- tsTON
+        or jp.token_address = '0:CD872FA7C5816052ACDF5332260443FAEC9AACC8C21CCA4D92E7F47034D11892' -- stTON
+        or jp.token_address = '0:CF76AF318C0872B58A9F1925FC29C156211782B9FB01F56760D292E56123BF87' -- hTON
+    then 0 -- USDT, and LSDs are liquid and doesn't need to be limited by liquidity
+     when asset_type = 'Jetton' then 1 -- other jettons needs to be checked by DEX liquidity
+     else 0 -- DEX LPs and SLPs liquidity is guaranteed by their smart contracts
+    end as is_need_liquidity_limit,
+   jp.timestamp as block_date, avg(price_usd) as price_usd
    from {{ ref('ton_jetton_price_daily') }} jp
-   -- Hotfix: exclude outliers to avoid spikes in the data
-   where jp.token_address  != '0:A6000ED48DAFED59CCD50441C76A098C3C912D48E414DDC12B4F30E38601B1C6'
-   and jp.token_address  != '0:C64926DA4E45846A985BE3696E8B013B628330CEEFDE0D57CDCF84628FBC6719'
-   group by 1, 2
+   group by 1, 2, 3
 ),
 ton_flow as (
     select block_date, source as address, -1 * value as ton_flow
@@ -80,12 +88,34 @@ jettons_flow as (
         {% if is_incremental() %}
         and {{ incremental_predicate('block_date') }}
         {% endif %}
-), transfers_amount_jetton as (
+), daily_liquidity as (
+ -- since we are using dex derived prices we can encounter a situation where the amount of tokens being transferred
+ -- is much higher than the amount of liquidity in the pools. To mitigate this we will use the daily liquidity of the tokens
+ -- and use it as the upper bound for the amount of tokens being transferred.
+  select block_date, jetton_master, sum(tvl_usd) as total_token_tvl_usd from (
+    select block_date, pool, jetton_left, jetton_right, avg(tvl_usd) as tvl_usd from {{ source('ton', 'dex_pools') }} 
+    where tvl_usd > 0
+    group by 1, 2, 3, 4)
+  cross join unnest(array[jetton_left, jetton_right]) as t(jetton_master)
+  group by 1, 2
+),
+transfers_amount_jetton as (
  select block_date, address,
-  sum(case when jetton_flow > 0 then jetton_flow * price_usd else 0 end) as transfer_amount_usd_received,
-  sum(case when jetton_flow < 0 then jetton_flow * price_usd else 0 end) as transfer_amount_usd_sent
+  sum(case
+    when jetton_flow > 0 and is_need_liquidity_limit = 0 -- treat volume as is
+        then jetton_flow * price_usd
+    when jetton_flow > 0 and is_need_liquidity_limit = 1 -- limit volume by total token TVL to avoid price manipulation for low-liquidity tokens
+        then least(jetton_flow * price_usd, coalesce(total_token_tvl_usd, 0))
+    else 0 end) as transfer_amount_usd_received,
+  sum(case
+    when jetton_flow < 0 and is_need_liquidity_limit = 0 -- treat volume as is
+        then jetton_flow * price_usd
+    when jetton_flow < 0 and is_need_liquidity_limit = 1 -- limit volume by total token TVL to avoid price manipulation for low-liquidity tokens
+        then -1 * least(abs(jetton_flow) * price_usd, coalesce(total_token_tvl_usd, 0))
+    else 0 end) as transfer_amount_usd_sent
   from jettons_flow
   join jetton_prices using(jetton_master, block_date)
+  left join daily_liquidity using(block_date, jetton_master)
 group by 1, 2
 ), transfers_amount as (
   select * from transfers_amount_jetton


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Since we are using DEX trades derived prices there is a risk to get enormous transfer volume for low liquidity tokens. To mitigate the issue I've added DEX TVL as an upper bound for the volume


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
