### PR TITLE
Add ONYC prices_solana_tokens.sql

### DIFF
--- a/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
@@ -778,6 +778,6 @@ FROM
         ('aura-auraonsol', 'solana', 'AURA', 'DtR4D9FtVoTX2569gaL837ZgrB6wNjj6tkmnX9Rdk9B2', 6),
         ('wct-walletconnect-token', 'solana', 'WCT', 'WCTk5xWdn5SYg56twGj32sUF3W4WFQ48ogezLBuYTBY', 9),
         ('holo-holoworld-ai', 'solana', 'HOLO', '69RX85eQoEsnZvXGmLNjYcWgVkp9r2JjahVm99KbJETU', 9),
-        ('onyc-onyc', 'solana', 'ONYC', '5Y8NV33Vv7WbnLfq3zBcKSdYPrk7g2KoiQoe7M2tcxp5', 9),
+        ('onyc-onyc', 'solana', 'ONyc', '5Y8NV33Vv7WbnLfq3zBcKSdYPrk7g2KoiQoe7M2tcxp5', 9),
         ('yzy-yzy', 'solana', 'YZY', 'DrZ26cKJDksVRWib3DVVsjo9eeXccc7hKhDJviiYEEZY', 6)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)


### PR DESCRIPTION
Hi! I added ONYC (contract: [5Y8NV33Vv7WbnLfq3zBcKSdYPrk7g2KoiQoe7M2tcxp5](https://solscan.io/token/5Y8NV33Vv7WbnLfq3zBcKSdYPrk7g2KoiQoe7M2tcxp5), decimals: 9) to the Solana prices model.
This makes ONYC available in Dune queries and dashboards alongside other Solana tokens.

Coinpaprika - https://coinpaprika.com/coin/onyc-onyc/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `ONYC` (Solana, 9 decimals) to `prices_solana_tokens.sql` with contract `5Y8NV33Vv7WbnLfq3zBcKSdYPrk7g2KoiQoe7M2tcxp5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb21e73c2224fa52c76acd792ba6b0cf6f64b838. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->