### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can watch the video version of this if you scroll down a bit.
 Navigate to the spellbook repo within your CLI (Command line interface).
 
 ```console
-cd user\directory\github\spellbook
+cd user/directory/github/spellbook
 # Change this to wherever spellbook is stored locally on your machine.
 ```
 


### PR DESCRIPTION
 Backslashes don't work on Linux and macOS
### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
