### PR TITLE
bridges: exclude failing model on dupes

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_deposits.sql
@@ -1,5 +1,6 @@
 {{ config(
-    schema = 'bridges_evms'
+    tags = ['prod_exclude']
+    , schema = 'bridges_evms'
     , alias = 'deposits'
     , materialized = 'incremental'
     , file_format = 'delta'


### PR DESCRIPTION
@hildobby it's happening again on dupes, excluding until we resolve the open GH issue.
```
14:44:45  Failure in model bridges_evms_deposits (models/_sector/bridges/flows/evms/bridges_evms_deposits.sql)
14:44:45
14:44:45    Database Error in model bridges_evms_deposits (models/_sector/bridges/flows/evms/bridges_evms_deposits.sql)
  TrinoUserError(type=USER_ERROR, name=MERGE_TARGET_ROW_MULTIPLE_MATCHES, message="One MERGE target table row matched more than one source row", query_id=20250820_134118_13397_avp3t)
  compiled code at [target/run/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_deposits.sql](https://nd058.us1.dbt.com/api/v2/accounts/58579/runs/70471842694010/artifacts/run/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_deposits.sql)
```