### PR TITLE
Add tx_index and block_number to dex.trades

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_macro.sql
@@ -99,6 +99,7 @@ select
     , tx_gas_used
     , tx_gas_price
     , tx_priority_fee_per_gas
+    , tx_index
     , contract_name
     , 'AR' as protocol
     , protocol_version
@@ -136,7 +137,7 @@ from (
         add_tx_columns(
             model_cte = 'calls'
             , blockchain = blockchain
-            , columns = ['from', 'to', 'success', 'nonce', 'gas_price', 'priority_fee_per_gas', 'gas_used']
+            , columns = ['from', 'to', 'success', 'nonce', 'gas_price', 'priority_fee_per_gas', 'gas_used', 'index']
         )
     }}
 )

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/LOP/oneinch_lop_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/LOP/oneinch_lop_macro.sql
@@ -230,6 +230,7 @@ select
     , tx_gas_used
     , tx_gas_price
     , tx_priority_fee_per_gas
+    , tx_index
     , contract_name
     , 'LOP' as protocol
     , protocol_version

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/oneinch_calls_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/oneinch_calls_macro.sql
@@ -18,6 +18,7 @@
     'tx_gas_used',
     'tx_gas_price',
     'tx_priority_fee_per_gas',
+    'tx_index',
     'contract_name',
     'protocol',
     'protocol_version',
@@ -100,6 +101,7 @@ select
     , tx_gas_used
     , tx_gas_price
     , tx_priority_fee_per_gas
+    , tx_index
     , contract_name
     , protocol
     , protocol_version

--- a/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
+++ b/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
@@ -55,6 +55,7 @@ WITH base_trades as (
         , base_trades.tx_from
         , base_trades.tx_to
         , base_trades.evt_index
+        , base_trades.tx_index
     FROM
         base_trades
     LEFT JOIN
@@ -123,6 +124,7 @@ SELECT
     , tx_from
     , tx_to
     , evt_index
+    , tx_index
 FROM
     enrichments_with_prices dexs
 LEFT JOIN erc4626_prices erc4626a

--- a/dbt_subprojects/dex/macros/models/enrich_dex_trades.sql
+++ b/dbt_subprojects/dex/macros/models/enrich_dex_trades.sql
@@ -55,6 +55,7 @@ WITH base_trades as (
         , base_trades.tx_from
         , base_trades.tx_to
         , base_trades.evt_index
+        , base_trades.tx_index
     FROM
         base_trades
     LEFT JOIN
@@ -100,6 +101,7 @@ SELECT
     , tx_from
     , tx_to
     , evt_index
+    , tx_index
 FROM
     enrichments_with_prices
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/oneinch_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/oneinch_lop_own_trades.sql
@@ -37,6 +37,7 @@ select
     , tx_from
     , tx_to
     , row_number() over(partition by tx_hash order by call_trace_address) as evt_index
+    , CAST(NULL AS BIGINT) as tx_index
 from {{ ref('oneinch_swaps') }}
 where
     protocol = 'LOP'

--- a/dbt_subprojects/dex/models/_projects/oneinch/oneinch_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/oneinch_lop_own_trades.sql
@@ -37,7 +37,7 @@ select
     , tx_from
     , tx_to
     , row_number() over(partition by tx_hash order by call_trace_address) as evt_index
-    , CAST(NULL AS BIGINT) as tx_index
+    , tx_index
 from {{ ref('oneinch_swaps') }}
 where
     protocol = 'LOP'

--- a/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_arbitrum_native_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_arbitrum_native_fills.sql
@@ -252,7 +252,8 @@ SELECT DISTINCT
     all_fills.contract_address,
     all_fills.native_order_type,
     tx."from" AS tx_from,
-    tx.to AS tx_to
+    tx.to AS tx_to,
+    tx."index" AS tx_index
 FROM all_fills
 INNER JOIN {{ source('arbitrum', 'transactions') }} tx
     ON all_fills.transaction_hash = tx.hash

--- a/dbt_subprojects/dex/models/_projects/zeroex/bnb/zeroex_bnb_native_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/bnb/zeroex_bnb_native_fills.sql
@@ -223,7 +223,8 @@ WITH
                 all_fills.contract_address,
                 native_order_type,
                 tx."from" AS tx_from,
-                tx.to AS tx_to
+                tx.to AS tx_to,
+                tx."index" AS tx_index
             FROM all_fills
             INNER JOIN {{ source('bnb', 'transactions')}} tx ON all_fills.transaction_hash = tx.hash
             AND all_fills.block_number = tx.block_number

--- a/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_ethereum_native_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_ethereum_native_fills.sql
@@ -393,7 +393,8 @@ SELECT distinct all_fills.block_time                                    AS block
                 all_fills.contract_address,
                 native_order_type,
                 tx."from" AS tx_from,
-                tx.to                                                   AS tx_to
+                tx.to                                                   AS tx_to,
+                tx."index"                                              AS tx_index
 FROM all_fills
 INNER JOIN {{ source('ethereum', 'transactions')}} tx
     ON all_fills.transaction_hash = tx.hash

--- a/dbt_subprojects/dex/models/_projects/zeroex/optimism/zeroex_optimism_native_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/optimism/zeroex_optimism_native_fills.sql
@@ -258,7 +258,8 @@ WITH
                 all_fills.contract_address,
                 native_order_type,
                 tx."from" AS tx_from,
-                tx.to AS tx_to
+                tx.to AS tx_to,
+                tx."index" AS tx_index
             FROM all_fills
             INNER JOIN {{ source('optimism', 'transactions')}} tx ON all_fills.transaction_hash = tx.hash
             AND all_fills.block_number = tx.block_number

--- a/dbt_subprojects/dex/models/_projects/zeroex/polygon/zeroex_polygon_native_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/polygon/zeroex_polygon_native_fills.sql
@@ -395,7 +395,8 @@ WITH
                 all_fills.contract_address,
                 native_order_type,
                 tx."from" AS tx_from,
-                tx.to AS tx_to
+                tx.to AS tx_to,
+                tx."index" AS tx_index
             FROM all_fills
             INNER JOIN {{ source('polygon', 'transactions')}} tx ON all_fills.transaction_hash = tx.hash
                 AND all_fills.block_number = tx.block_number and all_fills.block_time = tx.block_time 

--- a/dbt_subprojects/dex/models/_projects/zeroex/zeroex_native_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/zeroex_native_trades.sql
@@ -44,7 +44,7 @@ FROM (
       tx_from  as tx_from,
       tx_to  as tx_to,
       evt_index  as evt_index,
-      CAST(NULL AS BIGINT) as tx_index
+      tx_index
 
     FROM {{ model }}
     {% if not loop.last %}

--- a/dbt_subprojects/dex/models/_projects/zeroex/zeroex_native_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/zeroex_native_trades.sql
@@ -43,7 +43,8 @@ FROM (
       tx_hash  as tx_hash,
       tx_from  as tx_from,
       tx_to  as tx_to,
-      evt_index  as evt_index
+      evt_index  as evt_index,
+      CAST(NULL AS BIGINT) as tx_index
 
     FROM {{ model }}
     {% if not loop.last %}

--- a/dbt_subprojects/dex/models/trades/dex_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_trades.sql
@@ -92,6 +92,7 @@ WITH balancer_v3 AS (
         , tx_from
         , tx_to
         , evt_index
+        , tx_index
     FROM
         {{ model }}
     {% if is_incremental() %}
@@ -138,6 +139,7 @@ WITH balancer_v3 AS (
         , tx_from
         , tx_to
         , evt_index
+        , tx_index
     FROM
         {{ cte }}
     {% if not loop.last %}


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:

This PR adds the `tx_index` column to the `dex.trades` table.

While `block_number` was already present, `tx_index` was missing from the final output, despite being available in base tables. This addition is crucial for accurately distinguishing transactions on chains with sub-second blocks and improves the efficiency of related spells like `dex.sandwiches` and `dex.atomic_arbitrages`.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
[Slack Thread](https://duneanalytics.slack.com/archives/C08J8B5EF34/p1753813549113989?thread_ts=1753813549.113989&cid=C08J8B5EF34)

<a href="https://cursor.com/background-agent?bcId=bc-70312cb5-415a-4aff-85bc-fd6f733a8c51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70312cb5-415a-4aff-85bc-fd6f733a8c51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>