### PR TITLE
Revert "raydium: alternative fix for removing token filters (#8227)"

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v4_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v4_base_trades.sql
@@ -53,6 +53,7 @@
             AND ((sp.call_is_inner = false AND (trs_1.inner_instruction_index = 1 OR trs_1.inner_instruction_index = 2))
                 OR (sp.call_is_inner = true AND (trs_1.inner_instruction_index = sp.call_inner_instruction_index + 1 OR trs_1.inner_instruction_index = sp.call_inner_instruction_index + 2))
                 )
+            AND trs_1.token_version = 'spl_token'
             {% if is_incremental() %}
             AND {{incremental_predicate('trs_1.block_time')}}
             {% else %}
@@ -65,12 +66,14 @@
             AND ((sp.call_is_inner = false AND (trs_2.inner_instruction_index = 2 OR trs_2.inner_instruction_index = 3))
                 OR (sp.call_is_inner = true AND (trs_2.inner_instruction_index = sp.call_inner_instruction_index + 2 OR trs_2.inner_instruction_index = sp.call_inner_instruction_index + 3))
                 )
+            AND trs_2.token_version = 'spl_token'
             {% if is_incremental() %}
             AND {{incremental_predicate('trs_2.block_time')}}
             {% else %}
             AND trs_2.block_time >= TIMESTAMP '{{project_start_date}}'
             {% endif %}
         LEFT JOIN {{ ref('solana_utils_token_accounts') }} tk_2 ON tk_2.address = trs_2.from_token_account
+            AND tk_2.account_type = 'fungible'
         WHERE 1=1
         and trs_1.token_mint_address != trs_2.token_mint_address --gets rid of dupes from the OR statement in transfer joins
         and tk_2.token_balance_owner = '5Q544fKrFoe6tsEbD7S8EmxGTJYAKtTVhAW5Q5pge4j1' --raydium pool v4 authority. makes sure we don't accidently catch some fee transfer or something after the swap. should add for lifinity too later.

--- a/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v5_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v5_base_trades.sql
@@ -52,6 +52,7 @@
             AND ((sp.call_is_inner = false AND (trs_1.inner_instruction_index = 1 OR trs_1.inner_instruction_index = 2))
                 OR (sp.call_is_inner = true AND (trs_1.inner_instruction_index = sp.call_inner_instruction_index + 1 OR trs_1.inner_instruction_index = sp.call_inner_instruction_index + 2))
                 )
+            AND trs_1.token_version = 'spl_token'
             {% if is_incremental() %}
             AND {{incremental_predicate('trs_1.block_time')}}
             {% else %}
@@ -64,15 +65,17 @@
             AND ((sp.call_is_inner = false AND (trs_2.inner_instruction_index = 2 OR trs_2.inner_instruction_index = 3))
                 OR (sp.call_is_inner = true AND (trs_2.inner_instruction_index = sp.call_inner_instruction_index + 2 OR trs_2.inner_instruction_index = sp.call_inner_instruction_index + 3))
                 )
+            AND trs_2.token_version = 'spl_token'
             {% if is_incremental() %}
             AND {{incremental_predicate('trs_2.block_time')}}
             {% else %}
             AND trs_2.block_time >= TIMESTAMP '{{project_start_date}}'
             {% endif %}
         LEFT JOIN {{ ref('solana_utils_token_accounts') }} tk_2 ON tk_2.address = trs_2.from_token_account
+            AND tk_2.account_type = 'fungible'
         WHERE 1=1
         and trs_1.token_mint_address != trs_2.token_mint_address --gets rid of dupes from the OR statement in transfer joins
-        and tk_2.token_balance_owner = 'GpMZbSM2GgvTKHJirzeGfMFoaZ8UR2X7F4v8vHTvxFbL' --raydium pool v5 authority. makes sure we don't accidently catch some fee transfer or something after the swap. should add for lifinity too later.
+        and tk_2.token_balance_owner = 'GpMZbSM2GgvTKHJirzeGfMFoaZ8UR2X7F4v8vHTvxFbL' --raydium pool v4 authority. makes sure we don't accidently catch some fee transfer or something after the swap. should add for lifinity too later.
         {% if is_incremental() %}
         AND {{incremental_predicate('sp.call_block_time')}}
         {% else %}


### PR DESCRIPTION
raydium v4 is continually failing in prod for memory spill failures. not sure why this change would make the model much more memory intensive. need to revert for now to get the job running.