### PR TITLE
add ETH LST and EIGEN to strategy_and_token_metadata_latest

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_strategy_and_token_metadata_latest.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_strategy_and_token_metadata_latest.sql
@@ -27,3 +27,14 @@ AND strategy IN (
         strategy
     FROM {{ ref('eigenlayer_ethereum_whitelisted_strategy_latest') }}
 )
+
+
+UNION ALL
+
+
+SELECT
+    strategy,
+    token,
+    name AS symbol,
+    18 AS decimals
+FROM {{ ref('eigenlayer_ethereum_strategy_category') }}


### PR DESCRIPTION
### Description:

add ETH LST and EIGEN to strategy_and_token_metadata_latest, which is not covered by default

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
