### PR TITLE
Lending aave supply macro - new param

### DIFF
--- a/dbt_subprojects/hourly_spellbook/macros/sector/lending/lending_aave_compatible_supply.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/lending/lending_aave_compatible_supply.sql
@@ -141,7 +141,7 @@ src_LendingPool_evt_Withdraw as (
   {% endif %}
 ),
 
-{% if 'aave' in project %}
+{% if wrapped_token_gateway_available %}
 src_WrappedTokenGatewayV2_call_withdrawETH as (
   select *
   from {{ source(project_decoded_as ~ '_' ~ blockchain, 'WrappedTokenGatewayV2_call_withdrawETH') }}
@@ -179,7 +179,7 @@ base_supply as (
     'withdraw' as transaction_type,
     w.reserve as token_address,
     w.user as depositor,
-    {% if 'aave' in project %}
+    {% if wrapped_token_gateway_available %}
       cast(wrap.to as varbinary)
     {% else %}
       cast(null as varbinary)
@@ -193,7 +193,7 @@ base_supply as (
     w.evt_block_time,
     w.evt_block_number
   from src_LendingPool_evt_Withdraw w
-  {% if 'aave' in project %}
+  {% if wrapped_token_gateway_available %}
     left join src_WrappedTokenGatewayV2_call_withdrawETH wrap
       on w.evt_block_number = wrap.call_block_number
       and w.evt_tx_hash = wrap.call_tx_hash
@@ -248,6 +248,7 @@ from base_supply
     version,
     project_decoded_as = 'aave_v3',
     decoded_contract_name = 'Pool',
+    wrapped_token_gateway_available = true,
     decoded_wrapped_token_gateway_name = 'WrappedTokenGatewayV3'
   )
 %}
@@ -270,7 +271,7 @@ src_LendingPool_evt_Withdraw as (
   {% endif %}
 ),
 
-{% if 'aave' in project %}
+{% if wrapped_token_gateway_available %}
 src_WrappedTokenGatewayV3_call_withdrawETH as (
   select *
   from {{ source(project_decoded_as ~ '_' ~ blockchain, decoded_wrapped_token_gateway_name ~ '_call_withdrawETH') }}
@@ -317,7 +318,7 @@ base_supply as (
     'withdraw' as transaction_type,
     w.reserve as token_address,
     w.user as depositor,
-    {% if 'aave' in project %}
+    {% if wrapped_token_gateway_available %}
       cast(wrap.to as varbinary)
     {% else %}
       cast(null as varbinary)
@@ -331,7 +332,7 @@ base_supply as (
     w.evt_block_time,
     w.evt_block_number
   from src_LendingPool_evt_Withdraw w
-  {% if 'aave' in project %}
+  {% if wrapped_token_gateway_available %}
     left join src_WrappedTokenGatewayV3_call_withdrawETH wrap
       on w.evt_block_number = wrap.call_block_number
       and w.evt_tx_hash = wrap.call_tx_hash

--- a/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/base/platforms/seamlessprotocol_base_base_supply.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/base/platforms/seamlessprotocol_base_base_supply.sql
@@ -16,6 +16,7 @@
     project = 'seamlessprotocol',
     version = '1',
     project_decoded_as = 'seamlessprotocol',
-    decoded_contract_name = 'L2Pool'
+    decoded_contract_name = 'L2Pool',
+    wrapped_token_gateway_available = false
   )
 }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/ethereum/platforms/spark_ethereum_base_supply.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/ethereum/platforms/spark_ethereum_base_supply.sql
@@ -15,6 +15,7 @@
     blockchain = 'ethereum',
     project = 'spark',
     version = '1',
-    project_decoded_as = 'spark_protocol'
+    project_decoded_as = 'spark_protocol',
+    wrapped_token_gateway_available = false
   )
 }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/gnosis/platforms/realt_rmm_v2_gnosis_base_supply.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/gnosis/platforms/realt_rmm_v2_gnosis_base_supply.sql
@@ -15,6 +15,7 @@
     blockchain = 'gnosis',
     project = 'realt_rmm',
     version = '2',
-    project_decoded_as = 'real_rmm_v2'
+    project_decoded_as = 'real_rmm_v2',
+    wrapped_token_gateway_available = false
   )
 }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/zksync/platforms/zerolend_zksync_base_supply.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/zksync/platforms/zerolend_zksync_base_supply.sql
@@ -15,6 +15,7 @@
     blockchain = 'zksync',
     project = 'zerolend',
     version = '1',
-    project_decoded_as = 'zerolend'
+    project_decoded_as = 'zerolend',
+    wrapped_token_gateway_available = false
   )
 }}

--- a/sources/prices/prices_sources.yml
+++ b/sources/prices/prices_sources.yml
@@ -22,3 +22,4 @@ sources:
             description: "Token symbol"
           - name: price
             description: "USD price of a token"
+      - name: tokens


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

* updated `lending_aave_v3_compatible_supply` macro to add new `wrapped_token_gateway_available` param with default `true` - previous assumption that all Aave deployments have WrappedTokenGatewayV3 doesn't apply to Celo
* updated spells affected by this change

this PR depends on #7881 

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
