### PR TITLE
Reapply "raydium: alternative fix for removing token filters (#8227)"…

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v4_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v4_base_trades.sql
@@ -53,7 +53,6 @@
             AND ((sp.call_is_inner = false AND (trs_1.inner_instruction_index = 1 OR trs_1.inner_instruction_index = 2))
                 OR (sp.call_is_inner = true AND (trs_1.inner_instruction_index = sp.call_inner_instruction_index + 1 OR trs_1.inner_instruction_index = sp.call_inner_instruction_index + 2))
                 )
-            AND trs_1.token_version = 'spl_token'
             {% if is_incremental() %}
             AND {{incremental_predicate('trs_1.block_time')}}
             {% else %}
@@ -66,14 +65,12 @@
             AND ((sp.call_is_inner = false AND (trs_2.inner_instruction_index = 2 OR trs_2.inner_instruction_index = 3))
                 OR (sp.call_is_inner = true AND (trs_2.inner_instruction_index = sp.call_inner_instruction_index + 2 OR trs_2.inner_instruction_index = sp.call_inner_instruction_index + 3))
                 )
-            AND trs_2.token_version = 'spl_token'
             {% if is_incremental() %}
             AND {{incremental_predicate('trs_2.block_time')}}
             {% else %}
             AND trs_2.block_time >= TIMESTAMP '{{project_start_date}}'
             {% endif %}
         LEFT JOIN {{ ref('solana_utils_token_accounts') }} tk_2 ON tk_2.address = trs_2.from_token_account
-            AND tk_2.account_type = 'fungible'
         WHERE 1=1
         and trs_1.token_mint_address != trs_2.token_mint_address --gets rid of dupes from the OR statement in transfer joins
         and tk_2.token_balance_owner = '5Q544fKrFoe6tsEbD7S8EmxGTJYAKtTVhAW5Q5pge4j1' --raydium pool v4 authority. makes sure we don't accidently catch some fee transfer or something after the swap. should add for lifinity too later.

--- a/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v5_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v5_base_trades.sql
@@ -52,7 +52,6 @@
             AND ((sp.call_is_inner = false AND (trs_1.inner_instruction_index = 1 OR trs_1.inner_instruction_index = 2))
                 OR (sp.call_is_inner = true AND (trs_1.inner_instruction_index = sp.call_inner_instruction_index + 1 OR trs_1.inner_instruction_index = sp.call_inner_instruction_index + 2))
                 )
-            AND trs_1.token_version = 'spl_token'
             {% if is_incremental() %}
             AND {{incremental_predicate('trs_1.block_time')}}
             {% else %}
@@ -65,17 +64,15 @@
             AND ((sp.call_is_inner = false AND (trs_2.inner_instruction_index = 2 OR trs_2.inner_instruction_index = 3))
                 OR (sp.call_is_inner = true AND (trs_2.inner_instruction_index = sp.call_inner_instruction_index + 2 OR trs_2.inner_instruction_index = sp.call_inner_instruction_index + 3))
                 )
-            AND trs_2.token_version = 'spl_token'
             {% if is_incremental() %}
             AND {{incremental_predicate('trs_2.block_time')}}
             {% else %}
             AND trs_2.block_time >= TIMESTAMP '{{project_start_date}}'
             {% endif %}
         LEFT JOIN {{ ref('solana_utils_token_accounts') }} tk_2 ON tk_2.address = trs_2.from_token_account
-            AND tk_2.account_type = 'fungible'
         WHERE 1=1
         and trs_1.token_mint_address != trs_2.token_mint_address --gets rid of dupes from the OR statement in transfer joins
-        and tk_2.token_balance_owner = 'GpMZbSM2GgvTKHJirzeGfMFoaZ8UR2X7F4v8vHTvxFbL' --raydium pool v4 authority. makes sure we don't accidently catch some fee transfer or something after the swap. should add for lifinity too later.
+        and tk_2.token_balance_owner = 'GpMZbSM2GgvTKHJirzeGfMFoaZ8UR2X7F4v8vHTvxFbL' --raydium pool v5 authority. makes sure we don't accidently catch some fee transfer or something after the swap. should add for lifinity too later.
         {% if is_incremental() %}
         AND {{incremental_predicate('sp.call_block_time')}}
         {% else %}


### PR DESCRIPTION
… (#8242)

This reverts commit aa26fb436dd8f7447a5a1328c91064fc63aa023a.

reopening the raydium fix. we need to figure out why it's causing memory spill issues on full refresh.