### PR TITLE
Update spellbook price table references

### DIFF
--- a/dbt_subprojects/tokens/macros/transfers/transfers_enrich.sql
+++ b/dbt_subprojects/tokens/macros/transfers/transfers_enrich.sql
@@ -38,7 +38,7 @@ WITH base_transfers as (
         , symbol
         , price
     FROM
-        {{ source('prices_coinpaprika', prices_interval) }}
+        {{ source('prices_external', prices_interval) }}
     {% if is_incremental() %}
     WHERE
         {{ incremental_predicate('timestamp') }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/tron/tokens_tron_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/tron/tokens_tron_transfers.sql
@@ -38,7 +38,7 @@ WITH base_transfers as (
         , symbol
         , price
     FROM
-        {{ source('prices_coinpaprika', 'hour') }}    
+        {{ source('prices_external', 'hour') }}    
     WHERE
         1=1
         {% if is_incremental() -%}

--- a/sources/_subprojects_outputs/sqlmesh/_sources.yml
+++ b/sources/_subprojects_outputs/sqlmesh/_sources.yml
@@ -125,7 +125,7 @@ sources:
             description: "Source of the price data"
             type: varchar
 
-  - name: prices_coinpaprika
+  - name: prices_external
     description: "Price data from CoinPaprika API"
     tables:
       - name: minute


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-9014bacd-c887-4960-8f9a-cb7b2a815ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9014bacd-c887-4960-8f9a-cb7b2a815ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace all `prices_coinpaprika` references with `prices_external` in transfers enrichment and Tron transfers, and update the source config accordingly.
> 
> - **Tokens**:
>   - **Transfers enrich macro** (`dbt_subprojects/tokens/macros/transfers/transfers_enrich.sql`): Switch price source to `source('prices_external', prices_interval)`.
>   - **Tron transfers model** (`dbt_subprojects/tokens/models/transfers_and_balances/tron/tokens_tron_transfers.sql`): Use `source('prices_external', 'hour')` for prices.
> - **Config**:
>   - Update source name in `sources/_subprojects_outputs/sqlmesh/_sources.yml` from `prices_coinpaprika` to `prices_external` (minute/hour/day/latest).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e9f382f91a9da7833db456d21d1db37763cd603. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->