### PR TITLE
1inch project lineage: exclude bnb from project swaps

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/oneinch_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/oneinch_project_swaps.sql
@@ -7,11 +7,10 @@
     )
 }}
 
-
-
 {% for blockchain in oneinch_project_swaps_exposed_blockchains_list() %}
     {{ "-- depends_on: {{ ref('oneinch_' + blockchain + '_project_orders') }}" }}
-    
-    select * from {{ ref('oneinch_' + blockchain + '_project_swaps') }}
-    {% if not loop.last %} union all {% endif %}
+    {% if blockchain != 'bnb' %}
+        select * from {{ ref('oneinch_' + blockchain + '_project_swaps') }}
+        {% if not loop.last %} union all {% endif %}
+    {% endif %}
 {% endfor %}


### PR DESCRIPTION
fyi @grkhr @max-morrow 
unfortunately i need to exclude bnb for now. this lineage has officially become too complex to run full backfills and is crashing repeatedly on our large prod cluster. i haven't taken the time to deep dive this lineage, but i know it involves many heavy tables and complex logic. it will need to be redesigned most likely to scale to where the size of many EVM chains are headed.