### PR TITLE
[easy] Add poolId as maker column in Swaap Trades

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/swaap_compatible_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/swaap_compatible_trades.sql
@@ -11,7 +11,7 @@ WITH dexs AS
         t.evt_block_number AS block_number
         , t.evt_block_time AS block_time
         , CAST(null AS VARBINARY) AS taker
-        , t.contract_address AS maker
+        , t.PoolId AS maker -- singleton dex similar to uniswap, poolid as maker allows fetching metrics at pool level
         , CASE WHEN amountIn < INT256 '0' THEN abs(amountIn) ELSE abs(amountOut) END AS token_bought_amount_raw -- when amountIn is negative it means trader_a is buying tokenIn from the pool
         , CASE WHEN amountIn < INT256 '0' THEN abs(amountOut) ELSE abs(amountIn) END AS token_sold_amount_raw
         , CASE WHEN amountIn < INT256 '0' THEN t.tokenIn ELSE t.tokenOut END AS token_bought_address


### PR DESCRIPTION
Singleton like Uniswap V4, PoolId as maker column allows fetching pool level metrics for Swaap on dex trades!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `maker` to `PoolId` in `swaap_compatible_trades.sql` to identify trades at the pool level.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2128a2ece3148f5ce6dbce01f9178f5764eb501. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->