### PR TITLE
CUR2-835 TON Tonco Fix

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/tonco/ton/tonco_ton_nft_position_init.sql
+++ b/dbt_subprojects/daily_spellbook/models/tonco/ton/tonco_ton_nft_position_init.sql
@@ -5,7 +5,7 @@
     , file_format = 'delta'
     , incremental_strategy = 'merge'
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
-    , unique_key = ['tx_hash', 'block_date']
+    , unique_key = ['tx_hash', 'block_date', 'nftIndex']
     , post_hook='{{ expose_spells(\'["ton"]\',
                     "project",
                     "tonco",

--- a/dbt_subprojects/daily_spellbook/models/tonco/ton/tonco_ton_pool_init.sql
+++ b/dbt_subprojects/daily_spellbook/models/tonco/ton/tonco_ton_pool_init.sql
@@ -5,7 +5,7 @@
        , file_format = 'delta'
        , incremental_strategy = 'merge'
        , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
-       , unique_key = ['tx_hash', 'block_date']
+       , unique_key = ['tx_hash', 'block_date', 'pool_address']
        , post_hook='{{ expose_spells(\'["ton"]\',
                                    "project",
                                    "tonco",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands `unique_key` in TONCO incremental models to include `nftIndex` and `pool_address`.
> 
> - **DBT models (TONCO)**:
>   - `models/tonco/ton/tonco_ton_nft_position_init.sql`: update `unique_key` to `['tx_hash', 'block_date', 'nftIndex']`.
>   - `models/tonco/ton/tonco_ton_pool_init.sql`: update `unique_key` to `['tx_hash', 'block_date', 'pool_address']`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49d8a16536dbcdc9bf4e6e8fb5e9449c1b2b3037. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->