### PR TITLE
Exclude more solana models: phantom lineage, oneinch swaps

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_usd.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_usd.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema="phantom_swapper_solana",
         alias="fee_payments_usd",
         partition_by=["block_month"],

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_token_prices.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_token_prices.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema="phantom_swapper_solana",
         alias="fee_token_prices",
         partition_by=["block_month"],

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'phantom_swapper_solana',
     alias = 'bot_trades',
     partition_by = ['block_month'],

--- a/dbt_subprojects/solana/models/oneinch/oneinch_solana_swaps.sql
+++ b/dbt_subprojects/solana/models/oneinch/oneinch_solana_swaps.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_solana',
         alias = 'swaps',
         partition_by = ['block_month'],


### PR DESCRIPTION
fyi @Jam516 excluding the downstream models along with previous failure. plz remove tag when fixing models.

fyi @grkhr @max-morrow excluding oneinch swap for now. plz remove tag when fixing model.