### PR TITLE
Add DFDVx token to Solana prices

### DIFF
--- a/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
@@ -770,5 +770,6 @@ FROM
         ('fdusd-first-digital-usd', 'solana', 'FDUSD', '9zNQRsGLjNKwCUU5Gq5LR8beUCPzQMVMqKAi3SSZh54u', 6),
         ('me-magic-eden', 'solana', 'ME', 'MEFNBXixkEbait3xn9bkm8WsJzXtVsaJEn4c8Sam21u', 6),
         ('bbsol-bybit-staked-sol', 'solana', 'bbSOL', 'Bybit2vBJGhPF52GBdNaQfUJ6ZpThSgHBobjWZpLPb4B', 9),
-        ('pump-pumpfun', 'solana', 'PUMP', 'pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn', 6)
+        ('pump-pumpfun', 'solana', 'PUMP', 'pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn', 6),
+        ('dfdvx-defi-development-corp','solana','DFDVx','Xs2yquAgsHByNzx68WJC55WHjHBvG9JsMB7CWjTLyPy',6)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)


### PR DESCRIPTION
## Summary
- Added DFDVx (DeFi Development Corp) token to the Solana prices tokens list
- Token details: contract address `Xs2yquAgsHByNzx68WJC55WHjHBvG9JsMB7CWjTLyPy`, 6 decimals

## Test plan
- [ ] Verify token contract address is correct
- [ ] Confirm decimals value (6) is accurate
- [ ] Check that the entry follows the same format as other tokens in the file

🤖 Generated with [Claude Code](https://claude.ai/code)