### PR TITLE
CUR2-961 fix mezo pricing

### DIFF
--- a/dbt_subprojects/tokens/models/prices/mezo/prices_mezo_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/mezo/prices_mezo_tokens.sql
@@ -18,7 +18,9 @@ SELECT
 FROM
 (
     VALUES
-      ('usdc-usd-coin', 'MUSD', 0xdd468a1ddc392dcdbef6db6e34e89aa338f9f186, 18)
+      ('btc-bitcoin', 'BTC', 0x0000000000000000000000000000000000000000, 18)
+    , ('btc-bitcoin', 'BTC', 0x7b7c000000000000000000000000000000000000, 18)
+    , ('usdc-usd-coin', 'MUSD', 0xdd468a1ddc392dcdbef6db6e34e89aa338f9f186, 18)
     , ('usdc-usd-coin', 'mUSDC', 0x04671c72aab5ac02a03c1098314b1bb6b560c197, 6)
     , ('usdt-tether', 'mUSDT', 0xeb5a5d39de4ea42c2aa6a57eca2894376683bb8e, 6)
 ) as temp (token_id, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/prices_native_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_native_tokens.sql
@@ -49,7 +49,7 @@ with prices_native_tokens as (
         , ('linea', 'eth-ethereum')
         , ('mantle', 'mnt-mantle')
         , ('mode', 'eth-ethereum')
-        , ('mezo', 'btc-bitcoin')
+        --, ('mezo', 'btc-bitcoin') -- can't support this due to using different decimals than original BTC (18 instead of 8)
         --, ('monad', 'mon-monad') -- not on coinpaprika yet
         , ('noble', 'eth-ethereum')
         , ('nova', 'eth-ethereum')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Mezo BTC token entries and disables Mezo native token mapping to BTC due to decimal mismatch.
> 
> - **Prices/Mezo**:
>   - Add `btc-bitcoin` entries (symbols `BTC`) with 18 decimals for `0x000...000` and `0x7b7c...0000` in `prices_mezo_tokens.sql`.
>   - Retain Mezo stablecoin entries (`MUSD`, `mUSDC`, `mUSDT`).
> - **Prices/Native Tokens**:
>   - Comment out `('mezo', 'btc-bitcoin')` mapping in `prices_native_tokens.sql` (BTC uses different decimals on Mezo).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f138caf4a86b2b437ebd439450e5f993a53905b2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->