### PR TITLE
transfers from traces: remove hyperevm due to duplicates

### DIFF
--- a/dbt_subprojects/tokens/models/transfers_and_balances/hyperevm/tokens_hyperevm_transfers_from_traces.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/hyperevm/tokens_hyperevm_transfers_from_traces.sql
@@ -2,6 +2,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'tokens_' ~ blockchain,
         alias = 'transfers_from_traces',
         partition_by = ['block_month'],


### PR DESCRIPTION
fyi @max-morrow 
for now, i need to exclude from prod, as this is outputting duplicates somehow. i'm unable to dig deeper atm to resolve. i don't believe this is a chain used in your lineages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude `hyperevm` `transfers_from_traces` model from prod by adding `tags = ['prod_exclude']` to its dbt config.
> 
> - **DBT model config** (`tokens_hyperevm_transfers_from_traces.sql`):
>   - Add `tags = ['prod_exclude']` to exclude the model from prod runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb23ac5ad0be4a52460e19a4fa0f0a60b2c24094. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->