### PR TITLE
CUR2-662 [temp] exclude outlier tx in `cow_protocol_base_trades`

### DIFF
--- a/dbt_subprojects/dex/models/_projects/cow_protocol/base/cow_protocol_base_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/cow_protocol/base/cow_protocol_base_trades.sql
@@ -55,9 +55,12 @@ trades_with_prices AS (
                                  {% if is_incremental() %}
                                  AND {{ incremental_predicate('pb.minute') }}
                                  {% endif %}
-    {% if is_incremental() %}
-    WHERE {{ incremental_predicate('evt_block_time') }}
-    {% endif %}
+    WHERE
+        1 = 1 -- to keep where clause clean with incremental predicate
+        AND evt_tx_hash != 0xd5c5c3e91e2c0c0552178fccf6af790e692fb9dbf1930df5558c626f0c0ee097 -- known outlier tx which causes UINT256 overflow in surplus_usd calculation downstream
+        {% if is_incremental() -%}
+        AND {{ incremental_predicate('evt_block_time') }}
+        {% endif -%}
 ),
 -- Second subquery gets token symbol and decimals from tokens.erc20 (to display units bought and sold)
 trades_with_token_units as (
@@ -113,9 +116,12 @@ sorted_orders as (
             evt_block_number,
             orderUid
         from {{ source('gnosis_protocol_v2_base', 'GPv2Settlement_evt_Trade') }}
-        {% if is_incremental() %}
-        where {{ incremental_predicate('evt_block_time') }}
-        {% endif %}
+        where
+            1 = 1 -- to keep where clause clean with incremental predicate
+            and evt_tx_hash != 0xd5c5c3e91e2c0c0552178fccf6af790e692fb9dbf1930df5558c626f0c0ee097 -- known outlier tx which causes UINT256 overflow in surplus_usd calculation downstream
+            {% if is_incremental() -%}
+            and {{ incremental_predicate('evt_block_time') }}
+            {% endif -%}
     )
     group by evt_tx_hash, evt_block_number
 ),


### PR DESCRIPTION
this tx_hash leads to `surplus_usd` calculations failing on UINT256 overflow. longer term fix incoming from CoW team after.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Excludes a specific outlier `evt_tx_hash` from CoW Protocol Base trades in price join and order aggregation while preserving incremental predicates.
> 
> - **CoW Protocol Base trades (`dbt_subprojects/dex/models/_projects/cow_protocol/base/cow_protocol_base_trades.sql`)**:
>   - Exclude known outlier tx `0xd5c5c3e91e2c0c0552178fccf6af790e692fb9dbf1930df5558c626f0c0ee097` to prevent downstream overflow.
>     - Applied in `trades_with_prices` main query `WHERE` clause.
>     - Applied in `sorted_orders` subquery `where` clause.
>   - Preserve incremental predicates; restructured `WHERE`/`where` with `1 = 1` for cleaner conditional filters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c94a1f9630eea1fd3aae73fbb3a486e69343731a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->