### PR TITLE
CUR2-879: 1inch exclude bnb swap models

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_swaps.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_swaps.sql
@@ -2,6 +2,7 @@
 
 {{-
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps',
         materialized = 'view',

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_swaps_base.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_swaps_base.sql
@@ -2,6 +2,7 @@
 
 {{-
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps_base',
         partition_by = ['block_month', 'project'],

--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_swaps_second_side.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/bnb/project/oneinch_bnb_project_swaps_second_side.sql
@@ -2,6 +2,7 @@
 
 {{-
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch_' + blockchain,
         alias = 'project_swaps_second_side',
         partition_by = ['block_month', 'project'],


### PR DESCRIPTION
fyi @max-morrow 

we deployed #8898, but ran into issues with the bnb swap models.
We are not able to deploy these to production, even when largely increasing the resources of the cluster. 
This PR excludes those models that we were not able to deploy.