### PR TITLE
hide some prices models

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/prices/prices_usd_daily.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/prices/prices_usd_daily.sql
@@ -3,10 +3,7 @@
         alias = 'usd_daily',
         materialized = 'table',
         file_format = 'delta',
-        post_hook = '{{ expose_spells(\'["ethereum", "solana", "arbitrum", "base", "gnosis", "optimism", "bnb", "avalanche_c", "polygon", "scroll", "zksync"]\',
-                                    "sector",
-                                    "prices",
-                                    \'["aalan3"]\') }}'
+        post_hook = '{{ hide_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/prices/prices_usd_forward_fill.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/prices/prices_usd_forward_fill.sql
@@ -2,10 +2,7 @@
         
         schema='prices',
         alias = 'usd_forward_fill',
-        post_hook='{{ expose_spells(\'["ethereum", "solana", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c", "polygon", "zksync"]\',
-                                    "sector",
-                                    "prices",
-                                    \'["0xRob"]\') }}'
+        post_hook='{{ hide_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/prices/prices_usd_latest.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/prices/prices_usd_latest.sql
@@ -2,10 +2,7 @@
         schema='prices',
         alias = 'usd_latest',
         
-        post_hook='{{ expose_spells(\'["ethereum", "solana", "arbitrum", "gnosis", "optimism", "bnb", "avalanche_c", "zksync"]\',
-                                    "sector",
-                                    "prices",
-                                    \'["hildobby", "0xRob"]\') }}'
+        post_hook='{{ hide_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/prices/prices_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_tokens.sql
@@ -4,54 +4,7 @@
         materialized='table',
         file_format = 'delta',
         tags = ['static'],
-        post_hook = '{{ expose_spells(\'[
-                                        "arbitrum"
-                                        , "avalanche_c"
-                                        , "base"
-                                        , "bitcoin"
-                                        , "blast"
-                                        , "bnb"
-                                        , "boba"
-                                        , "cardano"
-                                        , "celo"
-                                        , "corn"
-                                        , "degen"
-                                        , "ethereum"
-                                        , "fantom"
-                                        , "flare"
-                                        , "gnosis"
-                                        , "hemi"
-                                        , "ink"
-                                        , "kaia"
-                                        , "katana"
-                                        , "linea"
-                                        , "nova"
-                                        , "optimism"
-                                        , "polygon"
-                                        , "ronin"
-                                        , "scroll"
-                                        , "sei"
-                                        , "shape"
-                                        , "solana"
-                                        , "sonic"
-                                        , "sophon"
-                                        , "superseed"
-                                        , "opbnb"
-                                        , "tac"
-                                        , "taiko"
-                                        , "unichain"
-                                        , "viction"
-                                        , "worldchain"
-                                        , "zksync"
-                                        , "zkevm"
-                                        , "zora"
-                                        , "abstract"
-                                        , "lens"
-                                        , "plume"
-                                    ]\',
-                                    "sector",
-                                    "prices",
-                                    \'["aalan3", "jeff-dude", "umer_h_adil", "0xBoxer", "rantum", "lgingerich", "hildobby", "cryptokoryo", "0xRob", "hosuke", "Henrystats"]\') }}'
+        post_hook = '{{ hide_spells() }}'
         )
 }}
 


### PR DESCRIPTION
Updated the post_hook in the following SQL models to utilize the hide_spells macro, removing the previous expose_spells configurations: prices_usd_daily.sql, prices_usd_forward_fill.sql, prices_usd_latest.sql, and prices_tokens.sql. This change enhances data privacy by hiding specific spells from the data explorer.