### PR TITLE
paraswap: exclude base chain v6 due to incorrect amounts

### DIFF
--- a/dbt_subprojects/dex/models/_projects/paraswap/base/paraswap_base_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/paraswap/base/paraswap_base_trades.sql
@@ -7,10 +7,9 @@
 
 {% set paraswap_models = [
 ref('paraswap_v5_base_trades')
-,ref('paraswap_v6_base_trades')
 ,ref('paraswap_delta_v2_base_trades')
  ] %}
-
+--exclude trouble model: ,ref('paraswap_v6_base_trades')
 
 SELECT *
 FROM (


### PR DESCRIPTION
we got an alert in prod for `amount_usd` inflated to irregular amounts. it came down to one tx in paraswap v6 on base chain.
```
select *
from dex_aggregator.trades
where project = 'paraswap'
and version = '6'
and blockchain = 'base'
and tx_hash = 0xd649a110dbfb69350d0b87f25022a767c6bf77976cc2d235fcd8eb2cf1b9419b
```
https://basescan.org/tx/0xd649a110dbfb69350d0b87f25022a767c6bf77976cc2d235fcd8eb2cf1b9419b

this tx appears to be assigning the same raw amount to both token bought and sold, when it should not be. this leads to incorrect `amount_usd` amounts which affect the overall table.

we need to exclude until the bug is resolved. this likely goes back to the macro which decodes traces, which would then affect all chains, and this tx just happened to uncover it?

fyi @alexshchur 