### PR TITLE
Add Balancer Vault address for Base network

### DIFF
--- a/dbt_subprojects/dex/models/addresses/base/dex_base_addresses.sql
+++ b/dbt_subprojects/dex/models/addresses/base/dex_base_addresses.sql
@@ -24,6 +24,7 @@ FROM (VALUES
       ('base', 0xf8b959870634e1bb1926f8790e5ec3592d44a82a, 'DackieSwap', 'Router'),
       ('base', 0x19ceead7105607cd444f5ad10dd51356436095a1, 'Odos', 'Router'),
       ('base', 0x3a23f943181408eac424116af7b7790c94cb97a5, 'Socket', 'Aggregator of Aggregators'),
-      ('base', 0x00000000009726632680fb29d3f7a9734e3010e2, 'Rainbow', 'Aggregator of Aggregators')
-
+      ('base', 0x00000000009726632680fb29d3f7a9734e3010e2, 'Rainbow', 'Aggregator of Aggregators'),
+      ('base', 0xba12222222228d8ba445958a75a0704d566bf2c8, 'Balancer', 'Vault'),
+      ('base', 0x8d80e1728c7bf0f8b9d56a823e026afb444ec2c8, 'Sushi', 'Router')
     ) AS x (blockchain, address, dex_name, distinct_name)

--- a/dbt_subprojects/dex/models/addresses/base/dex_base_addresses.sql
+++ b/dbt_subprojects/dex/models/addresses/base/dex_base_addresses.sql
@@ -25,6 +25,5 @@ FROM (VALUES
       ('base', 0x19ceead7105607cd444f5ad10dd51356436095a1, 'Odos', 'Router'),
       ('base', 0x3a23f943181408eac424116af7b7790c94cb97a5, 'Socket', 'Aggregator of Aggregators'),
       ('base', 0x00000000009726632680fb29d3f7a9734e3010e2, 'Rainbow', 'Aggregator of Aggregators'),
-      ('base', 0xba12222222228d8ba445958a75a0704d566bf2c8, 'Balancer', 'Vault'),
-      ('base', 0x8d80e1728c7bf0f8b9d56a823e026afb444ec2c8, 'Sushi', 'Router')
+      ('base', 0xba12222222228d8ba445958a75a0704d566bf2c8, 'Balancer', 'Vault')
     ) AS x (blockchain, address, dex_name, distinct_name)


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Changes:
- Added Balancer Vault address (0xba12222222228d8ba445958a75a0704d566bf2c8) to dex_base_addresses.sql
- Address is verified on Basescan and matches official Balancer documentation


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
