### PR TITLE
Revert "bridges: sui (ethereum side) (#8981)"

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/bridges_ethereum_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/bridges_ethereum_deposits.sql
@@ -19,7 +19,6 @@
     , 'bridges_' + blockchain + '_lighter_v1_deposits'
     , 'bridges_' + blockchain + '_avalanche_c_native_v2_deposits'
     , 'bridges_' + blockchain + '_zkync_native_v2_deposits'
-    , 'bridges_' + blockchain + '_sui_native_v1_deposits'
     , 'bridges_' + blockchain + '_synapse_rfq_deposits'
     , 'bridges_' + blockchain + '_zkbridge_v1_deposits'
     , 'bridges_' + blockchain + '_rainbow_v1_deposits'

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/bridges_ethereum_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/bridges_ethereum_withdrawals.sql
@@ -19,7 +19,6 @@
     , 'bridges_' + blockchain + '_lighter_v1_withdrawals'
     , 'bridges_' + blockchain + '_avalanche_c_native_v2_withdrawals'
     , 'bridges_' + blockchain + '_zkync_native_v2_withdrawals'
-    , 'bridges_' + blockchain + '_sui_native_v1_withdrawals'
     , 'bridges_' + blockchain + '_synapse_rfq_withdrawals'
     , 'bridges_' + blockchain + '_zkbridge_v1_withdrawals'
     , 'bridges_' + blockchain + '_polygon_native_v1_withdrawals'

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/platforms/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/platforms/_schema.yml
@@ -223,24 +223,6 @@ models:
     config:
       tags: [ 'arbitrum', 'bridges', 'flows' , 'withdrawals' ]
     description: "Arbitrum's v1 native bridge withdrawals events on Ethereum"
-  - name: bridges_ethereum_sui_native_v1_deposits
-    meta:
-      blockchain: ethereum
-      sector: bridges
-      project: sui
-      contributors: [ 'hildobby']
-    config:
-      tags: [ 'sui', 'bridges', 'flows' , 'withdrawals' ]
-    description: "Sui's v1 native bridge deposits events on Ethereum"
-  - name: bridges_ethereum_sui_native_v1_withdrawals
-    meta:
-      blockchain: ethereum
-      sector: bridges
-      project: sui
-      contributors: [ 'hildobby']
-    config:
-      tags: [ 'sui', 'bridges', 'flows' , 'withdrawals' ]
-    description: "Sui's v1 native bridge withdrawals events on Ethereum"
   - name: bridges_ethereum_synapse_rfq_deposits
     meta:
       blockchain: ethereum


### PR DESCRIPTION
merge conflicts made this get missed. need to remove to clean up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Sui native v1 (Ethereum side) deposits and withdrawals from bridge flow unions and deletes their schema model entries.
> 
> - **Ethereum bridge flows**:
>   - Remove Sui v1 from `bridges_ethereum_deposits.sql` and `bridges_ethereum_withdrawals.sql` union sources (`bridges_ethereum_sui_native_v1_deposits` / `..._withdrawals`).
> - **Schema**:
>   - Delete model entries for `bridges_ethereum_sui_native_v1_deposits` and `bridges_ethereum_sui_native_v1_withdrawals` in `platforms/_schema.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3bac6c8e58876d23439624a4194ae839235aa44. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->