### PR TITLE
DUX-992 Fix balance latest unique key per model

### DIFF
--- a/dbt_subprojects/tokens/macros/balances/balances_latest.sql
+++ b/dbt_subprojects/tokens/macros/balances/balances_latest.sql
@@ -19,6 +19,8 @@ where
     1 = 1
     {% if is_incremental() %}
     and {{ incremental_predicate('block_time') }}
+    {% else %}
+    and block_time >= date '2025-02-01'
     {% endif %}
 group by
     blockchain,

--- a/dbt_subprojects/tokens/macros/balances/balances_latest.sql
+++ b/dbt_subprojects/tokens/macros/balances/balances_latest.sql
@@ -9,10 +9,10 @@ select
     token_symbol,
     token_id,
     collection_name,
-    max(block_number) as block_number_latest,
-    max(date_trunc('day', block_time)) as block_date_latest,
-    max(block_time) as block_time_latest,
-    max_by(balance_raw, block_number) as balance_raw_latest,
+    max(block_number) as block_number,
+    max(date_trunc('day', block_time)) as block_date,
+    max(block_time) as block_time,
+    max_by(balance_raw, block_number) as balance_raw,
     max_by(balance, block_number) as balance_latest
 from {{balances}}
 where

--- a/dbt_subprojects/tokens/macros/balances/balances_latest.sql
+++ b/dbt_subprojects/tokens/macros/balances/balances_latest.sql
@@ -13,7 +13,7 @@ select
     max(date_trunc('day', block_time)) as block_date,
     max(block_time) as block_time,
     max_by(balance_raw, block_number) as balance_raw,
-    max_by(balance, block_number) as balance_latest
+    max_by(balance, block_number) as balance
 from {{balances}}
 where
     1 = 1

--- a/dbt_subprojects/tokens/macros/balances/balances_latest.sql
+++ b/dbt_subprojects/tokens/macros/balances/balances_latest.sql
@@ -19,8 +19,6 @@ where
     1 = 1
     {% if is_incremental() %}
     and {{ incremental_predicate('block_time') }}
-    {% else %}
-    and block_time >= date '2025-02-01'
     {% endif %}
 group by
     blockchain,

--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/_schema.yml
@@ -233,7 +233,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - unique_key
-            - block_date_latest
     columns:
       - name: unique_key
       - name: blockchain
@@ -243,8 +242,8 @@ models:
       - name: token_symbol
       - name: token_id
       - name: collection_name
-      - name: block_number_latest
-      - name: block_date_latest
-      - name: block_time_latest
-      - name: balance_raw_latest
-      - name: balance_latest
+      - name: block_number
+      - name: block_date
+      - name: block_time
+      - name: balance_raw
+      - name: balance

--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_latest.sql
@@ -5,7 +5,6 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["arbitrum"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_latest.sql
@@ -4,7 +4,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['unique_key', 'block_date_latest'],
+    unique_key = ['unique_key'],
     partition_by = ['block_date_latest'],
     post_hook='{{ expose_spells(\'["arbitrum"]\',
                                 "sector",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_latest.sql
@@ -5,7 +5,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date_latest'],
+    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["arbitrum"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/_schema.yml
@@ -232,7 +232,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - unique_key
-            - block_date_latest
     columns:
       - name: unique_key
       - name: blockchain
@@ -242,8 +241,8 @@ models:
       - name: token_symbol
       - name: token_id
       - name: collection_name
-      - name: block_number_latest
-      - name: block_date_latest
-      - name: block_time_latest
-      - name: balance_raw_latest
-      - name: balance_latest
+      - name: block_number
+      - name: block_date
+      - name: block_time
+      - name: balance_raw
+      - name: balance

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_latest.sql
@@ -5,7 +5,6 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["avalanche_c"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_latest.sql
@@ -5,7 +5,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date_latest'],
+    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["avalanche_c"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_latest.sql
@@ -4,7 +4,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['unique_key', 'block_date_latest'],
+    unique_key = ['unique_key'],
     partition_by = ['block_date_latest'],
     post_hook='{{ expose_spells(\'["avalanche_c"]\',
                                 "sector",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/_schema.yml
@@ -231,7 +231,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - unique_key
-            - block_date_latest
     columns:
       - name: unique_key
       - name: blockchain
@@ -241,8 +240,8 @@ models:
       - name: token_symbol
       - name: token_id
       - name: collection_name
-      - name: block_number_latest
-      - name: block_date_latest
-      - name: block_time_latest
-      - name: balance_raw_latest
-      - name: balance_latest
+      - name: block_number
+      - name: block_date
+      - name: block_time
+      - name: balance_raw
+      - name: balance

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_latest.sql
@@ -5,7 +5,6 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["base"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_latest.sql
@@ -4,7 +4,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['unique_key', 'block_date_latest'],
+    unique_key = ['unique_key'],
     partition_by = ['block_date_latest'],
     post_hook='{{ expose_spells(\'["base"]\',
                                 "sector",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_latest.sql
@@ -5,7 +5,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date_latest'],
+    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["base"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bnb/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bnb/_schema.yml
@@ -165,7 +165,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - unique_key
-            - block_date_latest
     columns:
       - name: unique_key
       - name: blockchain
@@ -175,8 +174,8 @@ models:
       - name: token_symbol
       - name: token_id
       - name: collection_name
-      - name: block_number_latest
-      - name: block_date_latest
-      - name: block_time_latest
-      - name: balance_raw_latest
-      - name: balance_latest
+      - name: block_number
+      - name: block_date
+      - name: block_time
+      - name: balance_raw
+      - name: balance

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances_latest.sql
@@ -5,7 +5,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date_latest'],
+    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["bnb"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances_latest.sql
@@ -5,7 +5,6 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["bnb"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances_latest.sql
@@ -4,7 +4,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['unique_key', 'block_date_latest'],
+    unique_key = ['unique_key'],
     partition_by = ['block_date_latest'],
     post_hook='{{ expose_spells(\'["bnb"]\',
                                 "sector",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/_schema.yml
@@ -232,7 +232,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - unique_key
-            - block_date_latest
     columns:
       - name: unique_key
       - name: blockchain
@@ -242,8 +241,8 @@ models:
       - name: token_symbol
       - name: token_id
       - name: collection_name
-      - name: block_number_latest
-      - name: block_date_latest
-      - name: block_time_latest
-      - name: balance_raw_latest
-      - name: balance_latest
+      - name: block_number
+      - name: block_date
+      - name: block_time
+      - name: balance_raw
+      - name: balance

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_latest.sql
@@ -5,7 +5,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date_latest'],
+    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_latest.sql
@@ -5,7 +5,6 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_latest.sql
@@ -4,7 +4,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['unique_key', 'block_date_latest'],
+    unique_key = ['unique_key'],
     partition_by = ['block_date_latest'],
     post_hook='{{ expose_spells(\'["ethereum"]\',
                                 "sector",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/_schema.yml
@@ -230,7 +230,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - unique_key
-            - block_date_latest
     columns:
       - name: unique_key
       - name: blockchain
@@ -240,8 +239,8 @@ models:
       - name: token_symbol
       - name: token_id
       - name: collection_name
-      - name: block_number_latest
-      - name: block_date_latest
-      - name: block_time_latest
-      - name: balance_raw_latest
-      - name: balance_latest
+      - name: block_number
+      - name: block_date
+      - name: block_time
+      - name: balance_raw
+      - name: balance

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_latest.sql
@@ -5,7 +5,6 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["linea"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_latest.sql
@@ -4,7 +4,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['unique_key', 'block_date_latest'],
+    unique_key = ['unique_key'],
     partition_by = ['block_date_latest'],
     post_hook='{{ expose_spells(\'["linea"]\',
                                 "sector",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_latest.sql
@@ -5,7 +5,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date_latest'],
+    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["linea"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/_schema.yml
@@ -232,7 +232,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - unique_key
-            - block_date_latest
     columns:
       - name: unique_key
       - name: blockchain
@@ -242,8 +241,8 @@ models:
       - name: token_symbol
       - name: token_id
       - name: collection_name
-      - name: block_number_latest
-      - name: block_date_latest
-      - name: block_time_latest
-      - name: balance_raw_latest
-      - name: balance_latest
+      - name: block_number
+      - name: block_date
+      - name: block_time
+      - name: balance_raw
+      - name: balance

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_latest.sql
@@ -5,7 +5,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date_latest'],
+    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["optimism"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_latest.sql
@@ -4,7 +4,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['unique_key', 'block_date_latest'],
+    unique_key = ['unique_key'],
     partition_by = ['block_date_latest'],
     post_hook='{{ expose_spells(\'["optimism"]\',
                                 "sector",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_latest.sql
@@ -5,7 +5,6 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["optimism"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/_schema.yml
@@ -232,7 +232,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - unique_key
-            - block_date_latest
     columns:
       - name: unique_key
       - name: blockchain
@@ -242,8 +241,8 @@ models:
       - name: token_symbol
       - name: token_id
       - name: collection_name
-      - name: block_number_latest
-      - name: block_date_latest
-      - name: block_time_latest
-      - name: balance_raw_latest
-      - name: balance_latest
+      - name: block_number
+      - name: block_date
+      - name: block_time
+      - name: balance_raw
+      - name: balance

--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_latest.sql
@@ -5,7 +5,6 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["polygon"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_latest.sql
@@ -5,7 +5,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date_latest'],
+    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["polygon"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_latest.sql
@@ -4,7 +4,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['unique_key', 'block_date_latest'],
+    unique_key = ['unique_key'],
     partition_by = ['block_date_latest'],
     post_hook='{{ expose_spells(\'["polygon"]\',
                                 "sector",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/scroll/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/scroll/_schema.yml
@@ -232,7 +232,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - unique_key
-            - block_date_latest
     columns:
       - name: unique_key
       - name: blockchain
@@ -242,8 +241,8 @@ models:
       - name: token_symbol
       - name: token_id
       - name: collection_name
-      - name: block_number_latest
-      - name: block_date_latest
-      - name: block_time_latest
-      - name: balance_raw_latest
-      - name: balance_latest
+      - name: block_number
+      - name: block_date
+      - name: block_time
+      - name: balance_raw
+      - name: balance

--- a/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances_latest.sql
@@ -5,7 +5,6 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["scroll"]\',
                                 "sector",
                                 "balances_latest",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances_latest.sql
@@ -4,7 +4,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['unique_key', 'block_date_latest'],
+    unique_key = ['unique_key'],
     partition_by = ['block_date_latest'],
     post_hook='{{ expose_spells(\'["scroll"]\',
                                 "sector",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances_latest.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances_latest.sql
@@ -5,7 +5,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['unique_key'],
-    partition_by = ['block_date_latest'],
+    partition_by = ['block_date'],
     post_hook='{{ expose_spells(\'["scroll"]\',
                                 "sector",
                                 "balances_latest",


### PR DESCRIPTION
fyi @et-dynamic 
since we included `block_date_latest` in the model unique key config, the merge statement logic breaks and it inserts a new row every time (table has grown much more than it should). we should rather be only joining on the `unique_key` column value and ensuring we update `block_date_latest` along with the balance amounts. this way we ensure we only have one row per `unique_key` column value as expected.