### PR TITLE
perf(bonkbot): create dedicated ctes for SOL and SPL/token2022 fee payments

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/bonkbot/bonkbot_solana_fee_payments_raw.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/bonkbot/bonkbot_solana_fee_payments_raw.sql
@@ -17,35 +17,52 @@
 
 with
     fee_addresses as (select '{{fee_receiver}}' as fee_receiver),
-    fee_payments as (
+    sol_payments as (
         select
             block_time,
             cast(date_trunc('month', block_time) as date) as block_month,
             fee_receiver,
-            if(
-                balance_change > 0, balance_change / 1e9, token_balance_change
-            ) as amount,
-            if(
-                balance_change > 0, '{{wsol_token}}', token_mint_address
-            ) as token_address,
+            balance_change / 1e9 as amount,
+            '{{wsol_token}}' token_address,
             tx_id
         from {{ source('solana','account_activity') }} as account_activity
         join
             fee_addresses
             on (
-                (
-                    fee_addresses.fee_receiver = account_activity.address
-                    and balance_change > 0
-                )
-                or (
-                    token_balance_owner = fee_addresses.fee_receiver
-                    and token_balance_change > 0
-                )
+                fee_addresses.fee_receiver = account_activity.address
+                and balance_change > 0
             )
         where
             {% if is_incremental() %} {{ incremental_predicate('block_time') }}
             {% else %} block_time >= timestamp '{{project_start_date}}'
             {% endif %} and tx_success
+    ),
+    token_payments as (
+        select
+            block_time,
+            cast(date_trunc('month', block_time) as date) as block_month,
+            fee_receiver,
+            token_balance_change as amount,
+            token_mint_address as token_address,
+            tx_id
+        from {{ source('solana','account_activity') }} as account_activity
+        join
+            fee_addresses
+            on (
+                token_balance_owner = fee_addresses.fee_receiver
+                and token_balance_change > 0
+            )
+        where
+            {% if is_incremental() %} {{ incremental_predicate('block_time') }}
+            {% else %} block_time >= timestamp '{{project_start_date}}'
+            {% endif %} and tx_success
+    ),
+    fee_payments as (
+        select *
+        from sol_payments
+        union all
+        select *
+        from token_payments
     ),
     -- Eliminate duplicates (e.g. both SOL + WSOL in a single transaction)
     aggregated_fee_payments_by_token_by_tx as (


### PR DESCRIPTION
Splits querying SOL fee payments and SPL/Token2022 fee payments into separate CTEs, to improve Trino query planning efficiency.