### PR TITLE
bnb contract mapping: update token standard name

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/contracts/bnb/contracts_bnb_contract_mapping_dynamic.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/bnb/contracts_bnb_contract_mapping_dynamic.sql
@@ -8,5 +8,5 @@
 }}
 
 {{contracts_contract_mapping(
-    chain='bnb', standard_name = 'bep'
+    chain='bnb'
 )}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove explicit `standard_name='bep'` from `contracts_contract_mapping` in `contracts_bnb_contract_mapping_dynamic.sql`, relying on defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ca0f49c6b27091a44747d5e1584d9725eed078f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->