### PR TITLE
Revert "bridges: across v2 and v3 withdrawal amounts fix"

### DIFF
--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v2_withdrawals.sql
@@ -9,7 +9,7 @@ WITH ranked AS (
     , d.evt_block_date AS block_date
     , d.evt_block_time AS block_time
     , d.evt_block_number AS block_number
-    , COALESCE(CAST(json_extract_scalar(d.relayExecutionInfo, '$.updatedOutputAmount') AS BIGINT), d.outputAmount) AS withdrawal_amount_raw
+    , d.outputAmount AS withdrawal_amount_raw
     , CASE WHEN varbinary_substring(d.depositor,1, 12) = 0x000000000000000000000000 THEN varbinary_substring(depositor,13) ELSE depositor END AS sender
     , CASE WHEN varbinary_substring(d.recipient,1, 12) = 0x000000000000000000000000 THEN varbinary_substring(recipient,13) ELSE recipient END AS recipient
     , CASE WHEN varbinary_substring(d.outputToken,1, 12) = 0x000000000000000000000000 THEN varbinary_substring(outputToken,13) ELSE outputToken END AS withdrawal_token_address

--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/across_v3_withdrawals.sql
@@ -9,7 +9,7 @@ WITH ranked AS (
     , d.evt_block_date AS block_date
     , d.evt_block_time AS block_time
     , d.evt_block_number AS block_number
-    , COALESCE(CAST(json_extract_scalar(d.relayExecutionInfo, '$.updatedOutputAmount') AS BIGINT), d.outputAmount) AS withdrawal_amount_raw
+    , d.outputAmount AS withdrawal_amount_raw
     , CASE WHEN varbinary_substring(d.depositor,1, 12) = 0x000000000000000000000000 THEN varbinary_substring(d.depositor,13) ELSE d.depositor END AS sender
     , CASE WHEN varbinary_substring(d.recipient,1, 12) = 0x000000000000000000000000 THEN varbinary_substring(d.recipient,13) ELSE d.recipient END AS recipient
     , CASE WHEN varbinary_substring(d.outputToken,1, 12) = 0x000000000000000000000000 THEN varbinary_substring(d.outputToken,13) ELSE d.outputToken END AS withdrawal_token_address


### PR DESCRIPTION
Reverts duneanalytics/spellbook#8991

fyi @hildobby 
forcing `bigint` here has broken the downstream cross chain raw withdrawals union model. there are values that break this data type.
```
23:41:29    Database Error in model bridges_evms_withdrawals_raw (models/_sector/bridges/flows/evms/bridges_evms_withdrawals_raw.sql)
  TrinoUserError(type=USER_ERROR, name=INVALID_CAST_ARGUMENT, message="Cannot cast '31996974382880203616' to BIGINT", query_id=20251111_234042_06982_vvayg)
  compiled code at [target/run/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_withdrawals_raw.sql](https://nd058.us1.dbt.com/api/v2/accounts/58579/runs/70471853057522/artifacts/run/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_withdrawals_raw.sql)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts prior change by removing BIGINT cast/JSON extract and setting `withdrawal_amount_raw` to `d.outputAmount` for Across v2 and v3 withdrawals.
> 
> - **Bridges (Across v2/v3)**:
>   - Set `withdrawal_amount_raw` to `d.outputAmount`.
>   - Removed `COALESCE(CAST(json_extract_scalar(d.relayExecutionInfo, '$.updatedOutputAmount') AS BIGINT), d.outputAmount)` logic to avoid BIGINT casting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b37b879abe665759924301c0c6e0a96fa36676d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->