### PR TITLE
raydium v4/5: init staging transfers models for performance optimization

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v4_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v4_base_trades.sql
@@ -44,7 +44,7 @@ all_swaps as (
         FROM {{ source('raydium_amm_solana', 'raydium_amm_call_swapBaseOut') }}
         WHERE
             1=1
-            {% if is_incremental() or true -%}
+            {% if is_incremental() -%}
             AND {{incremental_predicate('call_block_time')}}
             {% else -%}
             AND call_block_date >= DATE '{{project_start_date}}'
@@ -54,7 +54,7 @@ all_swaps as (
         FROM {{ source('raydium_amm_solana', 'raydium_amm_call_swapBaseIn') }}
         WHERE
             1=1
-            {% if is_incremental() or true -%}
+            {% if is_incremental() -%}
             AND {{incremental_predicate('call_block_time')}}
             {% else -%}
             AND call_block_date >= DATE '{{project_start_date}}'
@@ -68,7 +68,7 @@ all_swaps as (
         AND ((sp.call_is_inner = false AND trs_1.inner_instruction_index = 1)
             OR (sp.call_is_inner = true AND trs_1.inner_instruction_index = sp.call_inner_instruction_index + 1))
         AND trs_1.from_token_account = sp.account_uerSourceTokenAccount
-        {% if is_incremental() or true %}
+        {% if is_incremental() %}
         AND {{incremental_predicate('trs_1.block_time')}}
         {% else %}
         AND trs_1.block_date >= DATE '{{project_start_date}}'
@@ -81,7 +81,7 @@ all_swaps as (
         AND ((sp.call_is_inner = false AND trs_2.inner_instruction_index = 2)
             OR (sp.call_is_inner = true AND trs_2.inner_instruction_index = sp.call_inner_instruction_index + 2))
         AND trs_2.to_token_account = sp.account_uerDestinationTokenAccount
-        {% if is_incremental() or true %}
+        {% if is_incremental() %}
         AND {{incremental_predicate('trs_2.block_time')}}
         {% else %}
         AND trs_2.block_date >= DATE '{{project_start_date}}'

--- a/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v4_solana_token_transfers.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v4_solana_token_transfers.sql
@@ -24,7 +24,7 @@ with all_raydium_swaps as (
 		{{ source('raydium_amm_solana', 'raydium_amm_call_swapBaseOut') }}
 	where
 		1=1
-		{% if is_incremental() or true -%}
+		{% if is_incremental() -%}
 		and {{incremental_predicate('call_block_time')}}
 		{% else -%}
 		and call_block_date >= date '{{project_start_date}}'
@@ -39,7 +39,7 @@ with all_raydium_swaps as (
 		{{ source('raydium_amm_solana', 'raydium_amm_call_swapBaseIn') }}
 	where
 		1=1
-		{% if is_incremental() or true -%}
+		{% if is_incremental() -%}
 		and {{incremental_predicate('call_block_time')}}
 		{% else -%}
 		and call_block_date >= date '{{project_start_date}}'
@@ -59,7 +59,7 @@ with all_raydium_swaps as (
 	where
 		1=1
 		and token_version != 'native'
-		{% if is_incremental() or true %}
+		{% if is_incremental() %}
 		and {{ incremental_predicate('block_time') }}
 		{% else %}
 		and block_time >= timestamp '{{ project_start_date }}'

--- a/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v5_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v5_base_trades.sql
@@ -43,7 +43,7 @@ all_swaps as (
         FROM {{ source('raydium_cp_solana', 'raydium_cp_swap_call_swapBaseOutput') }}
         WHERE
             1=1
-            {% if is_incremental() or true -%}
+            {% if is_incremental() -%}
             AND {{incremental_predicate('call_block_time')}}
             {% else -%}
             AND call_block_date >= DATE '{{project_start_date}}'
@@ -53,7 +53,7 @@ all_swaps as (
         FROM {{ source('raydium_cp_solana', 'raydium_cp_swap_call_swapBaseInput') }}
         WHERE
             1=1
-            {% if is_incremental() or true -%}
+            {% if is_incremental() -%}
             AND {{incremental_predicate('call_block_time')}}
             {% else -%}
             AND call_block_date >= DATE '{{project_start_date}}'
@@ -68,7 +68,7 @@ all_swaps as (
             OR (sp.call_is_inner = true AND trs_1.inner_instruction_index = sp.call_inner_instruction_index + 1))
         AND trs_1.token_mint_address = sp.account_inputTokenMint
         AND trs_1.to_token_account = sp.account_inputVault
-        {% if is_incremental() or true -%}
+        {% if is_incremental() -%}
         AND {{incremental_predicate('trs_1.block_time')}}
         {% else -%}
         AND trs_1.block_date >= DATE '{{project_start_date}}'
@@ -82,7 +82,7 @@ all_swaps as (
             OR (sp.call_is_inner = true AND trs_2.inner_instruction_index = sp.call_inner_instruction_index + 2))
         AND trs_2.token_mint_address = sp.account_outputTokenMint
         AND trs_2.from_token_account = sp.account_outputVault
-        {% if is_incremental() or true -%}
+        {% if is_incremental() -%}
         AND {{incremental_predicate('trs_2.block_time')}}
         {% else -%}
         AND trs_2.block_date >= DATE '{{project_start_date}}'

--- a/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v5_solana_token_transfers.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v5_solana_token_transfers.sql
@@ -24,7 +24,7 @@ with all_raydium_swaps as (
 		{{ source('raydium_cp_solana', 'raydium_cp_swap_call_swapBaseOutput') }}
 	where
 		1=1
-		{% if is_incremental() or true -%}
+		{% if is_incremental() -%}
 		and {{incremental_predicate('call_block_time')}}
 		{% else -%}
 		and call_block_date >= date '{{project_start_date}}'
@@ -39,7 +39,7 @@ with all_raydium_swaps as (
 		{{ source('raydium_cp_solana', 'raydium_cp_swap_call_swapBaseInput') }}
 	where
 		1=1
-		{% if is_incremental() or true -%}
+		{% if is_incremental() -%}
 		and {{incremental_predicate('call_block_time')}}
 		{% else -%}
 		and call_block_date >= date '{{project_start_date}}'
@@ -59,7 +59,7 @@ with all_raydium_swaps as (
 	where
 		1=1
 		and token_version != 'native'
-		{% if is_incremental() or true %}
+		{% if is_incremental() %}
 		and {{ incremental_predicate('block_time') }}
 		{% else %}
 		and block_time >= timestamp '{{ project_start_date }}'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds incremental `token_transfers` staging models for Raydium v4/v5 and updates base trade models to use them with tighter incremental filtering.
> 
> - **Models**:
>   - **New staging**: `raydium_v4_solana.token_transfers`, `raydium_v5_solana.token_transfers`
>     - Incremental, partitioned by `block_date`, unique on `block_date` + `unique_instruction_key`.
>     - Filters out `native` tokens and restricts transfers to Raydium swap calls via join on (`block_date`, `block_slot`, `tx_index`, `outer_instruction_index`).
> - **Base trades (v4/v5)**:
>   - Replace joins to `source('tokens_solana','transfers')` with `ref('raydium_v{4,5}_solana_token_transfers')` for `trs_1` and `trs_2`.
>   - Drop explicit `token_version` filters (handled upstream) and consistently apply `incremental_predicate` on swap sources and transfer joins.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e12cfea58e233f47412631c8e7b971ab1f0361dc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->