### PR TITLE
Add Trades and Schema for Tapio Protocol on Arbitrum, Base, and Optimism Chains

### DIFF
--- a/dbt_subprojects/dex/models/_projects/tapio/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/tapio/_schema.yml
@@ -1,0 +1,104 @@
+version: 2
+
+models:
+  - name: tapio_trades
+    meta:
+      blockchain: ["arbitrum", "base", "optimism"]
+      sector: dex
+      contributors:
+        [
+          "jeff-dude",
+          "mtitus6",
+          "Henrystats",
+          "chrispearcx",
+          "wuligy",
+          "tomfutago",
+          "phu",
+          "brunota20",
+        ]
+    config:
+      tags: ["tapio", "dex", "trades", "arbitrum", "base", "optimism"]
+    description: >
+      DEX trades on Tapio across Arbitrum, Base, and Optimism.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - blockchain
+            - project
+            - version
+            - tx_hash
+            - evt_index
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain where the trade occurred (Arbitrum, Base, or Optimism)."
+      - &project
+        name: project
+        description: "Project name (Tapio)."
+      - &version
+        name: version
+        description: "Version of the Tapio protocol."
+      - &block_month
+        name: block_month
+        description: "Block month in UTC."
+      - &block_date
+        name: block_date
+        description: "Block date in UTC."
+      - &block_time
+        name: block_time
+        description: "Block time in UTC."
+      - &block_number
+        name: block_number
+        description: "Block number."
+      - &token_bought_symbol
+        name: token_bought_symbol
+        description: "Token symbol for the token bought in the trade."
+      - &token_sold_symbol
+        name: token_sold_symbol
+        description: "Token symbol for the token sold in the trade."
+      - &token_pair
+        name: token_pair
+        description: "Token symbol pair for each token involved in the trade."
+      - &token_bought_amount
+        name: token_bought_amount
+        description: "Value of the token bought at the time of execution in the original currency."
+      - &token_sold_amount
+        name: token_sold_amount
+        description: "Value of the token sold at the time of execution in the original currency."
+      - &token_bought_amount_raw
+        name: token_bought_amount_raw
+        description: "Raw value of the token bought at the time of execution in the original currency."
+      - &token_sold_amount_raw
+        name: token_sold_amount_raw
+        description: "Raw value of the token sold at the time of execution in the original currency."
+      - &amount_usd
+        name: amount_usd
+        description: "USD value of the trade at the time of execution."
+      - &token_bought_address
+        name: token_bought_address
+        description: "Contract address of the token bought."
+      - &token_sold_address
+        name: token_sold_address
+        description: "Contract address of the token sold."
+      - &taker
+        name: taker
+        description: "Address of the trader who purchased a token."
+      - &maker
+        name: maker
+        description: "Address of the trader who sold a token."
+      - &project_contract_address
+        name: project_contract_address
+        description: "Contract address of the Tapio protocol."
+      - &tx_hash
+        name: tx_hash
+        description: "Transaction hash."
+      - &tx_from
+        name: tx_from
+        description: "Address of the transaction sender (transaction.from)."
+      - &tx_to
+        name: tx_to
+        description: "Address of the transaction recipient (transaction.to)."
+      - &evt_index
+        name: evt_index
+        description: "Event index."

--- a/dbt_subprojects/dex/models/_projects/tapio/arbitrum/tapio_arbitrum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/tapio/arbitrum/tapio_arbitrum_trades.sql
@@ -1,0 +1,59 @@
+{{
+    config(
+        schema = 'tapio_arbitrum',
+        alias = 'trades',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['tx_hash', 'evt_index'],
+        post_hook='{{ expose_spells(\'["arbitrum"]\',
+                                "project",
+                                "tapio",
+                                \'["brunota20"]\') }}'
+    )
+}}
+
+WITH raw_trades AS (
+    SELECT
+        evt_tx_hash AS tx_hash,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number,
+        evt_index,
+        buyer AS taker,
+        amounts[0] AS token_sold_amount_raw,  -- amounts[_i] is the input token amount
+        amounts[1] AS token_bought_amount_raw,  -- amounts[_j] is the output token amount
+        contract_address AS maker,  -- The contract is the maker
+        tokens[_i] AS token_sold_address,  -- Replace _i with the correct index
+        tokens[_j] AS token_bought_address,  -- Replace _j with the correct index
+        feeAmount AS fee_amount,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
+        'tapio' AS project,
+        '1' AS version,  -- Adjust version if needed
+        'arbitrum' AS blockchain  -- Adjust blockchain if needed
+    FROM {{ source('tapio_blockchain', 'SelfPeggingAsset_evt_TokenSwapped') }}
+    {% if is_incremental() %}
+    WHERE evt_block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+)
+
+SELECT
+    blockchain,
+    project,
+    version,
+    date_trunc('month', block_time) AS block_month,
+    date_trunc('day', block_time) AS block_date,
+    block_time,
+    block_number,
+    token_bought_amount_raw,
+    token_sold_amount_raw,
+    token_bought_address,
+    token_sold_address,
+    taker,
+    maker,
+    contract_address AS project_contract_address,
+    tx_hash,
+    evt_index,
+    tx_from,
+    tx_to
+FROM raw_trades;

--- a/dbt_subprojects/dex/models/_projects/tapio/base/tapio_base_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/tapio/base/tapio_base_trades.sql
@@ -1,0 +1,59 @@
+{{
+    config(
+        schema = 'tapio_base',
+        alias = 'trades',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['tx_hash', 'evt_index'],
+        post_hook='{{ expose_spells(\'["base"]\',
+                                "project",
+                                "tapio",
+                                \'["brunota20"]\') }}'
+    )
+}}
+
+WITH raw_trades AS (
+    SELECT
+        evt_tx_hash AS tx_hash,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number,
+        evt_index,
+        buyer AS taker,
+        amounts[0] AS token_sold_amount_raw,  -- amounts[_i] is the input token amount
+        amounts[1] AS token_bought_amount_raw,  -- amounts[_j] is the output token amount
+        contract_address AS maker,  -- The contract is the maker
+        tokens[_i] AS token_sold_address,  -- Replace _i with the correct index
+        tokens[_j] AS token_bought_address,  -- Replace _j with the correct index
+        feeAmount AS fee_amount,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
+        'tapio' AS project,
+        '1' AS version,  -- Adjust version if needed
+        'base' AS blockchain  -- Adjust blockchain if needed
+    FROM {{ source('tapio_blockchain', 'SelfPeggingAsset_evt_TokenSwapped') }}
+    {% if is_incremental() %}
+    WHERE evt_block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+)
+
+SELECT
+    blockchain,
+    project,
+    version,
+    date_trunc('month', block_time) AS block_month,
+    date_trunc('day', block_time) AS block_date,
+    block_time,
+    block_number,
+    token_bought_amount_raw,
+    token_sold_amount_raw,
+    token_bought_address,
+    token_sold_address,
+    taker,
+    maker,
+    contract_address AS project_contract_address,
+    tx_hash,
+    evt_index,
+    tx_from,
+    tx_to
+FROM raw_trades;

--- a/dbt_subprojects/dex/models/_projects/tapio/optimism/tapio_optimism_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/tapio/optimism/tapio_optimism_trades.sql
@@ -1,0 +1,59 @@
+{{
+    config(
+        schema = 'tapio_optimism',
+        alias = 'trades',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['tx_hash', 'evt_index'],
+        post_hook='{{ expose_spells(\'["optimism"]\',
+                                "project",
+                                "tapio",
+                                \'["brunota20"]\') }}'
+    )
+}}
+
+WITH raw_trades AS (
+    SELECT
+        evt_tx_hash AS tx_hash,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number,
+        evt_index,
+        buyer AS taker,
+        amounts[0] AS token_sold_amount_raw,  -- amounts[_i] is the input token amount
+        amounts[1] AS token_bought_amount_raw,  -- amounts[_j] is the output token amount
+        contract_address AS maker,  -- The contract is the maker
+        tokens[_i] AS token_sold_address,  -- Replace _i with the correct index
+        tokens[_j] AS token_bought_address,  -- Replace _j with the correct index
+        feeAmount AS fee_amount,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
+        'tapio' AS project,
+        '1' AS version,  -- Adjust version if needed
+        'optimism' AS blockchain  -- Adjust blockchain if needed
+    FROM {{ source('tapio_blockchain', 'SelfPeggingAsset_evt_TokenSwapped') }}
+    {% if is_incremental() %}
+    WHERE evt_block_time >= date_trunc('day', now() - interval '7' day)
+    {% endif %}
+)
+
+SELECT
+    blockchain,
+    project,
+    version,
+    date_trunc('month', block_time) AS block_month,
+    date_trunc('day', block_time) AS block_date,
+    block_time,
+    block_number,
+    token_bought_amount_raw,
+    token_sold_amount_raw,
+    token_bought_address,
+    token_sold_address,
+    taker,
+    maker,
+    contract_address AS project_contract_address,
+    tx_hash,
+    evt_index,
+    tx_from,
+    tx_to
+FROM raw_trades;

--- a/dbt_subprojects/dex/models/_projects/tapio/tapio_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/tapio/tapio_trades.sql
@@ -1,0 +1,38 @@
+{{ config(
+        schema = 'tapio',
+        alias = 'trades',
+        materialized = 'view',
+        post_hook='{{ expose_spells(blockchains = \'["arbitrum", "base", "optimism"]\',
+                                      spell_type = "project", 
+                                      spell_name = "tapio", 
+                                      contributors = \'["jeff-dude", "mtitus6", "Henrystats", "chrispearcx", "wuligy", "tomfutago", "phu", "brunota20"]\') }}'
+        )
+}}
+
+
+SELECT  blockchain
+        , project
+        , version
+        , block_month
+        , block_date
+        , block_time
+        , block_number
+        , token_bought_symbol
+        , token_sold_symbol
+        , token_pair
+        , token_bought_amount
+        , token_sold_amount
+        , token_bought_amount_raw
+        , token_sold_amount_raw
+        , amount_usd
+        , token_bought_address
+        , token_sold_address
+        , taker
+        , maker
+        , project_contract_address
+        , tx_hash
+        , tx_from
+        , tx_to
+        , evt_index
+FROM {{ ref('dex_trades') }}
+WHERE project = 'tapio'


### PR DESCRIPTION
… tapio_blockchain.SelfPeggingAsset_evt_TokenSwapped

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

This PR introduces the tapio_trades model and its corresponding tapio_schema.yml file to track and document DEX trades for the Tapio protocol across Arbitrum, Base, and Optimism chains.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
