### PR TITLE
bridges: fix across macros

### DIFF
--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_deposits.sql
@@ -19,6 +19,6 @@ SELECT '{{blockchain}}' AS deposit_chain
 , contract_address
 , CAST(depositId_uint256 AS varchar) AS bridge_transfer_id
 FROM ({{ events }}) d
-LEFT JOIN {{ ref('bridges_cctp_chain_indexes') }} m ON d.destinationChainId=m.id
+LEFT JOIN {{ ref('bridges_across_chain_indexes') }} m ON d.destinationChainId=m.id
 
 {% endmacro %}

--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_deposits.sql
@@ -1,32 +1,5 @@
 {% macro across_v2_deposits(blockchain, events) %}
 
-
-WITH across_id_mapping AS (
-    SELECT id, blockchain
-    FROM (VALUES
-    (1, 'ethereum')
-    , (10, 'optimism')
-    , (137, 'polygon')
-    , (42161, 'arbitrum')
-    , (56, 'bnb')
-    , (324, 'zksync')
-    , (59144, 'linea')
-    , (8453, 'base')
-    , (7777777, 'zora')
-    , (81457, 'blast')
-    , (34443, 'mode')
-    , (232, 'lens')
-    , (57073, 'ink')
-    , (1135, 'list')
-    , (41455, 'aleph_zero')
-    , (690, 'redstone')
-    , (534352, 'scroll')
-    , (1868, 'soneium')
-    , (480, 'worldchain')
-    , (130, 'unichain')
-    ) AS x (id, blockchain)
-    )
-    
 SELECT '{{blockchain}}' AS deposit_chain
 , m.blockchain AS withdrawal_chain
 , 'Across' AS bridge_name
@@ -46,6 +19,6 @@ SELECT '{{blockchain}}' AS deposit_chain
 , contract_address
 , CAST(depositId_uint256 AS varchar) AS bridge_transfer_id
 FROM ({{ events }}) d
-LEFT JOIN across_id_mapping m ON d.destinationChainId=m.id
+LEFT JOIN {{ ref('bridges_cctp_chain_indexes') }} m ON d.destinationChainId=m.id
 
 {% endmacro %}

--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_withdrawals.sql
@@ -21,7 +21,7 @@ WITH ranked AS (
     , CAST(depositId_uint256 AS varchar) AS bridge_transfer_id
     , ROW_NUMBER() OVER (PARTITION BY d.originChainId, d.evt_block_number, d.evt_tx_hash, d.depositId_uint256 ORDER BY d.evt_index DESC) AS rn
     FROM ({{ events }}) d
-    LEFT JOIN {{ ref('bridges_cctp_chain_indexes') }} m ON d.originChainId=m.id
+    LEFT JOIN {{ ref('bridges_across_chain_indexes') }} m ON d.originChainId=m.id
     )
 
 SELECT deposit_chain

--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_withdrawals.sql
@@ -45,7 +45,7 @@ WITH across_id_mapping AS (
     , evt_index
     , contract_address
     , CAST(depositId_uint256 AS varchar) AS bridge_transfer_id
-    , ROW_NUMBER() OVER (PARTITION BY m.blockchain, evt_block_number, evt_tx_hash ORDER BY evt_index DESC) AS rn
+    , ROW_NUMBER() OVER (PARTITION BY d.originChainId, d.evt_block_number, d.evt_tx_hash, d.depositId_uint256 ORDER BY d.evt_index DESC) AS rn
     FROM ({{ events }}) d
     LEFT JOIN across_id_mapping m ON d.originChainId=m.id
     )

--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_withdrawals.sql
@@ -1,32 +1,6 @@
 {% macro across_v2_withdrawals(blockchain, events) %}
 
-WITH across_id_mapping AS (
-    SELECT id, blockchain
-    FROM (VALUES
-    (1, 'ethereum')
-    , (10, 'optimism')
-    , (137, 'polygon')
-    , (42161, 'arbitrum')
-    , (56, 'bnb')
-    , (324, 'zksync')
-    , (59144, 'linea')
-    , (8453, 'base')
-    , (7777777, 'zora')
-    , (81457, 'blast')
-    , (34443, 'mode')
-    , (232, 'lens')
-    , (57073, 'ink')
-    , (1135, 'list')
-    , (41455, 'aleph_zero')
-    , (690, 'redstone')
-    , (534352, 'scroll')
-    , (1868, 'soneium')
-    , (480, 'worldchain')
-    , (130, 'unichain')
-    ) AS x (id, blockchain)
-    )
-    
-, ranked AS (
+WITH ranked AS (
     SELECT m.blockchain AS deposit_chain
     , '{{blockchain}}' AS withdrawal_chain
     , 'Across' AS bridge_name
@@ -47,7 +21,7 @@ WITH across_id_mapping AS (
     , CAST(depositId_uint256 AS varchar) AS bridge_transfer_id
     , ROW_NUMBER() OVER (PARTITION BY d.originChainId, d.evt_block_number, d.evt_tx_hash, d.depositId_uint256 ORDER BY d.evt_index DESC) AS rn
     FROM ({{ events }}) d
-    LEFT JOIN across_id_mapping m ON d.originChainId=m.id
+    LEFT JOIN {{ ref('bridges_cctp_chain_indexes') }} m ON d.originChainId=m.id
     )
 
 SELECT deposit_chain

--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_withdrawals.sql
@@ -27,7 +27,7 @@ WITH across_id_mapping AS (
     )
     
 SELECT m.blockchain AS deposit_chain
-, 'arbitrum' AS withdrawal_chain
+, '{{blockchain}}' AS withdrawal_chain
 , 'Across' AS bridge_name
 , '2' AS bridge_version
 , evt_block_date AS block_date

--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_deposits.sql
@@ -1,31 +1,5 @@
 {% macro across_v3_deposits(blockchain, events) %}
 
-WITH across_id_mapping AS (
-    SELECT id, blockchain
-    FROM (VALUES
-    (1, 'ethereum')
-    , (10, 'optimism')
-    , (137, 'polygon')
-    , (42161, 'arbitrum')
-    , (56, 'bnb')
-    , (324, 'zksync')
-    , (59144, 'linea')
-    , (8453, 'base')
-    , (7777777, 'zora')
-    , (81457, 'blast')
-    , (34443, 'mode')
-    , (232, 'lens')
-    , (57073, 'ink')
-    , (1135, 'list')
-    , (41455, 'aleph_zero')
-    , (690, 'redstone')
-    , (534352, 'scroll')
-    , (1868, 'soneium')
-    , (480, 'worldchain')
-    , (130, 'unichain')
-    ) AS x (id, blockchain)
-    )
-    
 SELECT '{{blockchain}}' AS deposit_chain
 , m.blockchain AS withdrawal_chain
 , 'Across' AS bridge_name
@@ -45,6 +19,6 @@ SELECT '{{blockchain}}' AS deposit_chain
 , contract_address
 , CAST(depositId AS varchar) AS bridge_transfer_id
 FROM ({{ events }}) d
-LEFT JOIN across_id_mapping m ON d.destinationChainId=m.id
+LEFT JOIN {{ ref('bridges_cctp_chain_indexes') }} m ON d.destinationChainId=m.id
 
 {% endmacro %}

--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_deposits.sql
@@ -26,7 +26,7 @@ WITH across_id_mapping AS (
     ) AS x (id, blockchain)
     )
     
-SELECT 'arbitrum' AS deposit_chain
+SELECT '{{blockchain}}' AS deposit_chain
 , m.blockchain AS withdrawal_chain
 , 'Across' AS bridge_name
 , '3' AS bridge_version

--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_deposits.sql
@@ -19,6 +19,6 @@ SELECT '{{blockchain}}' AS deposit_chain
 , contract_address
 , CAST(depositId AS varchar) AS bridge_transfer_id
 FROM ({{ events }}) d
-LEFT JOIN {{ ref('bridges_cctp_chain_indexes') }} m ON d.destinationChainId=m.id
+LEFT JOIN {{ ref('bridges_across_chain_indexes') }} m ON d.destinationChainId=m.id
 
 {% endmacro %}

--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_withdrawals.sql
@@ -1,31 +1,5 @@
 {% macro across_v3_withdrawals(blockchain, events) %}
 
-WITH across_id_mapping AS (
-    SELECT id, blockchain
-    FROM (VALUES
-    (1, 'ethereum')
-    , (10, 'optimism')
-    , (137, 'polygon')
-    , (42161, 'arbitrum')
-    , (56, 'bnb')
-    , (324, 'zksync')
-    , (59144, 'linea')
-    , (8453, 'base')
-    , (7777777, 'zora')
-    , (81457, 'blast')
-    , (34443, 'mode')
-    , (232, 'lens')
-    , (57073, 'ink')
-    , (1135, 'list')
-    , (41455, 'aleph_zero')
-    , (690, 'redstone')
-    , (534352, 'scroll')
-    , (1868, 'soneium')
-    , (480, 'worldchain')
-    , (130, 'unichain')
-    ) AS x (id, blockchain)
-    )
-    
 SELECT m.blockchain AS deposit_chain
 , '{{blockchain}}' AS withdrawal_chain
 , 'Across' AS bridge_name
@@ -45,6 +19,6 @@ SELECT m.blockchain AS deposit_chain
 , contract_address
 , CAST(depositId AS varchar) AS bridge_transfer_id
 FROM ({{ events }}) d
-LEFT JOIN across_id_mapping m ON d.originChainId=m.id
+LEFT JOIN {{ ref('bridges_cctp_chain_indexes') }} m ON d.originChainId=m.id
 
 {% endmacro %}

--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_withdrawals.sql
@@ -27,7 +27,7 @@ WITH across_id_mapping AS (
     )
     
 SELECT m.blockchain AS deposit_chain
-, 'arbitrum' AS withdrawal_chain
+, '{{blockchain}}' AS withdrawal_chain
 , 'Across' AS bridge_name
 , '3' AS bridge_version
 , evt_block_date AS block_date

--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_withdrawals.sql
@@ -19,6 +19,6 @@ SELECT m.blockchain AS deposit_chain
 , contract_address
 , CAST(depositId AS varchar) AS bridge_transfer_id
 FROM ({{ events }}) d
-LEFT JOIN {{ ref('bridges_cctp_chain_indexes') }} m ON d.originChainId=m.id
+LEFT JOIN {{ ref('bridges_across_chain_indexes') }} m ON d.originChainId=m.id
 
 {% endmacro %}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/chain_indexes/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/chain_indexes/_schema.yml
@@ -17,3 +17,19 @@ models:
       - &blockchain
         name: blockchain
         description: "Blockchain name"
+  - name: bridges_cctp_chain_indexes
+    meta:
+      blockchain: ethereum
+      sector: bridges
+      project: across
+      contributors: [ 'hildobby']
+    config:
+      tags: [ 'bridges', 'chain_indexes' ]
+    description: "Across's blockchains indexes"
+    columns:
+      - &id
+        name: id
+        description: "Blockchain id"
+      - &blockchain
+        name: blockchain
+        description: "Blockchain name"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/chain_indexes/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/chain_indexes/_schema.yml
@@ -17,7 +17,7 @@ models:
       - &blockchain
         name: blockchain
         description: "Blockchain name"
-  - name: bridges_cctp_chain_indexes
+  - name: bridges_across_chain_indexes
     meta:
       blockchain: ethereum
       sector: bridges
@@ -27,9 +27,5 @@ models:
       tags: [ 'bridges', 'chain_indexes' ]
     description: "Across's blockchains indexes"
     columns:
-      - &id
-        name: id
-        description: "Blockchain id"
-      - &blockchain
-        name: blockchain
-        description: "Blockchain name"
+      - *id
+      - *blockchain

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/chain_indexes/bridges_across_chain_indexes.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/chain_indexes/bridges_across_chain_indexes.sql
@@ -32,4 +32,3 @@ SELECT id, blockchain
     , (999, 'hyperevm')
     , (34268394551451, 'solana')
     ) AS x (id, blockchain)
-    )

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/chain_indexes/bridges_across_chain_indexes.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/chain_indexes/bridges_across_chain_indexes.sql
@@ -1,0 +1,35 @@
+{{ config(
+    schema = 'bridges',
+    alias = 'across_chain_indexes',
+    materialized = 'view',
+    )
+}}
+
+-- source: https://docs.across.to/reference/supported-chains
+
+SELECT id, blockchain
+    FROM (VALUES
+    (1, 'ethereum')
+    , (10, 'optimism')
+    , (137, 'polygon')
+    , (42161, 'arbitrum')
+    , (56, 'bnb')
+    , (324, 'zksync')
+    , (59144, 'linea')
+    , (8453, 'base')
+    , (7777777, 'zora')
+    , (81457, 'blast')
+    , (34443, 'mode')
+    , (232, 'lens')
+    , (57073, 'ink')
+    , (1135, 'lisk')
+    , (41455, 'aleph_zero')
+    , (690, 'redstone')
+    , (534352, 'scroll')
+    , (1868, 'soneium')
+    , (480, 'worldchain')
+    , (130, 'unichain')
+    , (999, 'hyperevm')
+    , (34268394551451, 'solana')
+    ) AS x (id, blockchain)
+    )


### PR DESCRIPTION
i forgot to remove the `arbitrum` hardcoded blockchain name in 3/4 across macros, this led to duplicates since index is incremental per chain

there's also a bug where for across v2 withdrawals on arbitrum, sometimes the event is emitted twice in the same tx: https://dune.com/queries/5902663
only taking the event with the higher evt_index in each tx fixes that

those fixes are included in https://github.com/duneanalytics/spellbook/pull/8832