### PR TITLE
`dex_solana.trades`: remove warning, force error on amount_usd test

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/_schema.yml
+++ b/dbt_subprojects/solana/models/_sector/dex/_schema.yml
@@ -72,7 +72,6 @@ models:
         data_tests:
           - dbt_utils.accepted_range:
               max_value: 1000000000 # $1b is an arbitrary number, intended to flag outlier amounts early
-              severity: warn
       - &fee_tier
         name: fee_tier
         description: "Whirlpool fee tier (fee %)"


### PR DESCRIPTION
towards CUR2-575

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change `dex_solana_trades` `amount_usd` accepted_range test to error (remove `severity: warn`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 762c5922e273a193d972704ae7c9061006aeabd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->