### PR TITLE
CUR2-741 add back hyperevm dexes

### DIFF
--- a/dbt_subprojects/dex/models/trades/hyperevm/platforms/hybra_v3_hyperevm_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/hyperevm/platforms/hybra_v3_hyperevm_base_trades.sql
@@ -10,12 +10,40 @@
     )
 }}
 
-{{
-    uniswap_compatible_v3_trades(
-        blockchain = 'hyperevm',
-        project = 'hybra',
-        version = '3',
-        Pair_evt_Swap = source('hybra_hyperevm', 'uniswapv3pool_evt_swap'),
-        Factory_evt_PoolCreated = source('hybra_hyperevm', 'uniswapv3factory_evt_poolcreated')
-    )
-}} 
+WITH base_trades AS (
+    {{
+        uniswap_compatible_v3_trades(
+            blockchain = 'hyperevm',
+            project = 'hybra',
+            version = '3',
+            Pair_evt_Swap = source('hybra_hyperevm', 'uniswapv3pool_evt_swap'),
+            Factory_evt_PoolCreated = source('hybra_hyperevm', 'uniswapv3factory_evt_poolcreated')
+        )
+    }}
+),
+
+deduplicated_trades AS (
+    SELECT *,
+           ROW_NUMBER() OVER (PARTITION BY tx_hash, evt_index ORDER BY block_time) as rn
+    FROM base_trades
+)
+
+SELECT 
+    blockchain,
+    project,
+    version,
+    block_month,
+    block_date,
+    block_time,
+    block_number,
+    token_bought_amount_raw,
+    token_sold_amount_raw,
+    token_bought_address,
+    token_sold_address,
+    taker,
+    maker,
+    project_contract_address,
+    tx_hash,
+    evt_index
+FROM deduplicated_trades
+WHERE rn = 1 

--- a/dbt_subprojects/dex/models/trades/hyperevm/platforms/hyperswap_v3_hyperevm_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/hyperevm/platforms/hyperswap_v3_hyperevm_base_trades.sql
@@ -10,12 +10,40 @@
     )
 }}
 
-{{
-    uniswap_compatible_v3_trades(
-        blockchain = 'hyperevm',
-        project = 'hyperswap',
-        version = '3',
-        Pair_evt_Swap = source('hyperswap_hyperevm', 'hyperswapv3pool_evt_swap'),
-        Factory_evt_PoolCreated = source('hyperswap_hyperevm', 'hyperswapv3factory_evt_poolcreated')
-    )
-}} 
+WITH base_trades AS (
+    {{
+        uniswap_compatible_v3_trades(
+            blockchain = 'hyperevm',
+            project = 'hyperswap',
+            version = '3',
+            Pair_evt_Swap = source('hyperswap_hyperevm', 'hyperswapv3pool_evt_swap'),
+            Factory_evt_PoolCreated = source('hyperswap_hyperevm', 'hyperswapv3factory_evt_poolcreated')
+        )
+    }}
+),
+
+deduplicated_trades AS (
+    SELECT *,
+           ROW_NUMBER() OVER (PARTITION BY tx_hash, evt_index ORDER BY block_time) as rn
+    FROM base_trades
+)
+
+SELECT 
+    blockchain,
+    project,
+    version,
+    block_month,
+    block_date,
+    block_time,
+    block_number,
+    token_bought_amount_raw,
+    token_sold_amount_raw,
+    token_bought_address,
+    token_sold_address,
+    taker,
+    maker,
+    project_contract_address,
+    tx_hash,
+    evt_index
+FROM deduplicated_trades
+WHERE rn = 1 

--- a/dbt_subprojects/dex/models/trades/hyperevm/platforms/prjx_v3_hyperevm_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/hyperevm/platforms/prjx_v3_hyperevm_base_trades.sql
@@ -10,12 +10,40 @@
     )
 }}
 
-{{
-    uniswap_compatible_v3_trades(
-        blockchain = 'hyperevm',
-        project = 'prjx',
-        version = '3',
-        Pair_evt_Swap = source('prjx_hyperevm', 'uniswapv3pool_evt_swap'),
-        Factory_evt_PoolCreated = source('prjx_hyperevm', 'uniswapv3factory_evt_poolcreated')
-    )
-}} 
+WITH base_trades AS (
+    {{
+        uniswap_compatible_v3_trades(
+            blockchain = 'hyperevm',
+            project = 'prjx',
+            version = '3',
+            Pair_evt_Swap = source('prjx_hyperevm', 'uniswapv3pool_evt_swap'),
+            Factory_evt_PoolCreated = source('prjx_hyperevm', 'uniswapv3factory_evt_poolcreated')
+        )
+    }}
+),
+
+deduplicated_trades AS (
+    SELECT *,
+           ROW_NUMBER() OVER (PARTITION BY tx_hash, evt_index ORDER BY block_time) as rn
+    FROM base_trades
+)
+
+SELECT 
+    blockchain,
+    project,
+    version,
+    block_month,
+    block_date,
+    block_time,
+    block_number,
+    token_bought_amount_raw,
+    token_sold_amount_raw,
+    token_bought_address,
+    token_sold_address,
+    taker,
+    maker,
+    project_contract_address,
+    tx_hash,
+    evt_index
+FROM deduplicated_trades
+WHERE rn = 1 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `prod_exclude` tag from four hyperevm DEX `base_trades` models.
> 
> - **DBT models (hyperevm DEX)**:
>   - Remove `tags = ['prod_exclude']` from `config` in:
>     - `dbt_subprojects/dex/models/trades/hyperevm/platforms/hybra_v3_hyperevm_base_trades.sql`
>     - `dbt_subprojects/dex/models/trades/hyperevm/platforms/hyperswap_v2_hyperevm_base_trades.sql`
>     - `dbt_subprojects/dex/models/trades/hyperevm/platforms/hyperswap_v3_hyperevm_base_trades.sql`
>     - `dbt_subprojects/dex/models/trades/hyperevm/platforms/prjx_v3_hyperevm_base_trades.sql`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d085691ef17acf549a88d0cb80ab347cffdde89a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->