### PR TITLE
fix new evms schema models

### DIFF
--- a/dbt_subprojects/daily_spellbook/macros/helpers/evms_blockchains_list.sql
+++ b/dbt_subprojects/daily_spellbook/macros/helpers/evms_blockchains_list.sql
@@ -24,7 +24,6 @@
         "lens",
         "linea",
         "mantle",
-        "mode",
         "opbnb",
         "optimism",
         "polygon",

--- a/dbt_subprojects/daily_spellbook/models/evms/evms_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/evms/evms_schema.yml
@@ -238,11 +238,6 @@ models:
     config:
       tags: ["evms", "contracts"]
     description: "A view keeping track of what contracts are decoded across EVM chains on Dune; contains information associated with the decoded contract such as namespace, name, address, ABI."
-    data_tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - blockchain
-            - address
     columns:
       - *blockchain
       - name: abi

--- a/dbt_subprojects/daily_spellbook/models/evms/evms_tables/evms_erc1155_transfersbatch.sql
+++ b/dbt_subprojects/daily_spellbook/models/evms/evms_tables/evms_erc1155_transfersbatch.sql
@@ -22,7 +22,7 @@ FROM (
         , "from"
         , to
         , ids
-        , values
+        , "values"
         FROM {{ source('erc1155_' + blockchain, 'evt_TransferBatch') }}
         {% if not loop.last %}
         UNION ALL


### PR DESCRIPTION
- looks like `mode` isn't available on at least one, likely many of these. excluding for now. we know it's deprecated, but stale data (should) be there. feel free to open new PR to work fancy `if blockchain is mode, then blah blah, else others`. for now, unblocking prod.
- `values` column needs double quotes for keyword