### PR TITLE
Add Tradoor events decoding

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/tradoor/ton/tradoor_ton_perp_order.sql
+++ b/dbt_subprojects/daily_spellbook/models/tradoor/ton/tradoor_ton_perp_order.sql
@@ -1,0 +1,59 @@
+{{ config(
+       schema = 'tradoor_ton'
+       , alias = 'perp_order'
+       , materialized = 'incremental'
+       , file_format = 'delta'
+       , incremental_strategy = 'merge'
+       , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+       , unique_key = ['tx_hash', 'block_date']
+       , post_hook='{{ expose_spells(\'["ton"]\',
+                                   "project",
+                                   "tradoor",
+                                   \'["pshuvalov"]\') }}'
+   )
+ }}
+
+
+-- based on this implementation https://github.com/ton-studio/ton-etl/blob/e733691ebe61c24444acb622e5ad5b2fa317b352/parser/parsers/message/tradoor_trades.py
+
+WITH tradoor_pools AS (
+    SELECT pool_address, pool_name FROM (VALUES 
+    (upper('0:ff1338c9f6ed1fa4c264a19052bff64d10c8ad028628f52b2e0f4b357a12227e'), 'USDT-v2'),
+    (upper('0:0d36ba31cc15d776dd529b990872735972b0c4ceec77741f9ed3344e48e19084'), 'TON-v2'),
+    (upper('0:1b31de77fbf382b1023ad114d383e191506366d6e14af8c6264699081d3a2309'), 'USDT-v3')
+    ) AS T(pool_address, pool_name)
+),
+parsed_boc AS (
+    SELECT M.block_date, M.tx_hash, M.trace_id, M.tx_now, M.tx_lt, pool_address, pool_name, M.source as amm, body_boc
+    FROM {{ source('ton', 'messages') }} M
+    JOIN tradoor_pools ON M.source = pool_address
+    WHERE M.block_date > TIMESTAMP '2024-09-01'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('M.block_date') }}
+    {% endif %}
+    AND opcode = -1383190033 -- 0xad8e31ef
+    AND M.direction = 'out'
+    AND M.destination is null -- ext-out
+), parse_output as (
+select {{ ton_from_boc('body_boc', [
+    ton_begin_parse(),
+    ton_skip_bits(32),
+    ton_load_uint(8, 'op_type'),
+    ton_load_uint(16, 'token_id'),
+    ton_load_address('trader_addr'),
+    ton_load_uint(1, 'is_long'),
+    ton_load_coins('margin_delta'),
+    ton_load_coins('size_delta'),
+    ton_load_uint(128, 'trigger_price'),
+    ton_load_uint(1, 'trigger_above'),
+    ton_load_coins('execution_fee'),
+    ton_load_uint(64, 'order_id'),
+    ton_load_uint(64, 'trx_id'),
+    ton_load_uint(32, 'request_time')
+    ]) }} as result, * from parsed_boc
+)
+select block_date, tx_hash, trace_id, tx_now, tx_lt,
+pool_address, pool_name, result.op_type, result.token_id, result.trader_addr,
+result.is_long, result.margin_delta, result.size_delta, result.trigger_price,
+result.trigger_above, result.execution_fee, result.order_id, result.trx_id, result.request_time
+from parse_output

--- a/dbt_subprojects/daily_spellbook/models/tradoor/ton/tradoor_ton_perp_position_change.sql
+++ b/dbt_subprojects/daily_spellbook/models/tradoor/ton/tradoor_ton_perp_position_change.sql
@@ -1,0 +1,62 @@
+{{ config(
+       schema = 'tradoor_ton'
+       , alias = 'perp_position_change'
+       , materialized = 'incremental'
+       , file_format = 'delta'
+       , incremental_strategy = 'merge'
+       , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+       , unique_key = ['tx_hash', 'block_date']
+       , post_hook='{{ expose_spells(\'["ton"]\',
+                                   "project",
+                                   "tradoor",
+                                   \'["pshuvalov"]\') }}'
+   )
+ }}
+
+
+-- based on this implementation https://github.com/ton-studio/ton-etl/blob/e733691ebe61c24444acb622e5ad5b2fa317b352/parser/parsers/message/tradoor_trades.py
+
+WITH tradoor_pools AS (
+    SELECT pool_address, pool_name FROM (VALUES 
+    (upper('0:ff1338c9f6ed1fa4c264a19052bff64d10c8ad028628f52b2e0f4b357a12227e'), 'USDT-v2'),
+    (upper('0:0d36ba31cc15d776dd529b990872735972b0c4ceec77741f9ed3344e48e19084'), 'TON-v2'),
+    (upper('0:1b31de77fbf382b1023ad114d383e191506366d6e14af8c6264699081d3a2309'), 'USDT-v3')
+    ) AS T(pool_address, pool_name)
+),
+parsed_boc AS (
+    SELECT M.block_date, M.tx_hash, M.trace_id, M.tx_now, M.tx_lt, pool_address, pool_name, M.source as amm, body_boc
+    FROM {{ source('ton', 'messages') }} M
+    JOIN tradoor_pools ON M.source = pool_address
+    WHERE M.block_date > TIMESTAMP '2024-09-01'
+    {% if is_incremental() %}
+        AND {{ incremental_predicate('M.block_date') }}
+    {% endif %}
+    AND (opcode = 1197042366 or opcode = 592660044) -- position_increased or position_decreased
+    AND M.direction = 'out'
+    AND M.destination is null -- ext-out
+), parse_output as (
+select {{ ton_from_boc('body_boc', [
+    ton_begin_parse(),
+    ton_load_uint(32, 'opcode'),
+    ton_load_uint(64, 'trx_id'),
+    ton_load_uint(64, 'order_id'),
+    ton_load_uint(8, 'op_type'),
+    ton_load_uint(64, 'position_id'),
+    ton_load_address('trader_addr'),
+    ton_load_uint(16, 'token_id'),
+    ton_load_uint(1, 'is_long'),
+    ton_load_uint(128, 'margin_delta'),
+    ton_load_coins('margin_after'),
+    ton_load_uint(128, 'size_delta'),
+    ton_load_coins('size_after'),
+    ton_load_ref(),
+    ton_begin_parse(),
+    ton_load_uint(128, 'trade_price'),
+    ton_load_uint(128, 'entry_price')
+    ]) }} as result, * from parsed_boc
+)
+select block_date, tx_hash, trace_id, tx_now, tx_lt,
+pool_address, pool_name, case when result.opcode = 1197042366 then 1 else 0 end as is_increased, result.trx_id, result.order_id, result.op_type,
+result.position_id, result.trader_addr, result.token_id, result.is_long, result.margin_delta,
+result.margin_after, result.size_delta, result.size_after, result.trade_price, result.entry_price
+from parse_output

--- a/dbt_subprojects/daily_spellbook/models/tradoor/ton/tradoor_ton_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/tradoor/ton/tradoor_ton_schema.yml
@@ -1,0 +1,110 @@
+version: 2
+
+models:
+  - name: tradoor_ton_perp_order
+    meta:
+      blockchain: ton
+      sector: dex
+      contributors: pshuvalov
+    config:
+      tags: ['ton', 'tradoor', 'perpetual']
+    description: >
+      Tradoor Perp orders events
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - block_date
+            - op_type
+    columns:
+      - name: block_date
+        description: "block_date of the transaction"
+      - name: tx_hash
+        description: "transaction hash"
+      - name: trace_id
+        description: "trace id"
+      - name: tx_now
+        description: "transaction timestamp"
+      - name: tx_lt
+        description: "transaction logical time"
+      - name: pool_address
+        description: "pool address"
+      - name: pool_name
+        description: "pool name"
+      - name: trader_addr
+        description: "trader address"
+      - name: is_long
+        description: "is long"
+      - name: margin_delta
+        description: "margin delta"
+      - name: size_delta
+        description: "size delta"
+      - name: trigger_price
+        description: "trigger price"
+      - name: trigger_above
+        description: "trigger above"
+      - name: execution_fee
+        description: "execution fee"
+      - name: order_id
+        description: "order id"
+      - name: trx_id
+        description: "trx id"
+      - name: request_time
+        description: "request time"
+  - name: tradoor_ton_perp_position_change
+    meta:
+      blockchain: ton
+      sector: dex
+      contributors: pshuvalov
+    config:
+      tags: ['ton', 'tradoor', 'perpetual']
+    description: >
+      Tradoor Perp position change events
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - tx_hash
+            - block_date
+    columns:
+      - name: block_date
+        description: "block_date of the transaction"
+      - name: tx_hash
+        description: "transaction hash"
+      - name: trace_id
+        description: "trace id"
+      - name: tx_now
+        description: "transaction timestamp"
+      - name: tx_lt
+        description: "transaction logical time"
+      - name: pool_address
+        description: "pool address"
+      - name: pool_name
+        description: "pool name"
+      - name: is_increased
+        description: "is increased"
+      - name: trx_id
+        description: "trx id"
+      - name: order_id
+        description: "order id"
+      - name: op_type
+        description: "op type"
+      - name: position_id
+        description: "position id"
+      - name: trader_addr
+        description: "trader address"
+      - name: token_id
+        description: "token id"
+      - name: is_long
+        description: "is long"
+      - name: margin_delta
+        description: "margin delta"
+      - name: margin_after
+        description: "margin after"
+      - name: size_delta
+        description: "size delta"
+      - name: size_after
+        description: "size after"
+      - name: trade_price
+        description: "trade price"
+      - name: entry_price
+        description: "entry price"


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

This PR introduces decoding layer for [Tradoor](https://docs.tradoor.io/) perp DEX on TON. Two tables are populated: perp_orders (intents to open orders) and perp_position_change (orders execution) .

Monthly volume computed from the decoded tables are available here - https://dune.com/queries/5727971/9298068
the numbers are aligned with the volume data provided by the project itself to defillama - https://defillama.com/protocol/tradoor?tvl=false&perpVolume=true&groupBy=monthly


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
