### PR TITLE
🔧 Patch: Add date filter to avoid broken decoding after pump.fun upgrade

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/pumpswap/pumpswap_solana_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/pumpswap/pumpswap_solana_base_trades.sql
@@ -119,3 +119,4 @@ SELECT
     sp.tx_index
 FROM swaps sp
 LEFT JOIN pools p ON p.pool = sp.pool
+where sp.block_time < CAST('2025-04-24 09:00:00' AS TIMESTAMP)


### PR DESCRIPTION
The `pump.fun` program is being upgraded on **April 24th at 09:00 UTC**, which will break our manual decoding logic used in current dbt models (e.g. `dex.trades`).  

