### PR TITLE
CUR2-1119: `native.mints` overflow bug

### DIFF
--- a/dbt_subprojects/nft/macros/nft_mints.sql
+++ b/dbt_subprojects/nft/macros/nft_mints.sql
@@ -11,7 +11,7 @@ WITH namespaces AS (
 , nfts_per_tx AS (
     SELECT
         tx_hash
-        , sum(amount) AS nfts_minted_in_tx
+        , SUM(CAST(amount AS DOUBLE)) AS nfts_minted_in_tx
     FROM {{ ref('nft_transfers') }}
     WHERE
         blockchain = '{{blockchain}}'
@@ -19,7 +19,7 @@ WITH namespaces AS (
         AND {{incremental_predicate('block_time')}}
         {% endif %}
     GROUP BY tx_hash
-    HAVING sum(amount) > 0
+    HAVING SUM(CAST(amount AS DOUBLE)) > 0
     )
 
 SELECT


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

dbt error on full refresh:
```
Database Error in model nft_base_native_mints (models/_sector/mints/native/nft_base_native_mints.sql)
  TrinoUserError(type=USER_ERROR, name=NUMERIC_VALUE_OUT_OF_RANGE, message="UINT256 addition overflow: 1 + 115792089237316195423570985008687907853269984665640564039457584007913129639935", query_id=20251211_103156_00228_v5qs7)
```

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
