### PR TITLE
Add SuperoETHb Price on Base

### DIFF
--- a/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
@@ -240,6 +240,6 @@ FROM
     ('hyper-hyperlane', 'base', 'HYPER',0xc9d23ed2adb0f551369946bd377f8644ce1ca5c4, 18),
     ('zora-zora', 'base', 'ZORA',0x1111111111166b7FE7bd91427724B487980aFc69, 18),
     ('towns-towns', 'base', 'TOWNS', 0x00000000A22C618fd6b4D7E9A335C4B96B189a38, 18),
-    ('superoeth-super-oeth', 'base', 'superOETHb', 0xDBFeFD2e8460a6Ee4955A68582F85708BAEA60A3, 18)
+    ('superoeth-super-oeth', 'base', 'SUPEROETH', 0xDBFeFD2e8460a6Ee4955A68582F85708BAEA60A3, 18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)
 -- refresh 

--- a/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
@@ -242,4 +242,3 @@ FROM
     ('towns-towns', 'base', 'TOWNS', 0x00000000A22C618fd6b4D7E9A335C4B96B189a38, 18),
     ('superoeth-super-oeth', 'base', 'superOETHb', 0xDBFeFD2e8460a6Ee4955A68582F85708BAEA60A3, 18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)
--- refresh 

--- a/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
@@ -242,3 +242,4 @@ FROM
     ('towns-towns', 'base', 'TOWNS', 0x00000000A22C618fd6b4D7E9A335C4B96B189a38, 18),
     ('superoeth-super-oeth', 'base', 'superOETHb', 0xDBFeFD2e8460a6Ee4955A68582F85708BAEA60A3, 18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)
+-- refresh 

--- a/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
@@ -239,5 +239,6 @@ FROM
     ('sign-sign2', 'base', 'SIGN',0x868fced65edbf0056c4163515dd840e9f287a4c3, 18),
     ('hyper-hyperlane', 'base', 'HYPER',0xc9d23ed2adb0f551369946bd377f8644ce1ca5c4, 18),
     ('zora-zora', 'base', 'ZORA',0x1111111111166b7FE7bd91427724B487980aFc69, 18),
-    ('towns-towns', 'base', 'TOWNS', 0x00000000A22C618fd6b4D7E9A335C4B96B189a38, 18)
+    ('towns-towns', 'base', 'TOWNS', 0x00000000A22C618fd6b4D7E9A335C4B96B189a38, 18),
+    ('superoeth-super-oeth', 'base', 'superOETHb', 0xDBFeFD2e8460a6Ee4955A68582F85708BAEA60A3, 18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
@@ -240,6 +240,6 @@ FROM
     ('hyper-hyperlane', 'base', 'HYPER',0xc9d23ed2adb0f551369946bd377f8644ce1ca5c4, 18),
     ('zora-zora', 'base', 'ZORA',0x1111111111166b7FE7bd91427724B487980aFc69, 18),
     ('towns-towns', 'base', 'TOWNS', 0x00000000A22C618fd6b4D7E9A335C4B96B189a38, 18),
-    ('superoeth-super-oeth', 'base', 'SUPEROETH', 0xDBFeFD2e8460a6Ee4955A68582F85708BAEA60A3, 18)
+    ('superoeth-super-oeth', 'base', 'superOETHb', 0xDBFeFD2e8460a6Ee4955A68582F85708BAEA60A3, 18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)
 -- refresh 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `superOETHb` (token_id `superoeth-super-oeth`) to Base token price mapping.
> 
> - **Tokens/Prices (Base)**: Add `superOETHb` (`superoeth-super-oeth`, 18 decimals) with contract `0xDBFeFD2e8460a6Ee4955A68582F85708BAEA60A3` in `dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 449ce46d5c5a2cb91a3f6dcb29c7be6dd04b65ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->