### PR TITLE
1inch: fix method selection in lo table

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/oneinch/oneinch_project_orders.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/oneinch/oneinch_project_orders.sql
@@ -76,7 +76,25 @@ meta as (
         union all
 
         select
-            {{ orders_base_columns | join(', ') }}
+            blockchain
+            , block_number
+            , block_time
+            , tx_hash
+            , tx_from
+            , tx_to
+            , call_method as method
+            , call_selector
+            , call_trace_address
+            , call_from
+            , call_to
+            , call_gas_used
+            , maker
+            , maker_asset
+            , making_amount
+            , taker_asset
+            , taking_amount
+            , order_hash
+            , flags
             , contract_name as tag
             , '1inch' as project
             , null as order_start


### PR DESCRIPTION
@max-morrow more reason for us to ensure CI runs end-to-end for all models being rebuilt 🙏 
in the future, even if model isn't part of changes in PR, force the model in so it runs in CI on easy dates. 
the `lo` macro merged last month changed `method` to `call_method`, so we're forced to alias here.