### PR TITLE
`prices.tokens`: ensure fungible doesn't contain native address

### DIFF
--- a/dbt_subprojects/tokens/models/prices/_schema.yml
+++ b/dbt_subprojects/tokens/models/prices/_schema.yml
@@ -47,6 +47,11 @@ models:
     config:
       tags: ['prices', 'tokens', 'usd']
     description: "Price tokens list mapping CoinPaprika API Ids to token metadata"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - blockchain
+            - contract_address
     columns:
       - &token_id
         name: token_id

--- a/dbt_subprojects/tokens/models/prices/prices_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_tokens.sql
@@ -75,6 +75,7 @@ with fungible_tokens as (
             , symbol
             , decimals
         from {{ model }}
+        where contract_address is distinct from 0x0000000000000000000000000000000000000000
         {% if not loop.last -%}
         union all
         {% endif -%}


### PR DESCRIPTION
due to optimism having dynamic addresses, the `0x00..` address appears. we need to filter this out. will continue to use the old is distinct from approach.