### PR TITLE
CUR2-151 Balances daily agg: Use correct unique_key and partition by day

### DIFF
--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/_schema.yml
@@ -136,6 +136,11 @@ models:
     config:
       tags: ['tokens','balances', 'arbitrum']
     description: "Token balances daily base"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - unique_key
     columns:
           - name: day
           - name: block_number

--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_daily_agg_base.sql
@@ -5,7 +5,8 @@
         materialized='incremental',
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-        unique_key = ['block_number', 'unique_key'],
+        unique_key = ['day', 'unique_key'],
+        partition_by = ['day'],
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/_schema.yml
@@ -135,6 +135,11 @@ models:
     config:
       tags: ['tokens','balances', 'avalanche_c']
     description: "Token balances daily base"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - unique_key
     columns:
           - name: day
           - name: block_number

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_daily_agg_base.sql
@@ -5,7 +5,8 @@
         materialized='incremental',
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-        unique_key = ['block_number', 'unique_key'],
+        unique_key = ['day', 'unique_key'],
+        partition_by = ['day'],
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/_schema.yml
@@ -135,6 +135,11 @@ models:
     config:
       tags: ['tokens','balances', 'base']
     description: "Token balances daily base"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - unique_key
     columns:
           - name: day
           - name: block_number

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_daily_agg_base.sql
@@ -5,7 +5,8 @@
         materialized='incremental',
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-        unique_key = ['block_number', 'unique_key'],
+        unique_key = ['day', 'unique_key'],
+        partition_by = ['day'],
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/kaia/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/kaia/_schema.yml
@@ -164,6 +164,11 @@ models:
     config:
       tags: ['tokens','balances', 'kaia']
     description: "Token balances daily kaia"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - unique_key
     columns:
           - name: day
           - name: block_number

--- a/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_balances_daily_agg_base.sql
@@ -5,7 +5,7 @@
         materialized='incremental',
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-        unique_key = ['day', 'block_number', 'unique_key'],
+        unique_key = ['day', 'unique_key'],
         partition_by = ['day']
         )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/_schema.yml
@@ -133,6 +133,11 @@ models:
     config:
       tags: ['tokens','balances', 'linea']
     description: "Token balances daily base"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - unique_key
     columns:
           - name: day
           - name: block_number

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_daily_agg_base.sql
@@ -5,7 +5,8 @@
         materialized='incremental',
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-        unique_key = ['block_number', 'unique_key'],
+        unique_key = ['day', 'unique_key'],
+        partition_by = ['day'],
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/_schema.yml
@@ -153,6 +153,11 @@ models:
     config:
       tags: ['tokens','balances', 'optimism']
     description: "Token balances daily enriched"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - unique_key
     columns:
       - name: day
       - name: block_date

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/_schema.yml
@@ -135,6 +135,11 @@ models:
     config:
       tags: ['tokens','balances', 'optimism']
     description: "Token balances daily base"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - unique_key
     columns:
           - name: day
           - name: block_number
@@ -153,11 +158,6 @@ models:
     config:
       tags: ['tokens','balances', 'optimism']
     description: "Token balances daily enriched"
-    data_tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - day
-            - unique_key
     columns:
       - name: day
       - name: block_date

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_daily_agg_base.sql
@@ -5,7 +5,8 @@
         materialized='incremental',
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-        unique_key = ['block_number', 'unique_key'],
+        unique_key = ['day', 'unique_key'],
+        partition_by = ['day'],
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/_schema.yml
@@ -135,6 +135,11 @@ models:
     config:
       tags: ['tokens','balances', 'polygon']
     description: "Token balances daily base"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - unique_key
     columns:
           - name: day
           - name: block_number

--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_daily_agg_base.sql
@@ -5,7 +5,8 @@
         materialized='incremental',
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-        unique_key = ['block_number', 'unique_key'],
+        unique_key = ['day', 'unique_key'],
+        partition_by = ['day'],
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/_schema.yml
@@ -163,6 +163,11 @@ models:
     config:
       tags: ['tokens','balances', 'worldchain']
     description: "Token balances daily worldchain"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - unique_key
     columns:
           - name: day
           - name: block_number

--- a/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_balances_daily_agg_base.sql
@@ -5,7 +5,7 @@
         materialized='incremental',
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-        unique_key = ['day', 'block_number', 'unique_key'],
+        unique_key = ['day', 'unique_key'],
         partition_by = ['day']
         )
 }}


### PR DESCRIPTION
We are using the wrong `unique_key` which causes there to be multiple values for a day. This is not the case for ethereum which doesn't use `block_number` in the unique key.  