### PR TITLE
Use new blob_base_fee lookup table compatible with Pectra upgrade.

### DIFF
--- a/sources/_datasets/resident_wizards/_sources.yml
+++ b/sources/_datasets/resident_wizards/_sources.yml
@@ -3,5 +3,4 @@ version: 2
 sources:
   - name: resident_wizards
     tables:
-      - name: dataset_blob_base_fees_lookup
       - name: blob_base_fees_lookup_v2

--- a/sources/_datasets/resident_wizards/_sources.yml
+++ b/sources/_datasets/resident_wizards/_sources.yml
@@ -4,3 +4,4 @@ sources:
   - name: resident_wizards
     tables:
       - name: dataset_blob_base_fees_lookup
+      - name: blob_base_fees_lookup_v2


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Pectra upgrade included a change in the BLOB_BASE_FEE_UPDATE_FRACTION which made the lookup table incorrect.
The new table holds values for both Dencun and Pectra hard fork version configurations and should be used going forward. 


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
