### PR TITLE
oneinch daily temp: exclude until redesign of lineage is complete

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/_meta/oneinch_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/_meta/oneinch_mapped_contracts.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch',
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/arbitrum/_meta/oneinch_arbitrum_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/arbitrum/_meta/oneinch_arbitrum_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/arbitrum/project/oneinch_arbitrum_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/arbitrum/project/oneinch_arbitrum_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/arbitrum/project/oneinch_arbitrum_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/arbitrum/project/oneinch_arbitrum_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/arbitrum/project/oneinch_arbitrum_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/arbitrum/project/oneinch_arbitrum_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/arbitrum/project/oneinch_arbitrum_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/arbitrum/project/oneinch_arbitrum_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/arbitrum/project/oneinch_arbitrum_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/arbitrum/project/oneinch_arbitrum_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/avalanche_c/_meta/oneinch_avalanche_c_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/avalanche_c/_meta/oneinch_avalanche_c_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/avalanche_c/project/oneinch_avalanche_c_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/avalanche_c/project/oneinch_avalanche_c_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/avalanche_c/project/oneinch_avalanche_c_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/avalanche_c/project/oneinch_avalanche_c_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/avalanche_c/project/oneinch_avalanche_c_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/avalanche_c/project/oneinch_avalanche_c_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/avalanche_c/project/oneinch_avalanche_c_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/avalanche_c/project/oneinch_avalanche_c_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/avalanche_c/project/oneinch_avalanche_c_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/avalanche_c/project/oneinch_avalanche_c_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/base/_meta/oneinch_base_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/base/_meta/oneinch_base_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/base/project/oneinch_base_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/base/project/oneinch_base_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/base/project/oneinch_base_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/base/project/oneinch_base_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/base/project/oneinch_base_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/base/project/oneinch_base_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/base/project/oneinch_base_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/base/project/oneinch_base_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/base/project/oneinch_base_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/base/project/oneinch_base_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/_meta/oneinch_bnb_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/_meta/oneinch_bnb_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/ethereum/_meta/oneinch_ethereum_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/ethereum/_meta/oneinch_ethereum_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/ethereum/project/oneinch_ethereum_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/ethereum/project/oneinch_ethereum_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/ethereum/project/oneinch_ethereum_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/ethereum/project/oneinch_ethereum_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/ethereum/project/oneinch_ethereum_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/ethereum/project/oneinch_ethereum_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/ethereum/project/oneinch_ethereum_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/ethereum/project/oneinch_ethereum_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/ethereum/project/oneinch_ethereum_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/ethereum/project/oneinch_ethereum_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/fantom/_meta/oneinch_fantom_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/fantom/_meta/oneinch_fantom_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/fantom/project/oneinch_fantom_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/fantom/project/oneinch_fantom_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/fantom/project/oneinch_fantom_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/fantom/project/oneinch_fantom_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/fantom/project/oneinch_fantom_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/fantom/project/oneinch_fantom_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/fantom/project/oneinch_fantom_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/fantom/project/oneinch_fantom_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/fantom/project/oneinch_fantom_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/fantom/project/oneinch_fantom_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/gnosis/_meta/oneinch_gnosis_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/gnosis/_meta/oneinch_gnosis_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/gnosis/project/oneinch_gnosis_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/gnosis/project/oneinch_gnosis_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/gnosis/project/oneinch_gnosis_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/gnosis/project/oneinch_gnosis_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/gnosis/project/oneinch_gnosis_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/gnosis/project/oneinch_gnosis_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/gnosis/project/oneinch_gnosis_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/gnosis/project/oneinch_gnosis_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/gnosis/project/oneinch_gnosis_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/gnosis/project/oneinch_gnosis_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/linea/_meta/oneinch_linea_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/linea/_meta/oneinch_linea_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/linea/project/oneinch_linea_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/linea/project/oneinch_linea_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/linea/project/oneinch_linea_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/linea/project/oneinch_linea_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/linea/project/oneinch_linea_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/linea/project/oneinch_linea_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/linea/project/oneinch_linea_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/linea/project/oneinch_linea_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/linea/project/oneinch_linea_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/linea/project/oneinch_linea_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/oneinch_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/oneinch_project_orders.sql
@@ -1,5 +1,6 @@
 {{  
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch',
         alias = 'project_orders',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/oneinch_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/oneinch_project_swaps.sql
@@ -1,5 +1,6 @@
 {{  
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch',
         alias = 'project_swaps',
         materialized = 'view',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/optimism/_meta/oneinch_optimism_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/optimism/_meta/oneinch_optimism_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/optimism/project/oneinch_optimism_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/optimism/project/oneinch_optimism_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/optimism/project/oneinch_optimism_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/optimism/project/oneinch_optimism_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/optimism/project/oneinch_optimism_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/optimism/project/oneinch_optimism_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/optimism/project/oneinch_optimism_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/optimism/project/oneinch_optimism_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/optimism/project/oneinch_optimism_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/optimism/project/oneinch_optimism_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/polygon/_meta/oneinch_polygon_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/polygon/_meta/oneinch_polygon_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/polygon/project/oneinch_polygon_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/polygon/project/oneinch_polygon_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/polygon/project/oneinch_polygon_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/polygon/project/oneinch_polygon_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/polygon/project/oneinch_polygon_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/polygon/project/oneinch_polygon_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/polygon/project/oneinch_polygon_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/polygon/project/oneinch_polygon_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/polygon/project/oneinch_polygon_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/polygon/project/oneinch_polygon_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/sonic/_meta/oneinch_sonic_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/sonic/_meta/oneinch_sonic_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/sonic/project/oneinch_sonic_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/sonic/project/oneinch_sonic_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/sonic/project/oneinch_sonic_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/sonic/project/oneinch_sonic_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/sonic/project/oneinch_sonic_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/sonic/project/oneinch_sonic_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/sonic/project/oneinch_sonic_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/sonic/project/oneinch_sonic_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/sonic/project/oneinch_sonic_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/sonic/project/oneinch_sonic_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/unichain/_meta/oneinch_unichain_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/unichain/_meta/oneinch_unichain_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/unichain/project/oneinch_unichain_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/unichain/project/oneinch_unichain_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/unichain/project/oneinch_unichain_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/unichain/project/oneinch_unichain_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/unichain/project/oneinch_unichain_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/unichain/project/oneinch_unichain_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/unichain/project/oneinch_unichain_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/unichain/project/oneinch_unichain_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/unichain/project/oneinch_unichain_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/unichain/project/oneinch_unichain_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/zksync/_meta/oneinch_zksync_mapped_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/zksync/_meta/oneinch_zksync_mapped_contracts.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'mapped_contracts',
         materialized = 'table',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/zksync/project/oneinch_zksync_project_calls.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/zksync/project/oneinch_zksync_project_calls.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_calls',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/zksync/project/oneinch_zksync_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/zksync/project/oneinch_zksync_project_orders.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders',
         partition_by = ['block_month'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/zksync/project/oneinch_zksync_project_orders_raw_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/zksync/project/oneinch_zksync_project_orders_raw_logs.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_logs',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/zksync/project/oneinch_zksync_project_orders_raw_traces.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/zksync/project/oneinch_zksync_project_orders_raw_traces.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_orders_raw_traces',
         partition_by = ['block_date'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/zksync/project/oneinch_zksync_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/zksync/project/oneinch_zksync_project_swaps.sql
@@ -4,6 +4,7 @@
 
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         partition_by = ['block_month', 'project'],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds the prod_exclude tag to all oneinch models (core and per-chain) to exclude them from prod runs.
> 
> - **DBT models – oneinch**:
>   - Add `tags = ['prod_exclude']` to `mapped_contracts`, `project_calls`, `project_orders`, `project_orders_raw_logs`, `project_orders_raw_traces`, and `project_swaps` across all chains (`arbitrum`, `avalanche_c`, `base`, `bnb`, `ethereum`, `fantom`, `gnosis`, `linea`, `optimism`, `polygon`, `sonic`, `unichain`, `zksync`) and top-level aggregations in `oneinch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 733447fcab8d2122bfedf95527a88a0f16e98d3a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->