### PR TITLE
prod exclude somnex

### DIFF
--- a/dbt_subprojects/dex/models/trades/somnia/dex_somnia_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/somnia/dex_somnia_base_trades.sql
@@ -10,8 +10,7 @@
 ) }}
 
 {% set base_models = [
-    ref('quickswap_v3_somnia_base_trades'),
-    ref('somnex_v2_somnia_base_trades')
+    ref('quickswap_v3_somnia_base_trades')
 ] %}
 
 with base_union as (

--- a/dbt_subprojects/dex/models/trades/somnia/platforms/somnex_v2_somnia_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/somnia/platforms/somnex_v2_somnia_base_trades.sql
@@ -6,7 +6,8 @@
         file_format = 'delta',
         incremental_strategy = 'merge',
         unique_key = ['tx_hash', 'evt_index'],
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        tags = ['prod_exclude']
     )
 }}
 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `somnex_v2_somnia_base_trades` from the Somnia `base_trades` union and tags the Somnex v2 model with `prod_exclude`.
> 
> - **Somnia DEX base trades (`dex_somnia_base_trades.sql`)**:
>   - Remove `ref('somnex_v2_somnia_base_trades')` from `base_models` union, leaving only `quickswap_v3`.
> - **Somnex v2 model (`platforms/somnex_v2_somnia_base_trades.sql`)**:
>   - Add `tags = ['prod_exclude']` to model config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit decd54805025fd7f4f9544c9e6e6200d53367a28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->