### PR TITLE
bebop ethereum blend: exclude troubled models

### DIFF
--- a/dbt_subprojects/dex/models/_projects/bebop/ethereum/bebop_blend_ethereum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/bebop/ethereum/bebop_blend_ethereum_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'bebop_blend_ethereum',
     alias = 'trades',
     partition_by = ['block_month'],
@@ -7,6 +8,11 @@
     incremental_strategy = 'merge',
     unique_key = ['block_date', 'blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'trace_address']
 )}}
+
+/*
+    due to prod issues on may 12 2025, exclude from prod
+    check git history for model changes and context
+*/
 
 {% set project_start_date = '2024-05-01' %}
 

--- a/dbt_subprojects/dex/models/_projects/bebop/ethereum/bebop_ethereum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/bebop/ethereum/bebop_ethereum_trades.sql
@@ -11,9 +11,14 @@
 
 {% set bebop_models = [
     ref('bebop_rfq_ethereum_trades'),
-    ref('bebop_jam_ethereum_trades'),
-    ref('bebop_blend_ethereum_trades')
+    ref('bebop_jam_ethereum_trades')
 ] %}
+
+/*
+,ref('bebop_blend_ethereum_trades')
+due to prod issues on may 12 2025, exclude from prod
+check git history for model changes and context
+*/
 
 SELECT *
 FROM (


### PR DESCRIPTION
three specific tx's seem to be outputting incorrect data. it's possible it's many more rows, but we found this due to `amount_usd` being inflated to billions of dollars.

https://etherscan.io/tx/0xfb6af36386f5a12e2a134bdf9aa92796d3e3aaf0943dac6e4b5e281ef45d70fd
https://etherscan.io/tx/0x37cf6359120ea3142916a68c2600372b646a40dc7c4d6860277ff7c781531e88
https://etherscan.io/tx/0xc3996c851c8e1f97223777c46f1fc25d2cef48941ce268fa649666345da31863

the data below doesn't align with logs i see in the linked tx's above
![image](https://github.com/user-attachments/assets/252815d6-eb5c-4974-b31b-f27518925681)
