### PR TITLE
bridges: rename `withdraw_*` to `withdrawal_*`

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/bridges_crosschain_flows.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/bridges_crosschain_flows.sql
@@ -21,9 +21,9 @@ SELECT *
         , deposit_block_date
         , deposit_block_time
         , deposit_block_number
-        , withdraw_block_date
-        , withdraw_block_time
-        , withdraw_block_number
+        , withdrawal_block_date
+        , withdrawal_block_time
+        , withdrawal_block_number
         , deposit_amount_raw
         , deposit_amount
         , withdrawal_amount_raw
@@ -37,7 +37,7 @@ SELECT *
         , CAST(withdrawal_token_address AS VARCHAR) AS withdrawal_token_address
         , CAST(deposit_tx_from AS VARCHAR) AS deposit_tx_from
         , CAST(deposit_tx_hash AS VARCHAR) AS deposit_tx_hash
-        , CAST(withdraw_tx_hash AS VARCHAR) AS withdraw_tx_hash
+        , CAST(withdrawal_tx_hash AS VARCHAR) AS withdrawal_tx_hash
         , bridge_transfer_id
         FROM {{ ref('bridges_'~vm~'_flows') }}
         {% if not loop.last %}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/_schema.yml
@@ -16,8 +16,8 @@ models:
       - &deposit_chain
         name: deposit_chain
         description: "Blockchain where the tokens were sent"
-      - &withdraw_chain
-        name: withdraw_chain
+      - &withdrawal_chain
+        name: withdrawal_chain
         description: "Blockchain where the tokens were received"
       - &bridge_name
         name: bridge_name
@@ -37,8 +37,8 @@ models:
       - &deposit_amount_raw 
         name: deposit_amount_raw
         description: "Raw amount of tokens bridged from source chain"
-      - &withdraw_amount_raw 
-        name: withdraw_amount_raw
+      - &withdrawal_amount_raw 
+        name: withdrawal_amount_raw
         description: "Raw amount of tokens bridged to destination chain"
       - &sender 
         name: sender
@@ -49,14 +49,14 @@ models:
       - &deposit_token_standard  
         name: deposit_token_standard
         description: "Source blockchain token standard"
-      - &withdraw_token_standard
-        name: remote_token
+      - &withdrawal_token_standard
+        name: withdrawal_token_standard
         description: "Destination blockchain token standard"
       - &deposit_token_address  
         name: deposit_token_address
         description: "Source blockchain token address"
-      - &withdraw_token_address
-        name: withdraw_token_address
+      - &withdrawal_token_address
+        name: withdrawal_token_address
         description: "Destination blockchain token address"
       - &tx_from
         name: tx_from
@@ -86,20 +86,20 @@ models:
           combination_of_columns: ['tx_hash','evt_index']
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *block_date
       - *block_time
       - *block_number
       - *deposit_amount_raw
-      - *withdraw_amount_raw
+      - *withdrawal_amount_raw
       - *sender
       - *recipient
       - *deposit_token_standard
-      - *withdraw_token_standard
+      - *withdrawal_token_standard
       - *deposit_token_address
-      - *withdraw_token_address
+      - *withdrawal_token_address
       - *tx_from
       - *tx_hash
       - *evt_index  
@@ -118,20 +118,20 @@ models:
           combination_of_columns: ['tx_hash','evt_index']
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *block_date
       - *block_time
       - *block_number
       - *deposit_amount_raw 
-      - *withdraw_amount_raw 
+      - *withdrawal_amount_raw 
       - *sender
       - *recipient
       - *deposit_token_standard
-      - *withdraw_token_standard
+      - *withdrawal_token_standard
       - *deposit_token_address
-      - *withdraw_token_address
+      - *withdrawal_token_address
       - *tx_from
       - *tx_hash
       - *evt_index  
@@ -150,20 +150,20 @@ models:
           combination_of_columns: ['tx_hash','evt_index']
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *block_date
       - *block_time
       - *block_number
       - *deposit_amount_raw 
-      - *withdraw_amount_raw 
+      - *withdrawal_amount_raw 
       - *sender
       - *recipient
       - *deposit_token_standard
-      - *withdraw_token_standard
+      - *withdrawal_token_standard
       - *deposit_token_address
-      - *withdraw_token_address
+      - *withdrawal_token_address
       - *tx_from
       - *tx_hash
       - *evt_index  
@@ -182,20 +182,20 @@ models:
           combination_of_columns: ['tx_hash','evt_index']
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *block_date
       - *block_time
       - *block_number
       - *deposit_amount_raw 
-      - *withdraw_amount_raw 
+      - *withdrawal_amount_raw 
       - *sender
       - *recipient
       - *deposit_token_standard
-      - *withdraw_token_standard
+      - *withdrawal_token_standard
       - *deposit_token_address
-      - *withdraw_token_address
+      - *withdrawal_token_address
       - *tx_from
       - *tx_hash
       - *evt_index  
@@ -214,20 +214,20 @@ models:
           combination_of_columns: ['tx_hash','evt_index']
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *block_date
       - *block_time
       - *block_number
       - *deposit_amount_raw 
-      - *withdraw_amount_raw 
+      - *withdrawal_amount_raw 
       - *sender
       - *recipient
       - *deposit_token_standard
-      - *withdraw_token_standard
+      - *withdrawal_token_standard
       - *deposit_token_address
-      - *withdraw_token_address
+      - *withdrawal_token_address
       - *tx_from
       - *tx_hash
       - *evt_index  
@@ -246,20 +246,20 @@ models:
           combination_of_columns: ['tx_hash','evt_index']
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *block_date
       - *block_time
       - *block_number
       - *deposit_amount_raw 
-      - *withdraw_amount_raw 
+      - *withdrawal_amount_raw 
       - *sender
       - *recipient
       - *deposit_token_standard
-      - *withdraw_token_standard
+      - *withdrawal_token_standard
       - *deposit_token_address
-      - *withdraw_token_address
+      - *withdrawal_token_address
       - *tx_from
       - *tx_hash
       - *evt_index  
@@ -278,20 +278,20 @@ models:
           combination_of_columns: ['tx_hash','evt_index']
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *block_date
       - *block_time
       - *block_number
       - *deposit_amount_raw 
-      - *withdraw_amount_raw 
+      - *withdrawal_amount_raw 
       - *sender
       - *recipient
       - *deposit_token_standard
-      - *withdraw_token_standard
+      - *withdrawal_token_standard
       - *deposit_token_address
-      - *withdraw_token_address
+      - *withdrawal_token_address
       - *tx_from
       - *tx_hash
       - *evt_index  
@@ -310,20 +310,20 @@ models:
           combination_of_columns: ['tx_hash','evt_index']
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *block_date
       - *block_time
       - *block_number
       - *deposit_amount_raw 
-      - *withdraw_amount_raw 
+      - *withdrawal_amount_raw 
       - *sender
       - *recipient
       - *deposit_token_standard
-      - *withdraw_token_standard
+      - *withdrawal_token_standard
       - *deposit_token_address
-      - *withdraw_token_address
+      - *withdrawal_token_address
       - *tx_from
       - *tx_hash
       - *evt_index  
@@ -342,20 +342,20 @@ models:
           combination_of_columns: ['tx_hash','evt_index']
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *block_date
       - *block_time
       - *block_number
       - *deposit_amount_raw 
-      - *withdraw_amount_raw 
+      - *withdrawal_amount_raw 
       - *sender
       - *recipient
       - *deposit_token_standard
-      - *withdraw_token_standard
+      - *withdrawal_token_standard
       - *deposit_token_address
-      - *withdraw_token_address
+      - *withdrawal_token_address
       - *tx_from
       - *tx_hash
       - *evt_index  

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/arbitrum/platforms/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/arbitrum/platforms/_schema.yml
@@ -20,8 +20,8 @@ models:
       - &deposit_chain
         name: deposit_chain
         description: "Blockchain where the tokens were sent"
-      - &withdraw_chain
-        name: withdraw_chain
+      - &withdrawal_chain
+        name: withdrawal_chain
         description: "Blockchain where the tokens were received"
       - &bridge_name
         name: bridge_name
@@ -94,7 +94,7 @@ models:
             - source('circle_arbitrum','tokenmessenger_evt_mintandwithdraw')
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *deposit_amount_raw

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/avalanche_c/platforms/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/avalanche_c/platforms/_schema.yml
@@ -20,8 +20,8 @@ models:
       - &deposit_chain
         name: deposit_chain
         description: "Blockchain where the tokens were sent"
-      - &withdraw_chain
-        name: withdraw_chain
+      - &withdrawal_chain
+        name: withdrawal_chain
         description: "Blockchain where the tokens were received"
       - &bridge_name
         name: bridge_name
@@ -94,7 +94,7 @@ models:
             - source('circle_avalanche_c','tokenmessenger_evt_mintandwithdraw')
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *deposit_amount_raw

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/optimism/platforms/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/optimism/platforms/_schema.yml
@@ -20,8 +20,8 @@ models:
       - &deposit_chain
         name: deposit_chain
         description: "Blockchain where the tokens were sent"
-      - &withdraw_chain
-        name: withdraw_chain
+      - &withdrawal_chain
+        name: withdrawal_chain
         description: "Blockchain where the tokens were received"
       - &bridge_name
         name: bridge_name
@@ -94,7 +94,7 @@ models:
             - source('circle_optimism','tokenmessenger_evt_mintandwithdraw')
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *deposit_amount_raw

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/polygon/platforms/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/polygon/platforms/_schema.yml
@@ -20,8 +20,8 @@ models:
       - &deposit_chain
         name: deposit_chain
         description: "Blockchain where the tokens were sent"
-      - &withdraw_chain
-        name: withdraw_chain
+      - &withdrawal_chain
+        name: withdrawal_chain
         description: "Blockchain where the tokens were received"
       - &bridge_name
         name: bridge_name
@@ -94,7 +94,7 @@ models:
             - source('circle_polygon','tokenmessenger_evt_mintandwithdraw')
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *deposit_amount_raw

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/unichain/platforms/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/unichain/platforms/_schema.yml
@@ -20,8 +20,8 @@ models:
       - &deposit_chain
         name: deposit_chain
         description: "Blockchain where the tokens were sent"
-      - &withdraw_chain
-        name: withdraw_chain
+      - &withdrawal_chain
+        name: withdrawal_chain
         description: "Blockchain where the tokens were received"
       - &bridge_name
         name: bridge_name
@@ -94,7 +94,7 @@ models:
             - source('circle_unichain','tokenmessenger_evt_mintandwithdraw')
     columns:
       - *deposit_chain
-      - *withdraw_chain
+      - *withdrawal_chain
       - *bridge_name
       - *bridge_version
       - *deposit_amount_raw

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_flows.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_flows.sql
@@ -58,9 +58,9 @@ SELECT deposit_chain
 , d.block_date AS deposit_block_date
 , d.block_time AS deposit_block_time
 , d.block_number AS deposit_block_number
-, w.block_date AS withdraw_block_date
-, w.block_time AS withdraw_block_time
-, w.block_number AS withdraw_block_number
+, w.block_date AS withdrawal_block_date
+, w.block_time AS withdrawal_block_time
+, w.block_number AS withdrawal_block_number
 , d.deposit_amount_raw
 , d.deposit_amount
 , w.withdrawal_amount_raw
@@ -74,7 +74,7 @@ SELECT deposit_chain
 , w.withdrawal_token_address
 , d.tx_from AS deposit_tx_from
 , d.tx_hash AS deposit_tx_hash
-, w.tx_hash AS withdraw_tx_hash
+, w.tx_hash AS withdrawal_tx_hash
 , bridge_transfer_id
 FROM {{ ref('bridges_evms_withdrawals') }} w
 FULL OUTER JOIN latest_deposits d USING (bridge_name, bridge_version, deposit_chain, withdrawal_chain, bridge_transfer_id)


### PR DESCRIPTION
Some columns are currently named `withdraw_*` and some `withdrawal_*`, to keep things consistent before this project grows further, this PR renames all columns/YAML aliases from `withdraw_*` to `withdrawal_*`