### PR TITLE
CI: migrate workflows to cache v4

### DIFF
--- a/.github/workflows/pytest_automations.yml
+++ b/.github/workflows/pytest_automations.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.9"
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: cache
       with:
         path: ~/.cache/pip


### PR DESCRIPTION
GitHub runners now default to Node 20; actions/cache@v4 is the recommended version. Only workflow files changed—no functional impact.