### PR TITLE
pancakeswap v2 arbitrum: exclude for short term due to dupes

### DIFF
--- a/dbt_subprojects/dex/models/trades/arbitrum/platforms/pancakeswap_v2_arbitrum_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/arbitrum/platforms/pancakeswap_v2_arbitrum_base_trades.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        tags = ['prod_exclude'],
         schema = 'pancakeswap_v2_arbitrum',
         alias = 'base_trades',
         materialized = 'incremental',


### PR DESCRIPTION
job is failing in prod on duplicates for `tx_hash, evt_index`
will revisit to re-enable later, need to unblock prod.