### PR TITLE
Oneinch swaps model exclusion

### DIFF
--- a/dbt_subprojects/dex/models/_projects/oneinch/oneinch_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/oneinch_swaps.sql
@@ -2,6 +2,7 @@
 
 {{-
     config(
+        tags = ['prod_exclude'],
         schema = 'oneinch',
         alias = 'swaps',
         materialized = 'incremental',


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Excludes the `oneinch.swaps` model from production by adding `tags = ['prod_exclude']` to its config. This is necessary because the model currently produces duplicate records.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
[Slack Thread](https://duneanalytics.slack.com/archives/D092FEUSJGY/p1770896889141429?thread_ts=1770896889.141429&cid=D092FEUSJGY)

<p><a href="https://cursor.com/background-agent?bcId=bc-def6087a-05e4-5480-8b23-8e3a868805c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-def6087a-05e4-5480-8b23-8e3a868805c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

