### PR TITLE
Fix duplicate issue in aptos_fungible_asset_metadata

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_metadata.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_metadata.sql
@@ -36,7 +36,6 @@ WITH mr_fa_metadata AS (
         AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
         AND move_resource_module = 'fungible_asset'
         AND move_resource_name = 'Metadata'
-        AND block_date = DATE('2025-01-01')
     {% if is_incremental() %}
         AND {{ incremental_predicate('block_time') }}
     {% else %}
@@ -63,7 +62,6 @@ WITH mr_fa_metadata AS (
         AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
         AND move_resource_module = 'fungible_asset'
         AND move_resource_name IN ('Supply', 'ConcurrentSupply')
-        AND block_date = DATE('2025-01-01')
     {% if is_incremental() %}
         AND {{ incremental_predicate('block_time') }}
     {% else %}
@@ -79,7 +77,6 @@ WITH mr_fa_metadata AS (
         AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
         AND move_resource_module = 'object'
         AND move_resource_name = 'ObjectCore'
-        AND block_date = DATE('2025-01-01')
     {% if is_incremental() %}
         AND {{ incremental_predicate('block_time') }}
     {% else %}
@@ -107,7 +104,6 @@ WITH mr_fa_metadata AS (
         AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
         AND move_resource_module = 'coin'
         AND move_resource_name = 'CoinInfo'
-        AND block_date = DATE('2025-01-01')
     {% if is_incremental() %}
         AND {{ incremental_predicate('block_time') }}
     {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_metadata.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_metadata.sql
@@ -7,7 +7,6 @@
 -- creator_address is the asset address for v1 and owner for v2 (can change for v2)
 -- creator_address is not needed for coins/fa, it's a holdover from tokens (where it is used as key with name)
 {{ config(
-    tags = ['prod_exclude'],
     schema = 'aptos_fungible_asset',
     alias = 'metadata',
     materialized = 'incremental',
@@ -37,6 +36,7 @@ WITH mr_fa_metadata AS (
         AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
         AND move_resource_module = 'fungible_asset'
         AND move_resource_name = 'Metadata'
+        AND block_date = DATE('2025-01-01')
     {% if is_incremental() %}
         AND {{ incremental_predicate('block_time') }}
     {% else %}
@@ -63,6 +63,7 @@ WITH mr_fa_metadata AS (
         AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
         AND move_resource_module = 'fungible_asset'
         AND move_resource_name IN ('Supply', 'ConcurrentSupply')
+        AND block_date = DATE('2025-01-01')
     {% if is_incremental() %}
         AND {{ incremental_predicate('block_time') }}
     {% else %}
@@ -78,6 +79,7 @@ WITH mr_fa_metadata AS (
         AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
         AND move_resource_module = 'object'
         AND move_resource_name = 'ObjectCore'
+        AND block_date = DATE('2025-01-01')
     {% if is_incremental() %}
         AND {{ incremental_predicate('block_time') }}
     {% else %}
@@ -105,6 +107,7 @@ WITH mr_fa_metadata AS (
         AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
         AND move_resource_module = 'coin'
         AND move_resource_name = 'CoinInfo'
+        AND block_date = DATE('2025-01-01')
     {% if is_incremental() %}
         AND {{ incremental_predicate('block_time') }}
     {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_migration.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_migration.sql
@@ -30,10 +30,6 @@ FROM (
         AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
         AND move_resource_module = 'coin'
         AND move_resource_name = 'PairedCoinType'
-    {% if is_incremental() %}
-        AND {{ incremental_predicate('block_time') }}
-    {% else %}
         AND block_date BETWEEN DATE('2024-08-02') AND DATE('2025-09-01') -- FA (v2) migration period
-    {% endif %}
     GROUP BY move_address
 )

--- a/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_migration.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_migration.sql
@@ -1,8 +1,10 @@
 {{ config(
     schema = 'aptos_fungible_asset',
     alias = 'migration',
-    materialized = 'table',
+    materialized = 'incremental',
     file_format = 'delta',
+    incremental_strategy = 'merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     unique_key = ['asset_type_v2'],
 ) }}
 
@@ -11,7 +13,7 @@ SELECT
     tx_version,
     block_date,
     block_time,
-    date(date_trunc('month', block_time)) as block_month,
+    DATE(date_trunc('month', block_time)) as block_month,
     --
     '0x' || LPAD(lower(to_hex(move_address)), 64, '0') AS asset_type_v2,
     '0x' || LPAD(LTRIM(json_extract_scalar(move_data, '$.type.account_address'), '0x'), 64, '0') || '::' ||
@@ -30,6 +32,10 @@ FROM (
         AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
         AND move_resource_module = 'coin'
         AND move_resource_name = 'PairedCoinType'
-        AND block_date BETWEEN DATE('2024-08-02') AND DATE('2025-09-01') -- FA (v2) migration period
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('block_time') }}
+    {% else %}
+        AND block_date >= DATE('2024-08-02') -- beginning of FA (v2) migration
+    {% endif %}
     GROUP BY move_address
 )

--- a/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_migration.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_migration.sql
@@ -1,13 +1,10 @@
 {{ config(
     schema = 'aptos_fungible_asset',
-    alias = 'migrations',
-    materialized = 'incremental',
+    alias = 'migration',
+    materialized = 'table',
     file_format = 'delta',
-    incremental_strategy = 'merge',
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     unique_key = ['asset_type_v2'],
 ) }}
--- TODO: change into one time table after coins are no longer allowed to be created
 
 SELECT
     -- latest
@@ -36,7 +33,7 @@ FROM (
     {% if is_incremental() %}
         AND {{ incremental_predicate('block_time') }}
     {% else %}
-        AND block_date >= DATE('2024-08-02') -- beginning of FA (v2) migration
+        AND block_date BETWEEN DATE('2024-08-02') AND DATE('2025-09-01') -- FA (v2) migration period
     {% endif %}
     GROUP BY move_address
 )

--- a/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_migration.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_migration.sql
@@ -4,7 +4,6 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     unique_key = ['asset_type_v2'],
 ) }}
 


### PR DESCRIPTION
### Description:

Duplicate issue that came up in https://github.com/duneanalytics/spellbook/pull/8682 was due to `migration` table having duplicates.

~`migration` table should be a one time build (this solves the issue)~
`migration` table should be unique but will keep growing. CoinStore is fully migrated but coin (v1) can still be created (added to migration table on mint)
