### PR TITLE
enrich tron transfers towards cur2-771

### DIFF
--- a/dbt_subprojects/tokens/models/transfers_and_balances/tron/tokens_tron_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/tron/tokens_tron_base_transfers.sql
@@ -41,10 +41,10 @@ INNER JOIN {{ source('tron','transactions') }} tx
     AND tx.block_time = t.evt_block_time 
     AND tx.block_number = t.evt_block_number
     AND tx.hash = t.evt_tx_hash
-    {% if is_incremental() or true %}
+    {% if is_incremental() %}
     AND {{incremental_predicate('tx.block_time')}}
     {% endif %}
-{% if is_incremental() or true %}
+{% if is_incremental() %}
 WHERE {{incremental_predicate('t.evt_block_time')}}
 {% endif %}
 
@@ -78,6 +78,6 @@ SELECT
 FROM {{ source('tron','transactions') }} tx
 WHERE tx.success = true
     AND tx.value > UINT256 '0'
-    {% if is_incremental() or true %}
+    {% if is_incremental() %}
     AND {{incremental_predicate('tx.block_time')}}
     {% endif %}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/tron/tokens_tron_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/tron/tokens_tron_transfers.sql
@@ -23,7 +23,7 @@ WITH base_transfers as (
         {{ ref('tokens_tron_base_transfers') }}
     WHERE
         1=1
-        {% if is_incremental() or true -%}
+        {% if is_incremental() -%}
         AND {{ incremental_predicate('block_date') }}
         {% else -%}
         AND block_date >= TIMESTAMP '{{ transfers_start_date }}'
@@ -41,7 +41,7 @@ WITH base_transfers as (
         {{ source('prices_coinpaprika', 'hour') }}    
     WHERE
         1=1
-        {% if is_incremental() or true -%}
+        {% if is_incremental() -%}
         AND {{ incremental_predicate('timestamp') }}
         {% else -%}
         AND timestamp >= TIMESTAMP '{{ transfers_start_date }}'


### PR DESCRIPTION
### Summary
Adds human-readable base58-encoded address columns to Tron token transfers. Tron addresses in raw data are stored in varbinary format, making them difficult to read. This PR adds converted varchar columns while preserving the original varbinary columns.

### Changes

**tokens_tron_base_transfers.sql**
- Added 6 new `_varchar` columns using `to_tron_address()` function:
  - `tx_hash_varchar`, `contract_address_varchar`, `from_varchar`, `to_varchar`, `tx_from_varchar`, `tx_to_varchar`
- Transaction hashes use `SUBSTR(cast(tx_hash as varchar), 3)` to remove `0x` prefix
- Fixed `token_standard` from `'erc20'` to `'trc20'`

**transfers_enrich.sql**
- Added Tron-specific conditional block: `{% if blockchain == 'tron' %}`
- New columns are included in both `transfers` and `final` CTEs when processing Tron data
- Other blockchains unaffected

### Impact
- Original varbinary columns preserved for backwards compatibility
- New varchar columns available for easier querying and analysis
- **The main `tokens.transfers` table is not modified** - these columns only appear in Tron-specific tables (`tokens_tron.base_transfers` and `tokens_tron.transfers`)
- No breaking changes