### PR TITLE
`prices.usd`: update kaia feed, remove bad price on eth

### DIFF
--- a/dbt_subprojects/tokens/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -117,7 +117,6 @@ FROM
     ('drgn-dragonchain', 'ethereum', 'DRGN', 0x419c4db4b9e25d6db2ad9691ccb832c8d9fda05e, 18),
     ('dsla-dsla-protocol', 'ethereum', 'DSLA', 0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe, 18),
     ('dusk-dusk-network', 'ethereum', 'DUSK', 0x940a2db1b7008b6c776d4faaca729d6d4a4aa551, 18),
-    ('dx-dxchain-token', 'ethereum', 'DX', 0x973e52691176d36453868d9d86572788d27041a9, 18),
     ('dxd-dxdao', 'ethereum', 'DXD', 0xa1d65e8fb6e87b60feccbc582f7f97804b725521, 18),
     ('dydx-dydx', 'ethereum', 'DYDX', 0x92d6c1e31e14520e676a687f0a93788b716beff5, 18),
     ('dzar-digital-rand', 'ethereum', 'DZAR', 0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c, 6),

--- a/dbt_subprojects/tokens/models/prices/prices_native_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_native_tokens.sql
@@ -80,7 +80,7 @@ FROM
     ('ar-arweave', null, 'AR', null, null),
     ('glmr-moonbeam', null, 'GLMR', null, null),
     ('klay-klaytn', null, 'KLAY', null, null), --old symbol was KLAY, new symbol is KAIA, keep for existing queries downstream
-    ('klay-klaytn', null, 'KAIA', null, null), --coinpaprika hasn't updated token yet post-migration
+    ('kaia-kaia', null, 'KAIA', null, null),
     ('fuse-fuse-network', null, 'FUSE', null, null),
     ('zel-zelcash', null, 'FLUX', null, null),
     ('myria-myria', null, 'MYRIA', null, null),


### PR DESCRIPTION
at time of onboarding kaia to spellbook, `kaia-kaia` feed wasn't available from migration of klaytn. updating now.

removing bad feed which inflated 1000x+ for a 3-day period, the token appears to be dead.