### PR TITLE
Fix bridge withdrawals

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/bridges_ethereum_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/bridges_ethereum_withdrawals.sql
@@ -2,7 +2,7 @@
 
 {{ config(
     schema = 'bridges_' + blockchain,
-    alias = 'witdrawals',
+    alias = 'withdrawals',
     materialized = 'view'
     )
 }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_withdrawals.sql
@@ -41,6 +41,9 @@ FROM (
         , contract_address
         , bridge_transfer_id
         FROM {{ ref('bridges_'~chain~'_withdrawals') }}
+        {% if is_incremental() %}
+        WHERE  {{ incremental_predicate('block_time') }}
+        {% endif %}
         {% if not loop.last %}
         UNION ALL
         {% endif %}


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the Ethereum withdrawals view alias and adds an incremental block_time filter to EVMS withdrawals union for incremental runs.
> 
> - **Bridges (Ethereum)**:
>   - Correct alias to `withdrawals` in `bridges_ethereum_withdrawals.sql`.
> - **Bridges (EVMS)**:
>   - Add incremental `WHERE` filter using `incremental_predicate('block_time')` when selecting from per-chain `..._withdrawals` in `bridges_evms_withdrawals.sql` to scope incremental runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2b37617c8089f7d7431b18b7c30fa549a4c1aed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->