### PR TITLE
Add Aethir (ATH) to ERC20 registry and Prices.USD

### DIFF
--- a/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_erc20.sql
+++ b/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_erc20.sql
@@ -15,7 +15,7 @@ FROM
 (
     VALUES
     -- placeholder rows to give example of format, tokens already exist in tokens.erc20
-    (0x01c0987e88f778df6640787226bc96354e1a9766, 'UAT', 18)
-    , (0x080eb7238031f97ff011e273d6cad5ad0c2de532, 'KIT', 18)
+    (0xbe0Ed4138121EcFC5c0E56B40517da27E6c5226B, 'ATH', 18)
 )
+
 AS temp_table (contract_address, symbol, decimals)


### PR DESCRIPTION
This PR adds Aethir to the ERC20 registry. Please link to prices.usd as well 

Contract: 0xbe0Ed4138121EcFC5c0E56B40517da27E6c5226B
Symbol: ATH
Decimals: 18
CoinGecko ID: https://www.coingecko.com/en/coins/aethir

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
