### PR TITLE
Expose stablecoin tables in the data explorer

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/stablecoins_evm_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/stablecoins_evm_balances.sql
@@ -42,7 +42,10 @@
     schema = 'stablecoins_evm',
     alias = 'balances',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ expose_spells(blockchains = \'["' ~ chains | join('","') ~ '"]\',
+        spell_type = "sector",
+        spell_name = "stablecoins",
+        contributors = \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_multichain_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_multichain_balances.sql
@@ -1,9 +1,53 @@
+{% set chains = [
+  'abstract',
+  'arbitrum',
+  'avalanche_c',
+  'base',
+  'berachain',
+  'bnb',
+  'bob',
+  'celo',
+  'ethereum',
+  'fantom',
+  'flare',
+  'gnosis',
+  'hemi',
+  'hyperevm',
+  'ink',
+  'kaia',
+  'katana',
+  'linea',
+  'mantle',
+  'monad',
+  'opbnb',
+  'optimism',
+  'plasma',
+  'plume',
+  'polygon',
+  'ronin',
+  'scroll',
+  'sei',
+  'solana',
+  'somnia',
+  'sonic',
+  'story',
+  'taiko',
+  'tron',
+  'unichain',
+  'worldchain',
+  'xlayer',
+  'zksync'
+] %}
+
 {{
   config(
     schema = 'stablecoins_multichain',
     alias = 'balances',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ expose_spells(blockchains = \'["' ~ chains | join('","') ~ '"]\',
+        spell_type = "sector",
+        spell_name = "stablecoins",
+        contributors = \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_balances.sql
@@ -5,7 +5,10 @@
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ expose_spells(\'["tron"]\',
+        "sector",
+        "stablecoins",
+        \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_balances.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_balances.sql
@@ -5,7 +5,10 @@
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
-    , post_hook='{{ hide_spells() }}'
+    , post_hook='{{ expose_spells(\'["solana"]\',
+        "sector",
+        "stablecoins",
+        \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_transfers.sql
+++ b/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_transfers.sql
@@ -5,7 +5,10 @@
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view'
-    , post_hook='{{ hide_spells() }}'
+    , post_hook='{{ expose_spells(\'["solana"]\',
+        "sector",
+        "stablecoins",
+        \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/tokens/models/stablecoins/evm/stablecoins_evm_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/stablecoins_evm_transfers.sql
@@ -42,7 +42,10 @@
     schema = 'stablecoins_evm',
     alias = 'transfers',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ expose_spells(blockchains = \'["' ~ chains | join('","') ~ '"]\',
+        spell_type = "sector",
+        spell_name = "stablecoins",
+        contributors = \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/tokens/models/stablecoins/tron/transfers/stablecoins_tron_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/tron/transfers/stablecoins_tron_transfers.sql
@@ -5,7 +5,10 @@
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ expose_spells(\'["tron"]\',
+        "sector",
+        "stablecoins",
+        \'["tomfutago"]\') }}'
   )
 }}
 


### PR DESCRIPTION
## Summary

- Replace `hide_spells()` with `expose_spells()` on 7 stablecoin models so they become publicly visible in the Dune data explorer
- Models span 3 sub-projects: `daily_spellbook`, `solana`, and `tokens`
- Tables exposed: `stablecoins_evm.transfers`, `stablecoins_evm.balances`, `stablecoins_solana.transfers`, `stablecoins_solana.balances`, `stablecoins_tron.transfers`, `stablecoins_tron.balances`, `stablecoins_multichain.balances`

## Test plan

- [ ] Verify `dbt compile` succeeds in each affected sub-project
- [ ] After prod deploy, confirm tables appear in the data explorer under the stablecoins curated category

Made with [Cursor](https://cursor.com)