### PR TITLE
eigenlayer rewards: left join avs metadata

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_avs_paid_rewards.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_avs_paid_rewards.sql
@@ -15,5 +15,5 @@ SELECT DISTINCT
   a.avs,
   b.metadataURI
 FROM {{ ref('eigenlayer_ethereum_rewards_v1_flattened') }} AS a
-JOIN {{ ref('eigenlayer_ethereum_avs_metadata_uri_latest') }} AS b
+LEFT JOIN {{ ref('eigenlayer_ethereum_avs_metadata_uri_latest') }} AS b
   ON a.avs = b.avs


### PR DESCRIPTION
### Description:

eigenlayer rewards: left join avs metadata

there are a couple avs that don't hv metadata yet, previous inner join would hv neglected them


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
