### PR TITLE
fix balancer pool metrics daily prod failure

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/pools/balancer_pools_metrics_daily.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/pools/balancer_pools_metrics_daily.sql
@@ -1,4 +1,5 @@
 {{ config(
+    tags = ['prod_exclude'],
     schema = 'balancer',
     alias = 'pools_metrics_daily',
     materialized = 'incremental',


### PR DESCRIPTION
this model reads from multiple nested views, and the trino planner has a limit for 500 stages in query plan. due to all the views in the lineage, this surpasses 1k+ stages and fails.

for now, exclude to unblock prod jobs. to re-enable, upstream views must be materialized into tables to avoid stage limits.