### PR TITLE
re-enable augustus v6.2 on base

### DIFF
--- a/dbt_subprojects/dex/models/_projects/paraswap/base/paraswap_base_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/paraswap/base/paraswap_base_trades.sql
@@ -8,8 +8,8 @@
 {% set paraswap_models = [
 ref('paraswap_v5_base_trades')
 ,ref('paraswap_delta_v2_base_trades')
+,ref('paraswap_v6_base_trades')
  ] %}
---exclude trouble model: ,ref('paraswap_v6_base_trades')
 
 SELECT *
 FROM (


### PR DESCRIPTION
Re-enable `paraswap_v6_base_trades` after earlier disabling it https://github.com/duneanalytics/spellbook/pull/8529/files