### PR TITLE
Add WEN and DOGE tokens to Solana price tracking

### DIFF
--- a/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
@@ -740,7 +740,7 @@ FROM
         ('paxg-pax-gold','solana','PAXG','C6oFsE8nXRDThzrMEQ5SxaNFGKoyyfWDDVPw37JKvPTe',8),
         ('link-chainlink','solana','LINK','CWE8jPTUYhdCTZYWPTe1o5DFqfdjzWKc9WKz6rSjQUdG',6),
         ('virtual-virtual-protocol','solana','VIRTUAL','3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y',9),
-        ('ldo-lido-dao','solana','LDO','HZRCwxP2Vq9PCpPXooayhJ2bxTpo5xfpQrwB1svh332p',8)
+        ('ldo-lido-dao','solana','LDO','HZRCwxP2Vq9PCpPXooayhJ2bxTpo5xfpQrwB1svh332p',8),
         ('wen-wen','solana','WEN','WENWENvqqNya429ubCdR81ZmD69brwQaaBYY6p3LCpk',6),
         ('doge-dogecoin','solana','DOGE','9TY6DUg1VSssYH5tFE95qoq5hnAGFak4w3cn72sJNCoV',8)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
@@ -741,4 +741,6 @@ FROM
         ('link-chainlink','solana','LINK','CWE8jPTUYhdCTZYWPTe1o5DFqfdjzWKc9WKz6rSjQUdG',6),
         ('virtual-virtual-protocol','solana','VIRTUAL','3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y',9),
         ('ldo-lido-dao','solana','LDO','HZRCwxP2Vq9PCpPXooayhJ2bxTpo5xfpQrwB1svh332p',8)
+        ('wen-wen','solana','WEN','WENWENvqqNya429ubCdR81ZmD69brwQaaBYY6p3LCpk',6),
+        ('doge-dogecoin','solana','DOGE','9TY6DUg1VSssYH5tFE95qoq5hnAGFak4w3cn72sJNCoV',8)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
@@ -741,6 +741,6 @@ FROM
         ('link-chainlink','solana','LINK','CWE8jPTUYhdCTZYWPTe1o5DFqfdjzWKc9WKz6rSjQUdG',6),
         ('virtual-virtual-protocol','solana','VIRTUAL','3iQL8BFS2vE7mww4ehAqQHAsbmRNCrPxizWAT2Zfyr9y',9),
         ('ldo-lido-dao','solana','LDO','HZRCwxP2Vq9PCpPXooayhJ2bxTpo5xfpQrwB1svh332p',8),
-        ('wen-wen','solana','WEN','WENWENvqqNya429ubCdR81ZmD69brwQaaBYY6p3LCpk',6),
+        ('wen4-wen','solana','WEN','WENWENvqqNya429ubCdR81ZmD69brwQaaBYY6p3LCpk',6),
         ('doge-dogecoin','solana','DOGE','9TY6DUg1VSssYH5tFE95qoq5hnAGFak4w3cn72sJNCoV',8)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)


### PR DESCRIPTION
Added new tokens to prices_solana_tokens.sql:
- WEN (WENWENvqqNya429ubCdR81ZmD69brwQaaBYY6p3LCpk)
- DOGE (9TY6DUg1VSssYH5tFE95qoq5hnAGFak4w3cn72sJNCoV)

These tokens will now be tracked in the Solana price feed.