### PR TITLE
feat(tokens): Add Eclipse (ES) token to Solana tokens list

### DIFF
--- a/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
@@ -770,5 +770,6 @@ FROM
         ('fdusd-first-digital-usd', 'solana', 'FDUSD', '9zNQRsGLjNKwCUU5Gq5LR8beUCPzQMVMqKAi3SSZh54u', 6),
         ('me-magic-eden', 'solana', 'ME', 'MEFNBXixkEbait3xn9bkm8WsJzXtVsaJEn4c8Sam21u', 6),
         ('bbsol-bybit-staked-sol', 'solana', 'bbSOL', 'Bybit2vBJGhPF52GBdNaQfUJ6ZpThSgHBobjWZpLPb4B', 9),
-        ('pump-pumpfun', 'solana', 'PUMP', 'pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn', 6)
+        ('pump-pumpfun', 'solana', 'PUMP', 'pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn', 6),
+        ('es-eclipse', 'solana', 'ES', 'BqPqrrQuoQXFGGEAEMnPmDgZ6RWQCajWnY3V6Yp4DZWP', 6),
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Description:

Added new Eclipse (ES) token to the Solana tokens list.

Token details:

- Token ID: `es-eclipse`
- Blockchain: `solana`
- Symbol: `ES`
- Contract address: `BqPqrrQuoQXFGGEAEMnPmDgZ6RWQCajWnY3V6Yp4DZWP`
- Decimals: `6`

Changes:

- Added new entry to dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
- Token data verified via [Solscan](https://solscan.io/token/BqPqrrQuoQXFGGEAEMnPmDgZ6RWQCajWnY3V6Yp4DZWP)

Pull request is opened in draft status and will be ready for review after changes verification.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
