### PR TITLE
new token in sonic/prices_sonic_tokens.sql

### DIFF
--- a/dbt_subprojects/tokens/models/prices/sonic/prices_sonic_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/sonic/prices_sonic_tokens.sql
@@ -57,4 +57,5 @@ FROM
     , ('wbtc-wrapped-bitcoin', 'WBTC', 0x0555e30da8f98308edb960aa94c0db47230d2b9c, 8)
     , ('frxusd-frax-usd', 'frxUSD', 0x80eede496655fb9047dd39d9f418d5483ed600df, 18)
     , ('frxeth-frax-ether', 'frxETH', 0x2fb960611bdc322a9a4a994252658cae9fe2eea1, 18)
+    , ('pendle', 'PENDLE', 0xf1ef7d2d4c0c881cd634481e0586ed5d2871a74b, 18)
 ) as temp (token_id, symbol, contract_address, decimals)


### PR DESCRIPTION
### Description:

PENDLE (`0xf1ef7d2d4c0c881cd634481e0586ed5d2871a74b`) was added
[scan](https://sonicscan.org/token/0xf1eF7d2D4C0c881cd634481e0586ed5d2871A74B)


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
