### PR TITLE
exclude `stabble` from `dex_solana.trades` due to duplicates

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/stabble/stabble_solana_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/stabble/stabble_solana_base_trades.sql
@@ -1,5 +1,6 @@
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stabble_solana',
     alias = 'base_trades',
     partition_by = ['block_month'],


### PR DESCRIPTION
```
20:15:55  Failure in model stabble_solana_base_trades (models/_sector/dex/stabble/stabble_solana_base_trades.sql)
20:15:55
20:15:55    Database Error in model stabble_solana_base_trades (models/_sector/dex/stabble/stabble_solana_base_trades.sql)
  TrinoUserError(type=USER_ERROR, name=MERGE_TARGET_ROW_MULTIPLE_MATCHES, message="One MERGE target table row matched more than one source row", query_id=20250726_194946_00924_fvym2)
```