### PR TITLE
Add schema metadata for gas_solana_compute_limit model

### DIFF
--- a/dbt_subprojects/solana/models/_sector/gas/_schema.yml
+++ b/dbt_subprojects/solana/models/_sector/gas/_schema.yml
@@ -15,8 +15,13 @@ models:
       tags: ['solana', 'gas', 'fees']
 
     columns:
-      - name: blockchain
-      - name: block_month
+  - name: tx_id
+  - name: block_date
+  - name: block_hour
+  - name: block_time
+  - name: block_slot
+  - name: tx_index
+  - name: compute_limit
 
   - name: gas_solana_compute_unit_price #todo
   - name: gas_solana_tx_fees #todo


### PR DESCRIPTION
Adds a model-level schema description for gas_solana_compute_limit and removes an outdated TODO comment. No logic changes.

