### PR TITLE
Add IncrementSubaccountActionCount Event To GMX v2 Project

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_event_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_event_schema.yml
@@ -2391,6 +2391,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'claimable_collateral_updated']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2430,6 +2435,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'claimable_funding_updated']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2468,6 +2478,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'clear_pending_action']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2498,6 +2513,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'collateral_claimed']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2538,6 +2558,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'funding_fees_claimed']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2576,6 +2601,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'grant_role']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2606,6 +2636,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'revoke_role']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2636,6 +2671,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'set_atomic_oracle_provider']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2666,6 +2706,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'set_data_stream']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2700,6 +2745,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'set_oracle_provider_enabled']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2730,6 +2780,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'set_oracle_provider_for_token']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2760,6 +2815,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'set_price_feed']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2796,6 +2856,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'signal_grant_role']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2826,6 +2891,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'signal_pending_action']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2856,6 +2926,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'signal_revoke_role']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2886,6 +2961,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'signal_set_atomic_oracle_provider']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2916,6 +2996,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'signal_set_data_stream']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2950,6 +3035,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'signal_set_oracle_provider_enabled']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2980,6 +3070,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'signal_set_oracle_provider_for_token']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -3010,6 +3105,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'signal_set_price_feed']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -3046,6 +3146,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['arbitrum', 'gmx', 'event', 'swap_info']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -3085,3 +3190,42 @@ models:
         description: The amount of the price impact attributed to the input token
       - name: order_key
         description: A unique identifier linking this swap to a specific order
+
+  - name: gmx_v2_arbitrum_increment_subaccount_action_count
+    meta:
+      blockchain: arbitrum
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['arbitrum', 'gmx', 'event', 'increment_subaccount_action_count']
+    description: |
+      Aggregates counts of subaccount actions on the Arbitrum chain.
+      This model pulls from each chain-specific source and unifies them into a single 
+      table tracking how many times each subaccount performed each action.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
+    columns:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - *tx_from
+      - *tx_to
+      - name: event_name
+        description: The type of event recorded, always 'IncrementSubaccountActionCount'
+      - *msg_sender
+      - name: account
+        description: The primary account associated with the subaccount action
+      - name: subaccount
+        description: The subaccount identifier on which the action was performed
+      - name: next_value
+        description: The updated action-count after this event
+      - name: action_type
+        description: The type of subaccount action performed.

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_increment_subaccount_action_count.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_increment_subaccount_action_count.sql
@@ -1,0 +1,188 @@
+{{
+  config(
+    schema = 'gmx_v2_arbitrum',
+    alias = 'increment_subaccount_action_count',
+    materialized = 'incremental',
+    unique_key = ['tx_hash', 'index'],
+    incremental_strategy = 'merge'
+    )
+}}
+
+{%- set event_name = 'IncrementSubaccountActionCount' -%}
+{%- set blockchain_name = 'arbitrum' -%}
+
+
+WITH evt_data_1 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog1')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
+, evt_data_2 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog2')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
+, evt_data_3 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_arbitrum','EventEmitter_evt_EventLog')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
+-- unite 3 tables
+, evt_data AS (
+    SELECT * 
+    FROM evt_data_1
+    UNION ALL
+    SELECT *
+    FROM evt_data_2
+    UNION ALL
+    SELECT *
+    FROM evt_data_3
+)
+
+, parsed_data AS (
+    SELECT
+        tx_hash,
+        index,
+        json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
+        json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
+        json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
+    FROM
+        evt_data
+)
+
+, address_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(address_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, uint_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(uint_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, bytes32_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(bytes32_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, combined AS (
+    SELECT *
+    FROM address_items_parsed
+    UNION ALL 
+    SELECT *
+    FROM uint_items_parsed
+    UNION ALL
+    SELECT *
+    FROM bytes32_items_parsed
+)
+
+, evt_data_parsed AS (
+    SELECT
+        tx_hash,
+        index,
+        MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
+        MAX(CASE WHEN key_name = 'subaccount' THEN value END) AS subaccount,
+        MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value,
+        MAX(CASE WHEN key_name = 'actionType' THEN value END) AS action_type
+    FROM
+        combined
+    GROUP BY tx_hash, index
+)
+
+, full_data AS (
+    SELECT 
+        blockchain,
+        block_time,
+        DATE(block_time) AS block_date,
+        block_number,
+        ED.tx_hash,
+        ED.index,
+        contract_address,
+        event_name,
+        msg_sender,
+        from_hex(EDP.account) AS account,
+        from_hex(EDP.subaccount) AS subaccount,
+        TRY_CAST(EDP.next_value AS DOUBLE) AS next_value,
+        from_hex(EDP.action_type) AS action_type
+    FROM evt_data AS ED
+    LEFT JOIN evt_data_parsed AS EDP
+        ON ED.tx_hash = EDP.tx_hash
+            AND ED.index = EDP.index
+)
+
+--can be removed once decoded tables are fully denormalized
+{{
+    add_tx_columns(
+        model_cte = 'full_data'
+        , blockchain = blockchain_name
+        , columns = ['from', 'to']
+    )
+}}
+
+

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_event_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_event_schema.yml
@@ -2391,6 +2391,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'claimable_collateral_updated']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2430,6 +2435,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'claimable_funding_updated']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2468,6 +2478,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'clear_pending_action']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2498,6 +2513,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'collateral_claimed']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2538,6 +2558,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'funding_fees_claimed']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2576,6 +2601,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'grant_role']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2606,6 +2636,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'revoke_role']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2636,6 +2671,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'set_atomic_oracle_provider']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2666,6 +2706,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'set_data_stream']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2700,6 +2745,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'set_oracle_provider_enabled']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2730,6 +2780,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'set_oracle_provider_for_token']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2760,6 +2815,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'set_price_feed']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2796,6 +2856,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'signal_grant_role']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2826,6 +2891,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'signal_pending_action']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2856,6 +2926,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'signal_revoke_role']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2886,6 +2961,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'signal_set_atomic_oracle_provider']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2916,6 +2996,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'signal_set_data_stream']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2950,6 +3035,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'signal_set_oracle_provider_enabled']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -2980,6 +3070,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'signal_set_oracle_provider_for_token']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -3010,6 +3105,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'signal_set_price_feed']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -3046,6 +3146,11 @@ models:
       contributors: ai_data_master, gmx-io
     config:
       tags: ['avalanche_c', 'gmx', 'event', 'swap_info']
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
     columns:
       - *blockchain
       - *block_time
@@ -3085,3 +3190,43 @@ models:
         description: The amount of the price impact attributed to the input token
       - name: order_key
         description: A unique identifier linking this swap to a specific order
+
+  - name: gmx_v2_avalanche_c_increment_subaccount_action_count
+    meta:
+      blockchain: avalanche_c
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['avalanche_c', 'gmx', 'event', 'increment_subaccount_action_count']
+    description: |
+      Aggregates counts of subaccount actions on the Avalanche chain.
+      This model pulls from each chain-specific source and unifies them into a single 
+      table tracking how many times each subaccount performed each action.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - index
+    columns:
+      # ← inherit every shared column via your anchors:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - *tx_from
+      - *tx_to
+      - name: event_name
+        description: The type of event recorded, always 'IncrementSubaccountActionCount'
+      - *msg_sender
+      - name: account
+        description: The primary account associated with the subaccount action
+      - name: subaccount
+        description: The subaccount identifier on which the action was performed
+      - name: next_value
+        description: The updated action-count after this event
+      - name: action_type
+        description: The type of subaccount action performed.

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_increment_subaccount_action_count.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_increment_subaccount_action_count.sql
@@ -1,0 +1,188 @@
+{{
+  config(
+    schema = 'gmx_v2_avalanche_c',
+    alias = 'increment_subaccount_action_count',
+    materialized = 'incremental',
+    unique_key = ['tx_hash', 'index'],
+    incremental_strategy = 'merge'
+    )
+}}
+
+{%- set event_name = 'IncrementSubaccountActionCount' -%}
+{%- set blockchain_name = 'avalanche_c' -%}
+
+
+WITH evt_data_1 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog1')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
+, evt_data_2 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog2')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
+, evt_data_3 AS (
+    SELECT 
+        -- Main Variables
+        '{{ blockchain_name }}' AS blockchain,
+        evt_block_time AS block_time,
+        evt_block_number AS block_number, 
+        evt_tx_hash AS tx_hash,
+        evt_index AS index,
+        contract_address,
+        eventName AS event_name,
+        eventData AS data,
+        msgSender AS msg_sender
+    FROM {{ source('gmx_v2_avalanche_c','EventEmitter_evt_EventLog')}}
+    WHERE eventName = '{{ event_name }}'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
+-- unite 3 tables
+, evt_data AS (
+    SELECT * 
+    FROM evt_data_1
+    UNION ALL
+    SELECT *
+    FROM evt_data_2
+    UNION ALL
+    SELECT *
+    FROM evt_data_3
+)
+
+, parsed_data AS (
+    SELECT
+        tx_hash,
+        index,
+        json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
+        json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
+        json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
+    FROM
+        evt_data
+)
+
+, address_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(address_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, uint_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(uint_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, bytes32_items_parsed AS (
+    SELECT 
+        tx_hash,
+        index,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
+        json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
+    FROM 
+        parsed_data,
+        UNNEST(
+            CAST(json_extract(bytes32_items, '$.items') AS ARRAY(JSON))
+        ) AS t(item)
+)
+
+, combined AS (
+    SELECT *
+    FROM address_items_parsed
+    UNION ALL 
+    SELECT *
+    FROM uint_items_parsed
+    UNION ALL
+    SELECT *
+    FROM bytes32_items_parsed
+)
+
+, evt_data_parsed AS (
+    SELECT
+        tx_hash,
+        index,
+        MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
+        MAX(CASE WHEN key_name = 'subaccount' THEN value END) AS subaccount,
+        MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value,
+        MAX(CASE WHEN key_name = 'actionType' THEN value END) AS action_type
+    FROM
+        combined
+    GROUP BY tx_hash, index
+)
+
+, full_data AS (
+    SELECT 
+        blockchain,
+        block_time,
+        DATE(block_time) AS block_date,
+        block_number,
+        ED.tx_hash,
+        ED.index,
+        contract_address,
+        event_name,
+        msg_sender,
+        from_hex(EDP.account) AS account,
+        from_hex(EDP.subaccount) AS subaccount,
+        TRY_CAST(EDP.next_value AS DOUBLE) AS next_value,
+        from_hex(EDP.action_type) AS action_type
+    FROM evt_data AS ED
+    LEFT JOIN evt_data_parsed AS EDP
+        ON ED.tx_hash = EDP.tx_hash
+            AND ED.index = EDP.index
+)
+
+--can be removed once decoded tables are fully denormalized
+{{
+    add_tx_columns(
+        model_cte = 'full_data'
+        , blockchain = blockchain_name
+        , columns = ['from', 'to']
+    )
+}}
+
+

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/gmx_v2_event_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/gmx_v2_event_schema.yml
@@ -2943,3 +2943,39 @@ models:
         description: The amount of the price impact attributed to the input token
       - name: order_key
         description: A unique identifier linking this swap to a specific order
+
+
+  - name: gmx_v2_increment_subaccount_action_count
+    meta:
+      blockchain: arbitrum, avalanche_c
+      sector: dex
+      project: gmx
+      contributors: ai_data_master, gmx-io
+    config:
+      tags: ['arbitrum', 'avalanche_c', 'gmx', 'event', 'increment_subaccount_action_count']
+    description: |
+      Aggregates counts of subaccount actions on the Arbitrum and Avalanche chains.
+      This model pulls from each chain-specific source and unifies them into a single 
+      table tracking how many times each subaccount performed each action.
+    columns:
+      # ← inherit every shared column via your anchors:
+      - *blockchain
+      - *block_time
+      - *block_date
+      - *block_number
+      - *tx_hash
+      - *index
+      - *contract_address
+      - *tx_from
+      - *tx_to
+      - name: event_name
+        description: The type of event recorded, always 'IncrementSubaccountActionCount'
+      - *msg_sender
+      - name: account
+        description: The primary account associated with the subaccount action
+      - name: subaccount
+        description: The subaccount identifier on which the action was performed
+      - name: next_value
+        description: The updated action-count after this event
+      - name: action_type
+        description: The type of subaccount action performed.

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/gmx_v2_increment_subaccount_action_count.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/gmx_v2_increment_subaccount_action_count.sql
@@ -1,0 +1,38 @@
+{{ config(
+        schema='gmx_v2',
+        alias = 'increment_subaccount_action_count',
+        post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c"]\',
+                                    "project",
+                                    "gmx",
+                                    \'["ai_data_master","gmx-io"]\') }}'
+        )
+}}
+
+{%- set chains = [
+    'arbitrum',
+    'avalanche_c',
+] -%}
+
+{%- for chain in chains -%}
+SELECT 
+    blockchain,
+    block_time,
+    block_date,
+    block_number,
+    tx_hash,
+    index,
+    contract_address,
+    tx_from,
+    tx_to,
+    event_name,
+    msg_sender,
+    account,
+    subaccount,
+    next_value,
+    action_type
+FROM {{ ref('gmx_v2_' ~ chain ~ '_increment_subaccount_action_count') }}
+{% if not loop.last %}
+UNION ALL
+{% endif %}
+{%- endfor -%}
+


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

This PR adds new `IncrementSubaccountActionCount` event models for Arbitrum & Avalanche chains, and adds missing data tests to all incremental event models.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
