### PR TITLE
Fixing Solana NFT Token Classification + Retrieving Missing DEX Trades

### DIFF
--- a/dbt_subprojects/solana/models/tokens/solana/tokens_solana_nft.sql
+++ b/dbt_subprojects/solana/models/tokens/solana/tokens_solana_nft.sql
@@ -51,6 +51,7 @@ with
                 , call_tx_signer
                 , 'Token Metadata' as version 
             FROM {{ source('mpl_token_metadata_solana','mpl_token_metadata_call_Create') }}
+            WHERE json_value(createArgs, 'lax $.CreateArgs.V1.asset_data.AssetData.tokenStandard.TokenStandard') IN ('NonFungible', 'NonFungibleEdition', 'ProgrammableNonFungible')
             UNION ALL 
             SELECT 
                 m.call_tx_id

--- a/dbt_subprojects/solana/models/tokens/solana/tokens_solana_nft.sql
+++ b/dbt_subprojects/solana/models/tokens/solana/tokens_solana_nft.sql
@@ -51,7 +51,6 @@ with
                 , call_tx_signer
                 , 'Token Metadata' as version 
             FROM {{ source('mpl_token_metadata_solana','mpl_token_metadata_call_Create') }}
-            WHERE json_value(createArgs, 'lax $.CreateArgs.V1.asset_data.AssetData.tokenStandard.TokenStandard') IN ('NonFungible', 'NonFungibleEdition', 'ProgrammableNonFungible')
             UNION ALL 
             SELECT 
                 m.call_tx_id
@@ -205,6 +204,7 @@ SELECT
     , call_tx_signer
 FROM token_metadata tk 
 WHERE recent_update = 1
+AND token_standard IN ('NonFungible', 'NonFungibleEdition', 'ProgrammableNonFungible')
 
 UNION ALL 
 
@@ -230,3 +230,4 @@ SELECT
     , call_block_slot
     , call_tx_signer
 FROM cnfts 
+WHERE token_standard IN ('NonFungible', 'NonFungibleEdition', 'ProgrammableNonFungible')


### PR DESCRIPTION
### Description:
We were investigating some missing trades from the dex_solana.trades table. Example: [Solscan Link](https://solscan.io/tx/2mr7sZ7adRjHh5g99LxsEc6HN8pGndpACMxLM2sp57nN5a1vXSa7fogF4xSb56Kx248dmQGmGmQKvg2e3tiChVkD)

We found out that these trades were being filtered because, in the `dex_solana.trades` dbt transformation. We have the condition 'fungible' ([source](https://github.com/duneanalytics/spellbook/blob/4e1ebedfe246006522220ab21d7e4602fdf465a6/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v5_base_trades.sql#L75)). This is in fact a fungible token, so it shouldn't be filtered.

The problem is that the `solana_utils_token_accounts` dbt transformation is marking some account tokens as 'nft' when it shouldn't be ([source](https://github.com/duneanalytics/spellbook/blob/4e1ebedfe246006522220ab21d7e4602fdf465a6/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts.sql#L34)).

The exact issue lies in the `tokens_solana_nft` transformation:
According to [Metaplex docs](https://developers.metaplex.com/token-metadata/token-standard?utm_source=chatgpt.com), inside the createArgs, we can find the following TokenStandards:
- 0 / NonFungible: A non-fungible token with a Master Edition.
- 1 / FungibleAsset (1): A token with metadata that can also have attributes, sometimes called Semi-Fungible.
- 2 / Fungible (2): A token with simple metadata.
- 3 / NonFungibleEdition (3): A non-fungible token with an Edition account (printed from a Master edition).
- 4 / ProgrammableNonFungible (4): A special NonFungible token that is frozen at all times to enforce custom authorization rules.

There are no filters in the CTE query executed against the `mpl_token_metadata_solana.mpl_token_metadata_call_create ` table [source](https://github.com/duneanalytics/spellbook/blob/4e1ebedfe246006522220ab21d7e4602fdf465a6/dbt_subprojects/solana/models/tokens/solana/tokens_solana_nft.sql#L53), so it retrieves all token accounts, including fungible tokens like the example below.

### Solution:
Adding a WHERE condition to filter only token accounts related to non-fungible tokens will ensure that these fungible

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
