### PR TITLE
Fix broken link in contracts readme

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/contracts/readme.md
+++ b/dbt_subprojects/daily_spellbook/models/contracts/readme.md
@@ -9,7 +9,7 @@
 
 # Contract Mapping
 
-Table models are defined in [`macros/models/_sector/contracts`](../macros/models/_sector/contracts)
+Table models are defined in [`macros/sector/contracts`](../macros/sector/contracts)
 
 This repository contains all the source code for `contracts.contract_mapping` that you can use to join contract addresses on each chain to pull our mapped project names in the `contract_project` field.
 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

This commit fixes the incorrect path in the contracts readme.md file. The link was pointing to macros/models/_sector/contracts which doesn't exist in the project structure. It has been updated to point to the correct path macros/sector/contracts where the contract-related SQL files are actually located.



---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
