### PR TITLE
remove troubled paraswap models from ethereum view

### DIFF
--- a/dbt_subprojects/dex/models/_projects/paraswap/ethereum/paraswap_ethereum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/paraswap/ethereum/paraswap_ethereum_trades.sql
@@ -8,10 +8,14 @@
 {% set paraswap_models = [
     ref('paraswap_v4_ethereum_trades')
     ,ref('paraswap_v5_ethereum_trades')
-    ,ref('paraswap_v6_ethereum_trades')
     ,ref('paraswap_delta_v2_ethereum_trades')
-    ,ref('paraswap_delta_v1_ethereum_trades')
 ] %}
+
+/*
+    both are creating duplicate rows based on tx_hash + trace_address
+    ,ref('paraswap_delta_v1_ethereum_trades')
+    ,ref('paraswap_v6_ethereum_trades')
+*/
 
 
 SELECT *


### PR DESCRIPTION
these two models are outputting duplicates based on tx_hash + trace_address.
i'm seeing prod failure alerts for `dex_aggregator.trades` downstream due to this.

downstream table:
```
with dupes as (
    select block_date, blockchain, project, version, tx_hash, evt_index, trace_address, count(1)
    from dex_aggregator.trades
    group by block_date, blockchain, project, version, tx_hash, evt_index, trace_address
    having count(1) > 1
)
select *
from dupes
limit 1000
```


using delta v1 source query as example:
```
with source as (
    with
        
    settle_swap_withParsedOrderData AS (
        SELECT         
            call_trace_address,
            call_block_time, 
            call_block_number, 
            call_tx_hash, 
            call_tx_from, -- varbinary
            call_tx_to, -- varbinary
            JSON_EXTRACT(data, '$.orderData') AS parsed_order_data,
            contract_address    
        FROM "delta_prod"."paraswapdelta_ethereum"."ParaswapDeltav1_call_settleSwap"        
            where call_success = true
            
    ),
    settle_swap_parsedOrderWithSig AS (
        SELECT 
            JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST(parsed_order_data AS VARCHAR)), '$.feeAmount') AS feeAmount,
            JSON_EXTRACT(JSON_PARSE(TRY_CAST(parsed_order_data AS VARCHAR)), '$.orderWithSig') AS orderWithSig,
            JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST(parsed_order_data AS VARCHAR)), '$.calldataToExecute') AS calldataToExecute,
            * 
        FROM 
            settle_swap_withParsedOrderData
    ),
    settle_swap_unparsedOrders AS (
      SELECT
        JSON_EXTRACT(JSON_PARSE(TRY_CAST(orderWithSig AS VARCHAR)), '$.order') AS "order",
        JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST(orderWithSig AS VARCHAR)), '$.signature') AS signature,
        *
      FROM settle_swap_parsedOrderWithSig
    ),
    settle_swap_parsedOrders AS (
      SELECT
        from_hex(JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST("order" AS VARCHAR)), '$.owner')) AS "owner",
        FROM_HEX(JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST("order" AS VARCHAR)), '$.srcToken')) AS "src_token",
        FROM_HEX(JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST("order" AS VARCHAR)), '$.destToken')) AS "dest_token",
        cast(JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST("order" AS VARCHAR)), '$.srcAmount') as uint256) AS "src_amount",
        cast(JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST("order" AS VARCHAR)), '$.destAmount') as uint256) AS "dest_amount",
        JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST("order" AS VARCHAR)), '$.permit')  AS "permit",
        *
      FROM settle_swap_unparsedOrders
    ),
    settle_swap_with_wrapped_native AS (
      SELECT
      
    
    CASE 
            WHEN dest_token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee THEN 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 
            ELSE dest_token
        END AS dest_token_for_joining
    
    
    ,
      
    
    CASE 
            WHEN src_token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee THEN 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 
            ELSE src_token
        END AS src_token_for_joining
    
    
    ,
        *
      FROM settle_swap_parsedOrders
    ), delta_v1_settle_swap_model as (
    SELECT 
        w.*, 
        w.dest_token AS fee_token,
        CAST(s.price AS DECIMAL(38,18)) AS src_token_price_usd,
        CAST(d.price AS DECIMAL(38,18)) AS dest_token_price_usd, 
        COALESCE( 
            d.price *  CAST (w.feeAmount AS uint256) / POWER(10, d.decimals),
            -- src cost 
            
            (s.price *  CAST (w.src_amount AS uint256) / POWER(10, s.decimals))
            * CAST (w.feeAmount AS uint256) / CAST (w.dest_amount AS uint256),
            0
            
        )  AS gas_fee_usd,
        s.price *  CAST (w.src_amount AS uint256) / POWER(10, s.decimals)  AS src_token_order_usd,
        d.price *  CAST (w.dest_amount AS uint256) / POWER(10, d.decimals)  AS dest_token_order_usd
        
    FROM settle_swap_with_wrapped_native w 
    LEFT JOIN "delta_prod"."prices"."usd" d
      ON d.blockchain = 'ethereum'
      AND d.minute > TIMESTAMP '2024-06-01'
      
      AND d.contract_address = w.dest_token_for_joining
      AND d.minute = DATE_TRUNC('minute', w.call_block_time)
    LEFT JOIN "delta_prod"."prices"."usd" s
      ON s.blockchain = 'ethereum'
      AND s.minute > TIMESTAMP '2024-06-01'
      
      AND s.contract_address = w.src_token_for_joining
      AND s.minute = DATE_TRUNC('minute', w.call_block_time)
    ), delta_v1_settleSwap as (  
    select 
        'ethereum' as blockchain,
        'delta_v1_settle_swap_model' as method,
        0 as order_index,
        call_trace_address,
        call_block_number,
        call_block_time,
        call_tx_hash,
        call_tx_from, -- varbinary
        call_tx_to, -- varbinary
        cast(NULL as bigint) as evt_index, -- no events in delta v1
        -- parsed_order_data,
        feeAmount as fee_amount,
        -- orderWithSig as order_with_sig,
        calldataToExecute as calldata_to_execute,
        -- "order",
        signature,
        owner,
        src_token,
        dest_token,
        src_amount,
        dest_amount,
        src_token_for_joining,
        dest_token_for_joining,
        fee_token,
        src_token_price_usd,
        dest_token_price_usd,
        gas_fee_usd,
        src_token_order_usd,
        dest_token_order_usd,
        contract_address
     from delta_v1_settle_swap_model
    )
    ,
        
    safe_settle_batch_swap_ExpandedOrders AS (
      SELECT    
        call_trace_address,
        call_block_time,
        call_block_number,
        call_tx_hash,       
        call_tx_from, -- varbinary
        call_tx_to, -- varbinary
        output_successfulOrders,
        JSON_EXTRACT(data, '$.ordersData') AS parsed_orders,
        contract_address
      FROM "delta_prod"."paraswapdelta_ethereum"."ParaswapDeltav1_call_safeSettleBatchSwap"
       where call_success = true
       
    ), safe_settle_batch_swap_parsedOrderItems AS (
      SELECT
        index as order_index,
        JSON_ARRAY_GET(parsed_orders, index) AS parsed_order_data,
        *
      FROM safe_settle_batch_swap_ExpandedOrders
      CROSS JOIN UNNEST(SEQUENCE(0, CARDINALITY(output_successfulOrders) - 1)) AS t(index)
      WHERE
        output_successfulOrders[index + 1]
    ), safe_settle_batch_swap_parsedOrdersWithSig  AS (
      SELECT
        JSON_EXTRACT_SCALAR(parsed_order_data, '$.feeAmount') AS feeAmount,
        JSON_EXTRACT(parsed_order_data, '$.orderWithSig') AS orderWithSig,
        JSON_EXTRACT_SCALAR(parsed_order_data, '$.calldataToExecute') AS calldataToExecute,
        *
      FROM safe_settle_batch_swap_parsedOrderItems
    ), safe_settle_batch_swap_unparsedOrders AS (
      SELECT
        JSON_EXTRACT(JSON_PARSE(TRY_CAST(orderWithSig AS VARCHAR)), '$.order') AS "order",
        JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST(orderWithSig AS VARCHAR)), '$.signature') AS signature,
        *
      FROM safe_settle_batch_swap_parsedOrdersWithSig 
    ), safe_settle_batch_swap_parsedOrders AS (
      SELECT
        from_hex(JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST("order" AS VARCHAR)), '$.owner')) AS "owner",
        FROM_HEX(JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST("order" AS VARCHAR)), '$.srcToken')) AS "src_token",
        FROM_HEX(JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST("order" AS VARCHAR)), '$.destToken')) AS "dest_token",
        cast(JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST("order" AS VARCHAR)), '$.srcAmount') as uint256) AS "src_amount",
        cast(JSON_EXTRACT_SCALAR(JSON_PARSE(TRY_CAST("order" AS VARCHAR)), '$.destAmount') as uint256) AS "dest_amount",
        *
      FROM safe_settle_batch_swap_unparsedOrders
    ), safe_settle_batch_swap_wrapped_native AS (
      SELECT
        
    
    CASE 
            WHEN dest_token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee THEN 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 
            ELSE dest_token
        END AS dest_token_for_joining
    
    
    ,
      
    
    CASE 
            WHEN src_token = 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee THEN 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 
            ELSE src_token
        END AS src_token_for_joining
    
    
    ,
        *
      FROM safe_settle_batch_swap_parsedOrders
    ), delta_v1_safe_settle_batch_swap_model as (
    SELECT 
        w.*, 
        w.dest_token AS fee_token,
        CAST(s.price AS DECIMAL(38,18)) AS src_token_price_usd,
        CAST(d.price AS DECIMAL(38,18)) AS dest_token_price_usd, 
        COALESCE( 
            d.price *  CAST (w.feeAmount AS uint256) / POWER(10, d.decimals), -- compute directly if USD price is available        
            (s.price *  CAST (w.src_amount AS uint256) / POWER(10, s.decimals)) -- otherwise, fallback to src token price (pro rata)
            * CAST (w.feeAmount AS uint256) / CAST (w.dest_amount AS uint256)
            
        )  AS gas_fee_usd,
        s.price *  CAST (w.src_amount AS uint256) / POWER(10, s.decimals)  AS src_token_order_usd,
        d.price *  CAST (w.dest_amount AS uint256) / POWER(10, d.decimals)  AS dest_token_order_usd
        
    FROM safe_settle_batch_swap_wrapped_native w 
    LEFT JOIN "delta_prod"."prices"."usd" d
      ON d.blockchain = 'ethereum'
      AND d.minute > TIMESTAMP '2024-06-01'
      
      AND d.contract_address = w.dest_token_for_joining
      AND d.minute = DATE_TRUNC('minute', w.call_block_time)
    LEFT JOIN "delta_prod"."prices"."usd" s
      ON s.blockchain = 'ethereum'
      AND s.minute > TIMESTAMP '2024-06-01'
      
      AND s.contract_address = w.src_token_for_joining
      AND s.minute = DATE_TRUNC('minute', w.call_block_time)
    ORDER BY
      CARDINALITY(w.output_successfulOrders)
    ), delta_v1_safeSettleBatch as (  
      SELECT
        'ethereum' as blockchain,
        'delta_v1_safe_settle_batch_swap_model' as method,
        order_index,
        call_trace_address,
        call_block_number,
        call_block_time,
        call_tx_hash,
        call_tx_from, -- varbinary
        call_tx_to, -- varbinary
        cast(NULL as bigint) as evt_index, -- no events in delta v1
        -- parsed_order_data,
        feeAmount as fee_amount,
        -- orderWithSig as order_with_sig,
        calldataToExecute as calldata_to_execute,
        -- "order",
        signature,
        owner,
        src_token,
        dest_token,
        src_amount,
        dest_amount,
        src_token_for_joining,
        dest_token_for_joining,
        fee_token,
        src_token_price_usd,
        dest_token_price_usd,
        gas_fee_usd,
        src_token_order_usd,
        dest_token_order_usd,
        contract_address
      from delta_v1_safe_settle_batch_swap_model
    )
    ,
        delta_v1_master as (
            (select * from delta_v1_settleSwap)
                union all   
            (select * from delta_v1_safeSettleBatch)
        )
        
    select 
            delta_v1_master.blockchain,
            'velora_delta' as project,
            'v1' as version,
            date_trunc('month', call_block_time) AS block_month,
            DATE_TRUNC('day', call_block_time) as block_date,
            call_block_time as block_time,
            t_dest_token.symbol as token_bought_symbol,
            t_src_token.symbol as token_sold_symbol,
            CASE
                WHEN lower(t_dest_token.symbol) > lower(t_src_token.symbol)
                THEN concat(t_src_token.symbol, '-', t_dest_token.symbol)
                ELSE concat(t_dest_token.symbol, '-', t_src_token.symbol)
            END as token_pair,
            dest_amount / power(10, t_dest_token.decimals) as token_bought_amount,
            src_amount / power(10, t_src_token.decimals) as token_sold_amount,
            dest_amount as token_bought_amount_raw,
            src_amount as token_sold_amount_raw,
            COALESCE(dest_token_order_usd, src_token_order_usd) as amount_usd,
            dest_token as token_bought_address,
            src_token as token_sold_address,
            owner as taker,        
            
                CAST(NULL AS VARBINARY) as maker,
            
            delta_v1_master.contract_address as project_contract_address,
            call_tx_hash as tx_hash,
            call_tx_from as tx_from,
            call_tx_to as tx_to,
            case when CARDINALITY(call_trace_address) > 0 then call_trace_address else ARRAY[-1] end as trace_address,
            COALESCE(evt_index, 0) as evt_index, -- TMP: after joining envents in swapSettle can remove it
            order_index,
            method
        from delta_v1_master  
            LEFT JOIN 
            "delta_prod"."tokens"."erc20" t_src_token 
                ON t_src_token.blockchain = 'ethereum'
                AND t_src_token.contract_address = src_token
            LEFT JOIN 
            "delta_prod"."tokens"."erc20" t_dest_token
                ON t_dest_token.blockchain = 'ethereum'
                AND t_dest_token.contract_address = dest_token
     

)
select tx_hash, trace_address, count(1)
from source
group by tx_hash, trace_address
having count() > 1
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `paraswap_v6_ethereum_trades` and `paraswap_delta_v1_ethereum_trades` from the `paraswap_ethereum_trades` union due to duplicate rows.
> 
> - **DBT model `dbt_subprojects/dex/models/_projects/paraswap/ethereum/paraswap_ethereum_trades.sql`**:
>   - Remove `ref('paraswap_v6_ethereum_trades')` and `ref('paraswap_delta_v1_ethereum_trades')` from `paraswap_models` union.
>   - Add inline comment noting these models create duplicates keyed by `tx_hash + trace_address`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28f06ba278685a0ee7e083f3d8218a49be02052a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->