### PR TITLE
Prices usd table visibility

### DIFF
--- a/sources/prices/prices_sources.yml
+++ b/sources/prices/prices_sources.yml
@@ -10,8 +10,6 @@ sources:
         description: "Daily FX exchange rates between currency pairs"
       - name: usd
         description: "USD prices across blockchains"
-        meta:
-          docs_slug: /curated/asset-tracking/prices/prices
         columns:
           - name: minute
             description: "UTC event block time truncated to the minute mark"


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Hides the `prices.usd` source table from public visibility in Dune's data explorer documentation.

This is achieved by removing the `meta` section containing the `docs_slug` property from the `prices.usd` source definition in `sources/prices/prices_sources.yml`. The source table remains available for internal dbt model references.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
[Slack Thread](https://duneanalytics.slack.com/archives/D092A2R4EKX/p1771274430785519?thread_ts=1771274430.785519&cid=D092A2R4EKX)

<p><a href="https://cursor.com/background-agent?bcId=bc-23ac41a3-ae21-5c5f-866d-71ed206854fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23ac41a3-ae21-5c5f-866d-71ed206854fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

