### PR TITLE
seaport v3 nova: exclude due to source schema change

### DIFF
--- a/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/opensea_v3_nova_base_trades.sql
+++ b/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/opensea_v3_nova_base_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'opensea_v3_nova',
     alias = 'base_trades',
     materialized = 'incremental',

--- a/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/opensea_v3_nova_base_trades.sql
+++ b/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/opensea_v3_nova_base_trades.sql
@@ -1,5 +1,5 @@
 {{ config(
-    tags = ['prod_exclude'],
+    tags = ['static','prod_exclude'],
     schema = 'opensea_v3_nova',
     alias = 'base_trades',
     materialized = 'incremental',


### PR DESCRIPTION
```
12:24:35  Failure in model opensea_v3_nova_base_trades (models/_sector/trades/chains/nova/platforms/opensea_v3_nova_base_trades.sql)
12:24:35
12:24:35    Database Error in model opensea_v3_nova_base_trades (models/_sector/trades/chains/nova/platforms/opensea_v3_nova_base_trades.sql)
  TrinoUserError(type=USER_ERROR, name=COLUMN_NOT_FOUND, message="line 255:39: Column 'output_executions' cannot be resolved", query_id=20250227_121639_01470_rzwas)
```

looks like seaport v3 is outputting 0 rows per chain anyway, so adding `static` tag too. 