### PR TITLE
curve ethereum: fix duplicates in pools view

### DIFF
--- a/dbt_subprojects/dex/models/_projects/curvefi/ethereum/curve_ethereum_view_pools.sql
+++ b/dbt_subprojects/dex/models/_projects/curvefi/ethereum/curve_ethereum_view_pools.sql
@@ -249,6 +249,7 @@ v1_stableswap_ng as (
         ) }} dp
         ON dp.call_block_time = p.evt_block_time
         AND dp.call_tx_hash = p.evt_tx_hash
+        AND dp._coins = p.coins
 ),
 
 


### PR DESCRIPTION
before the join condition (commented out), the two filtered pools return dupes due to same tx having two deploys with no differentiator between them (block time, tx hash before).
```
SELECT
    'Factory V1 Stableswap Plain NG' AS version,
    dp._name AS name,
    dp._symbol AS symbol,
    dp.output_0 AS pool_address,
    dp._A AS A,
    dp._fee AS mid_fee,
    dp._fee AS out_fee,
    dp.output_0 AS token_address,
    dp.output_0 AS deposit_contract,
    p.coins[1] AS coin0,
    p.coins[2] AS coin1,
    COALESCE(try(p.coins[3]), CAST(NULL as varbinary)) as coin2,
    COALESCE(try(p.coins[4]), CAST(NULL as varbinary)) as coin3,
    CAST(NULL as varbinary) AS undercoin0,
    CAST(NULL as varbinary) AS undercoin1,
    CAST(NULL as varbinary) AS undercoin2,
    CAST(NULL as varbinary) AS undercoin3
FROM
    "delta_prod"."curvefi_ethereum"."CurveStableswapFactoryNG_evt_PlainPoolDeployed" as p
    LEFT JOIN "delta_prod"."curvefi_ethereum"."CurveStableswapFactoryNG_call_deploy_plain_pool" dp ON dp.call_block_time = p.evt_block_time
    AND dp.call_tx_hash = p.evt_tx_hash
    -- and dp._coins = p.coins
where
    dp.output_0 in (
        0xc522a6606bba746d7960404f22a3db936b6f4f50,
        0xed785af60bed688baa8990cd5c4166221599a441
    )
```

once we add the `coins` column which listed tokens within each pool, the join returns two rows as expected, one row per pool.
```
SELECT
    'Factory V1 Stableswap Plain NG' AS version,
    dp._name AS name,
    dp._symbol AS symbol,
    dp.output_0 AS pool_address,
    dp._A AS A,
    dp._fee AS mid_fee,
    dp._fee AS out_fee,
    dp.output_0 AS token_address,
    dp.output_0 AS deposit_contract,
    p.coins[1] AS coin0,
    p.coins[2] AS coin1,
    COALESCE(try(p.coins[3]), CAST(NULL as varbinary)) as coin2,
    COALESCE(try(p.coins[4]), CAST(NULL as varbinary)) as coin3,
    CAST(NULL as varbinary) AS undercoin0,
    CAST(NULL as varbinary) AS undercoin1,
    CAST(NULL as varbinary) AS undercoin2,
    CAST(NULL as varbinary) AS undercoin3
FROM
    "delta_prod"."curvefi_ethereum"."CurveStableswapFactoryNG_evt_PlainPoolDeployed" as p
    LEFT JOIN "delta_prod"."curvefi_ethereum"."CurveStableswapFactoryNG_call_deploy_plain_pool" dp ON dp.call_block_time = p.evt_block_time
    AND dp.call_tx_hash = p.evt_tx_hash
    and dp._coins = p.coins
where
    dp.output_0 in (
        0xc522a6606bba746d7960404f22a3db936b6f4f50,
        0xed785af60bed688baa8990cd5c4166221599a441
    )
```