### PR TITLE
update native token address in evm transfers

### DIFF
--- a/dbt_subprojects/tokens/models/transfers_and_balances/abstract/tokens_abstract_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/abstract/tokens_abstract_base_transfers.sql
@@ -15,7 +15,6 @@
     traces = source('abstract','traces'),
     transactions = source('abstract','transactions'),
     erc20_transfers = source('erc20_abstract','evt_Transfer'),
-    native_contract_address = '0x000000000000000000000000000000000000800a',
     include_traces = false
  )
  }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/apechain/tokens_apechain_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/apechain/tokens_apechain_base_transfers.sql
@@ -15,6 +15,5 @@
      , traces = source('apechain','traces')
      , transactions = source('apechain','transactions')
      , erc20_transfers = source('erc20_apechain','evt_Transfer')
-     , native_contract_address = '0x7f9fbf9bdd3f4105c478b996b648fe6e828a1e98'
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/apechain/tokens_apechain_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/apechain/tokens_apechain_base_transfers.sql
@@ -15,6 +15,6 @@
      , traces = source('apechain','traces')
      , transactions = source('apechain','transactions')
      , erc20_transfers = source('erc20_apechain','evt_Transfer')
-     , native_contract_address = var('ETH_ERC20_ADDRESS')
+     , native_contract_address = '0x7f9fbf9bdd3f4105c478b996b648fe6e828a1e98'
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='arbitrum',
     traces = source('arbitrum','traces'),
     transactions = source('arbitrum','transactions'),
-    erc20_transfers = source('erc20_arbitrum','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_arbitrum','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('arbitrum','traces'),
     transactions = source('arbitrum','transactions'),
     erc20_transfers = source('erc20_arbitrum','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('avalanche_c','traces'),
     transactions = source('avalanche_c','transactions'),
     erc20_transfers = source('erc20_avalanche_c','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='avalanche_c',
     traces = source('avalanche_c','traces'),
     transactions = source('avalanche_c','transactions'),
-    erc20_transfers = source('erc20_avalanche_c','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_avalanche_c','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/b3/tokens_b3_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/b3/tokens_b3_base_transfers.sql
@@ -15,6 +15,5 @@
      , traces = source('b3','traces')
      , transactions = source('b3','transactions')
      , erc20_transfers = source('erc20_b3','evt_Transfer')
-     , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='base',
     traces = source('base','traces'),
     transactions = source('base','transactions'),
-    erc20_transfers = source('erc20_base','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_base','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('base','traces'),
     transactions = source('base','transactions'),
     erc20_transfers = source('erc20_base','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/berachain/tokens_berachain_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/berachain/tokens_berachain_base_transfers.sql
@@ -15,7 +15,6 @@
     blockchain='berachain',
     traces = source('berachain','traces'),
     transactions = source('berachain','transactions'),
-    erc20_transfers = source('erc20_berachain','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_berachain','evt_Transfer')
   ) 
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/blast/tokens_blast_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/blast/tokens_blast_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='blast',
     traces = source('blast','traces'),
     transactions = source('blast','transactions'),
-    erc20_transfers = source('erc20_blast','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_blast','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/blast/tokens_blast_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/blast/tokens_blast_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('blast','traces'),
     transactions = source('blast','transactions'),
     erc20_transfers = source('erc20_blast','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_base_transfers.sql
@@ -15,7 +15,7 @@
     traces = source('bnb','traces'),
     transactions = source('bnb','transactions'),
     erc20_transfers = source('erc20_bnb','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_base_transfers.sql
@@ -14,8 +14,7 @@
     blockchain='bnb',
     traces = source('bnb','traces'),
     transactions = source('bnb','transactions'),
-    erc20_transfers = source('erc20_bnb','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_bnb','evt_Transfer')
 )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bob/tokens_bob_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bob/tokens_bob_base_transfers.sql
@@ -15,6 +15,5 @@
      , traces = source('bob','traces')
      , transactions = source('bob','transactions')
      , erc20_transfers = source('erc20_bob','evt_Transfer')
-     , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/boba/tokens_boba_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/boba/tokens_boba_base_transfers.sql
@@ -15,6 +15,5 @@
      , traces = source('boba','traces')
      , transactions = source('boba','transactions')
      , erc20_transfers = source('erc20_boba','evt_Transfer')
-     , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }} 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/celo/tokens_celo_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/celo/tokens_celo_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('celo','traces'),
     transactions = source('celo','transactions'),
     erc20_transfers = source('erc20_celo','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = '0x471ece3750da237f93b8e339c536989b8978a438'
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/celo/tokens_celo_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/celo/tokens_celo_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='celo',
     traces = source('celo','traces'),
     transactions = source('celo','transactions'),
-    erc20_transfers = source('erc20_celo','evt_Transfer'),
-    native_contract_address = '0x471ece3750da237f93b8e339c536989b8978a438'
+    erc20_transfers = source('erc20_celo','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/corn/tokens_corn_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/corn/tokens_corn_base_transfers.sql
@@ -15,6 +15,5 @@
      , traces = source('corn','traces')
      , transactions = source('corn','transactions')
      , erc20_transfers = source('erc20_corn','evt_Transfer')
-     , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }} 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/degen/tokens_degen_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/degen/tokens_degen_base_transfers.sql
@@ -15,6 +15,5 @@
      , traces = source('degen','traces')
      , transactions = source('degen','transactions')
      , erc20_transfers = source('erc20_degen','evt_Transfer')
-     , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }} 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_base_transfers.sql
@@ -15,7 +15,7 @@
     traces = source('ethereum','traces'),
     transactions = source('ethereum','transactions'),
     erc20_transfers = source('erc20_ethereum','evt_Transfer'),
-    native_contract_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )}}
 
 UNION ALL

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_base_transfers.sql
@@ -14,8 +14,7 @@
     blockchain='ethereum',
     traces = source('ethereum','traces'),
     transactions = source('ethereum','transactions'),
-    erc20_transfers = source('erc20_ethereum','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_ethereum','evt_Transfer')
 )}}
 
 UNION ALL

--- a/dbt_subprojects/tokens/models/transfers_and_balances/fantom/tokens_fantom_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/fantom/tokens_fantom_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('fantom','traces'),
     transactions = source('fantom','transactions'),
     erc20_transfers = source('erc20_fantom','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/fantom/tokens_fantom_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/fantom/tokens_fantom_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='fantom',
     traces = source('fantom','traces'),
     transactions = source('fantom','transactions'),
-    erc20_transfers = source('erc20_fantom','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_fantom','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/flare/tokens_flare_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/flare/tokens_flare_base_transfers.sql
@@ -15,6 +15,5 @@
     , traces = source('flare','traces')
     , transactions = source('flare','transactions')
     , erc20_transfers = source('erc20_flare','evt_Transfer')
-    , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }} 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/gnosis/tokens_gnosis_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/gnosis/tokens_gnosis_base_transfers.sql
@@ -14,8 +14,7 @@
     blockchain='gnosis',
     traces = source('gnosis','traces'),
     transactions = source('gnosis','transactions'),
-    erc20_transfers = source('erc20_gnosis','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_gnosis','evt_Transfer')
 )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/gnosis/tokens_gnosis_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/gnosis/tokens_gnosis_base_transfers.sql
@@ -15,7 +15,7 @@
     traces = source('gnosis','traces'),
     transactions = source('gnosis','transactions'),
     erc20_transfers = source('erc20_gnosis','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/goerli/tokens_goerli_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/goerli/tokens_goerli_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('goerli','traces'),
     transactions = source('goerli','transactions'),
     erc20_transfers = source('erc20_goerli','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/goerli/tokens_goerli_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/goerli/tokens_goerli_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='goerli',
     traces = source('goerli','traces'),
     transactions = source('goerli','transactions'),
-    erc20_transfers = source('erc20_goerli','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_goerli','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ink/tokens_ink_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ink/tokens_ink_base_transfers.sql
@@ -15,6 +15,5 @@
     , traces = source('ink','traces')
     , transactions = source('ink','transactions')
     , erc20_transfers = source('erc20_ink','evt_Transfer')
-    , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }} 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_base_transfers.sql
@@ -15,6 +15,5 @@
     , traces = source('kaia','traces')
     , transactions = source('kaia','transactions')
     , erc20_transfers = source('erc20_kaia','evt_Transfer')
-    , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }} 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/lens/tokens_lens_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/lens/tokens_lens_base_transfers.sql
@@ -15,7 +15,6 @@
     traces = source('lens','traces'),
     transactions = source('lens','transactions'),
     erc20_transfers = source('erc20_lens','evt_Transfer'),
-    native_contract_address = '0x000000000000000000000000000000000000800a',
     include_traces = false
 )
 }} 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='linea',
     traces = source('linea','traces'),
     transactions = source('linea','transactions'),
-    erc20_transfers = source('erc20_linea','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_linea','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('linea','traces'),
     transactions = source('linea','transactions'),
     erc20_transfers = source('erc20_linea','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/mantle/tokens_mantle_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/mantle/tokens_mantle_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='mantle',
     traces = source('mantle','traces'),
     transactions = source('mantle','transactions'),
-    erc20_transfers = source('erc20_mantle','evt_Transfer'),
-    native_contract_address = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000'
+    erc20_transfers = source('erc20_mantle','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/mantle/tokens_mantle_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/mantle/tokens_mantle_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('mantle','traces'),
     transactions = source('mantle','transactions'),
     erc20_transfers = source('erc20_mantle','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000'
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/nova/tokens_nova_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/nova/tokens_nova_base_transfers.sql
@@ -15,6 +15,5 @@
     , traces = source('nova','traces')
     , transactions = source('nova','transactions')
     , erc20_transfers = source('erc20_nova','evt_Transfer')
-    , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }} 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/opbnb/tokens_opbnb_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/opbnb/tokens_opbnb_base_transfers.sql
@@ -15,6 +15,5 @@
      , traces = source('opbnb','traces')
      , transactions = source('opbnb','transactions')
      , erc20_transfers = source('erc20_opbnb','evt_Transfer')
-     , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='optimism',
     traces = source('optimism','traces'),
     transactions = source('optimism','transactions'),
-    erc20_transfers = source('erc20_optimism','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_optimism','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('optimism','traces'),
     transactions = source('optimism','transactions'),
     erc20_transfers = source('erc20_optimism','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_base_transfers.sql
@@ -14,8 +14,7 @@
     blockchain='polygon',
     traces = source('polygon','traces'),
     transactions = source('polygon','transactions'),
-    erc20_transfers = source('erc20_polygon','evt_Transfer'),
-    native_contract_address = '0x0000000000000000000000000000000000001010'
+    erc20_transfers = source('erc20_polygon','evt_Transfer')
 )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ronin/tokens_ronin_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ronin/tokens_ronin_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('ronin','traces'),
     transactions = source('ronin','transactions'),
     erc20_transfers = source('erc20_ronin','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ronin/tokens_ronin_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ronin/tokens_ronin_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='ronin',
     traces = source('ronin','traces'),
     transactions = source('ronin','transactions'),
-    erc20_transfers = source('erc20_ronin','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_ronin','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('scroll','traces'),
     transactions = source('scroll','transactions'),
     erc20_transfers = source('erc20_scroll','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='scroll',
     traces = source('scroll','traces'),
     transactions = source('scroll','transactions'),
-    erc20_transfers = source('erc20_scroll','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_scroll','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sei/tokens_sei_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sei/tokens_sei_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='sei',
     traces = source('sei','traces'),
     transactions = source('sei','transactions'),
-    erc20_transfers = source('erc20_sei','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_sei','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sei/tokens_sei_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sei/tokens_sei_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('sei','traces'),
     transactions = source('sei','transactions'),
     erc20_transfers = source('erc20_sei','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sepolia/tokens_sepolia_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sepolia/tokens_sepolia_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('sepolia','traces'),
     transactions = source('sepolia','transactions'),
     erc20_transfers = source('erc20_sepolia','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sepolia/tokens_sepolia_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sepolia/tokens_sepolia_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='sepolia',
     traces = source('sepolia','traces'),
     transactions = source('sepolia','transactions'),
-    erc20_transfers = source('erc20_sepolia','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_sepolia','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/shape/tokens_shape_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/shape/tokens_shape_base_transfers.sql
@@ -15,6 +15,5 @@
      , traces = source('shape','traces')
      , transactions = source('shape','transactions')
      , erc20_transfers = source('erc20_shape','evt_Transfer')
-     , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sonic/tokens_sonic_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sonic/tokens_sonic_base_transfers.sql
@@ -15,6 +15,5 @@
     , traces = source('sonic','traces')
     , transactions = source('sonic','transactions')
     , erc20_transfers = source('erc20_sonic','evt_Transfer')
-    , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }} 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sophon/tokens_sophon_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sophon/tokens_sophon_base_transfers.sql
@@ -16,7 +16,6 @@
     traces = source('sophon','traces'),
     transactions = source('sophon','transactions'),
     erc20_transfers = source('erc20_sophon','evt_Transfer'),
-    native_contract_address = '0x000000000000000000000000000000000000800a',
     include_traces = false
   ) 
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/unichain/tokens_unichain_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/unichain/tokens_unichain_base_transfers.sql
@@ -15,6 +15,5 @@
      , traces = source('unichain','traces')
      , transactions = source('unichain','transactions')
      , erc20_transfers = source('erc20_unichain','evt_Transfer')
-     , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/viction/tokens_viction_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/viction/tokens_viction_base_transfers.sql
@@ -15,6 +15,5 @@
     , traces = source('viction','traces')
     , transactions = source('viction','transactions')
     , erc20_transfers = source('erc20_viction','evt_Transfer')
-    , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }} 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_base_transfers.sql
@@ -15,6 +15,5 @@
     , traces = source('worldchain','traces')
     , transactions = source('worldchain','transactions')
     , erc20_transfers = source('erc20_worldchain','evt_Transfer')
-    , native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }} 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/zkevm/tokens_zkevm_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/zkevm/tokens_zkevm_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('zkevm','traces'),
     transactions = source('zkevm','transactions'),
     erc20_transfers = source('erc20_zkevm','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/zkevm/tokens_zkevm_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/zkevm/tokens_zkevm_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='zkevm',
     traces = source('zkevm','traces'),
     transactions = source('zkevm','transactions'),
-    erc20_transfers = source('erc20_zkevm','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_zkevm','evt_Transfer')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/zksync/tokens_zksync_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/zksync/tokens_zksync_base_transfers.sql
@@ -15,7 +15,6 @@
     traces = source('zksync','traces'),
     transactions = source('zksync','transactions'),
     erc20_transfers = source('erc20_zksync','evt_Transfer'),
-    native_contract_address = '0x000000000000000000000000000000000000800a',
     include_traces = false
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/zora/tokens_zora_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/zora/tokens_zora_base_transfers.sql
@@ -15,6 +15,6 @@
     traces = source('zora','traces'),
     transactions = source('zora','transactions'),
     erc20_transfers = source('erc20_zora','evt_Transfer'),
-    native_contract_address = null
+    native_contract_address = var('ETH_ERC20_ADDRESS')
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/zora/tokens_zora_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/zora/tokens_zora_base_transfers.sql
@@ -14,7 +14,6 @@
     blockchain='zora',
     traces = source('zora','traces'),
     transactions = source('zora','transactions'),
-    erc20_transfers = source('erc20_zora','evt_Transfer'),
-    native_contract_address = var('ETH_ERC20_ADDRESS')
+    erc20_transfers = source('erc20_zora','evt_Transfer')
 )
 }}

--- a/sources/_subprojects_outputs/hourly_spellbook/_sources.yml
+++ b/sources/_subprojects_outputs/hourly_spellbook/_sources.yml
@@ -91,3 +91,7 @@ sources:
   - name: evms
     tables:
       - name: transaction_metrics
+
+  - name: dune
+    tables:
+      - name: blockchains


### PR DESCRIPTION
using `dune.blockchains` to validate values. many older chains didn't have a native token at all, while newer chains have started adding the value. this PR includes those which were missing and/or incorrect (assuming we trust the table).