### PR TITLE
Fix duplicate viction prices in pipeline

### DIFF
--- a/dbt_subprojects/tokens/models/prices/viction/prices_viction_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/viction/prices_viction_tokens.sql
@@ -18,8 +18,7 @@ SELECT
 FROM
 (
     VALUES
-    ('tomo-tomochain', 'WVIC', 0xC054751BdBD24Ae713BA3Dc9Bd9434aBe2abc1ce, 18)
-    , ('usdt-tether', 'USDT', 0x381B31409e4D220919B2cFF012ED94d70135A59e, 6)
+    ('usdt-tether', 'USDT', 0x381B31409e4D220919B2cFF012ED94d70135A59e, 6)
     , ('usdc-usd-coin', 'USDC', 0x20cC4574f263C54eb7aD630c9AC6d4d9068Cf127, 6)
     , ('c98-coin98', 'C98', 0x0fd0288aaae91eaf935e2ec14b23486f86516c8c, 18)
 ) as temp (token_id, symbol, contract_address, decimals)


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Resolves CUR2-473 by fixing duplicate entries for the Viction native token (VIC) in prices tables.

The root cause was the CoinPaprika `token_id` 'tomo-tomochain' being defined in both `prices_native_tokens.sql` and `prices_viction_tokens.sql`. This led to duplicate price data being pulled for both the native VIC (0x00...00) and wrapped WVIC (0xC054...) using the same external ID.

This PR removes the duplicate 'tomo-tomochain' entry from `prices_viction_tokens.sql`, ensuring that the native token is exclusively handled by `prices_native_tokens.sql` and eliminating the duplicate price entries.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
Linear Issue: [CUR2-473](https://linear.app/dune/issue/CUR2-473/duplicates-for-viction-native-token-in-prices-tables)

<a href="https://cursor.com/background-agent?bcId=bc-10792b27-ce10-480b-ac57-74946dd9211b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10792b27-ce10-480b-ac57-74946dd9211b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

