### PR TITLE
Expose gas Solana spell

### DIFF
--- a/dbt_subprojects/solana/models/_sector/gas/gas_solana_tx_fees.sql
+++ b/dbt_subprojects/solana/models/_sector/gas/gas_solana_tx_fees.sql
@@ -2,6 +2,10 @@
     schema = 'gas_solana',
     alias = 'tx_fees',
     materialized = 'view'
+    post_hook='{{ expose_spells(\'["solana"]\',
+                                    "sector",
+                                    "gas",
+                                    \'["0xBoxer"]\') }}'
     )
 }}
 


### PR DESCRIPTION
This PR exposes the Solana gas spell by updating the relevant model(s).

- Scope: 
- Motivation: make Solana gas fees available in spellbook
- Changes: minor edits (4 insertions)

Please review and merge.