### PR TITLE
`aptos_fungible_asset_metadata`: exclude model due to duplicates causing failures

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_metadata.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_metadata.sql
@@ -7,6 +7,7 @@
 -- creator_address is the asset address for v1 and owner for v2 (can change for v2)
 -- creator_address is not needed for coins/fa, it's a holdover from tokens (where it is used as key with name)
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'aptos_fungible_asset',
     alias = 'metadata',
     materialized = 'incremental',


### PR DESCRIPTION
fyi @ying-w 
our prod jobs which run this model are failing due to duplicates based on unique key assignment having multiple source rows match the target lookup during merge operations.
```
04:44:41  Failure in model aptos_fungible_asset_metadata (models/aptos/aptos_fungible_asset_metadata.sql)
04:44:41
04:44:41    Database Error in model aptos_fungible_asset_metadata (models/aptos/aptos_fungible_asset_metadata.sql)
  TrinoUserError(type=USER_ERROR, name=MERGE_TARGET_ROW_MULTIPLE_MATCHES, message="One MERGE target table row matched more than one source row", query_id=20250825_035105_09380_p9ymh)
```

can you look to find the issue / fix, then remove this new tag applied in config to see it run in CI pipeline again to test.