### PR TITLE
CUR2-1001 Filter balancer v2 inflated values

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/balancer_compatible_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/balancer_compatible_trades.sql
@@ -179,7 +179,6 @@ SELECT
 FROM dexs
 /* hardcoded filter for inflated volumes on whitehat effort to recover funds */
 WHERE CAST(date_trunc('day', dexs.block_time) AS date) != date '2025-11-12'
-    AND CAST(date_trunc('day', dexs.block_time) AS date) >= date '2025-11-01'
 
 {% endmacro %}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a hardcoded date filter to `balancer_compatible_v2_trades` to exclude `2025-11-12` and only include trades from `2025-11-01` onward, mitigating inflated volumes.
> 
> - **Data modeling — `dbt_subprojects/dex/macros/models/_project/balancer_compatible_trades.sql`**
>   - Update `balancer_compatible_v2_trades` final query to add a hardcoded date filter: exclude `2025-11-12` and include only dates `>= 2025-11-01` to remove inflated volumes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc7f5dc4a3518b60893366922a17a85aa54a9a6c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->