### PR TITLE
Contract mapping visibility

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/contracts/contracts_contract_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/contracts/contracts_contract_mapping.sql
@@ -1,9 +1,10 @@
 {{
  config(     
-       tags = ['prod_exclude'],
-       schema = 'contracts',
-       alias = 'contract_mapping'
- )
+      tags = ['prod_exclude'],
+      schema = 'contracts',
+      alias = 'contract_mapping',
+      post_hook = '{{ hide_spells() }}'
+)
 }}
 
 {% set chain_models = [


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

This PR makes the `contracts.contract_mapping` spell private by removing the `expose_spells` post-hook. This prevents it from appearing in the data explorer.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
[Slack Thread](https://duneanalytics.slack.com/archives/D092A2R4EKX/p1766483021829269?thread_ts=1766483021.829269&cid=D092A2R4EKX)

<a href="https://cursor.com/background-agent?bcId=bc-31106fd7-8246-44f6-b67e-ab2125176518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-31106fd7-8246-44f6-b67e-ab2125176518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

