### PR TITLE
`prices_native_tokens`: default contract address if not available

### DIFF
--- a/dbt_subprojects/tokens/models/prices/prices_native_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_native_tokens.sql
@@ -83,7 +83,7 @@ with prices_native_tokens as (
 select
     p.token_id
     , p.blockchain
-    , d.token_address as contract_address
+    , coalesce(d.token_address, 0x0000000000000000000000000000000000000000) as contract_address
     , d.token_symbol as symbol
     , d.token_decimals as decimals
 from prices_native_tokens as p


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets contract_address to the zero address when d.token_address is null in prices_native_tokens.
> 
> - **Prices**:
>   - Default `contract_address` to the zero address via `coalesce(d.token_address, 0x0000000000000000000000000000000000000000)` in `dbt_subprojects/tokens/models/prices/prices_native_tokens.sql`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c120d24e137e17f1b15c279dcf320ae3bb329397. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->