### PR TITLE
raydium staging models: update to monthly partitions

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/raydium/schema.yml
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/schema.yml
@@ -133,7 +133,7 @@ models:
       all decoded raydium_v4 hybrid amm swaps on Solana
     data_tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns: [ 'call_block_date', 'unique_instruction_key' ]
+          combination_of_columns: [ 'call_block_month', 'unique_instruction_key' ]
 
   - name: raydium_v4_base_trades
     meta:
@@ -196,7 +196,7 @@ models:
       all decoded raydium_v5 swaps on Solana
     data_tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns: [ 'call_block_date', 'unique_instruction_key' ]
+          combination_of_columns: [ 'call_block_month', 'unique_instruction_key' ]
 
   - name: raydium_v5_base_trades
     meta:

--- a/dbt_subprojects/solana/models/_sector/dex/raydium/staging/raydium_v4_solana_stg_decoded_swaps.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/staging/raydium_v4_solana_stg_decoded_swaps.sql
@@ -2,12 +2,12 @@
   config(
     schema = 'raydium_v4_solana'
     , alias = 'stg_decoded_swaps'
-    , partition_by = ['call_block_date']
+    , partition_by = ['call_block_month']
     , materialized = 'incremental'
     , file_format = 'delta'
     , incremental_strategy = 'merge'
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.call_block_time')]
-    , unique_key = ['call_block_date', 'unique_instruction_key']
+    , unique_key = ['call_block_month', 'unique_instruction_key']
   )
 }}
 
@@ -68,6 +68,7 @@ with swaps as (
 )
 select
 	*
+	, cast(date_trunc('month', call_block_date) as date) as call_block_month
     , {{ dbt_utils.generate_surrogate_key(['call_block_slot', 'call_tx_id', 'call_tx_index', 'call_outer_instruction_index', 'call_inner_instruction_index']) }} as unique_instruction_key
 from
 	swaps

--- a/dbt_subprojects/solana/models/_sector/dex/raydium/staging/raydium_v5_solana_stg_decoded_swaps.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/staging/raydium_v5_solana_stg_decoded_swaps.sql
@@ -2,12 +2,12 @@
   config(
     schema = 'raydium_v5_solana'
     , alias = 'stg_decoded_swaps'
-    , partition_by = ['call_block_date']
+    , partition_by = ['call_block_month']
     , materialized = 'incremental'
     , file_format = 'delta'
     , incremental_strategy = 'merge'
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.call_block_time')]
-    , unique_key = ['call_block_date', 'unique_instruction_key']
+    , unique_key = ['call_block_month', 'unique_instruction_key']
   )
 }}
 
@@ -69,6 +69,7 @@ with swaps as (
 
 select
 	*
+	, cast(date_trunc('month', call_block_date) as date) as call_block_month
 	, {{ dbt_utils.generate_surrogate_key(['call_block_slot', 'call_tx_id', 'call_tx_index', 'call_outer_instruction_index', 'call_inner_instruction_index']) }} as unique_instruction_key
 from
 	swaps


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches Raydium v4/v5 staging decoded swaps to monthly partitions and updates unique keys/tests accordingly.
> 
> - **Staging models** (`staging/raydium_v4_solana_stg_decoded_swaps.sql`, `staging/raydium_v5_solana_stg_decoded_swaps.sql`):
>   - Partition by `call_block_month` instead of `call_block_date`.
>   - Add computed `call_block_month` column.
>   - Update `unique_key` to `['call_block_month', 'unique_instruction_key']`.
> - **Schema tests** (`schema.yml`):
>   - Update `dbt_utils.unique_combination_of_columns` to use `call_block_month` for `raydium_v4_solana_stg_decoded_swaps` and `raydium_v5_solana_stg_decoded_swaps`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff1ed8790a1eb8f249d829cfdd86d7855ace7679. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->