### PR TITLE
Fix Phantom Swapper duplicates error

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
@@ -31,13 +31,13 @@ with sol_payments as (
         join {{ source('dex_solana', 'trades') }} as trades
             on trades.tx_id = account_activity.tx_id
             and trades.block_time = account_activity.block_time
-            {% if is_incremental() or true %} 
+            {% if is_incremental() %} 
             and {{ incremental_predicate('trades.block_time') }}
             {% else %} 
             and trades.block_time >= timestamp '{{query_start_date}}'
             {% endif %} 
         where
-            {% if is_incremental() or true %} 
+            {% if is_incremental() %} 
                 {{ incremental_predicate('account_activity.block_time') }}
             {% else %} 
                 account_activity.block_time >= timestamp '{{query_start_date}}'
@@ -60,7 +60,7 @@ with sol_payments as (
                 and token_balance_change > 0
             )
         where
-            {% if is_incremental() or true %} 
+            {% if is_incremental() %} 
                 {{ incremental_predicate('account_activity.block_time') }}
             {% else %} 
                 account_activity.block_time >= timestamp '{{query_start_date}}'
@@ -81,7 +81,7 @@ with sol_payments as (
             block_date
         from {{ source('solana', 'transactions') }}
         where
-            {% if is_incremental() or true %} 
+            {% if is_incremental() %} 
                 {{ incremental_predicate('block_date') }}
             {% else %} 
                 block_date >= timestamp '{{query_start_date}}'

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
@@ -32,9 +32,9 @@ with sol_payments as (
             on trades.tx_id = account_activity.tx_id
             and trades.block_time = account_activity.block_time
             {% if is_incremental() %} 
-                {{ incremental_predicate('trades.block_time') }}
+            and {{ incremental_predicate('trades.block_time') }}
             {% else %} 
-                trades.block_time >= timestamp '{{query_start_date}}'
+            and trades.block_time >= timestamp '{{query_start_date}}'
             {% endif %} 
         where
             {% if is_incremental() %} 

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
@@ -29,6 +29,9 @@ with sol_payments as (
                 fee_addresses.fee_receiver = account_activity.address
                 and balance_change > 0
             )
+        join {{ source('dex_solana', 'trades') }} as trades
+            on trades.tx_id = account_activity.tx_id
+            and trades.block_time = account_activity.block_time
         where
             {% if is_incremental() %} 
                 {{ incremental_predicate('account_activity.block_time') }}

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
@@ -1,5 +1,4 @@
 {{ config(
-    tags = ['prod_exclude'],
     schema = 'phantom_swapper_solana',
     alias = 'fee_payments_raw',
     partition_by = ['block_month'],

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
@@ -31,6 +31,11 @@ with sol_payments as (
         join {{ source('dex_solana', 'trades') }} as trades
             on trades.tx_id = account_activity.tx_id
             and trades.block_time = account_activity.block_time
+            {% if is_incremental() %} 
+                {{ incremental_predicate('trades.block_time') }}
+            {% else %} 
+                trades.block_time >= timestamp '{{query_start_date}}'
+            {% endif %} 
         where
             {% if is_incremental() %} 
                 {{ incremental_predicate('account_activity.block_time') }}

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
@@ -31,13 +31,13 @@ with sol_payments as (
         join {{ source('dex_solana', 'trades') }} as trades
             on trades.tx_id = account_activity.tx_id
             and trades.block_time = account_activity.block_time
-            {% if is_incremental() %} 
+            {% if is_incremental() or true %} 
             and {{ incremental_predicate('trades.block_time') }}
             {% else %} 
             and trades.block_time >= timestamp '{{query_start_date}}'
             {% endif %} 
         where
-            {% if is_incremental() %} 
+            {% if is_incremental() or true %} 
                 {{ incremental_predicate('account_activity.block_time') }}
             {% else %} 
                 account_activity.block_time >= timestamp '{{query_start_date}}'
@@ -60,7 +60,7 @@ with sol_payments as (
                 and token_balance_change > 0
             )
         where
-            {% if is_incremental() %} 
+            {% if is_incremental() or true %} 
                 {{ incremental_predicate('account_activity.block_time') }}
             {% else %} 
                 account_activity.block_time >= timestamp '{{query_start_date}}'
@@ -81,7 +81,7 @@ with sol_payments as (
             block_date
         from {{ source('solana', 'transactions') }}
         where
-            {% if is_incremental() %} 
+            {% if is_incremental() or true %} 
                 {{ incremental_predicate('block_date') }}
             {% else %} 
                 block_date >= timestamp '{{query_start_date}}'

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_usd.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_usd.sql
@@ -16,14 +16,14 @@ with
     fee_payments as (
         select *
         from {{ ref("phantom_swapper_solana_fee_payments_raw") }}
-        {% if is_incremental() %} where {{ incremental_predicate("block_time") }}
+        {% if is_incremental() or true %} where {{ incremental_predicate("block_time") }}
         {% else %} where block_time >= timestamp '{{query_start_date}}'
         {% endif %}
     ),
     fee_token_prices as (
         select *
         from {{ ref("phantom_swapper_solana_fee_token_prices") }}
-        {% if is_incremental() %} where {{ incremental_predicate("minute") }}
+        {% if is_incremental() or true %} where {{ incremental_predicate("minute") }}
         {% else %} where minute >= timestamp '{{query_start_date}}'
         {% endif %}
     )

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_usd.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_usd.sql
@@ -1,6 +1,5 @@
 {{
     config(
-        tags = ['prod_exclude'],
         schema="phantom_swapper_solana",
         alias="fee_payments_usd",
         partition_by=["block_month"],

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_usd.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_usd.sql
@@ -16,14 +16,14 @@ with
     fee_payments as (
         select *
         from {{ ref("phantom_swapper_solana_fee_payments_raw") }}
-        {% if is_incremental() or true %} where {{ incremental_predicate("block_time") }}
+        {% if is_incremental() %} where {{ incremental_predicate("block_time") }}
         {% else %} where block_time >= timestamp '{{query_start_date}}'
         {% endif %}
     ),
     fee_token_prices as (
         select *
         from {{ ref("phantom_swapper_solana_fee_token_prices") }}
-        {% if is_incremental() or true %} where {{ incremental_predicate("minute") }}
+        {% if is_incremental() %} where {{ incremental_predicate("minute") }}
         {% else %} where minute >= timestamp '{{query_start_date}}'
         {% endif %}
     )

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_token_prices.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_token_prices.sql
@@ -20,7 +20,7 @@ with
             from_base58(token_address) as contract_address_varbinary,
             token_address as contract_address_base58
         from {{ ref("phantom_swapper_solana_fee_payments_raw") }}
-        {% if is_incremental() or true %} where {{ incremental_predicate("block_time") }}
+        {% if is_incremental() %} where {{ incremental_predicate("block_time") }}
         {% else %} where block_time >= timestamp '{{query_start_date}}'
         {% endif %}
     ),
@@ -45,7 +45,7 @@ join
         prices.blockchain = tokens.blockchain
         and prices.contract_address = tokens.contract_address_varbinary
         and prices.minute = tokens.minute
-        {% if is_incremental() or true %} and {{ incremental_predicate("prices.minute") }}
+        {% if is_incremental() %} and {{ incremental_predicate("prices.minute") }}
         {% else %} and prices.minute >= timestamp '{{query_start_date}}'
         {% endif %}
     )

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_token_prices.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_token_prices.sql
@@ -1,6 +1,5 @@
 {{
     config(
-        tags = ['prod_exclude'],
         schema="phantom_swapper_solana",
         alias="fee_token_prices",
         partition_by=["block_month"],

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_token_prices.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_token_prices.sql
@@ -20,7 +20,7 @@ with
             from_base58(token_address) as contract_address_varbinary,
             token_address as contract_address_base58
         from {{ ref("phantom_swapper_solana_fee_payments_raw") }}
-        {% if is_incremental() %} where {{ incremental_predicate("block_time") }}
+        {% if is_incremental() or true %} where {{ incremental_predicate("block_time") }}
         {% else %} where block_time >= timestamp '{{query_start_date}}'
         {% endif %}
     ),
@@ -45,7 +45,7 @@ join
         prices.blockchain = tokens.blockchain
         and prices.contract_address = tokens.contract_address_varbinary
         and prices.minute = tokens.minute
-        {% if is_incremental() %} and {{ incremental_predicate("prices.minute") }}
+        {% if is_incremental() or true %} and {{ incremental_predicate("prices.minute") }}
         {% else %} and prices.minute >= timestamp '{{query_start_date}}'
         {% endif %}
     )

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_trades.sql
@@ -19,7 +19,7 @@ with filtered_transactions as (
             block_date
         from {{ source('solana', 'transactions') }}
         where
-            {% if is_incremental() or true %} 
+            {% if is_incremental() %} 
                 {{ incremental_predicate('block_date') }}
             {% else %} 
                 block_date >= timestamp '{{query_start_date}}'
@@ -69,7 +69,7 @@ with filtered_transactions as (
             fa1.fee_receiver IS NULL -- Exclude trades where FeeWallet is trader
             and fa2.fee_receiver IS NULL -- Exclude transactions signed by FeeWallet 
             and trades.trade_source IN ('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','6m2CDdhRgxpH4WjvdzxAYbGxwdGUz5MziiL5jek2kBma', 'JUPSjgjMFjU4453KMgxhqVmzep6W352bQpE4RsNqXAx')
-            {% if is_incremental() or true %}
+            {% if is_incremental() %}
                 and {{ incremental_predicate('trades.block_time') }}
                 and {{ incremental_predicate('fee_payments.block_time') }}
             {% else %}

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_trades.sql
@@ -1,5 +1,4 @@
 {{ config(
-    tags = ['prod_exclude'],
     schema = 'phantom_swapper_solana',
     alias = 'bot_trades',
     partition_by = ['block_month'],

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_trades.sql
@@ -19,7 +19,7 @@ with filtered_transactions as (
             block_date
         from {{ source('solana', 'transactions') }}
         where
-            {% if is_incremental() %} 
+            {% if is_incremental() or true %} 
                 {{ incremental_predicate('block_date') }}
             {% else %} 
                 block_date >= timestamp '{{query_start_date}}'
@@ -69,7 +69,7 @@ with filtered_transactions as (
             fa1.fee_receiver IS NULL -- Exclude trades where FeeWallet is trader
             and fa2.fee_receiver IS NULL -- Exclude transactions signed by FeeWallet 
             and trades.trade_source IN ('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4','6m2CDdhRgxpH4WjvdzxAYbGxwdGUz5MziiL5jek2kBma', 'JUPSjgjMFjU4453KMgxhqVmzep6W352bQpE4RsNqXAx')
-            {% if is_incremental() %}
+            {% if is_incremental() or true %}
                 and {{ incremental_predicate('trades.block_time') }}
                 and {{ incremental_predicate('fee_payments.block_time') }}
             {% else %}


### PR DESCRIPTION
@jeff-dude identified a duplicates error in the phantom swapper fee payments spell: https://github.com/duneanalytics/spellbook/pull/8417

Upon investigation, I found that the cause was a spambot called rocketpot which spams addresses with tiny amounts of SOL ([example](https://solscan.io/tx/3gmEqXALtN32LeDbm1LKPGAv83h8vAYjq5GvryJtBaNFmqNx4iBDNzR3vqTA5wps1EBHPX7sASEe67vQBtDodTf1))

To fix this, I join the solana trades table onto the fee payment query. This excludes edge cases like the rocketpot spamming, leaving only transactions where a phantom wallet is making a swap and a fee is being paid to phantom.

To test the fix, I made a query that contains the `phantom_swapper_fee_payments_raw` logic together with the new join and checks for recent duplicates. As you can see, no duplicates are found.
Fix - https://dune.com/queries/5370319
Original - https://dune.com/queries/5370136 (returns three duplicates found in that same time period)
