### PR TITLE
Labels for Plasma Pools

### DIFF
--- a/dbt_subprojects/dex/models/_projects/balancer/labels/plasma/labels_balancer_v3_pools_plasma.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/plasma/labels_balancer_v3_pools_plasma.sql
@@ -50,6 +50,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_plasma', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_plasma', 'StablePoolFactory_call_create') }} cc

--- a/sources/balancer/plasma/balancer_plasma_sources.yml
+++ b/sources/balancer/plasma/balancer_plasma_sources.yml
@@ -48,3 +48,5 @@ sources:
       - name: LBPool_evt_GradualWeightUpdateScheduled
 
       - name: GyroECLPPoolFactory_call_create
+
+      - name: ReclammPoolFactory_call_create


### PR DESCRIPTION
### Description:

Create labels to balancer V3 pools in Plasma chain

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add model to generate labels for Balancer V3 pools on Plasma and register required Plasma Balancer sources.
> 
> - **Labels (Plasma)**:
>   - New model `dbt_subprojects/dex/models/_projects/balancer/labels/plasma/labels_balancer_v3_pools_plasma.sql` to label Balancer V3 pools (`category`=`balancer_v3_pool`).
>   - Builds pool names from token symbols and normalized weights for `weighted`; uses pool symbol for `stable`, `LBP`, `ECLP`.
>   - Supports pool types: `weighted`, `stable`, `StableSurge`, `LBP`, `ECLP`, `reclamm` via various `*_call_create` sources and `Vault_evt_PoolRegistered`.
>   - Outputs: `blockchain`, `address`, `name`, `pool_type`, `category`, `contributor`, `source`, `created_at`, `updated_at`, `model_name`, `label_type`.
> - **Sources**:
>   - Add `sources/balancer/plasma/balancer_plasma_sources.yml` defining `balancer_v3_plasma` tables (Vault events, PoolFactory create/evt tables incl. Weighted, Stable, StableSurge, LBP, GyroECLP, Reclamm, ProtocolFee*).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2797e4c066665e344215239fc162398d870afa1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->