### PR TITLE
Revert "seaport v3 nova: exclude due to source schema change (#7751)"

### DIFF
--- a/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/opensea_v3_nova_base_trades.sql
+++ b/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/opensea_v3_nova_base_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['static'],
     schema = 'opensea_v3_nova',
     alias = 'base_trades',
     materialized = 'incremental',

--- a/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/opensea_v3_nova_base_trades.sql
+++ b/dbt_subprojects/nft/models/_sector/trades/chains/nova/platforms/opensea_v3_nova_base_trades.sql
@@ -1,5 +1,4 @@
 {{ config(
-    tags = ['static','prod_exclude'],
     schema = 'opensea_v3_nova',
     alias = 'base_trades',
     materialized = 'incremental',


### PR DESCRIPTION
This reverts commit 0e7e630df5a618e11bd8d1574676480cbfe717a1 as we've rolled out a change to view creation which keeps all column names of submitted contracts.

https://dune.com/queries/4811052