### PR TITLE
Update contract address symbol to ZOOMER

### DIFF
--- a/dbt_subprojects/tokens/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -1772,7 +1772,7 @@ FROM
     ('savm-satoshivm', 'ethereum', 'SAVM', 0x15e6e0d4ebeac120f9a97e71faa6a0235b85ed12, 18),
     ('hemule-hemule', 'ethereum', 'HEMULE', 0xeAA63125dd63f10874F99CdBbb18410e7Fc79dD3, 18),
     ('election-real-smurf-cat', 'ethereum', 'SMURFCAT', 0xfF836A5821E69066c87E268bC51b849FaB94240C, 18),
-    ('eth-zoomer', 'ethereum', 'ETH', 0x0d505c03d30e65f6e9b4ef88855a47a89e4b7676, 18),
+    ('eth-zoomer', 'ethereum', 'ZOOMER', 0x0d505c03d30e65f6e9b4ef88855a47a89e4b7676, 18),
     ('shia-shia1', 'ethereum', 'SHIA', 0x43D7E65B8fF49698D9550a7F315c87E67344FB59, 18),
     ('qanx-qanx-token', 'ethereum', 'QANX', 0xaaa9214f675316182eaa21c85f0ca99160cc3aaa, 18),
     ('hft1-hashflow', 'ethereum', 'HFT', 0xb3999f658c0391d94a37f7ff328f3fec942bcadc, 18),


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Updates the symbol for contract address `0x0D505C03d30e65f6e9b4Ef88855a47a89e4b7676` from 'ETH' to 'ZOOMER' in `prices_ethereum_tokens.sql` to reflect the correct token symbol.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
[Slack Thread](https://duneanalytics.slack.com/archives/C08J8B5EF34/p1756478580057199?thread_ts=1756478580.057199&cid=C08J8B5EF34)

<a href="https://cursor.com/background-agent?bcId=bc-cc2b3a81-4ec5-45fa-9ecc-2f55bc1886d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc2b3a81-4ec5-45fa-9ecc-2f55bc1886d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

