### PR TITLE
`prices_tokens_legacy`: add tac

### DIFF
--- a/dbt_subprojects/tokens/models/prices/prices_tokens_legacy.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_tokens_legacy.sql
@@ -43,6 +43,7 @@
     ,ref('prices_sonic_tokens')
     ,ref('prices_ink_tokens')
     ,ref('prices_sophon_tokens')
+    ,ref('prices_tac_tokens')
     ,ref('prices_opbnb_tokens')
     ,ref('prices_taiko_tokens')
     ,ref('prices_unichain_tokens')


### PR DESCRIPTION
fyi @krishgka 
this should hopefully be extremely short term, until we finalize plan for `prices.usd` next week. in the meantime, we need to add chain specific price models to this union model in addition to `prices_tokens`. we don't have any new chains for a bit, so likely not an issue, but just a heads up.

we will soon be cleaning this up, but for now, adding to keep parity between `prices_tokens` and `prices_tokens_legacy`