### PR TITLE
feat(solana): add Manifest DEX integration

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/dex_solana_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/dex_solana_base_trades.sql
@@ -37,6 +37,7 @@
       , ref('goonfi_solana_base_trades')
       , ref('obric_solana_base_trades')
       , ref('aquifer_solana_base_trades')
+      , ref('manifest_solana_base_trades')
       ]
 %}
 

--- a/dbt_subprojects/solana/models/_sector/dex/manifest/manifest_solana_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/manifest/manifest_solana_base_trades.sql
@@ -1,0 +1,113 @@
+{{
+  config(
+    schema = 'manifest_solana'
+    , alias = 'base_trades'
+    , partition_by = ['block_month']
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , unique_key = ['block_month', 'block_date', 'surrogate_key']
+    , pre_hook = '{{ enforce_join_distribution("PARTITIONED") }}'
+  )
+}}
+
+{% set project_start_date = '2025-07-31' %}
+
+WITH swaps AS (
+    SELECT
+          block_slot
+        , block_date
+        , block_time
+        , inner_instruction_index
+        , outer_instruction_index
+        , outer_executing_account
+        , is_inner
+        , tx_id
+        , tx_signer
+        , tx_index
+        , pool_id
+        , surrogate_key
+    FROM {{ ref('manifest_solana_stg_raw_swaps') }}
+    WHERE 1=1
+        {% if is_incremental() -%}
+        AND {{ incremental_predicate('block_date') }}
+        {% else -%}
+        AND block_date >= DATE '{{ project_start_date }}'
+        {% endif -%}
+)
+
+, transfers AS (
+    SELECT
+          s.block_date
+        , s.block_time
+        , s.block_slot
+        , CASE WHEN s.is_inner = false THEN 'direct' ELSE s.outer_executing_account END AS trade_source
+        , MAX(CASE WHEN tf.inner_instruction_index = s.inner_instruction_index + 2 THEN tf.amount END) AS token_bought_amount_raw
+        , MAX(CASE WHEN tf.inner_instruction_index = s.inner_instruction_index + 1 THEN tf.amount END) AS token_sold_amount_raw
+        , MAX(CASE WHEN tf.inner_instruction_index = s.inner_instruction_index + 2 THEN tf.from_token_account END) AS token_bought_vault
+        , MAX(CASE WHEN tf.inner_instruction_index = s.inner_instruction_index + 1 THEN tf.to_token_account END) AS token_sold_vault
+        , MAX(CASE WHEN tf.inner_instruction_index = s.inner_instruction_index + 2 THEN tf.token_mint_address END) AS token_bought_mint_address
+        , MAX(CASE WHEN tf.inner_instruction_index = s.inner_instruction_index + 1 THEN tf.token_mint_address END) AS token_sold_mint_address
+        , s.pool_id AS project_program_id
+        , s.tx_signer AS trader_id
+        , s.tx_id
+        , s.outer_instruction_index
+        , s.inner_instruction_index
+        , s.tx_index
+        , s.surrogate_key
+    FROM swaps s
+    INNER JOIN {{ source('tokens_solana', 'transfers') }} tf
+        ON  tf.tx_id = s.tx_id
+        AND tf.block_date = s.block_date
+        AND tf.block_slot = s.block_slot
+        AND tf.outer_instruction_index = s.outer_instruction_index
+        AND tf.inner_instruction_index IN (s.inner_instruction_index + 1, s.inner_instruction_index + 2)
+    WHERE tf.token_version IN ('spl_token', 'spl_token_2022')
+        {% if is_incremental() -%}
+        AND {{ incremental_predicate('tf.block_date') }}
+        {% else -%}
+        AND tf.block_date >= DATE '{{ project_start_date }}'
+        {% endif -%}
+    GROUP BY
+          s.block_date
+        , s.block_time
+        , s.block_slot
+        , CASE WHEN s.is_inner = false THEN 'direct' ELSE s.outer_executing_account END
+        , s.pool_id
+        , s.tx_signer
+        , s.tx_id
+        , s.outer_instruction_index
+        , s.inner_instruction_index
+        , s.tx_index
+        , s.surrogate_key
+    HAVING COUNT_IF(tf.inner_instruction_index = s.inner_instruction_index + 2) = 1
+       AND COUNT_IF(tf.inner_instruction_index = s.inner_instruction_index + 1) = 1
+)
+
+SELECT
+      'solana' AS blockchain
+    , 'manifest' AS project
+    , 1 AS version
+    , 'v1' AS version_name
+    , CAST(DATE_TRUNC('month', block_date) AS DATE) AS block_month
+    , block_time
+    , block_slot
+    , block_date
+    , trade_source
+    , token_bought_amount_raw
+    , token_sold_amount_raw
+    , CAST(NULL AS DOUBLE) AS fee_tier
+    , token_bought_mint_address
+    , token_sold_mint_address
+    , token_bought_vault
+    , token_sold_vault
+    , project_program_id
+    , 'MNFSTqtC93rEfYHB6hF82sKdZpUDFWkViLByLd1k1Ms' AS project_main_id
+    , trader_id
+    , tx_id
+    , outer_instruction_index
+    , inner_instruction_index
+    , tx_index
+    , surrogate_key
+FROM transfers

--- a/dbt_subprojects/solana/models/_sector/dex/manifest/manifest_solana_stg_raw_swaps.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/manifest/manifest_solana_stg_raw_swaps.sql
@@ -1,0 +1,52 @@
+{{
+  config(
+    schema = 'manifest_solana'
+    , alias = 'stg_raw_swaps'
+    , partition_by = ['block_month']
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , unique_key = ['block_month', 'block_date', 'surrogate_key']
+  )
+}}
+
+{% set project_start_date = '2025-07-31' %}
+
+-- manifest swap data from instruction_calls table
+WITH swaps AS (
+  SELECT
+    block_slot
+    , cast(date_trunc('month', block_date) AS DATE) AS block_month
+    , block_date
+    , block_time
+    , COALESCE(inner_instruction_index,0) as inner_instruction_index -- adjust to index 0 for direct trades
+    , outer_instruction_index
+    , inner_executing_account
+    , outer_executing_account
+    , executing_account
+    , is_inner
+    , tx_id
+    , tx_signer
+    , tx_index
+    , CAST(NULL as VARCHAR) AS pool_id -- Manifest does not use a pool system like other AMM's
+    , {{ solana_instruction_key(
+          'block_slot'
+        , 'tx_index'
+        , 'outer_instruction_index'
+        , 'inner_instruction_index'
+      ) }} as surrogate_key
+  FROM {{ source('solana','instruction_calls') }}
+  WHERE
+    1=1
+    AND executing_account = 'MNFSTqtC93rEfYHB6hF82sKdZpUDFWkViLByLd1k1Ms'
+    AND tx_success = true
+    AND BYTEARRAY_SUBSTRING(data, 1, 1) in (0x0d,0x04) --swap v2,swap
+    {% if is_incremental() -%}
+    AND {{ incremental_predicate('block_date') }}
+    {% else -%}
+    AND block_date >= DATE '{{ project_start_date }}'
+    {% endif -%}
+)
+select *
+from swaps

--- a/dbt_subprojects/solana/models/_sector/dex/manifest/manifest_solana_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/manifest/manifest_solana_trades.sql
@@ -1,0 +1,44 @@
+{{
+  config(
+        schema = 'manifest_solana',
+        alias = 'trades',
+        materialized = 'view',
+        post_hook='{{ expose_spells(\'["solana"]\',
+                                    "project",
+                                    "manifest",
+                                    \'["Eekeyguy"]\') }}')
+}}
+
+select
+      blockchain
+      , project
+      , version
+      , version_name
+      , block_month
+      , block_date
+      , block_time
+      , block_slot
+      , trade_source
+      , token_bought_symbol
+      , token_sold_symbol
+      , token_pair
+      , token_bought_amount
+      , token_sold_amount
+      , token_bought_amount_raw
+      , token_sold_amount_raw
+      , amount_usd
+      , fee_tier
+      , fee_usd
+      , token_bought_mint_address
+      , token_sold_mint_address
+      , token_bought_vault
+      , token_sold_vault
+      , project_program_id
+      , project_main_id
+      , trader_id
+      , tx_id
+      , outer_instruction_index
+      , inner_instruction_index
+      , tx_index
+from {{ref('dex_solana_trades')}}
+where project = 'manifest'

--- a/dbt_subprojects/solana/models/_sector/dex/manifest/schema.yml
+++ b/dbt_subprojects/solana/models/_sector/dex/manifest/schema.yml
@@ -1,0 +1,124 @@
+version: 2
+
+models:
+  - name: manifest_solana_stg_raw_swaps
+    meta:
+      blockchain: solana
+      contributors: [ Eekeguy ]
+    config:
+      tags: [ 'solana','dex', 'manifest' ]
+    description: >
+      staging model for manifest swap data from instruction_calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ['block_month', 'block_date', 'surrogate_key']
+
+  - name: manifest_solana_base_trades
+    meta:
+      blockchain: solana
+      contributors: [ Eekeguy ]
+    config:
+      tags: [ 'solana','dex', 'manifest' ]
+    description: >
+      all raw manifest dex trades on Solana
+    data_tests:
+      - check_columns_solana_dex_trades
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ['block_month', 'block_date', 'surrogate_key']
+
+  - name: manifest_solana_trades
+    meta:
+      blockchain: solana
+      contributors: [Eekeguy]
+    config:
+      tags: ['solana','dex', 'manifest']
+    description: >
+        all manifest dex trades on Solana
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain which the DEX is deployed"
+      - &project
+        name: project
+        description: "Project name of the DEX"
+      - &version
+        name: version
+        description: "Version of the contract built and deployed by the DEX project"
+      - &block_month
+        name: block_month
+        description: "UTC event block month of each DEX trade"
+      - &block_date
+        name: block_date
+        description: "UTC event block date of each DEX trade"
+      - &block_time
+        name: block_time
+        description: "UTC event block time of each DEX trade"
+      - &block_slot
+        name: block_slot
+        description: "block slot of each DEX trade"
+      - &trade_source
+        name: trade_source
+        description: "Was the trade a direct call to the manifest or did it go through another program like Jupiter (Dex Aggregator)"
+      - &token_bought_symbol
+        name: token_bought_symbol
+        description: "Token symbol for token bought in the trade"
+      - &token_sold_symbol
+        name: token_sold_symbol
+        description: "Token symbol for token sold in the trade"
+      - &token_pair
+        name: token_pair
+        description: "Token symbol pair for each token involved in the trade"
+      - &token_bought_amount
+        name: token_bought_amount
+        description: "Value of the token bought at time of execution in the original currency"
+      - &token_sold_amount
+        name: token_sold_amount
+        description: "Value of the token sold at time of execution in the original currency"
+      - &token_bought_amount_raw
+        name: token_bought_amount_raw
+        description: "Raw value of the token bought at time of execution in the original currency"
+      - &token_sold_amount_raw
+        name: token_sold_amount_raw
+        description: "Raw value of the token sold at time of execution in the original currency"
+      - &amount_usd
+        name: amount_usd
+        description: "USD value of the trade at time of execution"
+      - &fee_tier
+        name: fee_tier
+        description: "manifest fee tier (fee %)"
+      - &fee_usd
+        name: fee_usd
+        description: "manifest fee usd paid on swap"
+      - &token_bought_mint_address
+        name: token_bought_mint_address
+        description: "token mint address of the token bought"
+      - &token_sold_mint_address
+        name: token_sold_mint_address
+        description: "token mint address of the token sold"
+      - &token_bought_vault
+        name: token_bought_vault
+        description: "token associated address for the manifest, of the token bought"
+      - &token_sold_vault
+        name: token_sold_vault
+        description: "token associated address for the manifest, of the token sold"
+      - &project_program_id
+        name: project_program_id
+        description: "pool program id of the project"
+      - &project_main_id
+        name: project_main_id
+        description: "main program id of the project"
+      - &trader_id
+        name: trader_id
+        description: "id (address) of trader who purchased a token"
+      - &tx_id
+        name: tx_id
+        description: "Unique transaction id value tied to each transaction on the DEX"
+      - &outer_instruction_index
+        name: outer_instruction_index
+        description: "top level instruction index for a given transaction id"
+      - &inner_instruction_index
+        name: inner_instruction_index
+        description: "inner instruction index for a given transaction id"
+      - &tx_index
+        name: tx_index
+        description: "index of the transaction in the block slot"


### PR DESCRIPTION
## Summary
- Add Manifest DEX spellbook integration for Solana
- Includes staging table, base trades model, and trades view

## Test plan
- [ ] CI tests pass for Manifest models
- [ ] Verify data accuracy against on-chain transactions