### PR TITLE
Aptos stablecoin transfers

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_metadata.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_metadata.sql
@@ -1,11 +1,3 @@
--- `fungible_asset_metadata` from indexer is a current table, this table has historical
--- for FA, the 3 resources are grouped under the same state key (fungible_asset::Metadata, fungible_asset::ConcurrentSupply, object::ObjectCore)
--- so will be emitted together (parse without new lookup)
--- edge cases
--- indexer table removes assets when LENGTH(asset_type) > 1_000 Ex 521538257
--- asset_name can be unicode: Ex 321165430
--- creator_address is the asset address for v1 and owner for v2 (can change for v2)
--- creator_address is not needed for coins/fa, it's a holdover from tokens (where it is used as key with name)
 {{ config(
     schema = 'aptos_fungible_asset',
     alias = 'metadata',
@@ -20,6 +12,15 @@
         spell_name = "fungible_asset",
         contributors = \'["ying-w"]\') }}'
 ) }}
+
+-- `fungible_asset_metadata` from indexer is a current table, this table has historical
+-- for FA, the 3 resources are grouped under the same state key hash (fungible_asset::Metadata, fungible_asset::ConcurrentSupply, object::ObjectCore)
+-- so will be emitted together (parse without new lookup)
+-- edge cases:
+-- indexer table removes assets when LENGTH(asset_type) > 1_000 Ex 521538257
+-- asset_name can be unicode: Ex 321165430
+-- creator_address is the asset address for v1 and owner for v2 (can change for v2)
+-- creator_address is not needed for coins/fa, it's a holdover from tokens (where it is used as key with name)
 
 WITH mr_fa_metadata AS (
     SELECT

--- a/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_metadata.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_metadata.sql
@@ -15,6 +15,10 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     unique_key = ['block_month', 'tx_hash', 'asset_type'],
     partition_by = ['block_month'],
+    post_hook='{{ expose_spells(blockchains = \'["aptos"]\',
+        spell_type = "project",
+        spell_name = "fungible_asset",
+        contributors = \'["ying-w"]\') }}'
 ) }}
 
 WITH mr_fa_metadata AS (

--- a/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_metadata_current.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_metadata_current.sql
@@ -1,7 +1,11 @@
 {{ config(
     schema = 'aptos_fungible_asset',
     alias = 'metadata_current',
-    materialized = 'view'
+    materialized = 'view',
+    post_hook='{{ expose_spells(blockchains = \'["aptos"]\',
+        spell_type = "project",
+        spell_name = "fungible_asset",
+        contributors = \'["ying-w"]\') }}'
 ) }}
 
 WITH latest_metadata AS (

--- a/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_migration.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_migration.sql
@@ -5,12 +5,12 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['asset_type_v2'],
-    post_hook='{{ expose_spells(blockchains = \'["aptos"]\',
-        spell_type = "project",
-        spell_name = "fungible_asset",
-        contributors = \'["ying-w"]\') }}'
 ) }}
 
+-- coin to FA mapping is a deterministic lookup using SHA3
+-- however, SHA3 is not implemented in SQL so instead lookup using resource
+-- For pythno code using SHA3, see 'Finding migrated fungible assets' section of
+-- https://medium.com/aptoslabs/data-analyst-guide-to-aptos-defi-swaps-pt2-e343ac6be84e 
 SELECT
     -- latest
     tx_version,

--- a/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_migration.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/aptos_fungible_asset_migration.sql
@@ -5,6 +5,10 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['asset_type_v2'],
+    post_hook='{{ expose_spells(blockchains = \'["aptos"]\',
+        spell_type = "project",
+        spell_name = "fungible_asset",
+        contributors = \'["ying-w"]\') }}'
 ) }}
 
 SELECT


### PR DESCRIPTION
### Description:

For Aptos, you can have 1:many transfers and many:many transfers

An example of 1:many could be a defi swap and the money coming out being split between

- the account doing the swap (most of the money)
- the LP pool for the swap (fee)
- treasury for LP platform (fee)

An example of many:many occur when defi aggregators move money between different defi pools without using an intermediate accout to consolidate

- pool1 has 30 usd withdraw
- pool2 has 20 usd withdraw
- pool3 has 25 usd deposit
- pool4 has 25 usd deposit

Explained in more detail here: https://medium.com/aptoslabs/data-analyst-guide-to-aptos-supply-and-volume-pt-3-535e312946ad

This creates 4 new tables (2 staging) to track stablecoins and represent transfers as 1:1