### PR TITLE
chore: correct typo in variable name

### DIFF
--- a/scripts/validate_source_freshness_checks.py
+++ b/scripts/validate_source_freshness_checks.py
@@ -35,8 +35,8 @@ class Sources:
 
 def missing_freshness_checks(sources, manifest, check_type='warn'):
     sources = list(set(sources))
-    source_defintions = {source: manifest['sources'][source] for source in sources}
-    empty_checks = [key for key, value in source_defintions.items() if
+    source_definitions = {source: manifest['sources'][source] for source in sources}
+    empty_checks = [key for key, value in source_definitions.items() if
                     value['freshness'][f'{check_type}_after']['count'] is None]
     return empty_checks
 


### PR DESCRIPTION
### Description:

Correct typo in variable name from `source_defintions` to `source_definitions`.
