### PR TITLE
mint square zksync: fix alias config, add static tag

### DIFF
--- a/dbt_subprojects/nft/models/_sector/trades/chains/zksync/platforms/mint_square_zksync_base_trades.sql
+++ b/dbt_subprojects/nft/models/_sector/trades/chains/zksync/platforms/mint_square_zksync_base_trades.sql
@@ -1,6 +1,7 @@
 {{ config(
+    tags = ['static'],
     schema = 'mint_square_zksync',
-    aliAS = 'base_trades',
+    alias = 'base_trades',
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
@@ -8,6 +9,7 @@
     )
 }}
 
+--this model is static because the mint_square_zksync.Marketplace_evt_TakerAsk and mint_square_zksync.Marketplace_evt_TakerBid events last produce in 2023
 WITH mintsquare_trades AS (
     SELECT *
     , ROW_NUMBER() OVER (PARTITION BY tx_hash, nft_contract_address, nft_token_id ORDER BY evt_index ASC) AS id


### PR DESCRIPTION
discovered a weird bug when monitoring the cleanup script. this model continually appeared in the logs to be dropped, since it existed in manifest file but not the metastore. then the nft hourly job would just recreate it on the next run, and so on.

tl;dr:
- `alias` config vs. `aliAS` do not appear to match, must be case sensitive to behind the scenes dbt code
- when building the manifest before and after `alias` config fix, the json file shows different results
- nft hourly job is running and creating `mint_square_zksync.mint_square_zksync_base_trades` vs. what we expect of `mint_square_zksync.base_trades`
- cleanup script grabs `schema` and `alias` property, combines to write full table name, which was correctly doing `mint_square_zksync.base_trades`

i'll share before / after manifest files for comparison (truncating parts that don't matter for this scenario)
before:
```
 "model.nft.mint_square_zksync_base_trades": {
      "database": "hive",
      "schema": "mint_square_zksync",
      "name": "mint_square_zksync_base_trades",
      "resource_type": "model",
      "package_name": "nft",
      "path": "_sector/trades/chains/zksync/platforms/mint_square_zksync_base_trades.sql",
      "original_file_path": "models/_sector/trades/chains/zksync/platforms/mint_square_zksync_base_trades.sql",
      "unique_id": "model.nft.mint_square_zksync_base_trades",
      "fqn": [
        "nft",
        "_sector",
        "trades",
        "chains",
        "zksync",
        "platforms",
        "mint_square_zksync_base_trades"
      ],
      "alias": "mint_square_zksync_base_trades",
      "checksum": {
        "name": "sha256",
        "checksum": "0624b514a46fe608d4260eb9198fb61acb1e734a031c58943a1fccedb7c54a6a"
      },
      "relation_name": "hive.mint_square_zksync.mint_square_zksync_base_trades",
```

after:
```
    "model.nft.mint_square_zksync_base_trades": {
      "database": "hive",
      "schema": "mint_square_zksync",
      "name": "mint_square_zksync_base_trades",
      "resource_type": "model",
      "package_name": "nft",
      "path": "_sector/trades/chains/zksync/platforms/mint_square_zksync_base_trades.sql",
      "original_file_path": "models/_sector/trades/chains/zksync/platforms/mint_square_zksync_base_trades.sql",
      "unique_id": "model.nft.mint_square_zksync_base_trades",
      "fqn": [
        "nft",
        "_sector",
        "trades",
        "chains",
        "zksync",
        "platforms",
        "mint_square_zksync_base_trades"
      ],
      "alias": "base_trades",
      "checksum": {
        "name": "sha256",
        "checksum": "08a6ff8c02dac04abb6dc5eb946184071f8d1d1af10e42ce0415d8166f1feceb"
      },
      "relation_name": "hive.mint_square_zksync.base_trades",
```