### PR TITLE
Fix schema: correct decimals field name and close description bracket

### DIFF
--- a/dbt_subprojects/tokens/models/ovm/optimism/ovm_optimism_schema.yml
+++ b/dbt_subprojects/tokens/models/ovm/optimism/ovm_optimism_schema.yml
@@ -33,8 +33,8 @@ models:
         name: name
         description: "Token name"
       - &decimals
-        name: name
-        description: "Token decimals (assume 18 unless we have an L1 mapping"
+        name: decimals
+        description: "Token decimals (assume 18 unless we have an L1 mapping)"
       - &call_tx_hash
         name: call_tx_hash
         description: "Transaction hash of token creation transaction"


### PR DESCRIPTION
- Changed the column name from name to decimals for the decimals field to avoid duplication and ensure accurate schema documentation.
- Closed the parenthesis in the decimals field description for clarity and consistency.