### PR TITLE
Revert "feat: fee currency wrapper map (#7907)"

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/celo/gas_celo_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/celo/gas_celo_fees.sql
@@ -14,15 +14,7 @@
 
 {% set test_short_ci = false %}
 
-WITH
-
-fee_currency_wrapper_map (fee_currency_wrapper_contract, wrapped_token_contract, symbol) AS (
-    values
-    (0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72, 0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e, 'USDT'),
-    (0x2f25deb3848c207fc8e0c34035b3ba7fc157602b, 0xcebA9300f2b948710d2653dD7B07f33A8B32118C, 'USDC')
-),
-
-base_model AS (
+WITH base_model as (
     SELECT
         txns.block_time
         ,txns.block_number
@@ -42,7 +34,7 @@ base_model AS (
                          )
                 end
         ) as tx_fee_breakdown_raw
-        ,coalesce(fcwp.wrapped_token_contract, txns.fee_currency, {{var('ETH_ERC20_ADDRESS')}}) as tx_fee_currency
+        ,coalesce(txns.fee_currency, {{var('ETH_ERC20_ADDRESS')}}) as tx_fee_currency
         ,blocks.miner AS block_proposer
         ,txns.max_fee_per_gas
         ,txns.priority_fee_per_gas
@@ -59,7 +51,6 @@ base_model AS (
         {% if is_incremental() %}
         AND {{ incremental_predicate('blocks.time') }}
         {% endif %}
-    LEFT JOIN fee_currency_wrapper_map fcwp on txns.fee_currency = fcwp.fee_currency_wrapper_contract
     {% if test_short_ci %}
     WHERE {{ incremental_predicate('txns.block_time') }}
     OR txns.hash in (select tx_hash from {{ref('evm_gas_fees')}})

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/celo/gas_celo_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/celo/gas_celo_schema.yml
@@ -5,7 +5,7 @@ models:
     meta:
       blockchain: celo
       sector: gas
-      contributors: 0xRob, soispoke, tomfutago
+      contributors: 0xRob, soispoke
     config:
       tags: ['celo', 'gas', 'fees']
     description: >


### PR DESCRIPTION
@tomfutago we need to revert this to fix data quality issues. the calculations for `tx_fee` and `tx_fee_usd` inflate to incorrect values for USDC/USDT now due to how celo apparently handles decimals on the proxy contracts. while our prices tables have 6 decimals for these (as expected), looks like the proxy contract should be 18 decimals.

```
WITH
    fee_currency_wrapper_map (
        fee_currency_wrapper_contract,
        wrapped_token_contract,
        symbol
    ) AS (
        values
            (
                0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72,
                0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e,
                'USDT'
            ),
            (
                0x2f25deb3848c207fc8e0c34035b3ba7fc157602b,
                0xcebA9300f2b948710d2653dD7B07f33A8B32118C,
                'USDC'
            )
    ),
    base_model AS (
        SELECT
            txns.block_time,
            txns.block_number,
            txns.hash AS tx_hash,
            txns."from" AS tx_from,
            txns.to AS tx_to,
            cast(gas_price as uint256) as gas_price,
            txns.gas_used as gas_used,
            cast(gas_price as uint256) * cast(txns.gas_used as uint256) as tx_fee_raw,
            map_concat(
                map(),
                case
                    when txns.priority_fee_per_gas is null
                    or txns.priority_fee_per_gas < 0 then map(
                        array['base_fee'],
                        array[
                            (
                                cast(gas_price as uint256) * cast(txns.gas_used as uint256)
                            )
                        ]
                    )
                    else map(
                        array['base_fee', 'priority_fee'],
                        array[
                            (
                                cast(gas_price - priority_fee_per_gas as uint256) * cast(txns.gas_used as uint256)
                            ),
                            (
                                cast(priority_fee_per_gas as uint256) * cast(txns.gas_used as uint256)
                            )
                        ]
                    )
                end
            ) as tx_fee_breakdown_raw,
            coalesce(
                fcwp.wrapped_token_contract,
                txns.fee_currency,
                0x0000000000000000000000000000000000000000
            ) as tx_fee_currency,
            blocks.miner AS block_proposer,
            txns.max_fee_per_gas,
            txns.priority_fee_per_gas,
            txns.max_priority_fee_per_gas,
            blocks.base_fee_per_gas,
            txns.gas_limit,
            CASE --safe divide-by-zero
                WHEN txns.gas_limit = 0 THEN NULL
                WHEN txns.gas_limit != 0 THEN cast(txns.gas_used as double) / cast(txns.gas_limit as double)
            END AS gas_limit_usage
        FROM
            "delta_prod"."celo"."transactions" txns
            INNER JOIN "delta_prod"."celo"."blocks" blocks ON txns.block_number = blocks.number
            LEFT JOIN fee_currency_wrapper_map fcwp on txns.fee_currency = fcwp.fee_currency_wrapper_contract
        where
            txns.fee_currency in (
                0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72,
                0x2f25deb3848c207fc8e0c34035b3ba7fc157602b
            )
            and txns.hash in (
                0x3843c917c544eb2608cda5ea69c798108fbc8d2c4e6a6ab8c252785d6e8ed47c,
                0x8f179fb5cf778fcadb7a50712559e99d3d8e00fe721203441cbb8be2c5ce8316
            )
    )
SELECT
    'celo' as blockchain,
    CAST(date_trunc('month', block_time) AS DATE) AS block_month,
    CAST(date_trunc('day', block_time) AS DATE) AS block_date,
    block_time,
    block_number,
    tx_hash,
    gas_price,
    gas_used,
    p.symbol as currency_symbol,
    p.decimals,
    p.price,
    coalesce(tx_fee_raw, 0) as tx_fee_raw,
    coalesce(tx_fee_raw, 0) / pow(10, p.decimals) as tx_fee_broken,
    coalesce(tx_fee_raw, 0) / pow(10, p.decimals) * p.price as tx_fee_usd_broken,
    coalesce(tx_fee_raw, 0) / pow(10, 18) as tx_fee_fixed,
    coalesce(tx_fee_raw, 0) / pow(10, 18) * p.price as tx_fee_usd_fixed
FROM
    base_model
    LEFT JOIN prices.usd_with_native p ON p.blockchain = 'celo'
    AND p.contract_address = tx_fee_currency
    AND p.minute = date_trunc('minute', block_time)
    and p.contract_address in (
        0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e,
        0xcebA9300f2b948710d2653dD7B07f33A8B32118C
    )
limit
    100
```