### PR TITLE
feat: add varchar columns to gas_tron_fees for human-readable Tron addresses

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/tron/gas_tron_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/tron/gas_tron_fees.sql
@@ -27,10 +27,8 @@ WITH base_model as (
             WHEN txns.gas_limit != 0 THEN cast(txns.gas_used as double) / cast(txns.gas_limit as double)
         END AS gas_limit_usage
     FROM {{ source( 'tron', 'transactions') }} txns
-    WHERE txns.block_time >= TIMESTAMP '2025-10-15'
-        AND txns.block_time < TIMESTAMP '2025-10-16'
     {% if is_incremental() %}
-    AND {{ incremental_predicate('txns.block_time') }}
+    WHERE {{ incremental_predicate('txns.block_time') }}
     {% endif %}
    )
 


### PR DESCRIPTION
## Summary

Adds human-readable base58-encoded varchar columns to the Tron gas fees model, following the same pattern implemented in PR #8818 for tokens_tron_base_transfers.

## Changes

- Added `tx_hash_varchar` - removes 0x prefix from transaction hash
- Added `tx_from_varchar` - base58-encoded sender address
- Added `tx_to_varchar` - base58-encoded recipient address

## Impact

- Original varbinary columns preserved for backwards compatibility
- Makes Tron addresses easier to read and query
- Consistent with tokens_tron models

## Testing

- [x] dbt compile successful
- [x] Query tested on Dune and returns expected results
- [x] No linter errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `tx_hash_varchar`, `tx_from_varchar`, and `tx_to_varchar` to expose human-readable Tron tx hash and addresses.
> 
> - **Data Model (`dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/tron/gas_tron_fees.sql`)**:
>   - **New Columns**:
>     - `tx_hash_varchar`: hash without `0x` prefix.
>     - `tx_from_varchar`: base58-encoded sender (`to_tron_address(tx_from)`).
>     - `tx_to_varchar`: base58-encoded recipient (`to_tron_address(tx_to)`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5c88fcfc9c42b50fd7f0f8c9c70c4d39d09e28c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->