### PR TITLE
test run sui lending

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/sui/tvl/lending/sui_tvl_lending_pools_suilend_bronze.sql
+++ b/dbt_subprojects/daily_spellbook/models/sui/tvl/lending/sui_tvl_lending_pools_suilend_bronze.sql
@@ -12,7 +12,7 @@
 
 -- Suilend lending pools for TVL calculation (Bronze Layer)
 
-{% set sui_project_start_date = var('sui_project_start_date', '2024-02-01') %}
+{% set sui_project_start_date = var('sui_project_start_date', '2025-09-28') %}
 
 with suilend_raw as (
     -- Suilend raw objects for array processing

--- a/dbt_subprojects/daily_spellbook/models/sui/tvl/lending/sui_tvl_lending_pools_suilend_bronze.sql
+++ b/dbt_subprojects/daily_spellbook/models/sui/tvl/lending/sui_tvl_lending_pools_suilend_bronze.sql
@@ -12,7 +12,7 @@
 
 -- Suilend lending pools for TVL calculation (Bronze Layer)
 
-{% set sui_project_start_date = var('sui_project_start_date', '2025-09-28') %}
+{% set sui_project_start_date = var('sui_project_start_date', '2024-02-01') %}
 
 with suilend_raw as (
     -- Suilend raw objects for array processing

--- a/dbt_subprojects/daily_spellbook/models/sui/tvl/lending/sui_tvl_lending_pools_suilend_bronze.sql
+++ b/dbt_subprojects/daily_spellbook/models/sui/tvl/lending/sui_tvl_lending_pools_suilend_bronze.sql
@@ -154,6 +154,246 @@ with suilend_raw as (
         , checkpoint
     from suilend_raw
     where json_extract_scalar(object_json, '$.reserves[4].id.id') is not null
+    
+    union all
+    
+    -- Extract reserves[5]
+    select
+        timestamp_ms
+        , block_time
+        , block_date
+        , block_month
+        , date_hour
+        , protocol
+        , json_extract_scalar(object_json, '$.reserves[5].id.id') as market_id
+        , case 
+            when starts_with(json_extract_scalar(object_json, '$.reserves[5].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[5].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[5].coin_type.name'))
+        end as coin_type
+        , cast(json_extract_scalar(object_json, '$.reserves[5].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[5].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , object_id
+        , version
+        , checkpoint
+    from suilend_raw
+    where json_extract_scalar(object_json, '$.reserves[5].id.id') is not null
+    
+    union all
+    
+    -- Extract reserves[6]
+    select
+        timestamp_ms
+        , block_time
+        , block_date
+        , block_month
+        , date_hour
+        , protocol
+        , json_extract_scalar(object_json, '$.reserves[6].id.id') as market_id
+        , case 
+            when starts_with(json_extract_scalar(object_json, '$.reserves[6].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[6].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[6].coin_type.name'))
+        end as coin_type
+        , cast(json_extract_scalar(object_json, '$.reserves[6].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[6].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , object_id
+        , version
+        , checkpoint
+    from suilend_raw
+    where json_extract_scalar(object_json, '$.reserves[6].id.id') is not null
+    
+    union all
+    
+    -- Extract reserves[7]
+    select
+        timestamp_ms
+        , block_time
+        , block_date
+        , block_month
+        , date_hour
+        , protocol
+        , json_extract_scalar(object_json, '$.reserves[7].id.id') as market_id
+        , case 
+            when starts_with(json_extract_scalar(object_json, '$.reserves[7].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[7].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[7].coin_type.name'))
+        end as coin_type
+        , cast(json_extract_scalar(object_json, '$.reserves[7].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[7].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , object_id
+        , version
+        , checkpoint
+    from suilend_raw
+    where json_extract_scalar(object_json, '$.reserves[7].id.id') is not null
+    
+    union all
+    
+    -- Extract reserves[8]
+    select
+        timestamp_ms
+        , block_time
+        , block_date
+        , block_month
+        , date_hour
+        , protocol
+        , json_extract_scalar(object_json, '$.reserves[8].id.id') as market_id
+        , case 
+            when starts_with(json_extract_scalar(object_json, '$.reserves[8].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[8].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[8].coin_type.name'))
+        end as coin_type
+        , cast(json_extract_scalar(object_json, '$.reserves[8].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[8].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , object_id
+        , version
+        , checkpoint
+    from suilend_raw
+    where json_extract_scalar(object_json, '$.reserves[8].id.id') is not null
+    
+    union all
+    
+    -- Extract reserves[9]
+    select
+        timestamp_ms
+        , block_time
+        , block_date
+        , block_month
+        , date_hour
+        , protocol
+        , json_extract_scalar(object_json, '$.reserves[9].id.id') as market_id
+        , case 
+            when starts_with(json_extract_scalar(object_json, '$.reserves[9].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[9].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[9].coin_type.name'))
+        end as coin_type
+        , cast(json_extract_scalar(object_json, '$.reserves[9].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[9].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , object_id
+        , version
+        , checkpoint
+    from suilend_raw
+    where json_extract_scalar(object_json, '$.reserves[9].id.id') is not null
+    
+    union all
+    
+    -- Extract reserves[10]
+    select
+        timestamp_ms
+        , block_time
+        , block_date
+        , block_month
+        , date_hour
+        , protocol
+        , json_extract_scalar(object_json, '$.reserves[10].id.id') as market_id
+        , case 
+            when starts_with(json_extract_scalar(object_json, '$.reserves[10].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[10].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[10].coin_type.name'))
+        end as coin_type
+        , cast(json_extract_scalar(object_json, '$.reserves[10].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[10].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , object_id
+        , version
+        , checkpoint
+    from suilend_raw
+    where json_extract_scalar(object_json, '$.reserves[10].id.id') is not null
+    
+    union all
+    
+    -- Extract reserves[11]
+    select
+        timestamp_ms
+        , block_time
+        , block_date
+        , block_month
+        , date_hour
+        , protocol
+        , json_extract_scalar(object_json, '$.reserves[11].id.id') as market_id
+        , case 
+            when starts_with(json_extract_scalar(object_json, '$.reserves[11].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[11].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[11].coin_type.name'))
+        end as coin_type
+        , cast(json_extract_scalar(object_json, '$.reserves[11].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[11].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , object_id
+        , version
+        , checkpoint
+    from suilend_raw
+    where json_extract_scalar(object_json, '$.reserves[11].id.id') is not null
+    
+    union all
+    
+    -- Extract reserves[12]
+    select
+        timestamp_ms
+        , block_time
+        , block_date
+        , block_month
+        , date_hour
+        , protocol
+        , json_extract_scalar(object_json, '$.reserves[12].id.id') as market_id
+        , case 
+            when starts_with(json_extract_scalar(object_json, '$.reserves[12].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[12].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[12].coin_type.name'))
+        end as coin_type
+        , cast(json_extract_scalar(object_json, '$.reserves[12].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[12].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , object_id
+        , version
+        , checkpoint
+    from suilend_raw
+    where json_extract_scalar(object_json, '$.reserves[12].id.id') is not null
+    
+    union all
+    
+    -- Extract reserves[13]
+    select
+        timestamp_ms
+        , block_time
+        , block_date
+        , block_month
+        , date_hour
+        , protocol
+        , json_extract_scalar(object_json, '$.reserves[13].id.id') as market_id
+        , case 
+            when starts_with(json_extract_scalar(object_json, '$.reserves[13].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[13].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[13].coin_type.name'))
+        end as coin_type
+        , cast(json_extract_scalar(object_json, '$.reserves[13].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[13].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , object_id
+        , version
+        , checkpoint
+    from suilend_raw
+    where json_extract_scalar(object_json, '$.reserves[13].id.id') is not null
+    
+    union all
+    
+    -- Extract reserves[14]
+    select
+        timestamp_ms
+        , block_time
+        , block_date
+        , block_month
+        , date_hour
+        , protocol
+        , json_extract_scalar(object_json, '$.reserves[14].id.id') as market_id
+        , case 
+            when starts_with(json_extract_scalar(object_json, '$.reserves[14].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[14].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[14].coin_type.name'))
+        end as coin_type
+        , cast(json_extract_scalar(object_json, '$.reserves[14].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[14].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , object_id
+        , version
+        , checkpoint
+    from suilend_raw
+    where json_extract_scalar(object_json, '$.reserves[14].id.id') is not null
 )
 
 select 
@@ -170,4 +410,4 @@ select
     , object_id
     , version
     , checkpoint 
-from suilend_base 
+from suilend_base

--- a/dbt_subprojects/daily_spellbook/models/sui/tvl/lending/sui_tvl_lending_pools_suilend_bronze.sql
+++ b/dbt_subprojects/daily_spellbook/models/sui/tvl/lending/sui_tvl_lending_pools_suilend_bronze.sql
@@ -157,7 +157,7 @@ with suilend_raw as (
     
     union all
     
-    -- Extract reserves[5]
+    -- Extract reserves[21] - BTC token
     select
         timestamp_ms
         , block_time
@@ -165,23 +165,23 @@ with suilend_raw as (
         , block_month
         , date_hour
         , protocol
-        , json_extract_scalar(object_json, '$.reserves[5].id.id') as market_id
+        , json_extract_scalar(object_json, '$.reserves[21].id.id') as market_id
         , case 
-            when starts_with(json_extract_scalar(object_json, '$.reserves[5].coin_type.name'), '0x') 
-            then json_extract_scalar(object_json, '$.reserves[5].coin_type.name')
-            else concat('0x', json_extract_scalar(object_json, '$.reserves[5].coin_type.name'))
+            when starts_with(json_extract_scalar(object_json, '$.reserves[21].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[21].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[21].coin_type.name'))
         end as coin_type
-        , cast(json_extract_scalar(object_json, '$.reserves[5].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
-        , cast(json_extract_scalar(object_json, '$.reserves[5].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[21].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[21].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
         , object_id
         , version
         , checkpoint
     from suilend_raw
-    where json_extract_scalar(object_json, '$.reserves[5].id.id') is not null
+    where json_extract_scalar(object_json, '$.reserves[21].id.id') is not null
     
     union all
     
-    -- Extract reserves[6]
+    -- Extract reserves[24] - LBTC token
     select
         timestamp_ms
         , block_time
@@ -189,23 +189,23 @@ with suilend_raw as (
         , block_month
         , date_hour
         , protocol
-        , json_extract_scalar(object_json, '$.reserves[6].id.id') as market_id
+        , json_extract_scalar(object_json, '$.reserves[24].id.id') as market_id
         , case 
-            when starts_with(json_extract_scalar(object_json, '$.reserves[6].coin_type.name'), '0x') 
-            then json_extract_scalar(object_json, '$.reserves[6].coin_type.name')
-            else concat('0x', json_extract_scalar(object_json, '$.reserves[6].coin_type.name'))
+            when starts_with(json_extract_scalar(object_json, '$.reserves[24].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[24].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[24].coin_type.name'))
         end as coin_type
-        , cast(json_extract_scalar(object_json, '$.reserves[6].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
-        , cast(json_extract_scalar(object_json, '$.reserves[6].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[24].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[24].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
         , object_id
         , version
         , checkpoint
     from suilend_raw
-    where json_extract_scalar(object_json, '$.reserves[6].id.id') is not null
+    where json_extract_scalar(object_json, '$.reserves[24].id.id') is not null
     
     union all
     
-    -- Extract reserves[7]
+    -- Extract reserves[36] - xBTC token
     select
         timestamp_ms
         , block_time
@@ -213,187 +213,19 @@ with suilend_raw as (
         , block_month
         , date_hour
         , protocol
-        , json_extract_scalar(object_json, '$.reserves[7].id.id') as market_id
+        , json_extract_scalar(object_json, '$.reserves[36].id.id') as market_id
         , case 
-            when starts_with(json_extract_scalar(object_json, '$.reserves[7].coin_type.name'), '0x') 
-            then json_extract_scalar(object_json, '$.reserves[7].coin_type.name')
-            else concat('0x', json_extract_scalar(object_json, '$.reserves[7].coin_type.name'))
+            when starts_with(json_extract_scalar(object_json, '$.reserves[36].coin_type.name'), '0x') 
+            then json_extract_scalar(object_json, '$.reserves[36].coin_type.name')
+            else concat('0x', json_extract_scalar(object_json, '$.reserves[36].coin_type.name'))
         end as coin_type
-        , cast(json_extract_scalar(object_json, '$.reserves[7].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
-        , cast(json_extract_scalar(object_json, '$.reserves[7].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[36].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
+        , cast(json_extract_scalar(object_json, '$.reserves[36].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
         , object_id
         , version
         , checkpoint
     from suilend_raw
-    where json_extract_scalar(object_json, '$.reserves[7].id.id') is not null
-    
-    union all
-    
-    -- Extract reserves[8]
-    select
-        timestamp_ms
-        , block_time
-        , block_date
-        , block_month
-        , date_hour
-        , protocol
-        , json_extract_scalar(object_json, '$.reserves[8].id.id') as market_id
-        , case 
-            when starts_with(json_extract_scalar(object_json, '$.reserves[8].coin_type.name'), '0x') 
-            then json_extract_scalar(object_json, '$.reserves[8].coin_type.name')
-            else concat('0x', json_extract_scalar(object_json, '$.reserves[8].coin_type.name'))
-        end as coin_type
-        , cast(json_extract_scalar(object_json, '$.reserves[8].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
-        , cast(json_extract_scalar(object_json, '$.reserves[8].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
-        , object_id
-        , version
-        , checkpoint
-    from suilend_raw
-    where json_extract_scalar(object_json, '$.reserves[8].id.id') is not null
-    
-    union all
-    
-    -- Extract reserves[9]
-    select
-        timestamp_ms
-        , block_time
-        , block_date
-        , block_month
-        , date_hour
-        , protocol
-        , json_extract_scalar(object_json, '$.reserves[9].id.id') as market_id
-        , case 
-            when starts_with(json_extract_scalar(object_json, '$.reserves[9].coin_type.name'), '0x') 
-            then json_extract_scalar(object_json, '$.reserves[9].coin_type.name')
-            else concat('0x', json_extract_scalar(object_json, '$.reserves[9].coin_type.name'))
-        end as coin_type
-        , cast(json_extract_scalar(object_json, '$.reserves[9].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
-        , cast(json_extract_scalar(object_json, '$.reserves[9].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
-        , object_id
-        , version
-        , checkpoint
-    from suilend_raw
-    where json_extract_scalar(object_json, '$.reserves[9].id.id') is not null
-    
-    union all
-    
-    -- Extract reserves[10]
-    select
-        timestamp_ms
-        , block_time
-        , block_date
-        , block_month
-        , date_hour
-        , protocol
-        , json_extract_scalar(object_json, '$.reserves[10].id.id') as market_id
-        , case 
-            when starts_with(json_extract_scalar(object_json, '$.reserves[10].coin_type.name'), '0x') 
-            then json_extract_scalar(object_json, '$.reserves[10].coin_type.name')
-            else concat('0x', json_extract_scalar(object_json, '$.reserves[10].coin_type.name'))
-        end as coin_type
-        , cast(json_extract_scalar(object_json, '$.reserves[10].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
-        , cast(json_extract_scalar(object_json, '$.reserves[10].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
-        , object_id
-        , version
-        , checkpoint
-    from suilend_raw
-    where json_extract_scalar(object_json, '$.reserves[10].id.id') is not null
-    
-    union all
-    
-    -- Extract reserves[11]
-    select
-        timestamp_ms
-        , block_time
-        , block_date
-        , block_month
-        , date_hour
-        , protocol
-        , json_extract_scalar(object_json, '$.reserves[11].id.id') as market_id
-        , case 
-            when starts_with(json_extract_scalar(object_json, '$.reserves[11].coin_type.name'), '0x') 
-            then json_extract_scalar(object_json, '$.reserves[11].coin_type.name')
-            else concat('0x', json_extract_scalar(object_json, '$.reserves[11].coin_type.name'))
-        end as coin_type
-        , cast(json_extract_scalar(object_json, '$.reserves[11].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
-        , cast(json_extract_scalar(object_json, '$.reserves[11].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
-        , object_id
-        , version
-        , checkpoint
-    from suilend_raw
-    where json_extract_scalar(object_json, '$.reserves[11].id.id') is not null
-    
-    union all
-    
-    -- Extract reserves[12]
-    select
-        timestamp_ms
-        , block_time
-        , block_date
-        , block_month
-        , date_hour
-        , protocol
-        , json_extract_scalar(object_json, '$.reserves[12].id.id') as market_id
-        , case 
-            when starts_with(json_extract_scalar(object_json, '$.reserves[12].coin_type.name'), '0x') 
-            then json_extract_scalar(object_json, '$.reserves[12].coin_type.name')
-            else concat('0x', json_extract_scalar(object_json, '$.reserves[12].coin_type.name'))
-        end as coin_type
-        , cast(json_extract_scalar(object_json, '$.reserves[12].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
-        , cast(json_extract_scalar(object_json, '$.reserves[12].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
-        , object_id
-        , version
-        , checkpoint
-    from suilend_raw
-    where json_extract_scalar(object_json, '$.reserves[12].id.id') is not null
-    
-    union all
-    
-    -- Extract reserves[13]
-    select
-        timestamp_ms
-        , block_time
-        , block_date
-        , block_month
-        , date_hour
-        , protocol
-        , json_extract_scalar(object_json, '$.reserves[13].id.id') as market_id
-        , case 
-            when starts_with(json_extract_scalar(object_json, '$.reserves[13].coin_type.name'), '0x') 
-            then json_extract_scalar(object_json, '$.reserves[13].coin_type.name')
-            else concat('0x', json_extract_scalar(object_json, '$.reserves[13].coin_type.name'))
-        end as coin_type
-        , cast(json_extract_scalar(object_json, '$.reserves[13].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
-        , cast(json_extract_scalar(object_json, '$.reserves[13].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
-        , object_id
-        , version
-        , checkpoint
-    from suilend_raw
-    where json_extract_scalar(object_json, '$.reserves[13].id.id') is not null
-    
-    union all
-    
-    -- Extract reserves[14]
-    select
-        timestamp_ms
-        , block_time
-        , block_date
-        , block_month
-        , date_hour
-        , protocol
-        , json_extract_scalar(object_json, '$.reserves[14].id.id') as market_id
-        , case 
-            when starts_with(json_extract_scalar(object_json, '$.reserves[14].coin_type.name'), '0x') 
-            then json_extract_scalar(object_json, '$.reserves[14].coin_type.name')
-            else concat('0x', json_extract_scalar(object_json, '$.reserves[14].coin_type.name'))
-        end as coin_type
-        , cast(json_extract_scalar(object_json, '$.reserves[14].ctoken_supply') as decimal(38,0)) as coin_collateral_amount
-        , cast(json_extract_scalar(object_json, '$.reserves[14].borrowed_amount.value') as decimal(38,0)) as coin_borrow_amount
-        , object_id
-        , version
-        , checkpoint
-    from suilend_raw
-    where json_extract_scalar(object_json, '$.reserves[14].id.id') is not null
+    where json_extract_scalar(object_json, '$.reserves[36].id.id') is not null
 )
 
 select 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extend Suilend bronze model to parse BTC-related reserves (indices 21, 24, 36) with collateral and borrow amounts.
> 
> - **Sui TVL — Suilend bronze model (`sui_tvl_lending_pools_suilend_bronze.sql`)**:
>   - Add extraction of additional reserves for BTC markets:
>     - `reserves[21]` BTC, `reserves[24]` LBTC, `reserves[36]` xBTC.
>     - Extracts `market_id`, normalizes `coin_type`, and pulls `ctoken_supply` and `borrowed_amount.value`.
>   - No other functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2511aded57e3a544edd5bbcf67666f4235a6a6f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->