### PR TITLE
fix column name in uniswap optimism pools

### DIFF
--- a/dbt_subprojects/dex/models/_projects/gamma/optimism/gamma_optimism_uniswap_pools.sql
+++ b/dbt_subprojects/dex/models/_projects/gamma/optimism/gamma_optimism_uniswap_pools.sql
@@ -50,7 +50,7 @@ SELECT lp_name, contract_address
 
 SELECT distinct
     'optimism' AS blockchain,
-    lp_name, mm.contract_address, pool AS pool_contract, fee, token0, token1
+    lp_name, mm.contract_address, id AS pool_contract, fee, token0, token1
     FROM manual_mapping mm
     INNER JOIN {{ source('optimism', 'creation_traces') }} ct 
         ON ct.address = mm.contract_address


### PR DESCRIPTION
fyi @henrystats 
any time we change a column name or add/remove to existing models, plz do run `dbt ls` to find all downstream models and ensure the column changes are accounted for.