### PR TITLE
tokens erc20: set as full table

### DIFF
--- a/dbt_subprojects/tokens/models/tokens/tokens_erc20.sql
+++ b/dbt_subprojects/tokens/models/tokens/tokens_erc20.sql
@@ -75,7 +75,7 @@ with t as (
     )
 )
 select
-    *
+    t.*
 from t
 {% if is_incremental() -%}
 left join {{this}} as target

--- a/dbt_subprojects/tokens/models/tokens/tokens_erc20.sql
+++ b/dbt_subprojects/tokens/models/tokens/tokens_erc20.sql
@@ -6,7 +6,7 @@
         ,incremental_strategy = 'append'
         ,unique_key = ['blockchain', 'contract_address']
         ,file_format = 'delta'
-        ,partition_by = 'blockchain'
+        ,partition_by = ['blockchain']
         ,post_hook='{{ expose_spells(\'[
                                         "arbitrum"
                                         ,"avalanche_c"

--- a/dbt_subprojects/tokens/models/tokens/tokens_erc20.sql
+++ b/dbt_subprojects/tokens/models/tokens/tokens_erc20.sql
@@ -2,7 +2,7 @@
     config(
         schema = 'tokens'
         ,alias = 'erc20'
-        ,materialized = 'view'
+        ,materialized = 'table'
         ,post_hook='{{ expose_spells(\'[
                                         "arbitrum"
                                         ,"avalanche_c"


### PR DESCRIPTION
lets see how performance is on full table rebuild. i may make it incremental + append and do join to target to find only new rows. see how those run times compare.
the other benefit of incremental is that we may get around our bug in cleanup script where vacuum breaks the version. this seemingly only happens on table types.