### PR TITLE
feat(dex): Add 3rd party executor fee compensation calculation

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/paraswap/delta/v2/executor_fee_amount_usd.sql
+++ b/dbt_subprojects/dex/macros/models/_project/paraswap/delta/v2/executor_fee_amount_usd.sql
@@ -2,7 +2,7 @@
  COALESCE( 
         d.price * w.executorFeeAmount / POWER(10, d.decimals), -- compute directly (dest token is gas fee compensation if it's augustus axecutor)
         s.price *  w.srcAmount / POWER(10, s.decimals) * CAST (w.executorFeeAmount AS DECIMAL) / (CAST (w.destAmount AS DECIMAL)), -- compute pro-rata based on src token if it's augustus executor
-        -- TODO: also add 3rd party executor fee compensation -- based on spent native token, divided by amount of orders if multiple
+        n.price * tx.gas_used * tx.gas_price / POWER(10, n.decimals) / COALESCE(tx.order_count, 1), -- divide by number of orders in tx if multiple
         0
     )  AS gas_fee_usd
 {% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/paraswap/delta/v2/executor_fee_amount_usd.sql
+++ b/dbt_subprojects/dex/macros/models/_project/paraswap/delta/v2/executor_fee_amount_usd.sql
@@ -2,7 +2,8 @@
  COALESCE( 
         d.price * w.executorFeeAmount / POWER(10, d.decimals), -- compute directly (dest token is gas fee compensation if it's augustus axecutor)
         s.price *  w.srcAmount / POWER(10, s.decimals) * CAST (w.executorFeeAmount AS DECIMAL) / (CAST (w.destAmount AS DECIMAL)), -- compute pro-rata based on src token if it's augustus executor
-        n.price * tx.gas_used * tx.gas_price / POWER(10, n.decimals) / COALESCE(tx.order_count, 1), -- divide by number of orders in tx if multiple
+        -- 3rd party executor fee compensation based on spent native token
+        native_price * tx.gas_used * tx.gas_price / POWER(10, 18) / COALESCE(tx.order_count, 1), -- divide by number of orders in tx if multiple
         0
     )  AS gas_fee_usd
 {% endmacro %}


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Implements the TODO in executor_fee_amount_usd.sql to calculate 3rd party executor fee compensation based on spent native token. The calculation takes the native token price, multiplies by gas used and gas price, then divides by the number of orders in the transaction to distribute the cost evenly.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
