### PR TITLE
balancer v3 arbitrum mapping: exclude on table name change

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/erc4626_tokens/arbitrum/balancer_v3_arbitrum_erc4626_token_mapping.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/erc4626_tokens/arbitrum/balancer_v3_arbitrum_erc4626_token_mapping.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'balancer_v3_arbitrum',
         alias = 'erc4626_token_mapping', 
         materialized = 'table',


### PR DESCRIPTION
fyi @viniabussafi 
```
13:52:09  Failure in model balancer_v3_arbitrum_erc4626_token_mapping (models/_project/balancer/erc4626_tokens/arbitrum/balancer_v3_arbitrum_erc4626_token_mapping.sql)
13:52:09
13:52:09    Database Error in model balancer_v3_arbitrum_erc4626_token_mapping (models/_project/balancer/erc4626_tokens/arbitrum/balancer_v3_arbitrum_erc4626_token_mapping.sql)
  TrinoUserError(type=USER_ERROR, name=TABLE_NOT_FOUND, message="line 18:6: Table 'delta_prod.aave_v3_arbitrum.statatoken_evt_initialized' does not exist", query_id=20250227_130641_27877_kwx57)
```