### PR TITLE
add Phantom Cash solana stablecoin

### DIFF
--- a/dbt_subprojects/solana/models/tokens/solana/tokens_solana_stablecoins.sql
+++ b/dbt_subprojects/solana/models/tokens/solana/tokens_solana_stablecoins.sql
@@ -23,4 +23,5 @@ from (Values
     , ('solana', 'ZUSD','FrBfWJ4qE5sCzKm3k3JaAtqZcXUh4LvJygDeketsrsH4', 6,'Dollar-Pegged','GMO-Z')
     , ('solana', 'PAI', 'Ea5SjE2Y6yvCeW5dYTn7PYMuW5ikXkvbGdcmSnXeaLjS', 6,'Crypto Stablecoin', 'Parrot')
     , ('solana', 'FDUSD', '9zNQRsGLjNKwCUU5Gq5LR8beUCPzQMVMqKAi3SSZh54u', 6,'Fiat Stablecoin', 'First Digital Labs')
+    , ('solana', 'CASH', 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH', 6,'Fiat Stablecoin', 'CASH')
 ) as t(blockchain, symbol, address, decimals, backing, name)


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

This pull request adds a new stablecoin entry to the Solana stablecoins model. The change is minor and simply updates the list of recognized stablecoins.

- Added the `CASH` stablecoin (symbol: `CASH`, address: `CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH`) as a fiat-backed stablecoin issued by `CASH` to the `tokens_solana_stablecoins.sql` model.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
