### PR TITLE
1inch: daily project update to new source names

### DIFF
--- a/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_macro.sql
+++ b/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_macro.sql
@@ -62,7 +62,7 @@ meta as (
         , map_concat(flags, map_from_entries(array[('cross_chain', hashlock is not null)])) as order_flags
     from (
         select *, row_number() over(partition by block_number, tx_hash order by call_trace_address) as counter
-        from {{ source('oneinch_' + blockchain, 'lop') }}
+        from {{ source('oneinch_' + blockchain, 'lo') }}
         where
             call_success
             {% if is_incremental() %}

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/oneinch_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/oneinch_project_orders.sql
@@ -87,7 +87,7 @@ meta as (
             , null as order_deadline
             , 1 as call_trade
             , 1 as call_trades
-        from {{ source('oneinch', 'lop') }}
+        from {{ source('oneinch', 'lo') }}
         where call_success
     )
     join meta using(blockchain)


### PR DESCRIPTION
fyi @max-morrow 
i am forced to update here to avoid compile breaking on daily project. i am not certain this will work, if columns have changed. i know you have #8898 open to finalize, but i am required to take short term action. if these models fail on new sources, i will need to exclude from prod until we finalize linked PR and deploy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch 1inch source references from `lop` to `lo` in swaps macro and project orders model.
> 
> - **DBT: 1inch sources**
>   - Rename source table reference from `lop` to `lo`.
>     - `macros/project/oneinch/project/oneinch_project_swaps_macro.sql`: use `source('oneinch_' + blockchain, 'lo')`.
>     - `models/_projects/oneinch/oneinch_project_orders.sql`: use `source('oneinch', 'lo')`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8d58dac8557e564977b75bf9833dd60e2c0070a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->