### PR TITLE
fix bridge withdrawals typo

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/bridges_ethereum_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/bridges_ethereum_withdrawals.sql
@@ -2,7 +2,7 @@
 
 {{ config(
     schema = 'bridges_' + blockchain,
-    alias = 'witdrawals',
+    alias = 'withdrawals',
     materialized = 'view'
     )
 }}


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects view alias from `witdrawals` to `withdrawals` in `bridges/_sector/flows/chains/ethereum/bridges_ethereum_withdrawals.sql`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d932b4e450eabac4a4c0cf198e71b3f85617895a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->