### PR TITLE
fix: preserve newlines when shrinking manifest raw_code and compiled_code

### DIFF
--- a/scripts/docs_shrink_manifest.py
+++ b/scripts/docs_shrink_manifest.py
@@ -14,11 +14,11 @@ class ManifestEditor:
         compiled_code = node.get('compiled_code', '')
 
         if raw_code.count('\n') > max_lines:
-            node['raw_code'] = ''.join(
+            node['raw_code'] = '\n'.join(
                 raw_code.split('\n')[0:max_lines])
 
         if compiled_code.count('\n') > max_lines:
-            node['compiled_code'] = ''.join(
+            node['compiled_code'] = '\n'.join(
                 compiled_code.split('\n')[0:max_lines])
 
         return node


### PR DESCRIPTION
Previously, the script replaced multi-line code blocks with a single concatenated line when limiting the number of lines in the raw_code and compiled_code fields of the manifest. This update changes the logic to correctly preserve line breaks by joining the first N lines with newline characters. This ensures that the resulting code remains readable and maintains its original structure, even after truncation.

