### PR TITLE
pancakeswap liquidity: enhance join conditions for performance

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/pancakeswap_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/pancakeswap_compatible_liquidity.sql
@@ -78,6 +78,7 @@ modify_liquidity_events as (
             call_tx_from,
             call_tx_to,
             call_trace_address,
+            call_block_date,
             call_block_time,
             call_block_number,
             -- pool key: currency0/1 + hooks (all varbinary)
@@ -143,6 +144,7 @@ modify_liquidity_events as (
             contract_address,
             evt_tx_hash,
             evt_tx_from,
+            evt_block_date,
             evt_block_time,
             evt_block_number,
             evt_index,
@@ -186,6 +188,8 @@ modify_liquidity_events as (
         INNER JOIN 
         calls_decoded cd
             ON cd.call_tx_hash = e.evt_tx_hash
+            AND cd.call_block_date = e.evt_block_date 
+            AND cd.call_block_number = e.evt_block_number
             AND cd.call_rn = e.evt_rn
 ),
 


### PR DESCRIPTION
fyi @henrystats 
similar to the uniswap macro, adding additional join conditions here as that really seemed to help performance.
please let me know if this raises any flags.
if there are other macros that have this same logic, plz do open new PR and add this 🙏 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds block date fields and tightens call–event join in the PancakeSwap liquidity macro by also matching on block date and block number.
> 
> - **Dex macro `pancakeswap_compatible_liquidity`**:
>   - Add `call_block_date` to `get_calls` and `evt_block_date` to `evts` selections.
>   - Strengthen call↔event join in `modify_liquidity_events` by matching on `cd.call_tx_hash = e.evt_tx_hash`, `cd.call_block_date = e.evt_block_date`, `cd.call_block_number = e.evt_block_number`, and `cd.call_rn = e.evt_rn`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05b0209883ada8a970d78b9c177cf68350f4346f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->