### PR TITLE
bridges: remove celer v1 duplicate

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/bridges_ethereum_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/bridges_ethereum_deposits.sql
@@ -13,7 +13,6 @@
     , 'bridges_' + blockchain + '_across_v1_deposits'
     , 'bridges_' + blockchain + '_across_v2_deposits'
     , 'bridges_' + blockchain + '_across_v3_deposits'
-    , 'bridges_' + blockchain + '_celer_v1_deposits'
     , 'bridges_' + blockchain + '_arbitrum_native_v1_deposits'
     , 'bridges_' + blockchain + '_ronin_native_v1_deposits'
     , 'bridges_' + blockchain + '_ronin_native_v2_deposits'


### PR DESCRIPTION
fyi @hildobby 
looks like merge conflict resolution left one duplicate behind. removing here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove duplicate `bridges_ethereum_celer_v1_deposits` entry from `bridges_ethereum_deposits.sql` platforms list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c2ab86f56f45616b5961d0e69df7b16371b0a7d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->