### PR TITLE
CUR2-961 clean up old patch for mezo native prices

### DIFF
--- a/dbt_subprojects/tokens/models/prices/mezo/prices_mezo_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/mezo/prices_mezo_tokens.sql
@@ -18,8 +18,7 @@ SELECT
 FROM
 (
     VALUES
-      ('btc-bitcoin', 'BTC', 0x0000000000000000000000000000000000000000, 18)
-    , ('btc-bitcoin', 'BTC', 0x7b7c000000000000000000000000000000000000, 18)
+      ('btc-bitcoin', 'BTC', 0x7b7c000000000000000000000000000000000000, 18)
     , ('usdc-usd-coin', 'MUSD', 0xdd468a1ddc392dcdbef6db6e34e89aa338f9f186, 18)
     , ('usdc-usd-coin', 'mUSDC', 0x04671c72aab5ac02a03c1098314b1bb6b560c197, 6)
     , ('usdt-tether', 'mUSDT', 0xeb5a5d39de4ea42c2aa6a57eca2894376683bb8e, 6)

--- a/dbt_subprojects/tokens/models/prices/prices_native_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_native_tokens.sql
@@ -49,7 +49,7 @@ with prices_native_tokens as (
         , ('linea', 'eth-ethereum')
         , ('mantle', 'mnt-mantle')
         , ('mode', 'eth-ethereum')
-        --, ('mezo', 'btc-bitcoin') -- can't support this due to using different decimals than original BTC (18 instead of 8)
+        , ('mezo', 'btc-bitcoin')
         --, ('monad', 'mon-monad') -- not on coinpaprika yet
         , ('noble', 'eth-ethereum')
         , ('nova', 'eth-ethereum')


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Mezo native BTC mapping and removes the zero-address BTC entry, keeping the correct Mezo BTC address in Mezo token list.
> 
> - **Prices / Tokens**:
>   - **Mezo (`prices_mezo_tokens.sql`)**: Remove zero-address `BTC` entry; retain `BTC` at `0x7b7c...` and keep existing `mUSDC`, `MUSD`, `mUSDT` entries.
>   - **Native tokens (`prices_native_tokens.sql`)**: Add `('mezo', 'btc-bitcoin')` to native token mappings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75bb9de05e1e17897934d264ec6ee5aacc51dc23. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->