### PR TITLE
prod exclude failing bridge models

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/bridges_crosschain_flows.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/bridges_crosschain_flows.sql
@@ -1,7 +1,8 @@
 {{ config(
     schema = 'bridges_crosschain',
     alias = 'flows',
-    materialized = 'view'
+    materialized = 'view',
+    tags = ['prod_exclude']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/bridges_crosschain_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/bridges_crosschain_withdrawals.sql
@@ -2,6 +2,7 @@
     schema = 'bridges_crosschain'
     , alias = 'withdrawals'
     , materialized = 'view'
+    , tags = ['prod_exclude']
 )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_flows.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_flows.sql
@@ -2,6 +2,7 @@
     schema = 'bridges_evms'
     , alias = 'flows'
     , materialized = 'view'
+    , tags = ['prod_exclude']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_withdrawals.sql
@@ -6,6 +6,7 @@
     , incremental_strategy='merge'
     , unique_key = ['deposit_chain','withdrawal_chain','bridge_name','bridge_version','bridge_transfer_id']
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    , tags = ['prod_exclude']
 )
 }}
 


### PR DESCRIPTION
@hildobby These models are failing in production with the following error.
Please debug this using CI and open a PR to resolve.

```
Error Information
Error Type | INTERNAL_ERROR
Error Code | GENERIC_INTERNAL_ERROR (65536)

Stack Trace
java.lang.IllegalArgumentException: No catalog handle for partitioning handle: SINGLE
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:220)
	at io.trino.execution.scheduler.PipelinedQueryScheduler$DistributedStagesScheduler.createStageScheduler(PipelinedQueryScheduler.java:1144)
	at io.trino.execution.scheduler.PipelinedQueryScheduler$DistributedStagesScheduler.create(PipelinedQueryScheduler.java:924)
	at io.trino.execution.scheduler.PipelinedQueryScheduler.createDistributedStagesScheduler(PipelinedQueryScheduler.java:320)
	at io.trino.execution.scheduler.PipelinedQueryScheduler.start(PipelinedQueryScheduler.java:303)
	at io.trino.execution.SqlQueryExecution.start(SqlQueryExecution.java:442)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:272)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:150)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$2(LocalDispatchQuery.java:134)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$12(MoreFutures.java:570)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:545)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1137)
	at io.trino.$gen.Trino_453_45_g7c73bf1____20250929_095336_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)
```


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit ced95283e51d4c9b09e73cb47d6ecbc3381c5d34. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->