### PR TITLE
Fix Balancer v3 token pair alphabetical ordering

### DIFF
--- a/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
+++ b/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
@@ -101,8 +101,11 @@ SELECT
         token_bought_symbol) AS token_bought_symbol
     , COALESCE(erc4626b.underlying_token_symbol,
         token_sold_symbol) AS token_sold_symbol
-    , CONCAT(COALESCE(erc4626a.underlying_token_symbol, token_bought_symbol), '-', 
-        COALESCE(erc4626b.underlying_token_symbol, token_sold_symbol)) AS token_pair
+    , CASE
+        WHEN lower(COALESCE(erc4626a.underlying_token_symbol, token_bought_symbol)) > lower(COALESCE(erc4626b.underlying_token_symbol, token_sold_symbol)) 
+            THEN CONCAT(COALESCE(erc4626b.underlying_token_symbol, token_sold_symbol), '-', COALESCE(erc4626a.underlying_token_symbol, token_bought_symbol))
+        ELSE CONCAT(COALESCE(erc4626a.underlying_token_symbol, token_bought_symbol), '-', COALESCE(erc4626b.underlying_token_symbol, token_sold_symbol))
+        END AS token_pair
     , token_bought_amount
     , token_sold_amount
     , token_bought_amount_raw


### PR DESCRIPTION
- Apply alphabetical ordering logic to token pairs after erc4626 token resolution
- Ensures token pairs like USDT-USDC are consistently stored as USDC-USDT
- Aligns with token pair ordering logic used in other DEX implementations
- Fixes issue where erc4626 vault token pairs were not alphabetically sorted

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `token_pair` in Balancer v3 trades is case-insensitively alphabetized after ERC4626 underlying symbol resolution for consistent pair naming.
> 
> - **Balancer v3 enrich macro** (`dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql`):
>   - **Token pair computation**:
>     - Replace direct concat with case-insensitive alphabetical ordering of coalesced symbols (`ERC4626` underlying or original), ensuring consistent `token_pair` (e.g., `USDC-USDT`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f5669c28814a798990a8131795b3e7b004b5c05. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->