### PR TITLE
Remove AMPL (Ampleforth) from stablecoin lists

### DIFF
--- a/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/tokens_ethereum_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/tokens_ethereum_erc20_stablecoins_core.sql
@@ -55,7 +55,6 @@ from (values
      (0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b), -- BOB
      (0x956f47f50a910163d8bf957cf5846d573e7f87ca), -- FEI
      (0x9a1997c130f4b2997166975d9aff92797d5134c2), -- USDap
-     (0xd46ba6d942050d489dbd938a2c909a5d5039a161), -- AMPL
      (0x03ab458634910aad20ef5f1c8ee96f1d6ac54919), -- RAI
      (0x674c6ad92fd080e4004b2312b45f796a192d27a0), -- USDN
      (0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b), -- M

--- a/dbt_subprojects/tokens/models/stablecoins/evm/tokens_erc20_stablecoins_metadata.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/tokens_erc20_stablecoins_metadata.sql
@@ -51,7 +51,6 @@ from (values
 ('ethereum', 0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b, 'Crypto-backed stablecoin', 'BOB', 18, 'zkBOB'),
 ('ethereum', 0x956f47f50a910163d8bf957cf5846d573e7f87ca, 'Algorithmic stablecoin', 'FEI', 18, 'Fei Protocol'),
 ('ethereum', 0x9a1997c130f4b2997166975d9aff92797d5134c2, 'RWA-backed stablecoin', 'USDap', 18, 'Bondappetite'),
-('ethereum', 0xd46ba6d942050d489dbd938a2c909a5d5039a161, 'Crypto-backed stablecoin', 'AMPL', 9, 'Ampleforth'),
 ('ethereum', 0x03ab458634910aad20ef5f1c8ee96f1d6ac54919, 'Crypto-backed stablecoin', 'RAI', 18, 'Reflexer'),
 ('ethereum', 0x674c6ad92fd080e4004b2312b45f796a192d27a0, 'Algorithmic stablecoin', 'USDN', 18, 'Neutrino'),
 ('ethereum', 0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b, 'Fiat-backed stablecoin', 'M', 6, 'M^0'),


### PR DESCRIPTION
## Summary
- Remove AMPL (Ampleforth, `0xd46ba6d942050d489dbd938a2c909a5d5039a161`) from the Ethereum core stablecoin list and stablecoin metadata
- AMPL is a rebase token, not a stablecoin — it should not be tracked as one

## Test plan
- [ ] Verify `dbt compile` passes in the `tokens` sub-project
- [ ] Confirm AMPL no longer appears in downstream stablecoin balance/transfer models

🤖 Generated with [Claude Code](https://claude.com/claude-code)