### PR TITLE
bridges raw: exclude due to stage failure

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_deposits_raw.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_deposits_raw.sql
@@ -6,6 +6,7 @@
     , incremental_strategy='merge'
     , unique_key = ['deposit_chain','tx_hash','evt_index','bridge_transfer_id']
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    , tags = ['prod_exclude']
 )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_withdrawals_raw.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_withdrawals_raw.sql
@@ -6,6 +6,7 @@
     , incremental_strategy='merge'
     , unique_key = ['withdrawal_chain','tx_hash','evt_index','bridge_transfer_id']
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    , tags = ['prod_exclude']
 )
 }}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tag EVM bridges raw deposit/withdrawal models with `prod_exclude` to skip production execution.
> 
> - **DBT models**:
>   - Add `tags = ['prod_exclude']` to `models/_sector/bridges/flows/evms/bridges_evms_deposits_raw.sql` and `models/_sector/bridges/flows/evms/bridges_evms_withdrawals_raw.sql` to exclude from prod runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8b87a18e2b467bbcb341dc2df97754dc601bfe2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->