### PR TITLE
Add `PSOL` (Phantom Staked SOL) and `BLESS` to Solana prices list

### DIFF
--- a/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
@@ -777,6 +777,6 @@ FROM
         ('codec-codec-flow', 'solana', 'CODEC', '69LjZUUzxj3Cb3Fxeo1X4QpYEQTboApkhXTysPpbpump', 6),
         ('aura-auraonsol', 'solana', 'AURA', 'DtR4D9FtVoTX2569gaL837ZgrB6wNjj6tkmnX9Rdk9B2', 6),
         ('psol-phantom-staked-sol', 'solana', 'PSOL', 'pSo1f9nQXWgXibFtKf7NWYxb5enAM4qfP6UJSiXRQfL', 9),
-        ('bless-bless', 'solana', 'BLESS', 'DtR4D9FtVoTX2569gaL837ZgrB6wNjj6tkmnX9Rdk9B2', 9),
+        ('bless-bless', 'solana', 'BLESS', 'A1t2UviBYwyfYZDJyKY2W6Td8ritgsCriUDuNaAQN49S', 9),
         ('wct-walletconnect-token', 'solana', 'WCT', 'WCTk5xWdn5SYg56twGj32sUF3W4WFQ48ogezLBuYTBY', 9)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)


### PR DESCRIPTION
### Description:
Hi! Adds two Solana tokens to the prices lookup used by the token_price model:
- PSOL — https://coinpaprika.com/coin/psol-phantom-staked-sol/
- BLESS — https://coinpaprika.com/coin/bless-bless/