### PR TITLE
fix schema

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/base/platforms/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/base/platforms/_schema.yml
@@ -48,40 +48,19 @@ models:
             - source('celer_base','bridge_evt_send')
   - name: bridges_base_celer_v1_withdrawals
     meta:
-      blockchain: celer
+      blockchain: base
       sector: bridges
       project: celer
       contributors: [ 'hildobby']
     config:
-      tags: [ 'celer', 'bridges', 'flows', 'withdrawals' ]
+      tags: [ 'base', 'bridges', 'flows', 'withdrawals' ]
     description: "Celer v1 bridge withdrawals events on Base"
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns: ['tx_hash','evt_index']
       - equal_rowcount_with_sources:
           evt_sources:
-            - source('celer_base','bridge_evt_relay')
-    columns:
-      - *deposit_chain
-      - *withdraw_chain
-      - *bridge_name
-      - *bridge_version
-      - *deposit_amount_raw
-      - *deposit_token_address
-      - *block_date
-      - *block_time
-      - *block_number
-      - *withdrawal_amount_raw 
-      - *sender
-      - *recipient
-      - *deposit_token_standard
-      - *withdrawal_token_standard
-      - *withdrawal_token_address
-      - *tx_from
-      - *tx_hash
-      - *evt_index  
-      - *contract_address 
-      - *bridge_transfer_id 
+            - source('celer_base','bridge_evt_relay') 
   - name: bridges_base_across_v2_deposits
     meta:
       blockchain: base


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `bridges_base_celer_v1_withdrawals` schema by setting blockchain/tags to `base` and removing the explicit `columns` block.
> 
> - **Bridges schema (Base/Celer)** in `dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/base/platforms/_schema.yml`:
>   - Update `bridges_base_celer_v1_withdrawals`:
>     - Set `meta.blockchain` to `base`.
>     - Change `config.tags` from `celer` to `base`.
>     - Remove explicit `columns` definitions (relies on model defaults).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f61921b2f6352db944187a84455ad9295d505536. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->