### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/dbt_precommit_hooks.yml
+++ b/.github/workflows/dbt_precommit_hooks.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v3
       - uses: jitterbit/get-changed-files@v1
         id: abc

--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup variables
         run: | # Spellbook is a special case because it's not a subdirectory

--- a/.github/workflows/pytest_automations.yml
+++ b/.github/workflows/pytest_automations.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0