### PR TITLE
prices_katana_tokens.sql

### DIFF
--- a/dbt_subprojects/tokens/models/prices/katana/prices_katana_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/katana/prices_katana_tokens.sql
@@ -24,4 +24,5 @@ FROM
     , ('usdt-tether', 'vbUSDT', 0x2DCa96907fde857dd3D816880A0df407eeB2D2F2, 6)
     , ('wbtc-wrapped-bitcoin', 'vbBTC', 0x0913DA6Da4b42f538B445599b46Bb4622342Cf52, 8)
     , ('usds-usds', 'vbUSDS', 0x62D6A123E8D19d06d68cf0d2294F9A3A0362c6b3, 18)
+    , ('wsteth-wrapped-liquid-staked-ether-20', 'wstETH', 0x7Fb4D0f51544F24F385a421Db6e7D4fC71Ad8e5C, 18)
 ) as temp (token_id, symbol, contract_address, decimals)


### PR DESCRIPTION
add wrapped staked eth for katana team

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `wstETH` to `prices/katana/prices_katana_tokens.sql` with 18 decimals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4f313853d68e4a6678a4bd822e704235b2266d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->