### PR TITLE
`nft.trades`: exclude rarible polygon due to dupes

### DIFF
--- a/dbt_subprojects/nft/models/_sector/trades/chains/polygon/nft_polygon_base_trades.sql
+++ b/dbt_subprojects/nft/models/_sector/trades/chains/polygon/nft_polygon_base_trades.sql
@@ -5,6 +5,7 @@
     )
 }}
 -- (project, project_version, model)
+--temp: exclude ,ref('rarible_polygon_base_trades') due to duplicates
 {% set nft_models = [
      ref('aavegotchi_polygon_base_trades')
     ,ref('aurem_polygon_base_trades')
@@ -13,7 +14,6 @@
     ,ref('element_polygon_base_trades')
     ,ref('fractal_polygon_base_trades')
     ,ref('opensea_v2_polygon_base_trades')
-    ,ref('rarible_polygon_base_trades')
     ,ref('tofu_polygon_base_trades')
     ,ref('magiceden_polygon_base_trades')
     ,ref('magiceden_v2_polygon_base_trades')

--- a/dbt_subprojects/nft/models/_sector/trades/chains/polygon/platforms/rarible_polygon_base_trades.sql
+++ b/dbt_subprojects/nft/models/_sector/trades/chains/polygon/platforms/rarible_polygon_base_trades.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'rarible_polygon',
     alias = 'base_trades',
     materialized = 'incremental',


### PR DESCRIPTION
```
16:17:27  Failure in model rarible_polygon_base_trades (models/_sector/trades/chains/polygon/platforms/rarible_polygon_base_trades.sql)
16:17:27
16:17:27    Database Error in model rarible_polygon_base_trades (models/_sector/trades/chains/polygon/platforms/rarible_polygon_base_trades.sql)
  TrinoUserError(type=USER_ERROR, name=MERGE_TARGET_ROW_MULTIPLE_MATCHES, message="One MERGE target table row matched more than one source row", query_id=20250921_160846_01421_8k8av)
  compiled code at [target/run/nft/models/_sector/trades/chains/polygon/platforms/rarible_polygon_base_trades.sql](https://nd058.us1.dbt.com/api/v2/accounts/58579/runs/70471846547561/artifacts/run/nft/models/_sector/trades/chains/polygon/platforms/rarible_polygon_base_trades.sql)
```