### PR TITLE
jupiter agg: update unique keys to ensure proper merges

### DIFF
--- a/dbt_subprojects/solana/models/jupiter/jupiter_solana_aggregator_swaps.sql
+++ b/dbt_subprojects/solana/models/jupiter/jupiter_solana_aggregator_swaps.sql
@@ -7,7 +7,7 @@
         file_format = 'delta',
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-        unique_key = ['log_index','tx_id','output_mint','input_mint'],
+        unique_key = ['block_month','amm','log_index','tx_id','output_mint','input_mint'],
         pre_hook='{{ enforce_join_distribution("PARTITIONED") }}',
         post_hook='{{ expose_spells(\'["jupiter"]\',
                                     "project",

--- a/dbt_subprojects/solana/models/jupiter/jupiter_solana_schema.yml
+++ b/dbt_subprojects/solana/models/jupiter/jupiter_solana_schema.yml
@@ -53,10 +53,12 @@ models:
     data_tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:
+          - block_month
+          - amm
           - log_index
-          - input_mint
-          - output_mint
           - tx_id
+          - output_mint
+          - input_mint
     meta:
       blockchain: solana
       contributors: [ilemi]


### PR DESCRIPTION
prod started to fail on "duplicates" based on the current unique key config. when narrowing down to the specific `tx_id` which gave trouble, it's actually a legit scenario and the keys should be updated.

tx [here](https://solscan.io/tx/6S6xYUgMrbqBMbvwWLKacQqomwKncpZJVsJv2EoBnqwkUKxEdYFzwkF7TCUdVgV22Z9FhqHPjEYfvFYkBXY1g95). we can see USDC <--> USDC on jupiter v4 and v6 in same tx. one goes through one AMM, the other through a different AMM. slightly different amounts.

i think we've gotten lucky to not hit this scenario in the past (or it exists in historical data and didn't realize).

i wrote quick test queries to ensure this would remain unique. ran compile, wrapped source query in CTE, grouped by new keys, no results for count > 1 ✅ 

i will plan to merge with modified turned off, so no historical backfill is needed. this only affects how we write merges.