### PR TITLE
Fix partition timestamps

### DIFF
--- a/.github/workflows/daily_spellbook.yml
+++ b/.github/workflows/daily_spellbook.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - dbt_subprojects/daily_spellbook/**
+      - dbt_macros/shared/**
       - .github/workflows/daily_spellbook.yml
       - .github/workflows/dbt_run.yml
 

--- a/.github/workflows/dex.yml
+++ b/.github/workflows/dex.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - dbt_subprojects/dex/**
+      - dbt_macros/shared/**
       - .github/workflows/dex.yml
       - .github/workflows/dbt_run.yml
 

--- a/.github/workflows/hourly_spellbook.yml
+++ b/.github/workflows/hourly_spellbook.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - dbt_subprojects/hourly_spellbook/**
+      - dbt_macros/shared/**
       - .github/workflows/hourly_spellbook.yml
       - .github/workflows/dbt_run.yml
 

--- a/.github/workflows/nft.yml
+++ b/.github/workflows/nft.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - dbt_subprojects/nft/**
+      - dbt_macros/shared/**
       - .github/workflows/nft.yml
       - .github/workflows/dbt_run.yml
 

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - dbt_subprojects/solana/**
+      - dbt_macros/shared/**
       - .github/workflows/solana.yml
       - .github/workflows/dbt_run.yml
 

--- a/.github/workflows/tokens.yml
+++ b/.github/workflows/tokens.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - dbt_subprojects/tokens/**
+      - dbt_macros/shared/**
       - .github/workflows/tokens.yml
       - .github/workflows/dbt_run.yml
 

--- a/dbt_macros/shared/balances_incremental_subset_daily.sql
+++ b/dbt_macros/shared/balances_incremental_subset_daily.sql
@@ -117,7 +117,7 @@ days as (
 forward_fill as (
     select
         blockchain,
-        cast(d.day as timestamp) as day,
+        d.day,
         address,
         token_symbol,
         token_address,

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions_raw.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions_raw.sql
@@ -27,7 +27,7 @@ balances as (
 
 select
     'polygon' as blockchain
-    , date_trunc('month', day) as month
+    , cast(date_trunc('month', day) as date) as month
     , day
     , address
     , token_address

--- a/dbt_subprojects/daily_spellbook/models/chainswap/arbitrum/chain_swap_arbitrum_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/arbitrum/chain_swap_arbitrum_trades.sql
@@ -115,7 +115,7 @@ with
 select distinct
     block_time,
     date_trunc('day', block_time) as block_date,
-    date_trunc('month', block_time) as block_month,
+    cast(date_trunc('month', block_time) as date) as block_month,
     '{{blockchain}}' as blockchain,
     -- Trade
     amount_usd,

--- a/dbt_subprojects/daily_spellbook/models/chainswap/avalanche_c/chain_swap_avalanche_c_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/avalanche_c/chain_swap_avalanche_c_trades.sql
@@ -117,7 +117,7 @@ with
 select distinct
     block_time,
     date_trunc('day', block_time) as block_date,
-    date_trunc('month', block_time) as block_month,
+    cast(date_trunc('month', block_time) as date) as block_month,
     '{{blockchain}}' as blockchain,
     -- Trade
     amount_usd,

--- a/dbt_subprojects/daily_spellbook/models/chainswap/base/chain_swap_base_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/base/chain_swap_base_trades.sql
@@ -121,7 +121,7 @@ with
 select distinct
     block_time,
     date_trunc('day', block_time) as block_date,
-    date_trunc('month', block_time) as block_month,
+    cast(date_trunc('month', block_time) as date) as block_month,
     '{{blockchain}}' as blockchain,
     -- Trade
     amount_usd,

--- a/dbt_subprojects/daily_spellbook/models/chainswap/bnb/chain_swap_bnb_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/bnb/chain_swap_bnb_trades.sql
@@ -116,7 +116,7 @@ with
 select distinct
     block_time,
     date_trunc('day', block_time) as block_date,
-    date_trunc('month', block_time) as block_month,
+    cast(date_trunc('month', block_time) as date) as block_month,
     '{{blockchain}}' as blockchain,
     -- Trade
     amount_usd,

--- a/dbt_subprojects/daily_spellbook/models/chainswap/ethereum/chain_swap_ethereum_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/ethereum/chain_swap_ethereum_trades.sql
@@ -123,7 +123,7 @@ with
 select distinct
     block_time,
     date_trunc('day', block_time) as block_date,
-    date_trunc('month', block_time) as block_month,
+    cast(date_trunc('month', block_time) as date) as block_month,
     '{{blockchain}}' as blockchain,
     -- Trade
     amount_usd,

--- a/dbt_subprojects/daily_spellbook/models/chainswap/optimism/chain_swap_optimism_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/optimism/chain_swap_optimism_trades.sql
@@ -123,7 +123,7 @@ with
 select distinct
     block_time,
     date_trunc('day', block_time) as block_date,
-    date_trunc('month', block_time) as block_month,
+    cast(date_trunc('month', block_time) as date) as block_month,
     '{{blockchain}}' as blockchain,
     -- Trade
     amount_usd,

--- a/dbt_subprojects/daily_spellbook/models/chainswap/polygon/chain_swap_polygon_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/polygon/chain_swap_polygon_trades.sql
@@ -123,7 +123,7 @@ with
 select distinct
     block_time,
     date_trunc('day', block_time) as block_date,
-    date_trunc('month', block_time) as block_month,
+    cast(date_trunc('month', block_time) as date) as block_month,
     '{{blockchain}}' as blockchain,
     -- Trade
     amount_usd,

--- a/dbt_subprojects/dex/macros/models/_project/zeroex/zeroex_v2.sql
+++ b/dbt_subprojects/dex/macros/models/_project/zeroex/zeroex_v2.sql
@@ -500,7 +500,7 @@ SELECT
         '0x-API' AS project,
         'settler' AS version,
         DATE_TRUNC('day', block_time) block_date,
-        DATE_TRUNC('month', block_time) AS block_month,
+        cast(DATE_TRUNC('month', block_time) as date) AS block_month,
         block_time,
         block_number,
         taker_symbol,

--- a/dbt_subprojects/dex/models/bot_trades/flokibot/base/flokibot_base_bot_trades.sql
+++ b/dbt_subprojects/dex/models/bot_trades/flokibot/base/flokibot_base_bot_trades.sql
@@ -137,7 +137,7 @@ with
 select
     block_time,
     date_trunc('day', bot_trades.block_time) as block_date,
-    date_trunc('month', bot_trades.block_time) as block_month,
+    cast(date_trunc('month', bot_trades.block_time) as date) as block_month,
     '{{project_name}}' as bot,
     block_number,
     '{{blockchain}}' as blockchain,

--- a/dbt_subprojects/dex/models/bot_trades/flokibot/bnb/flokibot_bnb_bot_trades.sql
+++ b/dbt_subprojects/dex/models/bot_trades/flokibot/bnb/flokibot_bnb_bot_trades.sql
@@ -143,7 +143,7 @@ with
 select
     block_time,
     date_trunc('day', bot_trades.block_time) as block_date,
-    date_trunc('month', bot_trades.block_time) as block_month,
+    cast(date_trunc('month', bot_trades.block_time) as date) as block_month,
     '{{project_name}}' as bot,
     block_number,
     '{{blockchain}}' as blockchain,

--- a/dbt_subprojects/dex/models/bot_trades/flokibot/ethereum/flokibot_ethereum_bot_trades.sql
+++ b/dbt_subprojects/dex/models/bot_trades/flokibot/ethereum/flokibot_ethereum_bot_trades.sql
@@ -137,7 +137,7 @@ with
 select
     block_time,
     date_trunc('day', bot_trades.block_time) as block_date,
-    date_trunc('month', bot_trades.block_time) as block_month,
+    cast(date_trunc('month', bot_trades.block_time) as date) as block_month,
     '{{project_name}}' as bot,
     block_number,
     '{{blockchain}}' as blockchain,

--- a/dbt_subprojects/dex/models/bot_trades/pepeboost/ethereum/pepeboost_ethereum_bot_trades.sql
+++ b/dbt_subprojects/dex/models/bot_trades/pepeboost/ethereum/pepeboost_ethereum_bot_trades.sql
@@ -144,7 +144,7 @@ WITH
 SELECT
   block_time,
   date_trunc('day', botTrades.block_time) as block_date,
-  date_trunc('month', botTrades.block_time) as block_month,
+  cast(date_trunc('month', botTrades.block_time) as date) as block_month,
   '{{project_name}}' as bot,
   block_number,
   '{{blockchain}}' AS blockchain,


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:
partition by timestamp is not safe for now. 
We'll use partition by date instead


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
