### PR TITLE
fix(schema): rename currency_name to currency_symbol in ofac sanctioned addresses model

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/addresses/ethereum/addresses_ethereum_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/addresses/ethereum/addresses_ethereum_schema.yml
@@ -21,7 +21,7 @@ models:
         description: "Blockchain on which this address has been sanctioned by OFAC"
       - name: currency_contract
         description: "Contract address of OFAC sanctioned currency"
-      - name: currency_name
+      - name: currency_symbol
         description: "Currency symbol of OFAC sanctioned currency"
         
   - name: addresses_ethereum_defi


### PR DESCRIPTION
Renamed the column currency_name to currency_symbol in the addresses_ethereum_ofac_sanctioned model section of addresses_ethereum_schema.yml.

This change was made because the SQL model uses the column name currency_symbol, while the schema file previously used currency_name. This mismatch caused dbt to not associate the column description with the actual column, resulting in missing documentation.

Now, the schema column name matches the model, ensuring proper documentation generation and eliminating potential confusion for users.