### PR TITLE
`lido_accounting` missing source

### DIFF
--- a/sources/prices/prices_sources.yml
+++ b/sources/prices/prices_sources.yml
@@ -22,3 +22,4 @@ sources:
             description: "Token symbol"
           - name: price
             description: "USD price of a token"
+      - name: tokens


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

`dbt compile` fails on missing source for this spell

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
