### PR TITLE
CUR2-989 exclude contract mapping lineage due to consistent failures

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/contracts/arbitrum/contracts_arbitrum_base_iterated_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/arbitrum/contracts_arbitrum_base_iterated_creators.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_arbitrum',
         alias = 'base_iterated_creators',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/arbitrum/contracts_arbitrum_base_starting_level.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/arbitrum/contracts_arbitrum_base_starting_level.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_arbitrum',
         alias = 'base_starting_level',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/arbitrum/contracts_arbitrum_contract_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/arbitrum/contracts_arbitrum_contract_mapping.sql
@@ -1,5 +1,6 @@
  {{
-  config(     
+  config(
+        tags = ['prod_exclude'],
         schema = 'contracts_arbitrum',
         alias = 'contract_mapping',
         materialized ='table',

--- a/dbt_subprojects/daily_spellbook/models/contracts/arbitrum/contracts_arbitrum_find_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/arbitrum/contracts_arbitrum_find_self_destruct_contracts.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_arbitrum',
         alias = 'find_self_destruct_contracts',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/avalanche_c/contracts_avalanche_c_base_iterated_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/avalanche_c/contracts_avalanche_c_base_iterated_creators.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_avalanche_c',
         alias = 'base_iterated_creators',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/avalanche_c/contracts_avalanche_c_base_starting_level.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/avalanche_c/contracts_avalanche_c_base_starting_level.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_avalanche_c',
         alias = 'base_starting_level',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/avalanche_c/contracts_avalanche_c_contract_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/avalanche_c/contracts_avalanche_c_contract_mapping.sql
@@ -1,5 +1,6 @@
  {{
-  config(     
+  config(
+        tags = ['prod_exclude'],
         schema = 'contracts_avalanche_c',
         alias = 'contract_mapping',
         materialized ='table',

--- a/dbt_subprojects/daily_spellbook/models/contracts/avalanche_c/contracts_avalanche_c_find_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/avalanche_c/contracts_avalanche_c_find_self_destruct_contracts.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_avalanche_c',
         alias = 'find_self_destruct_contracts',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/base/contracts_base_base_iterated_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/base/contracts_base_base_iterated_creators.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_base',
         alias = 'base_iterated_creators',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/base/contracts_base_base_starting_level.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/base/contracts_base_base_starting_level.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_base',
         alias = 'base_starting_level',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/base/contracts_base_contract_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/base/contracts_base_contract_mapping.sql
@@ -1,5 +1,6 @@
  {{
-  config(     
+  config(
+        tags = ['prod_exclude'],
         schema = 'contracts_base',
         alias = 'contract_mapping',
         materialized ='table',

--- a/dbt_subprojects/daily_spellbook/models/contracts/base/contracts_base_find_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/base/contracts_base_find_self_destruct_contracts.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_base',
         alias = 'find_self_destruct_contracts',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/bnb/contracts_bnb_base_iterated_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/bnb/contracts_bnb_base_iterated_creators.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_bnb',
         alias = 'base_iterated_creators',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/bnb/contracts_bnb_base_starting_level.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/bnb/contracts_bnb_base_starting_level.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_bnb',
         alias = 'base_starting_level',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/bnb/contracts_bnb_contract_mapping_dynamic.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/bnb/contracts_bnb_contract_mapping_dynamic.sql
@@ -1,5 +1,6 @@
  {{
-  config(     
+  config(
+        tags = ['prod_exclude'],
         schema = 'contracts_bnb',
         alias = 'contract_mapping_dynamic',
         materialized ='table',

--- a/dbt_subprojects/daily_spellbook/models/contracts/bnb/contracts_bnb_find_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/bnb/contracts_bnb_find_self_destruct_contracts.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_bnb',
         alias = 'find_self_destruct_contracts',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/celo/contracts_celo_base_iterated_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/celo/contracts_celo_base_iterated_creators.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'contracts_celo',
         alias = 'base_iterated_creators',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/celo/contracts_celo_base_starting_level.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/celo/contracts_celo_base_starting_level.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'contracts_celo',
         alias = 'base_starting_level',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/celo/contracts_celo_contract_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/celo/contracts_celo_contract_mapping.sql
@@ -1,5 +1,6 @@
 {{
-    config(     
+    config(
+        tags = ['prod_exclude'],
         schema = 'contracts_celo',
         alias = 'contract_mapping',
         materialized ='table',

--- a/dbt_subprojects/daily_spellbook/models/contracts/celo/contracts_celo_find_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/celo/contracts_celo_find_self_destruct_contracts.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'contracts_celo',
         alias = 'find_self_destruct_contracts',
         materialized = 'incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/contracts_contract_creator_address_list.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/contracts_contract_creator_address_list.sql
@@ -1,6 +1,6 @@
 {{ 
   config(
-    tags = ['static'],
+    tags = ['static', 'prod_exclude'],
     schema = 'contracts',
     alias = 'contract_creator_address_list',
     unique_key='creator_address',

--- a/dbt_subprojects/daily_spellbook/models/contracts/contracts_contract_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/contracts_contract_mapping.sql
@@ -1,5 +1,6 @@
  {{
   config(     
+        tags = ['prod_exclude'],
         schema = 'contracts',
         alias = 'contract_mapping',
         post_hook='{{ expose_spells(\'["ethereum", "base", "optimism", "zora", "arbitrum", "celo", "polygon", "bnb", "avalanche_c", "fantom", "gnosis","zksync"]\',

--- a/dbt_subprojects/daily_spellbook/models/contracts/contracts_contract_overrides.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/contracts_contract_overrides.sql
@@ -1,6 +1,6 @@
 {{ 
   config(
-    tags = ['static'],
+    tags = ['static', 'prod_exclude'],
     schema = 'contracts',
     alias = 'contract_overrides',
     unique_key='contract_address',

--- a/dbt_subprojects/daily_spellbook/models/contracts/contracts_deterministic_contract_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/contracts_deterministic_contract_creators.sql
@@ -1,6 +1,6 @@
 {{ 
   config(
-    tags = ['static'],
+    tags = ['static', 'prod_exclude'],
     schema = 'contracts',
     alias = 'deterministic_contract_creators',
     unique_key='creator_address',

--- a/dbt_subprojects/daily_spellbook/models/contracts/contracts_predeploys.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/contracts_predeploys.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts',
         alias = 'predeploys',
         post_hook='{{ expose_spells(\'["ethereum", "base", "optimism", "zora"]\',

--- a/dbt_subprojects/daily_spellbook/models/contracts/contracts_project_name_mappings.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/contracts_project_name_mappings.sql
@@ -1,6 +1,6 @@
 {{ 
   config(
-    tags = ['static'],
+    tags = ['static', 'prod_exclude'],
     schema = 'contracts',
     alias = 'project_name_mappings',
     unique_key='dune_name',

--- a/dbt_subprojects/daily_spellbook/models/contracts/contracts_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/contracts_self_destruct_contracts.sql
@@ -1,17 +1,13 @@
  {{
   config(
-        
-        schema = 'contracts',
-        alias = 'self_destruct_contracts',
-        materialized ='incremental',
-        file_format ='delta',
-        incremental_strategy='merge',
-        unique_key = ['blockchain', 'contract_address'],
-        partition_by=['blockchain'],
-        post_hook='{{ expose_spells(\'["ethereum", "optimism", "base", "zora"]\',
-                                    "sector",
-                                    "contracts",
-                                    \'["msilb7", "chuxin"]\') }}'
+      tags = ['prod_exclude'],
+      schema = 'contracts',
+      alias = 'self_destruct_contracts',
+      materialized ='incremental',
+      file_format ='delta',
+      incremental_strategy='merge',
+      unique_key = ['blockchain', 'contract_address'],
+      partition_by=['blockchain']
   )
 }}
 {% set chain_models = [

--- a/dbt_subprojects/daily_spellbook/models/contracts/contracts_system_predeploys.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/contracts_system_predeploys.sql
@@ -1,6 +1,6 @@
  {{
   config(
-	tags = ['static'],
+	tags = ['static', 'prod_exclude'],
 	schema = 'contracts',
         alias = 'system_predeploys',
         post_hook='{{ expose_spells(\'["ethereum", "base", "optimism", "zora"]\',

--- a/dbt_subprojects/daily_spellbook/models/contracts/ethereum/contracts_ethereum_base_iterated_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/ethereum/contracts_ethereum_base_iterated_creators.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_ethereum',
         alias = 'base_iterated_creators',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/ethereum/contracts_ethereum_base_starting_level.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/ethereum/contracts_ethereum_base_starting_level.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_ethereum',
         alias = 'base_starting_level',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/ethereum/contracts_ethereum_contract_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/ethereum/contracts_ethereum_contract_mapping.sql
@@ -1,5 +1,6 @@
  {{
-  config(     
+  config(
+        tags = ['prod_exclude'],
         schema = 'contracts_ethereum',
         alias = 'contract_mapping',
         materialized ='table',

--- a/dbt_subprojects/daily_spellbook/models/contracts/ethereum/contracts_ethereum_find_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/ethereum/contracts_ethereum_find_self_destruct_contracts.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_ethereum',
         alias = 'find_self_destruct_contracts',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/fantom/contracts_fantom_base_iterated_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/fantom/contracts_fantom_base_iterated_creators.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_fantom',
         alias = 'base_iterated_creators',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/fantom/contracts_fantom_base_starting_level.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/fantom/contracts_fantom_base_starting_level.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_fantom',
         alias = 'base_starting_level',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/fantom/contracts_fantom_contract_mapping_dynamic.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/fantom/contracts_fantom_contract_mapping_dynamic.sql
@@ -1,5 +1,6 @@
  {{
-  config(     
+  config(
+        tags = ['prod_exclude'],
         schema = 'contracts_fantom',
         alias = 'contract_mapping_dynamic',
         materialized ='table',

--- a/dbt_subprojects/daily_spellbook/models/contracts/fantom/contracts_fantom_find_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/fantom/contracts_fantom_find_self_destruct_contracts.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_fantom',
         alias = 'find_self_destruct_contracts',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/gnosis/contracts_gnosis_base_iterated_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/gnosis/contracts_gnosis_base_iterated_creators.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_gnosis',
         alias = 'base_iterated_creators',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/gnosis/contracts_gnosis_base_starting_level.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/gnosis/contracts_gnosis_base_starting_level.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_gnosis',
         alias = 'base_starting_level',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/gnosis/contracts_gnosis_contract_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/gnosis/contracts_gnosis_contract_mapping.sql
@@ -1,5 +1,6 @@
  {{
-  config(     
+  config(
+        tags = ['prod_exclude'],
         schema = 'contracts_gnosis',
         alias = 'contract_mapping',
         materialized ='table',

--- a/dbt_subprojects/daily_spellbook/models/contracts/gnosis/contracts_gnosis_find_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/gnosis/contracts_gnosis_find_self_destruct_contracts.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_gnosis',
         alias = 'find_self_destruct_contracts',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/optimism/contracts_optimism_base_iterated_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/optimism/contracts_optimism_base_iterated_creators.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_optimism',
         alias = 'base_iterated_creators',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/optimism/contracts_optimism_base_starting_level.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/optimism/contracts_optimism_base_starting_level.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_optimism',
         alias = 'base_starting_level',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/optimism/contracts_optimism_contract_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/optimism/contracts_optimism_contract_mapping.sql
@@ -1,5 +1,6 @@
  {{
-  config(     
+  config(
+        tags = ['prod_exclude'],
         schema = 'contracts_optimism',
         alias = 'contract_creator_project_mapping',
         materialized ='table',

--- a/dbt_subprojects/daily_spellbook/models/contracts/optimism/contracts_optimism_find_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/optimism/contracts_optimism_find_self_destruct_contracts.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_optimism',
         alias = 'find_self_destruct_contracts',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/polygon/contracts_polygon_base_iterated_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/polygon/contracts_polygon_base_iterated_creators.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_polygon',
         alias = 'base_iterated_creators',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/polygon/contracts_polygon_base_starting_level.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/polygon/contracts_polygon_base_starting_level.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_polygon',
         alias = 'base_starting_level',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/polygon/contracts_polygon_contract_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/polygon/contracts_polygon_contract_mapping.sql
@@ -1,5 +1,6 @@
  {{
-  config(     
+  config(
+        tags = ['prod_exclude'],
         schema = 'contracts_polygon',
         alias = 'contract_mapping',
         materialized ='table',

--- a/dbt_subprojects/daily_spellbook/models/contracts/polygon/contracts_polygon_find_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/polygon/contracts_polygon_find_self_destruct_contracts.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_polygon',
         alias = 'find_self_destruct_contracts',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/zksync/contracts_zksync_base_iterated_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/zksync/contracts_zksync_base_iterated_creators.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_zksync',
         alias = 'base_iterated_creators',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/zksync/contracts_zksync_base_starting_level.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/zksync/contracts_zksync_base_starting_level.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_zksync',
         alias = 'base_starting_level',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/zksync/contracts_zksync_contract_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/zksync/contracts_zksync_contract_mapping.sql
@@ -1,5 +1,6 @@
  {{
-  config(     
+  config(
+        tags = ['prod_exclude'],
         schema = 'contracts_zksync',
         alias = 'contract_mapping',
         materialized ='table',

--- a/dbt_subprojects/daily_spellbook/models/contracts/zksync/contracts_zksync_find_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/zksync/contracts_zksync_find_self_destruct_contracts.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_zksync',
         alias = 'find_self_destruct_contracts',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/zora/contracts_zora_base_iterated_creators.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/zora/contracts_zora_base_iterated_creators.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_zora',
         alias = 'base_iterated_creators',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/zora/contracts_zora_base_starting_level.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/zora/contracts_zora_base_starting_level.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_zora',
         alias = 'base_starting_level',
         materialized ='incremental',

--- a/dbt_subprojects/daily_spellbook/models/contracts/zora/contracts_zora_contract_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/zora/contracts_zora_contract_mapping.sql
@@ -1,5 +1,6 @@
  {{
-  config(     
+  config(
+        tags = ['prod_exclude'],
         schema = 'contracts_zora',
         alias = 'contract_mapping',
         materialized ='table',

--- a/dbt_subprojects/daily_spellbook/models/contracts/zora/contracts_zora_find_self_destruct_contracts.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/zora/contracts_zora_find_self_destruct_contracts.sql
@@ -1,5 +1,6 @@
  {{
   config(
+        tags = ['prod_exclude'],
         schema = 'contracts_zora',
         alias = 'find_self_destruct_contracts',
         materialized ='incremental',


### PR DESCRIPTION
the models in this lineage are too heavy to run in prod and fail the daily job essentially every run. this lineage needs to be refactored and optimized to run efficiently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `prod_exclude` tag to contracts lineage models across chains and removes a post_hook from `contracts_self_destruct_contracts` to exclude heavy lineage from prod.
> 
> - **Contracts lineage tagging**:
>   - Add `tags = ['prod_exclude']` to `contracts_*` models (iterated creators, starting level, contract_mapping, find_self_destruct_contracts) across `ethereum`, `base`, `optimism`, `zora`, `arbitrum`, `celo`, `polygon`, `bnb`, `avalanche_c`, `fantom`, `gnosis`, `zksync`.
>   - Tag static models `contracts_contract_creator_address_list`, `contracts_contract_overrides`, `contracts_deterministic_contract_creators`, `contracts_project_name_mappings`, `contracts_system_predeploys`, and `contracts_predeploys` with `prod_exclude`.
> - **Self-destruct aggregation**:
>   - Add `prod_exclude` and remove `post_hook` from `contracts/contracts_self_destruct_contracts.sql`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 087d6e4e92b9ae9df4783668acfee16b8c333182. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->