### PR TITLE
Revert "Fix Balancer v3 token pair alphabetical ordering"

### DIFF
--- a/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
+++ b/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
@@ -101,11 +101,8 @@ SELECT
         token_bought_symbol) AS token_bought_symbol
     , COALESCE(erc4626b.underlying_token_symbol,
         token_sold_symbol) AS token_sold_symbol
-    , CASE
-        WHEN lower(COALESCE(erc4626a.underlying_token_symbol, token_bought_symbol)) > lower(COALESCE(erc4626b.underlying_token_symbol, token_sold_symbol)) 
-            THEN CONCAT(COALESCE(erc4626b.underlying_token_symbol, token_sold_symbol), '-', COALESCE(erc4626a.underlying_token_symbol, token_bought_symbol))
-        ELSE CONCAT(COALESCE(erc4626a.underlying_token_symbol, token_bought_symbol), '-', COALESCE(erc4626b.underlying_token_symbol, token_sold_symbol))
-        END AS token_pair
+    , CONCAT(COALESCE(erc4626a.underlying_token_symbol, token_bought_symbol), '-', 
+        COALESCE(erc4626b.underlying_token_symbol, token_sold_symbol)) AS token_pair
     , token_bought_amount
     , token_sold_amount
     , token_bought_amount_raw


### PR DESCRIPTION
Reverts duneanalytics/spellbook#8891

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts Balancer v3 `token_pair` to simple `token_bought-symbol - token_sold-symbol` concatenation (no alphabetical ordering).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39438c3cd6911aa1ef2e6f7025224eae209c07ed. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->