### PR TITLE
Fix solana_utils token accounts

### DIFF
--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   dbt-test:
     runs-on: [ self-hosted, linux, spellbook-trino-ci ]
-    timeout-minutes: 90
+    timeout-minutes: 300
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   dbt-test:
     runs-on: [ self-hosted, linux, spellbook-trino-ci ]
-    timeout-minutes: 300
+    timeout-minutes: 90
 
     steps:
       - name: Check out repository code

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_candidates.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_candidates.sql
@@ -1,0 +1,35 @@
+{{
+  config(
+        schema = 'solana_utils',
+        alias = 'token_accounts_candidates',
+        materialized = 'table',
+        file_format = 'delta',
+        post_hook='{{ expose_spells(\'["solana"]\',
+                                    "sector",
+                                    "solana_utils",
+                                    \'["ilemi"]\') }}')
+}}
+
+-- This model identifies addresses that have multiple token_balance_owner or token_mint_address values
+-- These are the only addresses that need the expensive time-window processing in token_accounts_timed
+
+WITH address_counts AS (
+    SELECT 
+        address,
+        COUNT(DISTINCT token_balance_owner) AS unique_owner_count,
+        COUNT(DISTINCT token_mint_address) AS unique_mint_count
+    FROM {{ source('solana', 'account_activity') }}
+    WHERE 
+        writable = true
+        and token_mint_address is not null
+        and token_balance_owner is not null
+        AND block_time >= DATE('2020-03-01') --filter for test run
+    GROUP BY address
+    HAVING unique_owner_count > 1 OR unique_mint_count > 1
+)
+
+SELECT
+    address,
+    unique_owner_count,
+    unique_mint_count
+FROM address_counts 

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_candidates.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_candidates.sql
@@ -23,7 +23,6 @@ WITH address_counts AS (
         writable = true
         and token_mint_address is not null
         and token_balance_owner is not null
-        AND block_time >= DATE('2025-03-01') --filter for test run
     GROUP BY address
     HAVING COUNT(DISTINCT token_balance_owner) > 1 OR COUNT(DISTINCT token_mint_address) > 1
 )

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_candidates.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_candidates.sql
@@ -10,25 +10,41 @@
                                     \'["ilemi"]\') }}')
 }}
 
--- This model identifies addresses that have multiple token_balance_owner or token_mint_address values
--- These are the only addresses that need the expensive time-window processing in token_accounts_timed
+-- This model identifies addresses with multiple owners or mint addresses
+-- Uses standard SQL that's compatible with TrinoSQL
 
-WITH address_counts AS (
+WITH filtered_activity AS (
+    -- Apply all filters once to reduce data volume
+    SELECT 
+        address,
+        token_balance_owner,
+        token_mint_address
+    FROM {{ source('solana', 'account_activity') }}
+    WHERE 
+        writable = true
+        AND token_mint_address IS NOT NULL
+        AND token_balance_owner IS NOT NULL
+        AND block_time >= DATE('2025-04-01') -- Test run with future date
+),
+
+-- Group and count distinct values
+address_counts AS (
     SELECT 
         address,
         COUNT(DISTINCT token_balance_owner) AS unique_owner_count,
         COUNT(DISTINCT token_mint_address) AS unique_mint_count
-    FROM {{ source('solana', 'account_activity') }}
-    WHERE 
-        writable = true
-        and token_mint_address is not null
-        and token_balance_owner is not null
+    FROM filtered_activity
     GROUP BY address
-    HAVING COUNT(DISTINCT token_balance_owner) > 1 OR COUNT(DISTINCT token_mint_address) > 1
+    -- Skip HAVING to avoid another GROUP BY scan, we'll filter later
+),
+
+-- Get only the addresses that have multiple values
+candidate_addresses AS (
+    SELECT address
+    FROM address_counts
+    WHERE unique_owner_count > 1 OR unique_mint_count > 1
 )
 
-SELECT
-    address,
-    unique_owner_count,
-    unique_mint_count
-FROM address_counts 
+-- Final output with just the addresses we need
+SELECT address
+FROM candidate_addresses 

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_candidates.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_candidates.sql
@@ -23,9 +23,9 @@ WITH address_counts AS (
         writable = true
         and token_mint_address is not null
         and token_balance_owner is not null
-        AND block_time >= DATE('2020-03-01') --filter for test run
+        AND block_time >= DATE('2025-03-01') --filter for test run
     GROUP BY address
-    HAVING unique_owner_count > 1 OR unique_mint_count > 1
+    HAVING COUNT(DISTINCT token_balance_owner) > 1 OR COUNT(DISTINCT token_mint_address) > 1
 )
 
 SELECT

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_candidates.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_candidates.sql
@@ -24,7 +24,7 @@ WITH filtered_activity AS (
         writable = true
         AND token_mint_address IS NOT NULL
         AND token_balance_owner IS NOT NULL
-        AND block_time >= DATE('2025-04-01') -- Test run with future date
+        AND block_time >= DATE('2025-03-01') -- Test run with future date
 ),
 
 -- Group and count distinct values

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_combined.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_combined.sql
@@ -33,4 +33,4 @@ SELECT
     valid_to,
     account_type,
     'timed' AS source_model
-FROM {{ ref('solana_utils_token_accounts_timed') }} 
+FROM {{ ref('solana_utils_token_accounts_timing') }} 

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_combined.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_combined.sql
@@ -1,0 +1,36 @@
+{{
+  config(
+        schema = 'solana_utils',
+        alias = 'token_accounts_combined',
+        materialized = 'view',
+        post_hook='{{ expose_spells(\'["solana"]\',
+                                    "sector",
+                                    "solana_utils",
+                                    \'["ilemi"]\') }}')
+}}
+
+-- This model combines both static and timed token accounts into one unified view
+-- Static accounts (the majority) are processed efficiently with simpler logic
+-- Timed accounts (with multiple owners/mints) get the full time-period processing
+
+SELECT
+    address,
+    token_balance_owner,
+    token_mint_address,
+    valid_from,
+    valid_to,
+    account_type,
+    'static' AS source_model
+FROM {{ ref('solana_utils_token_accounts_static') }}
+
+UNION ALL
+
+SELECT
+    address,
+    token_balance_owner,
+    token_mint_address,
+    valid_from,
+    valid_to,
+    account_type,
+    'timed' AS source_model
+FROM {{ ref('solana_utils_token_accounts_timed') }} 

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_static.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_static.sql
@@ -71,7 +71,7 @@ SELECT
     bd.token_balance_owner,
     bd.token_mint_address,
     bd.valid_from,
-    current_timestamp AS valid_to,
+    cast(now() as timestamp) AS valid_to,
     CASE
         WHEN nft.account_mint IS NOT NULL THEN 'nft'
         ELSE 'fungible'

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_static.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_static.sql
@@ -1,0 +1,103 @@
+{{
+  config(
+        schema = 'solana_utils',
+        tags = ['prod_exclude'],
+        alias = 'token_accounts_static',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['address', 'token_balance_owner', 'token_mint_address'],
+        post_hook='{{ expose_spells(\'["solana"]\',
+                                    "sector",
+                                    "solana_utils",
+                                    \'["ilemi"]\') }}')
+}}
+
+-- This model processes addresses with only one owner/mint (the majority)
+-- Using TrinoSQL compatible approaches
+
+{% if is_incremental() %}
+-- For incremental runs, find recently modified addresses
+WITH addresses_to_process AS (
+    SELECT DISTINCT act.address
+    FROM {{ source('solana', 'account_activity') }} act
+    LEFT JOIN {{ ref('solana_utils_token_accounts_candidates') }} cand
+        ON act.address = cand.address
+    WHERE {{incremental_predicate('act.block_time')}}
+    AND act.writable = true
+    AND act.block_time >= DATE('2025-04-01') -- Test run with future date
+    AND cand.address IS NULL -- Only addresses NOT in candidates
+),
+{% else %}
+WITH addresses_to_process AS (
+    -- For full runs, get all addresses not in candidates
+    SELECT DISTINCT act.address
+    FROM {{ source('solana', 'account_activity') }} act
+    LEFT JOIN {{ ref('solana_utils_token_accounts_candidates') }} cand
+        ON act.address = cand.address
+    WHERE act.writable = true
+    AND act.token_mint_address IS NOT NULL
+    AND act.token_balance_owner IS NOT NULL
+    AND act.block_time >= DATE('2025-04-01') -- Test run with future date
+    AND cand.address IS NULL -- Only addresses NOT in candidates
+),
+{% endif %}
+
+-- Get the earliest transaction for each address
+earliest_tx AS (
+    SELECT 
+        a.address,
+        MIN(a.block_time) AS min_time
+    FROM {{ source('solana', 'account_activity') }} a
+    WHERE writable = true
+    AND a.token_mint_address IS NOT NULL
+    AND a.token_balance_owner IS NOT NULL
+    AND a.block_time >= DATE('2025-04-01') -- Test run with future date
+    AND a.address IN (SELECT address FROM addresses_to_process)
+    GROUP BY a.address
+),
+
+-- Get a representative record (using MAX to get a single value)
+-- Since these are static accounts, all records have the same owner/mint
+representative_record AS (
+    SELECT 
+        a.address,
+        -- Use aggregates to get one value per address
+        MAX(a.token_balance_owner) AS token_balance_owner,
+        MAX(a.token_mint_address) AS token_mint_address
+    FROM {{ source('solana', 'account_activity') }} a
+    WHERE a.writable = true
+    AND a.token_mint_address IS NOT NULL
+    AND a.token_balance_owner IS NOT NULL
+    AND a.block_time >= DATE('2025-04-01') -- Test run with future date
+    AND a.address IN (SELECT address FROM addresses_to_process)
+    GROUP BY a.address
+),
+
+-- Combine both to get complete static account data
+static_accounts AS (
+    SELECT
+        r.address,
+        r.token_balance_owner,
+        r.token_mint_address,
+        e.min_time AS valid_from
+    FROM representative_record r
+    INNER JOIN earliest_tx e
+        ON r.address = e.address
+)
+
+-- Join with NFT data for classification
+SELECT
+    sa.address,
+    sa.token_balance_owner,
+    sa.token_mint_address,
+    sa.valid_from,
+    CAST(NOW() AS TIMESTAMP) AS valid_to,
+    CASE
+        WHEN nft.account_mint IS NOT NULL THEN 'nft'
+        ELSE 'fungible'
+    END AS account_type
+FROM static_accounts sa
+LEFT JOIN {{ ref('tokens_solana_nft') }} nft
+    ON sa.token_mint_address = nft.account_mint
+    AND nft.token_standard NOT IN ('Fungible', 'FungibleAsset') 

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_static.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_static.sql
@@ -12,91 +12,71 @@
                                     \'["ilemi"]\') }}')
 }}
 
--- This model processes addresses with only one owner/mint (the majority)
--- Using TrinoSQL compatible approaches
+-- Simplified model for better Trino compatibility
 
 {% if is_incremental() %}
--- For incremental runs, find recently modified addresses
-WITH addresses_to_process AS (
-    SELECT DISTINCT act.address
+-- For incremental runs
+WITH base_data AS (
+    SELECT 
+        act.address,
+        act.token_balance_owner,
+        act.token_mint_address,
+        MIN(act.block_time) AS valid_from
     FROM {{ source('solana', 'account_activity') }} act
-    LEFT JOIN {{ ref('solana_utils_token_accounts_candidates') }} cand
-        ON act.address = cand.address
-    WHERE {{incremental_predicate('act.block_time')}}
-    AND act.writable = true
-    AND act.block_time >= DATE('2025-04-01') -- Test run with future date
-    AND cand.address IS NULL -- Only addresses NOT in candidates
-),
+    WHERE 
+        act.writable = true
+        AND act.token_mint_address IS NOT NULL
+        AND act.token_balance_owner IS NOT NULL
+        AND act.block_time >= DATE('2025-04-01')
+        AND {{incremental_predicate('act.block_time')}}
+        AND NOT EXISTS (
+            SELECT 1 
+            FROM {{ ref('solana_utils_token_accounts_candidates') }} cand
+            WHERE act.address = cand.address
+        )
+    GROUP BY 
+        act.address,
+        act.token_balance_owner,
+        act.token_mint_address
+)
 {% else %}
-WITH addresses_to_process AS (
-    -- For full runs, get all addresses not in candidates
-    SELECT DISTINCT act.address
+-- For full runs
+WITH base_data AS (
+    SELECT 
+        act.address,
+        act.token_balance_owner,
+        act.token_mint_address,
+        MIN(act.block_time) AS valid_from
     FROM {{ source('solana', 'account_activity') }} act
-    LEFT JOIN {{ ref('solana_utils_token_accounts_candidates') }} cand
-        ON act.address = cand.address
-    WHERE act.writable = true
-    AND act.token_mint_address IS NOT NULL
-    AND act.token_balance_owner IS NOT NULL
-    AND act.block_time >= DATE('2025-04-01') -- Test run with future date
-    AND cand.address IS NULL -- Only addresses NOT in candidates
-),
+    WHERE 
+        act.writable = true
+        AND act.token_mint_address IS NOT NULL
+        AND act.token_balance_owner IS NOT NULL
+        AND act.block_time >= DATE('2025-04-01')
+        AND NOT EXISTS (
+            SELECT 1 
+            FROM {{ ref('solana_utils_token_accounts_candidates') }} cand
+            WHERE act.address = cand.address
+        )
+    GROUP BY 
+        act.address,
+        act.token_balance_owner,
+        act.token_mint_address
+)
 {% endif %}
 
--- Get the earliest transaction for each address
-earliest_tx AS (
-    SELECT 
-        a.address,
-        MIN(a.block_time) AS min_time
-    FROM {{ source('solana', 'account_activity') }} a
-    WHERE writable = true
-    AND a.token_mint_address IS NOT NULL
-    AND a.token_balance_owner IS NOT NULL
-    AND a.block_time >= DATE('2025-04-01') -- Test run with future date
-    AND a.address IN (SELECT address FROM addresses_to_process)
-    GROUP BY a.address
-),
-
--- Get a representative record (using MAX to get a single value)
--- Since these are static accounts, all records have the same owner/mint
-representative_record AS (
-    SELECT 
-        a.address,
-        -- Use aggregates to get one value per address
-        MAX(a.token_balance_owner) AS token_balance_owner,
-        MAX(a.token_mint_address) AS token_mint_address
-    FROM {{ source('solana', 'account_activity') }} a
-    WHERE a.writable = true
-    AND a.token_mint_address IS NOT NULL
-    AND a.token_balance_owner IS NOT NULL
-    AND a.block_time >= DATE('2025-04-01') -- Test run with future date
-    AND a.address IN (SELECT address FROM addresses_to_process)
-    GROUP BY a.address
-),
-
--- Combine both to get complete static account data
-static_accounts AS (
-    SELECT
-        r.address,
-        r.token_balance_owner,
-        r.token_mint_address,
-        e.min_time AS valid_from
-    FROM representative_record r
-    INNER JOIN earliest_tx e
-        ON r.address = e.address
-)
-
--- Join with NFT data for classification
+-- Final output with NFT classification
 SELECT
-    sa.address,
-    sa.token_balance_owner,
-    sa.token_mint_address,
-    sa.valid_from,
-    CAST(NOW() AS TIMESTAMP) AS valid_to,
+    bd.address,
+    bd.token_balance_owner,
+    bd.token_mint_address,
+    bd.valid_from,
+    current_timestamp AS valid_to,
     CASE
         WHEN nft.account_mint IS NOT NULL THEN 'nft'
         ELSE 'fungible'
     END AS account_type
-FROM static_accounts sa
+FROM base_data bd
 LEFT JOIN {{ ref('tokens_solana_nft') }} nft
-    ON sa.token_mint_address = nft.account_mint
+    ON bd.token_mint_address = nft.account_mint
     AND nft.token_standard NOT IN ('Fungible', 'FungibleAsset') 

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_static.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_static.sql
@@ -27,7 +27,7 @@ WITH base_data AS (
         act.writable = true
         AND act.token_mint_address IS NOT NULL
         AND act.token_balance_owner IS NOT NULL
-        AND act.block_time >= DATE('2025-04-01')
+        AND act.block_time >= DATE('2025-03-01')
         AND {{incremental_predicate('act.block_time')}}
         AND NOT EXISTS (
             SELECT 1 
@@ -52,7 +52,7 @@ WITH base_data AS (
         act.writable = true
         AND act.token_mint_address IS NOT NULL
         AND act.token_balance_owner IS NOT NULL
-        AND act.block_time >= DATE('2025-04-01')
+        AND act.block_time >= DATE('2025-03-01')
         AND NOT EXISTS (
             SELECT 1 
             FROM {{ ref('solana_utils_token_accounts_candidates') }} cand
@@ -71,7 +71,7 @@ SELECT
     bd.token_balance_owner,
     bd.token_mint_address,
     bd.valid_from,
-    cast(now() as timestamp) AS valid_to,
+    current_timestamp AS valid_to,
     CASE
         WHEN nft.account_mint IS NOT NULL THEN 'nft'
         ELSE 'fungible'

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_static.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_static.sql
@@ -1,7 +1,6 @@
 {{
   config(
         schema = 'solana_utils',
-        tags = ['prod_exclude'],
         alias = 'token_accounts_static',
         materialized = 'incremental',
         file_format = 'delta',

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
@@ -31,7 +31,7 @@ activity_for_processing AS (
     WHERE 
         act.writable = true
         AND act.token_mint_address IS NOT NULL
-        AND act.block_time >= DATE('2025-04-01') -- Test run
+        AND act.block_time >= DATE('2025-03-01') -- Test run
 ),
 
 -- Number activity chronologically per address for LAG calculations
@@ -111,7 +111,7 @@ SELECT
     tp.token_mint_address,
     tp.valid_from,
     -- For the last period of each address (where valid_to is NULL), set to current time
-    COALESCE(tp.valid_to, CAST(NOW() AS TIMESTAMP)) AS valid_to,
+    COALESCE(tp.valid_to, current_timestamp) AS valid_to,
     CASE
         WHEN nft.account_mint IS NOT NULL THEN 'nft'
         ELSE 'fungible'

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
@@ -12,25 +12,11 @@
                                     \'["ilemi"]\') }}')
 }}
 
--- This model creates time periods for addresses with multiple owners/mints
 
-{% if is_incremental() %}
---limiting data to only the partitions that have changed for incremental runs
 WITH addresses_to_process AS (
-    SELECT DISTINCT act.address
-    FROM {{ source('solana', 'account_activity') }} act
-    INNER JOIN {{ ref('solana_utils_token_accounts_candidates') }} cand
-        ON act.address = cand.address
-    WHERE {{incremental_predicate('act.block_time')}}
-    AND act.block_time >= DATE('2025-04-01') -- Test run with future date
-),
-{% else %}
-WITH addresses_to_process AS (
-    -- For full runs, get all candidate addresses
     SELECT address
     FROM {{ ref('solana_utils_token_accounts_candidates') }}
 ),
-{% endif %}
 
 -- Only process activity for candidate addresses
 activity_for_processing AS (
@@ -45,8 +31,7 @@ activity_for_processing AS (
     WHERE 
         act.writable = true
         AND act.token_mint_address IS NOT NULL
-        AND act.token_balance_owner IS NOT NULL
-        AND act.block_time >= DATE('2025-04-01') -- Test run with future date
+        AND act.block_time >= DATE('2025-04-01') -- Test run
 ),
 
 -- Number activity chronologically per address for LAG calculations

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
@@ -1,6 +1,7 @@
 {{
   config(
         schema = 'solana_utils',
+        tags = ['prod_exclude'],
         alias = 'token_accounts_timed',
         materialized = 'incremental',
         file_format = 'delta',
@@ -16,7 +17,7 @@
 -- it's partitioned by address
 -- it contains a row for every transaction that has modified an account
 
-/*
+
 
 {% if is_incremental() %}
 
@@ -121,4 +122,3 @@ LEFT JOIN nft_addresses nft
 
 
 
-*/

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
@@ -12,9 +12,15 @@
                                     \'["ilemi"]\') }}')
 }}
 
+-- account_activity table is updated by a streaming service
+-- it's partitioned by address
+-- it contains a row for every transaction that has modified an account
+
+/*
+
 {% if is_incremental() %}
 
---attemting to limit data read to only the partitions that have changed
+--attemting to limit data read to only the partitions that have changed for incremental runs
 WITH affected_partitions AS (
     SELECT DISTINCT address
     FROM {{ source('solana', 'account_activity') }}
@@ -35,6 +41,7 @@ WITH affected_partitions AS (
             ON act.address = ap.address
         {% endif %}
         where act.writable = true
+        and act.block_time >= DATE ('2025-03-25')
       ),
 
       state_offsetter AS (
@@ -111,3 +118,7 @@ SELECT
 FROM period_intervals aa
 LEFT JOIN nft_addresses nft
     ON aa.token_mint_address = nft.account_mint
+
+
+
+*/

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
@@ -1,0 +1,78 @@
+{{
+  config(
+        schema = 'solana_utils',
+        alias = 'token_accounts_timed',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['address'],
+        post_hook='{{ expose_spells(\'["solana"]\',
+                                    "sector",
+                                    "solana_utils",
+                                    \'["ilemi"]\') }}')
+}}
+
+WITH
+      token_offsetter AS (
+      -- adds helper column to identify when an address was assigned a new token
+            SELECT
+                  *
+                  , LAG(token_mint_address) OVER (PARTITION BY address, token_balance_owner ORDER BY block_time ASC) AS prev_token
+            FROM {{ source('solana','account_activity') }}
+            {% if is_incremental() %}
+            WHERE {{incremental_predicate('block_time')}}
+            {% endif %}
+      )
+
+      , pair_orderings AS (
+      -- identifies the ordering of each address-mint pairing with support for repeated pairings
+            SELECT
+                  *
+                  , SUM(
+                        CASE
+                        WHEN token_mint_address != prev_token THEN 1
+                        ELSE 0
+                        END
+                  ) OVER (PARTITION BY address, token_balance_owner ORDER BY block_time ASC) AS token_pairing_rank
+            FROM token_offsetter
+      )
+
+      , account_activity_base AS (
+      -- flattens data to each address-mint pairing with start/end timestamps
+            SELECT
+                  address
+                  , token_balance_owner
+                  , token_mint_address
+                  , CAST(MIN(block_time) AS TIMESTAMP) AS activity_start
+                  , CAST(MAX(block_time) AS TIMESTAMP) AS activity_end
+            FROM pair_orderings
+            GROUP BY 1, 2, 3, token_pairing_rank
+      )
+
+      , nft_addresses AS (
+      -- updated nft logic to exclude fungible token_standard types from nft classification
+            SELECT
+                  account_mint
+            FROM {{ ref('tokens_solana_nft') }}
+            WHERE
+                  account_mint IS NOT NULL
+                  -- without this filter the old table classified many fungible tokens (e.g. JUP,DRIFT) as account_type=nft
+                  AND token_standard NOT IN ('Fungible', 'FungibleAsset')
+            GROUP BY 1
+      )
+
+-- final table retains existing solana.account_activity columns with additional start/end columns
+SELECT
+    aa.address
+    , aa.token_balance_owner
+    , aa.token_mint_address
+    , aa.activity_start
+    , aa.activity_end
+    , CASE
+            WHEN nft.account_mint IS NOT NULL THEN 'nft'
+            ELSE 'fungible'
+      END AS account_type
+FROM account_activity_base aa
+LEFT JOIN nft_addresses nft
+    ON aa.token_mint_address = nft.account_mint
+ORDER BY address, activity_start

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
@@ -120,6 +120,3 @@ FROM time_periods tp
 LEFT JOIN {{ ref('tokens_solana_nft') }} nft
     ON tp.token_mint_address = nft.account_mint
     AND nft.token_standard NOT IN ('Fungible', 'FungibleAsset')
-
-
-

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
@@ -59,13 +59,13 @@ WITH affected_partitions AS (
       )
 
       , account_activity_base AS (
-      -- flattens data to each address-mint pairing with start/end timestamps
+      -- flattens data to each address-mint pairing with valid_from/valid_to timestamps
             SELECT
                   address
                   , token_balance_owner
                   , token_mint_address
-                  , CAST(MIN(block_time) AS TIMESTAMP) AS activity_start
-                  , CAST(MAX(block_time) AS TIMESTAMP) AS activity_end
+                  , CAST(MIN(block_time) AS TIMESTAMP) AS valid_from
+                  , CAST(MAX(block_time) AS TIMESTAMP) AS valid_to
             FROM pair_orderings
             GROUP BY address, token_balance_owner, token_mint_address, token_pairing_rank
       )
@@ -81,13 +81,13 @@ WITH affected_partitions AS (
             GROUP BY 1
       )
 
--- final table retains existing solana.account_activity columns with additional start/end columns
+-- final table retains existing solana.account_activity columns with additional valid_from/valid_to columns
 SELECT
     aa.address
     , aa.token_balance_owner
     , aa.token_mint_address
-    , aa.activity_start
-    , aa.activity_end
+    , aa.valid_from
+    , aa.valid_to
     , CASE
             WHEN nft.account_mint IS NOT NULL THEN 'nft'
             ELSE 'fungible'

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
@@ -1,7 +1,7 @@
 {{
   config(
         schema = 'solana_utils',
-        alias = 'token_accounts_timed',
+        alias = 'token_accounts_timing',
         materialized = 'incremental',
         file_format = 'delta',
         incremental_strategy = 'merge',

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
@@ -1,7 +1,6 @@
 {{
   config(
         schema = 'solana_utils',
-        tags = ['prod_exclude'],
         alias = 'token_accounts_timed',
         materialized = 'incremental',
         file_format = 'delta',

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_token_accounts_timing.sql
@@ -5,7 +5,7 @@
         materialized = 'incremental',
         file_format = 'delta',
         incremental_strategy = 'merge',
-        unique_key = ['address', 'token_balance_owner', 'token_mint_address', 'token_pairing_rank'],
+        unique_key = ['address', 'token_balance_owner', 'token_mint_address', 'valid_from', 'valid_to'],
         post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",
                                     "solana_utils",


### PR DESCRIPTION
pushing a fix for solana_utils.token_accounts which currently wrongly assumes that token accounts cannot get reassigned to new token_mint_addresses. 