### PR TITLE
Angstrom base trades exclusion

### DIFF
--- a/dbt_subprojects/dex/models/trades/ethereum/dex_ethereum_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/ethereum/dex_ethereum_base_trades.sql
@@ -51,6 +51,7 @@
     , ref('eulerswap_ethereum_base_trades')
     , ref('ekubo_v1_ethereum_base_trades')
     , ref('ekubo_v3_ethereum_base_trades')
+    , ref('angstrom_ethereum_base_trades')
 ] %}
 with base_union as (
         {% for base_model in base_models %}

--- a/dbt_subprojects/dex/models/trades/ethereum/platforms/angstrom_ethereum_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/ethereum/platforms/angstrom_ethereum_base_trades.sql
@@ -1,5 +1,6 @@
 {{ config(
-    schema = 'angstrom_ethereum'
+    tags = ['prod_exclude']
+    , schema = 'angstrom_ethereum'
     , alias = 'base_trades'
     , materialized = 'incremental'
     , file_format = 'delta'


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Excludes `angstrom_ethereum.base_trades` from the production `dex_ethereum_base_trades` model to address the critical `dex.trades-latency` SLO alert.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
[Slack Thread](https://duneanalytics.slack.com/archives/C05J73MG5F1/p1770798146428729?thread_ts=1770798146.428729&cid=C05J73MG5F1)

<p><a href="https://cursor.com/background-agent?bcId=bc-5620c317-092a-5061-87c3-fa97d600f182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5620c317-092a-5061-87c3-fa97d600f182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

