### PR TITLE
CUR2-899 bridges: handle withdrawal duplicates

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_withdrawals.sql
@@ -4,7 +4,7 @@
     , materialized = 'incremental'
     , file_format = 'delta'
     , incremental_strategy='merge'
-    , unique_key = ['deposit_chain','deposit_chain_id','withdrawal_chain','bridge_name','bridge_version','bridge_transfer_id', 'duplicate_index']
+    , unique_key = ['deposit_chain','deposit_chain_id','withdrawal_chain','bridge_name','bridge_version','bridge_transfer_id','duplicate_index']
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
 )
 }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/schema.yml
@@ -11,7 +11,7 @@ models:
     description: "Bridge deposits events on EVM chains"
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns: ['deposit_chain','withdrawal_chain','withdrawal_chain_id','bridge_name','bridge_version','bridge_transfer_id', 'duplicate_index']
+          combination_of_columns: ['deposit_chain','withdrawal_chain','withdrawal_chain_id','bridge_name','bridge_version','bridge_transfer_id','duplicate_index']
     columns:
       - &deposit_chain
         name: deposit_chain
@@ -101,7 +101,7 @@ models:
     description: "Bridge withdrawals events on EVM chains"
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns: ['deposit_chain','deposit_chain_id','withdrawal_chain','bridge_name','bridge_version','bridge_transfer_id']
+          combination_of_columns: ['deposit_chain','deposit_chain_id','withdrawal_chain','bridge_name','bridge_version','bridge_transfer_id','duplicate_index']
     columns:
       - *deposit_chain
       - *withdrawal_chain


### PR DESCRIPTION
Last week we had duplicates for deposits and I added handling for those. This error is the same but for withdrawals, so this PR fixes those in the same way. With this merged, there should no longer be duplicates in any spells culminating into (and including) `bridges_evms.flows`