### PR TITLE
CUR2-1130: `tokens_ethereum.transfers_from_traces` temp dupe exclusion

### DIFF
--- a/dbt_subprojects/tokens/macros/transfers_from_traces/transfers_from_traces_macro.sql
+++ b/dbt_subprojects/tokens/macros/transfers_from_traces/transfers_from_traces_macro.sql
@@ -118,7 +118,7 @@ select
 from tft
 left join tokens using(contract_address)
 left join prices using(contract_address, timestamp)
-
+where not (blockchain = 'ethereum' and block_date = cast('2025-12-11' as date) and unique_key = 0x9927b20e013cfefe69272dddcb5e8b36972ea0f5)
 
 
 {%- endmacro -%}


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

also applies to:
```
where (block_date = cast('2024-09-22' as date) and unique_key = 0xab0c5334e5f4d594ce0cc2a7f5ae5944d99e5ede)
   or (block_date = cast('2024-01-25' as date) and unique_key = 0xd543326022b7230e30215b3a4fb016e04317a34a)
   or (block_date = cast('2023-04-23' as date) and unique_key = 0x15a7e9ff2157290acfe8bb9d9ff442fb52dced17)
   or (block_date = cast('2022-03-06' as date) and unique_key = 0x0f557de4b9ba471970f5f64347baa8497812efdb)
```

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
