### PR TITLE
Revert "Uni V4 Liquidity Logic Fees Fix (#8872)"

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
@@ -171,7 +171,7 @@ sort_table as (
     , version = '4'
     , PoolManager_evt_ModifyLiquidity = null
     , PoolManager_evt_Swap = null
-    , PoolManager_call_ModifyLiquidity = null
+    , PoolManager_call_Take = null 
     , liquidity_pools = null
     , liquidity_sqrtpricex96 = null
     )
@@ -237,147 +237,201 @@ get_prices as (
 
 modify_liquidity_events as (
     with 
-
-    get_calls as (
+    
+    get_events as (
         select 
-            contract_address,
-            call_success,
-            call_tx_hash,
-            call_tx_from,
-            call_tx_to,
-            call_trace_address,
-            call_block_time,
-            call_block_number,
-            -- pool key: currency0/1 + hooks (all varbinary)
-            FROM_HEX(JSON_EXTRACT_SCALAR(JSON_PARSE("key"), '$.currency0')) AS currency0,
-            FROM_HEX(JSON_EXTRACT_SCALAR(JSON_PARSE("key"), '$.currency1')) AS currency1,
-            FROM_HEX(JSON_EXTRACT_SCALAR(JSON_PARSE("key"), '$.hooks'))     AS hooks,
-
-            -- raw packed outputs (two signed 128-bit legs inside an int256)
-            CAST(output_callerDelta   AS VARBINARY) AS callerDelta_vb,
-            CAST(output_feesAccrued   AS VARBINARY) AS feesAccrued_vb,
-
-            -- params (decoded for handy metadata)
-            CAST(JSON_EXTRACT(JSON_PARSE(params), '$.tickLower')      AS BIGINT)  AS tickLower,
-            CAST(JSON_EXTRACT(JSON_PARSE(params), '$.tickUpper')      AS BIGINT)  AS tickUpper,
-            CAST(CAST(JSON_EXTRACT(JSON_PARSE(params), '$.liquidityDelta') AS VARCHAR) AS INT256) AS params_liquidityDelta,
-
-            -- for deterministic call↔event pairing within a tx
-            ROW_NUMBER() OVER (PARTITION BY call_tx_hash ORDER BY call_trace_address) AS call_rn
-        from 
-        {{ PoolManager_call_ModifyLiquidity }}
-        where call_success 
-        {%- if is_incremental() %}
-        and {{ incremental_predicate('call_block_time') }}
-        {%- endif %} 
-    ),
-
-    calls_decoded as (
-        SELECT
-            c.*,
-
-            -- ---- decode callerDelta (top/bottom 16 bytes, sign-extended to int256) ----
-            CASE
-                WHEN BITWISE_AND(VARBINARY_TO_BIGINT(VARBINARY_SUBSTRING(c.callerDelta_vb, 1, 1)), FROM_BASE('80', 16)) = FROM_BASE('80', 16)
-                THEN VARBINARY_TO_INT256(VARBINARY_CONCAT(FROM_HEX('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'), VARBINARY_SUBSTRING(c.callerDelta_vb, 1, 16)))
-                ELSE VARBINARY_TO_INT256(VARBINARY_CONCAT(FROM_HEX('0x00000000000000000000000000000000'), VARBINARY_SUBSTRING(c.callerDelta_vb, 1, 16)))
-            END AS callerDelta_token0,
-
-            CASE
-                WHEN BITWISE_AND(VARBINARY_TO_BIGINT(VARBINARY_SUBSTRING(c.callerDelta_vb, 17, 1)), FROM_BASE('80', 16)) = FROM_BASE('80', 16)
-                THEN VARBINARY_TO_INT256(VARBINARY_CONCAT(FROM_HEX('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'), VARBINARY_SUBSTRING(c.callerDelta_vb, 17, 16)))
-                ELSE VARBINARY_TO_INT256(VARBINARY_CONCAT(FROM_HEX('0x00000000000000000000000000000000'), VARBINARY_SUBSTRING(c.callerDelta_vb, 17, 16)))
-            END AS callerDelta_token1,
-
-            -- ---- decode feesAccrued (top/bottom 16 bytes, sign-extended to int256) ----
-            CASE
-                WHEN BITWISE_AND(VARBINARY_TO_BIGINT(VARBINARY_SUBSTRING(c.feesAccrued_vb, 1, 1)), FROM_BASE('80', 16)) = FROM_BASE('80', 16)
-                THEN VARBINARY_TO_INT256(VARBINARY_CONCAT(FROM_HEX('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'), VARBINARY_SUBSTRING(c.feesAccrued_vb, 1, 16)))
-                ELSE VARBINARY_TO_INT256(VARBINARY_CONCAT(FROM_HEX('0x00000000000000000000000000000000'), VARBINARY_SUBSTRING(c.feesAccrued_vb, 1, 16)))
-            END AS feesAccrued_token0,
-
-            CASE
-                WHEN BITWISE_AND(VARBINARY_TO_BIGINT(VARBINARY_SUBSTRING(c.feesAccrued_vb, 17, 1)), FROM_BASE('80', 16)) = FROM_BASE('80', 16)
-                THEN VARBINARY_TO_INT256(VARBINARY_CONCAT(FROM_HEX('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'), VARBINARY_SUBSTRING(c.feesAccrued_vb, 17, 16)))
-                ELSE VARBINARY_TO_INT256(VARBINARY_CONCAT(FROM_HEX('0x00000000000000000000000000000000'), VARBINARY_SUBSTRING(c.feesAccrued_vb, 17, 16)))
-            END AS feesAccrued_token1
-        FROM 
-        get_calls c
-    ),
-
-
-    evts as (
-        select
-            contract_address,
-            evt_tx_hash,
-            evt_tx_from,
-            evt_block_time,
-            evt_block_number,
-            evt_index,
-            id,                -- pool id lives here
-            sender,            -- caller/sender (useful metadata)
-            tickLower,
-            tickUpper,
-            liquidityDelta,    -- int256 in the event log
-            salt,
-            ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_index) AS evt_rn
+            evt_tx_from as tx_from
+            , evt_block_time
+            , evt_block_number
+            , evt_block_number + evt_index/1e6 as block_index_sum
+            , id
+            , evt_tx_hash
+            , evt_index
+            , 'modify_liquidity' as event_type
+            , salt
+            , tickLower
+            , tickUpper
+            , liquidityDelta
+            , sender -- needed for fee logic
         from 
         {{ PoolManager_evt_ModifyLiquidity }}
         {%- if is_incremental() %}
         where {{ incremental_predicate('evt_block_time') }}
         {%- endif %} 
+    ),
+
+    add_latest_price as (
+        select 
+            ab.*,
+            gp.sqrtpricex96
+        from (
+        select 
+            ge.*
+            , gp.previous_block_index_sum
+        from 
+        get_events ge 
+        left join 
+        get_prices gp 
+            on ge.id = gp.id 
+            and ge.block_index_sum >= gp.previous_block_index_sum
+            and ge.block_index_sum < gp.block_index_sum 
+        ) ab 
+        inner join 
+        get_prices gp 
+            on ab.id = gp.id
+            and ab.previous_block_index_sum = gp.block_index_sum 
+    ),
+
+    prep_for_calculations as (
+        select 
+            * 
+            , sqrtpricex96 / power(2, 96) AS sqrtprice
+            , sqrt(power(1.0001, tickLower)) AS sqrtRatioL
+            , sqrt(power(1.0001, tickUpper)) AS sqrtRatioU
+        from 
+        add_latest_price
     )
 
-        SELECT
-            e.id 
-            , cd.call_tx_from as tx_from 
-            , e.evt_block_time as block_time 
-            , e.evt_block_number as block_number 
-            , e.evt_tx_hash as tx_hash
-            , e.evt_index
-            , e.evt_block_number + e.evt_index/1e6 as block_index_sum
-            , 'modify_liquidity' as event_type 
-            , cd.currency0 as token0 
-            , cd.currency1 as token1
-            , e.tickLower 
-            , e.tickUpper   
-            , e.liquidityDelta
-            , e.salt 
-            -- decoded outputs (signed int256, raw token units)
-            -- output_callerDelta signage is from the POV of user, so we must flip signs for pool's POV
-            , -1* cd.callerDelta_token0 as amount0
-            , -1* cd.callerDelta_token1 as amount1
-            , -1* cd.feesAccrued_token0  as fee_amount0
-            , -1* cd.feesAccrued_token1  as fee_amount1
-        FROM 
-        evts e
-        INNER JOIN 
-        calls_decoded cd
-            ON cd.call_tx_hash = e.evt_tx_hash
-            AND cd.call_rn = e.evt_rn
+    select 
+        *
+        , case
+            when sqrtPrice <= sqrtRatioL then liquidityDelta * ((sqrtRatioU - sqrtRatioL)/(sqrtRatioL*sqrtRatioU))
+            when sqrtPrice >= sqrtRatioU then 0
+            else liquidityDelta * ((sqrtRatioU - sqrtPrice) / (sqrtPrice * sqrtRatioU))
+          end as amount0
+        , case
+            when sqrtPrice <= sqrtRatioL then 0
+            when sqrtPrice >= sqrtRatioU then liquidityDelta * (sqrtRatioU - sqrtRatioL)
+            else liquidityDelta * (sqrtPrice - sqrtRatioL)
+          end as amount1
+    from 
+    prep_for_calculations
 ),
 
-final_liquidity_events as (
+fee_collection as (
+    with 
+
+    get_fees as (
+        select 
+            call_tx_from as tx_from
+            , call_tx_hash as tx_hash 
+            , call_block_time as block_time 
+            , call_block_number as block_number 
+            , 1 as evt_index -- we don't actually use index here for anything and some indexes are missing in the call table so hardcoding here as evt_index 
+            , amount 
+            , currency 
+        from 
+        {{ PoolManager_call_Take }}
+        where call_success
+        {%- if is_incremental() %}
+        and {{ incremental_predicate('call_block_time') }}
+        {%- endif %} 
+    ),
+
+    agg_fees as (
+        select 
+            tx_hash
+            , tx_from
+            , block_time
+            , block_number
+            , min(evt_index) as evt_index
+            , sum(amount) as fee_amount 
+            , currency as fee_currency
+        from 
+        get_fees 
+        group by 1, 2, 3, 4, 7
+    ),
+
+    modify_events as (
+        select 
+            evt_block_time as block_time
+            , evt_block_number as block_number 
+            , id 
+            , evt_tx_hash as tx_hash 
+            , evt_index 
+            , amount0 
+            , amount1 
+        from 
+        modify_liquidity_events
+        where liquidityDelta <= int256 '0'
+    ),
+
+    single_pools as (
+        select 
+            tx_hash 
+            , count(distinct id) as num_pools 
+        from 
+        modify_events 
+        group by 1 
+        having count(distinct id) = 1 -- only one pool in txn 
+    ),
+
+    agg_events as (
+        select 
+            me.tx_hash
+            , me.block_number 
+            , me.id 
+            , sum(me.amount0) as amount0
+            , sum(me.amount1) as amount1 
+        from 
+        modify_events me 
+        inner join 
+        single_pools sp 
+            on me.tx_hash = sp.tx_hash 
+        group by 1, 2, 3 
+    ),
+
+    join_with_pools as (
+        select 
+            gf.tx_from
+            , gf.tx_hash 
+            , gf.block_time 
+            , gf.block_number 
+            , gf.evt_index 
+            , 'fee_collection' as event_type
+            , ae.id 
+            , -amount0 as modify_amount0 
+            , -amount1 as modify_amount1
+            , token0 
+            , token1 
+            , sum(case when fee_currency = token0 then fee_amount else 0 end) as amount0 
+            , sum(case when fee_currency = token1 then fee_amount else 0 end) as amount1
+        from 
+        agg_fees gf 
+        inner join 
+        agg_events ae 
+            on gf.tx_hash = ae.tx_hash 
+            and gf.block_number = ae.block_number 
+        inner join 
+        get_pools gp 
+            on ae.id = gp.id 
+        group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+    )
+
     select 
-        ab.*,
-        gp.sqrtpricex96
-    from (
-    select 
-        ge.*
-        , gp.previous_block_index_sum
+        id
+        , tx_from 
+        , block_time 
+        , block_number 
+        , tx_hash 
+        , evt_index
+        , event_type 
+        , token0 
+        , token1 
+        , case 
+            when amount0 > modify_amount0 then amount0 - modify_amount0 else 0 
+        end as amount0 -- subtract total modify liquidity amount from total amount logged in take()
+        , case 
+            when amount1 > modify_amount1 then amount1 - modify_amount1 else 0 
+        end as amount1
+        , cast(null as int256) as liquidityDelta
+        , cast(null as uint256) as sqrtPriceX96
+        , cast(null as double) as tickLower
+        , cast(null as double) as tickUpper
+        , cast(null as varbinary) as salt 
     from 
-    modify_liquidity_events ge 
-    left join 
-    get_prices gp 
-        on ge.id = gp.id 
-        and ge.block_index_sum >= gp.previous_block_index_sum
-        and ge.block_index_sum < gp.block_index_sum 
-    ) ab 
-    left join 
-    get_prices gp 
-        on ab.id = gp.id
-        and ab.previous_block_index_sum = gp.block_index_sum 
-), 
+    join_with_pools
+),
 
 swap_events as (
     select 
@@ -401,39 +455,17 @@ swap_events as (
     {%- endif %}
 ),
 
-swap_fees_paid as (
-    select 
-        evt_tx_from as tx_from
-        , evt_block_time
-        , evt_block_number 
-        , evt_tx_hash 
-        , evt_index 
-        , id 
-        , if (amount0 < int256 '0', abs(amount0) * fee/1e6, 0) as amount0
-        , if (amount1 < int256 '0', abs(amount1) * fee/1e6, 0) as amount1
-        , cast(liquidity as int256) as liquidityDelta
-        , sqrtPriceX96
-        , cast(null as double) as tickLower
-        , cast(null as double) as tickUpper
-        , cast(null as varbinary) as salt 
-    from 
-    {{ PoolManager_evt_Swap }}
-    {%- if is_incremental() %}
-    where {{ incremental_predicate('evt_block_time') }}
-    {%- endif %}
-),
-
 liquidity_change_base as (
     select 
         ml.id
         , ml.tx_from 
-        , ml.block_time
-        , ml.block_number 
-        , ml.tx_hash 
+        , ml.evt_block_time as block_time
+        , ml.evt_block_number as block_number 
+        , ml.evt_tx_hash as tx_hash 
         , ml.evt_index 
         , ml.event_type 
-        , ml.token0 
-        , ml.token1 
+        , gp.token0 
+        , gp.token1 
         , ml.amount0 
         , ml.amount1 
         , ml.liquidityDelta
@@ -442,29 +474,10 @@ liquidity_change_base as (
         , ml.tickUpper
         , ml.salt
     from 
-    final_liquidity_events ml 
-
-    union all 
-
-    select 
-        ml.id
-        , ml.tx_from 
-        , ml.block_time
-        , ml.block_number 
-        , ml.tx_hash 
-        , ml.evt_index 
-        , 'fees_accrued' as event_type
-        , ml.token0 
-        , ml.token1 
-        , ml.fee_amount0 
-        , ml.fee_amount1 
-        , ml.liquidityDelta
-        , ml.sqrtPriceX96
-        , ml.tickLower
-        , ml.tickUpper
-        , ml.salt
-    from 
-    final_liquidity_events ml 
+    modify_liquidity_events ml 
+    inner join 
+    get_pools gp 
+        on ml.id = gp.id 
 
     union all 
 
@@ -494,27 +507,25 @@ liquidity_change_base as (
     union all 
 
     select 
-        se.id
-        , se.tx_from 
-        , se.evt_block_time as block_time
-        , se.evt_block_number as block_number 
-        , se.evt_tx_hash as tx_hash 
-        , se.evt_index 
-        , 'swap_fees_paid' as event_type 
-        , gp.token0 
-        , gp.token1 
-        , se.amount0 
-        , se.amount1 
-        , se.liquidityDelta
-        , se.sqrtPriceX96
-        , se.tickLower
-        , se.tickUpper
-        , se.salt
+        id
+        , tx_from 
+        , block_time
+        , block_number 
+        , tx_hash 
+        , evt_index 
+        , event_type 
+        , token0 
+        , token1 
+        , -amount0 as amount0
+        , -amount1 as amount1
+        , liquidityDelta
+        , sqrtPriceX96
+        , tickLower
+        , tickUpper
+        , salt
     from 
-    swap_fees_paid se
-    inner join 
-    get_pools gp 
-        on se.id = gp.id 
+    fee_collection
+    where tx_hash not in (select evt_tx_hash from swap_events)
 )
     select 
           '{{blockchain}}' as blockchain

--- a/dbt_subprojects/dex/models/_projects/uniswap/arbitrum/base_liquidity_events/uniswap_v4_arbitrum_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/arbitrum/base_liquidity_events/uniswap_v4_arbitrum_base_liquidity_events.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_arbitrum', 'PoolManager_evt_Swap') 
         , liquidity_pools = ref('uniswap_v4_arbitrum_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_arbitrum_sqrtpricex96')
-        , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_arbitrum', 'PoolManager_call_ModifyLiquidity')
+        , PoolManager_call_Take = source('uniswap_v4_arbitrum', 'poolmanager_call_take')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/avalanche_c/base_liquidity_events/uniswap_v4_avalanche_c_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/avalanche_c/base_liquidity_events/uniswap_v4_avalanche_c_base_liquidity_events.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_avalanche_c', 'PoolManager_evt_Swap') 
         , liquidity_pools = ref('uniswap_v4_avalanche_c_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_avalanche_c_sqrtpricex96')
-        , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_avalanche_c', 'PoolManager_call_ModifyLiquidity')
+        , PoolManager_call_Take = source('uniswap_v4_avalanche_c', 'poolmanager_call_take')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/base/base_liquidity_events/uniswap_v4_base_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/base/base_liquidity_events/uniswap_v4_base_base_liquidity_events.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_base', 'PoolManager_evt_Swap') 
         , liquidity_pools = ref('uniswap_v4_base_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_base_sqrtpricex96')
-        , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_base', 'PoolManager_call_ModifyLiquidity')
+        , PoolManager_call_Take = source('uniswap_v4_base', 'poolmanager_call_take')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/blast/base_liquidity_events/uniswap_v4_blast_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/blast/base_liquidity_events/uniswap_v4_blast_base_liquidity_events.sql
@@ -20,6 +20,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_blast', 'PoolManager_evt_Swap') 
         , liquidity_pools = ref('uniswap_v4_blast_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_blast_sqrtpricex96')
-        , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_blast', 'PoolManager_call_ModifyLiquidity')
+        , PoolManager_call_Take = source('uniswap_v4_blast', 'poolmanager_call_take')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/bnb/base_liquidity_events/uniswap_v4_bnb_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/bnb/base_liquidity_events/uniswap_v4_bnb_base_liquidity_events.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_bnb', 'PoolManager_evt_Swap') 
         , liquidity_pools = ref('uniswap_v4_bnb_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_bnb_sqrtpricex96')
-        , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_bnb', 'PoolManager_call_ModifyLiquidity')
+        , PoolManager_call_Take = source('uniswap_v4_bnb', 'poolmanager_call_take')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/ethereum/base_liquidity_events/uniswap_v4_ethereum_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/ethereum/base_liquidity_events/uniswap_v4_ethereum_base_liquidity_events.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_ethereum', 'PoolManager_evt_Swap') 
         , liquidity_pools = ref('uniswap_v4_ethereum_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_ethereum_sqrtpricex96')
-        , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_ethereum', 'PoolManager_call_ModifyLiquidity')
+        , PoolManager_call_Take = source('uniswap_v4_ethereum', 'poolmanager_call_take')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/ink/base_liquidity_events/uniswap_v4_ink_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/ink/base_liquidity_events/uniswap_v4_ink_base_liquidity_events.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_ink', 'PoolManager_evt_Swap') 
         , liquidity_pools = ref('uniswap_v4_ink_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_ink_sqrtpricex96')
-        , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_ink', 'PoolManager_call_ModifyLiquidity')
+        , PoolManager_call_Take = source('uniswap_v4_ink', 'poolmanager_call_take')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/optimism/base_liquidity_events/uniswap_v4_optimism_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/optimism/base_liquidity_events/uniswap_v4_optimism_base_liquidity_events.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_optimism', 'PoolManager_evt_Swap') 
         , liquidity_pools = ref('uniswap_v4_optimism_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_optimism_sqrtpricex96')
-        , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_optimism', 'PoolManager_call_ModifyLiquidity')
+        , PoolManager_call_Take = source('uniswap_v4_optimism', 'poolmanager_call_take')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/polygon/base_liquidity_events/uniswap_v4_polygon_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/polygon/base_liquidity_events/uniswap_v4_polygon_base_liquidity_events.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_polygon', 'PoolManager_evt_Swap') 
         , liquidity_pools = ref('uniswap_v4_polygon_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_polygon_sqrtpricex96')
-        , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_polygon', 'PoolManager_call_ModifyLiquidity')
+        , PoolManager_call_Take = source('uniswap_v4_polygon', 'poolmanager_call_take')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/unichain/base_liquidity_events/uniswap_v4_unichain_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/unichain/base_liquidity_events/uniswap_v4_unichain_base_liquidity_events.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_unichain', 'PoolManager_evt_Swap') 
         , liquidity_pools = ref('uniswap_v4_unichain_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_unichain_sqrtpricex96')
-        , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_unichain', 'PoolManager_call_ModifyLiquidity')
+        , PoolManager_call_Take = source('uniswap_v4_unichain', 'poolmanager_call_take')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/uniswap_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/uniswap_base_liquidity_events.sql
@@ -1,7 +1,13 @@
 {{ config(
-        schema = 'uniswap',
-        alias = 'base_liquidity_events'
-        )
+    schema = 'uniswap'
+    , alias = 'base_liquidity_events'
+    , partition_by = ['block_month', 'blockchain', 'project']
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'event_type']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
 }}
 
 {% set models = [
@@ -50,6 +56,9 @@ with base_union as (
                 , salt
         FROM
             {{ model }}
+        {% if is_incremental() %}
+        WHERE {{ incremental_predicate('block_time') }}
+        {% endif %}
         {% if not loop.last %}
            UNION ALL
         {% endif %}
@@ -60,3 +69,4 @@ select
     *
 from
     base_union
+-- comment to refresh

--- a/dbt_subprojects/dex/models/_projects/uniswap/uniswap_daily_agg_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/uniswap_daily_agg_liquidity_events.sql
@@ -21,10 +21,10 @@ select
     , token1 
     , token0_symbol 
     , token1_symbol 
-    , sum(case when event_type = 'fees_accrued' then 2 * amount0_raw else amount0_raw end) as amount0_raw
-    , sum(case when event_type = 'fees_accrued' then 2 * amount1_raw else amount1_raw end) as amount1_raw
-    , sum(case when event_type = 'fees_accrued' then 2 * amount0 else amount0 end) as amount0 
-    , sum(case when event_type = 'fees_accrued' then 2 * amount1 else amount1 end) as amount1
+    , sum(amount0_raw) as amount0_raw 
+    , sum(amount1_raw) as amount1_raw 
+    , sum(amount0) as amount0 
+    , sum(amount1) as amount1 
 from 
 {{ ref('uniswap_liquidity_events') }}
 {% if is_incremental() %}

--- a/dbt_subprojects/dex/models/_projects/uniswap/uniswap_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/uniswap_liquidity_events.sql
@@ -58,4 +58,4 @@ WITH dexes AS (
                {{ incremental_predicate('block_time') }}
           {% endif %}
 
--- refreshing
+-- refresh 

--- a/dbt_subprojects/dex/models/_projects/uniswap/uniswap_tvl_daily.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/uniswap_tvl_daily.sql
@@ -329,4 +329,4 @@ prices_day as (
         and tl.blockchain = pd_b.blockchain 
 {% endif %}
 
--- trigger refresh 
+-- refresh 

--- a/dbt_subprojects/dex/models/_projects/uniswap/worldchain/base_liquidity_events/uniswap_v4_worldchain_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/worldchain/base_liquidity_events/uniswap_v4_worldchain_base_liquidity_events.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_worldchain', 'PoolManager_evt_Swap') 
         , liquidity_pools = ref('uniswap_v4_worldchain_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_worldchain_sqrtpricex96')
-        , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_worldchain', 'PoolManager_call_ModifyLiquidity')
+        , PoolManager_call_Take = source('uniswap_v4_worldchain', 'poolmanager_call_take')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/zora/base_liquidity_events/uniswap_v4_zora_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/zora/base_liquidity_events/uniswap_v4_zora_base_liquidity_events.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_zora', 'PoolManager_evt_Swap') 
         , liquidity_pools = ref('uniswap_v4_zora_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_zora_sqrtpricex96')
-        , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_zora', 'PoolManager_call_ModifyLiquidity')
+        , PoolManager_call_Take = source('uniswap_v4_zora', 'poolmanager_call_take')
     )
 }}

--- a/sources/_sector/dex/liquidity/arbitrum/_sources.yml
+++ b/sources/_sector/dex/liquidity/arbitrum/_sources.yml
@@ -4,4 +4,4 @@ sources:
   - name: uniswap_v4_arbitrum
     tables:
       - name: PoolManager_evt_ModifyLiquidity
-      - name: PoolManager_call_ModifyLiquidity
+      - name: poolmanager_call_take

--- a/sources/_sector/dex/liquidity/avalanche_c/_schema.yml
+++ b/sources/_sector/dex/liquidity/avalanche_c/_schema.yml
@@ -4,4 +4,4 @@ sources:
   - name: uniswap_v4_avalanche_c
     tables:
       - name: PoolManager_evt_ModifyLiquidity
-      - name: PoolManager_call_ModifyLiquidity
+      - name: poolmanager_call_take

--- a/sources/_sector/dex/liquidity/base/_sources.yml
+++ b/sources/_sector/dex/liquidity/base/_sources.yml
@@ -4,7 +4,7 @@ sources:
   - name: uniswap_v4_base
     tables:
       - name: PoolManager_evt_ModifyLiquidity
-      - name: PoolManager_call_ModifyLiquidity
+      - name: poolmanager_call_take
 
   - name: pancakeswap_infinity_base
     tables:

--- a/sources/_sector/dex/liquidity/blast/_schema.yml
+++ b/sources/_sector/dex/liquidity/blast/_schema.yml
@@ -4,4 +4,4 @@ sources:
   - name: uniswap_v4_blast
     tables:
       - name: PoolManager_evt_ModifyLiquidity
-      - name: PoolManager_call_ModifyLiquidity
+      - name: poolmanager_call_take

--- a/sources/_sector/dex/liquidity/bnb/_schema.yml
+++ b/sources/_sector/dex/liquidity/bnb/_schema.yml
@@ -4,7 +4,7 @@ sources:
   - name: uniswap_v4_bnb
     tables:
       - name: PoolManager_evt_ModifyLiquidity
-      - name: PoolManager_call_ModifyLiquidity
+      - name: poolmanager_call_take
 
   - name: pancakeswap_infinity_bnb
     tables:

--- a/sources/_sector/dex/liquidity/ethereum/_sources.yml
+++ b/sources/_sector/dex/liquidity/ethereum/_sources.yml
@@ -4,7 +4,7 @@ sources:
   - name: uniswap_v4_ethereum
     tables:
       - name: PoolManager_evt_ModifyLiquidity
-      - name: PoolManager_call_ModifyLiquidity
+      - name: poolmanager_call_take
 
   - name: ekubo_ethereum
     tables:

--- a/sources/_sector/dex/liquidity/ink/_schema.yml
+++ b/sources/_sector/dex/liquidity/ink/_schema.yml
@@ -4,4 +4,4 @@ sources:
   - name: uniswap_v4_ink
     tables:
       - name: PoolManager_evt_ModifyLiquidity
-      - name: PoolManager_call_ModifyLiquidity
+      - name: poolmanager_call_take

--- a/sources/_sector/dex/liquidity/optimism/_schema.yml
+++ b/sources/_sector/dex/liquidity/optimism/_schema.yml
@@ -4,4 +4,4 @@ sources:
   - name: uniswap_v4_optimism
     tables:
       - name: PoolManager_evt_ModifyLiquidity
-      - name: PoolManager_call_ModifyLiquidity
+      - name: poolmanager_call_take

--- a/sources/_sector/dex/liquidity/polygon/_schema.yml
+++ b/sources/_sector/dex/liquidity/polygon/_schema.yml
@@ -4,4 +4,4 @@ sources:
   - name: uniswap_v4_polygon
     tables:
       - name: PoolManager_evt_ModifyLiquidity
-      - name: PoolManager_call_ModifyLiquidity
+      - name: poolmanager_call_take

--- a/sources/_sector/dex/liquidity/unichain/_schema.yml
+++ b/sources/_sector/dex/liquidity/unichain/_schema.yml
@@ -4,4 +4,4 @@ sources:
   - name: uniswap_v4_unichain
     tables:
       - name: PoolManager_evt_ModifyLiquidity
-      - name: PoolManager_call_ModifyLiquidity
+      - name: poolmanager_call_take

--- a/sources/_sector/dex/liquidity/worldchain/_schema.yml
+++ b/sources/_sector/dex/liquidity/worldchain/_schema.yml
@@ -4,4 +4,4 @@ sources:
   - name: uniswap_v4_worldchain
     tables:
       - name: PoolManager_evt_ModifyLiquidity
-      - name: PoolManager_call_ModifyLiquidity
+      - name: poolmanager_call_take

--- a/sources/_sector/dex/liquidity/zora/_schema.yml
+++ b/sources/_sector/dex/liquidity/zora/_schema.yml
@@ -4,4 +4,4 @@ sources:
   - name: uniswap_v4_zora
     tables:
       - name: PoolManager_evt_ModifyLiquidity
-      - name: PoolManager_call_ModifyLiquidity
+      - name: poolmanager_call_take


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors Uniswap v4 liquidity pipeline to derive modify amounts from events and aggregate fee collection via `PoolManager_call_Take`, with incremental/config and source updates across chains.
> 
> - **Uniswap v4 base liquidity macro (`uniswap_compatible_v4_base_liquidity_events`)**:
>   - Replace reliance on `PoolManager_call_ModifyLiquidity` decoding with event-driven computation: derive `amount0/amount1` from `evt_ModifyLiquidity` using `sqrtPriceX96` and ticks.
>   - Add fee collection via `PoolManager_call_Take`: aggregate per-tx fees by currency, map to single-pool modify events, emit `fee_collection` events (excluding txs with swaps).
>   - Adjust swap handling and unify event output; remove separate `fees_accrued` path.
> - **Per-chain models**:
>   - Update macro args to use `PoolManager_call_Take` for all supported chains.
> - **Sources**:
>   - Replace `PoolManager_call_ModifyLiquidity` with `poolmanager_call_take` in source configs across chains.
> - **Aggregations and configs**:
>   - `uniswap_base_liquidity_events`: add incremental materialization, partitioning, unique keys, and incremental predicate; apply incremental filter to unions.
>   - `uniswap_daily_agg_liquidity_events`: simplify sums by removing special handling for `fees_accrued`.
>   - Minor comment/formatting tweaks in related models.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95d0b190df8b7aa5a159f0dd95b90481085d9715. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->