### PR TITLE
Add YZY prices solana

### DIFF
--- a/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
@@ -776,5 +776,6 @@ FROM
         ('frag-fragmetric', 'solana', 'FRAG', 'FRAGMEWj2z65qM62zqKhNtwNFskdfKs4ekDUDX3b4VD5', 9),
         ('codec-codec-flow', 'solana', 'CODEC', '69LjZUUzxj3Cb3Fxeo1X4QpYEQTboApkhXTysPpbpump', 6),
         ('aura-auraonsol', 'solana', 'AURA', 'DtR4D9FtVoTX2569gaL837ZgrB6wNjj6tkmnX9Rdk9B2', 6),
+        ('yzy-yzy', 'solana', 'YZY', 'DrZ26cKJDksVRWib3DVVsjo9eeXccc7hKhDJviiYEEZY', 6),
         ('wct-walletconnect-token', 'solana', 'WCT', 'WCTk5xWdn5SYg56twGj32sUF3W4WFQ48ogezLBuYTBY', 9)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)


### PR DESCRIPTION
Added YZY token to the Solana prices list. CoinPaprika - [click_click_click](https://coinpaprika.com/coin/yzy-yzy/)

Just so the prices can be picked up in queries and converted to USD.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `YZY` (Solana) to `prices_solana_tokens.sql` with contract `DrZ26cKJDksVRWib3DVVsjo9eeXccc7hKhDJviiYEEZY` and 6 decimals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8b77ead816f8f96e446fcaf07e4e034d6e0985d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->