### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/commit_manifest.yml
+++ b/.github/workflows/commit_manifest.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/setup-python@v3
     - name: Checkout main branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: main
 

--- a/.github/workflows/dbt_precommit_hooks.yml
+++ b/.github/workflows/dbt_precommit_hooks.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v3
       - uses: jitterbit/get-changed-files@v1
         id: abc

--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup variables
         run: | # Spellbook is a special case because it's not a subdirectory

--- a/.github/workflows/prices_check.yml
+++ b/.github/workflows/prices_check.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
 
       - name: Fetch base commit

--- a/.github/workflows/pytest_automations.yml
+++ b/.github/workflows/pytest_automations.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/spellbook_metadata.yml
+++ b/.github/workflows/spellbook_metadata.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v3
       - name: Checkout main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected