### PR TITLE
Hide tokens.nft from data explorer

### DIFF
--- a/dbt_subprojects/tokens/models/tokens/tokens_nft.sql
+++ b/dbt_subprojects/tokens/models/tokens/tokens_nft.sql
@@ -1,8 +1,5 @@
 {{ config( alias = 'nft',
-        post_hook='{{ expose_spells(\'["avalanche_c","bnb","ethereum","optimism", "gnosis", "fantom","arbitrum","polygon","base","celo","zora","zksync"]\',
-                                    "sector",
-                                    "tokens",
-                                    \'["0xRob"]\') }}')}}
+        post_hook='{{ hide_spells() }}')}}
 
 
 {% set sources = [


### PR DESCRIPTION
Replace `expose_spells` with `hide_spells()` in `tokens_nft.sql` to hide the model from the data explorer.

---
<a href="https://cursor.com/background-agent?bcId=bc-284b8b7b-dcef-47bf-be35-4fa87dc23542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-284b8b7b-dcef-47bf-be35-4fa87dc23542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace `expose_spells` with `hide_spells()` in `dbt_subprojects/tokens/models/tokens/tokens_nft.sql` to hide the NFT model.
> 
> - **DBT config**:
>   - Update `post_hook` in `dbt_subprojects/tokens/models/tokens/tokens_nft.sql` from `expose_spells(...)` to `hide_spells()` to hide `tokens.nft`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 861ab6e18d165112de92b83849381b915345bda6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->