### PR TITLE
Add NFT entities to ton.accounts and support for jetton funding transactions

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/ton/ton_accounts.sql
+++ b/dbt_subprojects/daily_spellbook/models/ton/ton_accounts.sql
@@ -63,6 +63,7 @@ TON_STATES AS (
         MAX_BY(hash = trace_id, lt) FILTER (WHERE end_status = 'active' AND orig_status != 'active') deployment_by_external,
 
         MIN_BY(hash, lt) initial_funding_tx_hash,
+        MIN_BY(trace_id, lt) initial_funding_trace_id,
         MIN_BY(block_time, lt) initial_funding_at,
         MIN_BY(block_date, lt) initial_funding_date
     FROM {{ source('ton', 'transactions') }} T
@@ -76,6 +77,13 @@ TON_STATES AS (
   SELECT DISTINCT pool_address, 'dex_pool' AS interface FROM {{ source('ton', 'dex_trades') }}
 ), DEX_ROUTERS AS (
   SELECT DISTINCT router_address, 'dex_router' AS interface FROM {{ source('ton', 'dex_trades') }}
+), NFT_ITEMS AS (
+  SELECT DISTINCT nft_item_address, 'nft_item' AS interface FROM {{ source('ton', 'nft_events') }}
+), NFT_SALES AS (
+  SELECT DISTINCT sale_contract, 'nft_sale' AS interface FROM {{ source('ton', 'nft_events') }}
+), NFT_COLLECTIONS AS (
+  SELECT DISTINCT collection_address, 'nft_collection' AS interface FROM {{ source('ton', 'nft_events') }}
+  WHERE collection_address IS NOT NULL
 ), UNIQUE_CODE_ACCOUNTS AS (
   -- To avoid situation when some jetton wallet is updated to the code_hash of an existing contract of a different type
   SELECT account, MAX(account_state_code_hash_after) as code_hash
@@ -91,13 +99,21 @@ TON_STATES AS (
   LEFT JOIN JETTON_MASTERS JM ON JM.jetton_master = account
   LEFT JOIN DEX_POOLS DP ON DP.pool_address = account
   LEFT JOIN DEX_ROUTERS DR ON DR.router_address = account
-  CROSS JOIN UNNEST(ARRAY[JW.interface, JM.interface, DP.interface, DR.interface]) AS I(interface)
+  LEFT JOIN NFT_ITEMS NI ON NI.nft_item_address = account
+  LEFT JOIN NFT_COLLECTIONS NC ON NC.collection_address = account
+  LEFT JOIN NFT_SALES NS ON NS.sale_contract = account
+  CROSS JOIN UNNEST(ARRAY[JW.interface, JM.interface, DP.interface, DR.interface, NI.interface, NC.interface, NS.interface]) AS I(interface)
   WHERE I.interface IS NOT NULL
+  GROUP BY 1
+), JETTON_SENDERS AS (
+  SELECT trace_id, destination, MIN_BY(source, lt) AS source FROM {{ source('ton', 'jetton_events') }} -- pre-aggregated to avoid duplicates
+  WHERE aborted = FALSE
   GROUP BY 1
 )
 SELECT T.address, T.status, T.last_tx_hash, T.last_tx_at, T.balance, T.code_hash, T.deployment_tx_hash, T.deployment_at, T.deployment_by_external,
-T.initial_funding_tx_hash, T.initial_funding_at, M.source AS first_tx_sender,
+T.initial_funding_tx_hash, T.initial_funding_at, COALESCE(J.source, M.source) AS first_tx_sender,
 array_union(COALESCE(J.interfaces, ARRAY[]), CASE WHEN I.interface IS NOT NULL THEN ARRAY[I.interface] ELSE ARRAY[] END) AS interfaces FROM TON_STATES T 
 LEFT JOIN {{ source('ton', 'messages') }} M ON T.initial_funding_tx_hash = M.tx_hash and M.direction ='in' and M.block_date = T.initial_funding_date
+LEFT JOIN JETTON_SENDERS J ON T.initial_funding_trace_id = J.trace_id AND T.address = J.destination
 LEFT JOIN JETTON_RELATED_CODE_HASHES J on T.code_hash = J.code_hash
 LEFT JOIN INTERFACES I on T.code_hash = I.code_hash

--- a/sources/_base_sources/other/ton_base_sources.yml
+++ b/sources/_base_sources/other/ton_base_sources.yml
@@ -651,6 +651,138 @@ sources:
             description: "Time at which the pool data was ingested"
             data_type: timestamp
 
+      - name: nft_events
+        loaded_at_field: ingested_at
+        description: "TON NFT events"
+        columns:
+          - name: type
+            description: "Event type"
+            data_type: varchar
+
+          - name: nft_item_address
+            description: "NFT item address"
+            data_type: varchar
+          
+          - name: is_init
+            description: "true if the NFT is initialized"
+            data_type: bool
+  
+          - name: nft_item_index
+            description: "NFT index"
+            data_type: varchar
+
+          - name: collection_address
+            description: "NFT collection address"
+            data_type: varchar
+          
+          - name: owner_address
+            description: "NFT owner address"
+            data_type: varchar
+
+          - name: content_onchain
+            description: "NFT content present onchain"
+            data_type: varchar
+          
+          - name: timestamp
+            description: "timestamp of the NFT state update or action"
+            data_type: bigint
+
+          - name: lt
+            description: "logical time of the NFT state update or action"
+            data_type: bigint
+
+          - name: tx_hash
+            description: "Transaction hash"
+            data_type: varchar
+          
+          - name: trace_id
+            description: "Trace identifier"
+            data_type: varchar
+
+          - name: prev_owner
+            description: "previous owner address (if applicable)"
+            data_type: varchar
+          
+          - name: query_id
+            description: "query id (if exists)"
+            data_type: decimal(20,0)
+
+          - name: forward_amount
+            description: "amount of the forward message from transfer message (if related to the event)"
+            data_type: decimal(38,0)
+          
+          - name: forward_payload
+            description: "payload of the forward message from transfer message (if related to the event)"
+            data_type: varbinary
+          
+          - name: comment
+            description: "text comment from forward_payload"
+            data_type: varchar
+
+          - name: custom_payload
+            description: "custom payload from the transfer message (if related to the event)"
+            data_type: varbinary
+          
+          - name: sale_contract
+            description: "address of the sale contract (if related to the event)"
+            data_type: varchar
+
+          - name: sale_type
+            description: "type of the sale (sale or auction)"
+            data_type: varchar
+
+          - name: sale_end_time
+            description: "end time of the sale (if applicable)"
+            data_type: bigint
+          
+          - name: marketplace_address
+            description: "NFT sale marketplace address"
+            data_type: varchar
+
+          - name: marketplace_fee_address
+            description: "NFT sale marketplace address"
+            data_type: varchar
+          
+          - name: marketplace_fee
+            description: "NFT sale marketplace fee"
+            data_type: decimal(38,0)
+
+          - name: sale_price
+            description: "price of the NFT"
+            data_type: decimal(38,0)
+
+          - name: payment_asset
+            description: "asset type of the payment"
+            data_type: varchar
+          
+          - name: royalty_address
+            description: "NFT sale royalty address"
+            data_type: varchar
+          
+          - name: royalty_amount
+            description: "NFT sale royalty amount"
+            data_type: decimal(38,0)
+          
+          - name: auction_max_bid
+            description: "maximum bid amount in the auction"
+            data_type: decimal(38,0)
+
+          - name: auction_min_bid
+            description: "minimum bid amount in the auction"
+            data_type: decimal(38,0)
+
+          - name: auction_min_step
+            description: "minimum bid step in the auction"
+            data_type: decimal(38,0)
+            
+          - name: updated_at
+            description: "Last update timestamp"
+            data_type: timestamp
+          
+          - name: ingested_at
+            description: "Time at which the NFT event was ingested"
+            data_type: timestamp
+
       - name: dex_trades
         loaded_at_field: ingested_at
         description: "TON DEX trades information"


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

* Added nft_item, nft_collections and nft_sale interfaces derived from nft_events table
* Added nft_events table to the raw sources layer (otherwise ``{{ source('ton', 'nft_events') }}`` was disabled)
* Improved method to determine first funds sender. Initially we were tracking the first TON transfer, but if address received jettons we need to take into account ``ton.jetton_events`` transfer to discover real sender. Comparison of the updated method with the old one is available [here](https://dune.com/queries/5037417).


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
