### PR TITLE
`phantom_swapper` solana trades: add prod exclude tag due to dupes

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'phantom_swapper_solana',
     alias = 'fee_payments_raw',
     partition_by = ['block_month'],


### PR DESCRIPTION
fyi @Jam516 
this model has started failing on duplicates. i tried to track it down and see what the issue could be. this is the best i could come up with for now:
- 4 `tx_id` values have dupes in the last ~day (one shared in query below)
- in the tx, multiple rows have balance > 0
- two of the addresses in the tx match to `fee_addresses`, when it looks like expectation is only one should be returned
- one of the `fee_receiver` values is in the hardcoded list of the union

```
          select
              account_activity.block_time,
              cast(date_trunc('month', account_activity.block_time) as date) as block_month,
              fee_addresses.fee_receiver,
              account_activity.address,
              account_activity.balance_change / 1e9 as amount,
              'So11111111111111111111111111111111111111112' token_address,
              account_activity.tx_id
          from "delta_prod"."solana"."account_activity" as account_activity
          join
              phantom_swapper_solana.fee_addresses as fee_addresses
              on (
                  fee_addresses.fee_receiver = account_activity.address
                  and balance_change > 0
              )
          where
               
                  account_activity.block_time >= timestamp '2025-06-24'
               and tx_id = '4j7M1n4mYAiLqX4SiDqgRPeqUufF3foFXAiu1H3CDZoa1u47zEX8VWLKRJ4ZTYP4Un8dh8sYTF8hwmtPX8yonxMR'
              and tx_success
```