### PR TITLE
add borrow balances to fluid liquidity

### DIFF
--- a/dbt_subprojects/dex/models/_projects/fluid/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/fluid/_schema.yml
@@ -88,6 +88,59 @@ models:
             - version
             - dex
             - block_date
+    columns:
+      - *blockchain
+      - *project
+      - *version
+      - *dex
+      - &token0
+        name: token0
+        description: "Token0 is the Dex's Supply Token"
+      - &token1
+        name: token1
+        description: "Token1 is the Dex's Borrow Token"
+      - &token0_symbol
+        name: token0_symbol
+        description: "Token0 Symbol"
+      - &token1_symbol
+        name: token1_symbol
+        description: "Token1 Symbol"
+      - &token0_balance_raw
+        name: token0_balance_raw
+        description: "Smart collateral deposited in the dex (Supply Token)"
+      - &token1_balance_raw
+        name: token1_balance_raw
+        description: "Smart collateral deposited in the dex (Debt Token)"
+      - &token0_balance
+        name: token0_balance
+        description: "Smart collateral enriched with decimals deposited in the dex (Supply Token)"
+      - &token1_balance
+        name: token1_balance
+        description: "Smart collateral enriched with decimals deposited in the dex (Debt Token)"
+      - &token0_balance_usd
+        name: token0_balance_usd
+        description: "Smart collateral value in USD deposited in the dex (Supply Token)"
+      - &token1_balance_usd
+        name: token1_balance_usd
+        description: "Smart collateral value in USD deposited in the dex (Debt Token)"
+      - &borrow_token0_balance_raw
+        name: borrow_token0_balance_raw
+        description: "Smart debt deposited in the dex (Supply Token)"
+      - &borrow_token1_balance_raw
+        name: borrow_token1_balance_raw
+        description: "Smart debt deposited in the dex (Debt Token)"
+      - &borrow_token0_balance
+        name: borrow_token0_balance
+        description: "Smart debt enriched with decimals deposited in the dex (Supply Token)"
+      - &borrow_token1_balance
+        name: borrow_token1_balance
+        description: "Smart debt enriched with decimals deposited in the dex (Debt Token)"
+      - &borrow_token0_balance_usd
+        name: borrow_token0_balance_usd
+        description: "Smart debt value in USD deposited in the dex (Supply Token)"
+      - &borrow_token1_balance_usd
+        name: borrow_token1_balance_usd
+        description: "Smart debt value in USD deposited in the dex (Debt Token)"
 
   - name: fluid_tvl_daily
     meta:
@@ -96,3 +149,24 @@ models:
       contributors: Henrystats, dknugo
     config:
       tags: [ 'dex' ]
+    columns:
+      - *blockchain
+      - *project
+      - *version
+      - *dex
+      - *token0
+      - *token1
+      - *token0_symbol
+      - *token1_symbol
+      - *token0_balance_raw
+      - *token1_balance_raw
+      - *token0_balance
+      - *token1_balance
+      - *token0_balance_usd
+      - *token1_balance_usd
+      - *borrow_token0_balance_raw
+      - *borrow_token1_balance_raw
+      - *borrow_token0_balance
+      - *borrow_token1_balance
+      - *borrow_token0_balance_usd
+      - *borrow_token1_balance_usd

--- a/dbt_subprojects/dex/models/_projects/fluid/fluid_base_tvl_daily.sql
+++ b/dbt_subprojects/dex/models/_projects/fluid/fluid_base_tvl_daily.sql
@@ -37,6 +37,12 @@ daily_events as (
         , amount1
         , amount0_price 
         , amount1_price 
+        , borrow_amount0_raw 
+        , borrow_amount1_raw 
+        , borrow_amount0 
+        , borrow_amount1
+        , borrow_amount0_price 
+        , borrow_amount1_price 
     from 
     {{ ref('fluid_daily_agg_liquidity_events') }}
     where {{ incremental_predicate('block_date') }}
@@ -68,6 +74,12 @@ tvl_min_daily as (
         , amount1
         , amount0_price 
         , amount1_price 
+        , borrow_amount0_raw 
+        , borrow_amount1_raw 
+        , borrow_amount0 
+        , borrow_amount1
+        , borrow_amount0_price 
+        , borrow_amount1_price 
     from 
     {{this}}
     where block_date = (select block_date - interval '1' day from min_daily) -- use last day before incremental
@@ -98,6 +110,12 @@ daily_cum as (
         , sum(amount1) over (partition by blockchain, project, version, dex order by block_date asc) as token1_balance_tmp
         , max(amount0_price) over (partition by blockchain, project, version, dex order by block_date asc) as amount0_price_tmp
         , max(amount1_price) over (partition by blockchain, project, version, dex order by block_date asc) as amount1_price_tmp
+        , sum(borrow_amount0_raw) over (partition by blockchain, project, version, dex order by block_date asc) as borrow_token0_balance_raw_tmp
+        , sum(borrow_amount1_raw) over (partition by blockchain, project, version, dex order by block_date asc) as borrow_token1_balance_raw_tmp
+        , sum(borrow_amount0) over (partition by blockchain, project, version, dex order by block_date asc) as borrow_token0_balance_tmp
+        , sum(borrow_amount1) over (partition by blockchain, project, version, dex order by block_date asc) as borrow_token1_balance_tmp
+        , max(borrow_amount0_price) over (partition by blockchain, project, version, dex order by block_date asc) as borrow_amount0_price_tmp
+        , max(borrow_amount1_price) over (partition by blockchain, project, version, dex order by block_date asc) as borrow_amount1_price_tmp 
         , lead(block_date, 1, current_timestamp) over (partition by blockchain, project, version, dex order by block_date asc) as next_day
     from 
     daily_events_final 
@@ -132,6 +150,16 @@ tvl_daily as (
         , token1_balance_tmp * (amount1_price_tmp /1e12) as token1_balance
         , amount0_price
         , amount1_price
+        , borrow_token0_balance_raw_tmp as borrow_amount0_raw
+        , borrow_token1_balance_raw_tmp as borrow_amount1_raw
+        , borrow_token0_balance_raw_tmp * (borrow_amount0_price_tmp /1e12) as borrow_token0_balance_raw 
+        , borrow_token1_balance_raw_tmp * (borrow_amount1_price_tmp /1e12) as borrow_token1_balance_raw 
+        , borrow_token0_balance_tmp as borrow_amount0
+        , borrow_token1_balance_tmp as borrow_amount1
+        , borrow_token0_balance_tmp * (borrow_amount0_price_tmp /1e12) as borrow_token0_balance
+        , borrow_token1_balance_tmp * (borrow_amount1_price_tmp /1e12) as borrow_token1_balance
+        , borrow_amount0_price
+        , borrow_amount1_price 
         , case 
             when c.block_date = d.day then check_filter
             else 'include'
@@ -192,6 +220,18 @@ prices_day as (
         , amount1 
         , amount0_price 
         , amount1_price
+        , borrow_token0_balance_raw 
+        , borrow_token1_balance_raw 
+        , borrow_token0_balance
+        , borrow_token1_balance
+        , borrow_token0_balance * coalesce(pa.price, pd_a.price) as borrow_token0_balance_usd
+        , borrow_token1_balance * coalesce(pb.price, pd_b.price) as borrow_token1_balance_usd
+        , borrow_amount0_raw
+        , borrow_amount1_raw 
+        , borrow_amount0
+        , borrow_amount1 
+        , borrow_amount0_price 
+        , borrow_amount1_price
     from 
     tvl_daily tl 
     left join 

--- a/dbt_subprojects/dex/models/_projects/fluid/fluid_daily_agg_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/fluid/fluid_daily_agg_liquidity_events.sql
@@ -39,6 +39,12 @@ select
     , sum(case when fp.borrow_token = ep.token_address then ep.supply_amount_raw else 0 end) as amount1_raw 
     , sum(case when fp.borrow_token = ep.token_address then ep.supply_amount_raw / pow(10, fp.borrow_token_decimals) else 0 end) as amount1
     , max(case when fp.borrow_token = ep.token_address then ep.supply_exchange_price else 0 end) as amount1_price
+    , sum(case when fp.supply_token = ep.token_address then ep.borrow_amount_raw else 0 end) as borrow_amount0_raw 
+    , sum(case when fp.supply_token = ep.token_address then ep.borrow_amount_raw / pow(10, fp.supply_token_decimals) else 0 end) as borrow_amount0
+    , max(case when fp.supply_token = ep.token_address then ep.borrow_exchange_price else 0 end) as borrow_amount0_price
+    , sum(case when fp.borrow_token = ep.token_address then ep.borrow_amount_raw else 0 end) as borrow_amount1_raw 
+    , sum(case when fp.borrow_token = ep.token_address then ep.borrow_amount_raw / pow(10, fp.borrow_token_decimals) else 0 end) as borrow_amount1
+    , max(case when fp.borrow_token = ep.token_address then ep.borrow_exchange_price else 0 end) as borrow_amount1_price
 from 
 enrich_prices ep 
 inner join 

--- a/dbt_subprojects/dex/models/_projects/fluid/fluid_tvl_daily.sql
+++ b/dbt_subprojects/dex/models/_projects/fluid/fluid_tvl_daily.sql
@@ -25,6 +25,12 @@
         , token1_balance
         , token0_balance_usd
         , token1_balance_usd
+        , borrow_token0_balance_raw 
+        , borrow_token1_balance_raw 
+        , borrow_token0_balance
+        , borrow_token1_balance
+        , borrow_token0_balance_usd
+        , borrow_token1_balance_usd
     from 
     {{ ref('fluid_base_tvl_daily') }}
     -- we need a couple of columns from the final incremental table to be able to refresh the table incrementally

--- a/dbt_subprojects/dex/models/_projects/fluid/fluid_tvl_daily.sql
+++ b/dbt_subprojects/dex/models/_projects/fluid/fluid_tvl_daily.sql
@@ -37,3 +37,4 @@
     -- these columns can be confusing if displayed on dune 
     -- hence why we build a seperate table thay isn't materialized 
     -- this table selects just the relevant columns 
+    -- force refresh


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add and propagate borrow balance metrics (raw, normalized, USD) across Fluid daily agg and TVL models, and document them in schema.
> 
> - **Models (Fluid DEX TVL)**:
>   - `fluid_daily_agg_liquidity_events`: Adds borrow metrics (`borrow_amount0_raw/amount/price`, `borrow_amount1_raw/amount/price`).
>   - `fluid_base_tvl_daily`:
>     - Propagates borrow metrics; computes cumulative borrow balances (`borrow_token0/1_balance[_raw]`) and corresponding USD values.
>     - Integrates borrow prices into window calcs and final outputs (incremental and full paths).
>   - `fluid_tvl_daily`: Exposes new borrow balance fields and USD values from `fluid_base_tvl_daily`.
> - **Schema**:
>   - `_schema.yml`: Documents new columns (token metadata, supply/borrow balances and USD) and references them for `fluid_tvl_daily`; minor tag normalization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 035cdf77b8ffec966ee8deddb8f472f633e24ad8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->