### PR TITLE
yeiswap on sei: exclude failing model

### DIFF
--- a/dbt_subprojects/dex/models/trades/sei/platforms/yei_swap_sei_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/sei/platforms/yei_swap_sei_base_trades.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'yei_swap_sei',
         alias = 'base_trades',
         materialized = 'incremental',


### PR DESCRIPTION
error in prod:
```
21:41:52    Database Error in model yei_swap_sei_base_trades (models/trades/sei/platforms/yei_swap_sei_base_trades.sql)
  TrinoUserError(type=USER_ERROR, name=SCHEMA_NOT_FOUND, message="line 34:9: Schema 'yei_swap_sei' does not exist", query_id=20250709_212508_63982_fxuus)
```

did someone change the decoded source table names?
fyi @yei-admin 