### PR TITLE
Stablecoin tables launch

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/stablecoins_evm_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/stablecoins_evm_balances.sql
@@ -42,7 +42,10 @@
     schema = 'stablecoins_evm',
     alias = 'balances',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ expose_spells(blockchains = \'["' + chains | join('","') + '"]\',
+                                    spell_type = "sector",
+                                    spell_name = "stablecoins",
+                                    contributors = \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_multichain_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_multichain_balances.sql
@@ -3,7 +3,10 @@
     schema = 'stablecoins_multichain',
     alias = 'balances',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ expose_spells(\'["abstract","arbitrum","avalanche_c","base","berachain","bnb","bob","celo","ethereum","fantom","flare","gnosis","hemi","hyperevm","ink","kaia","katana","linea","mantle","monad","opbnb","optimism","plasma","plume","polygon","ronin","scroll","sei","solana","somnia","sonic","story","taiko","tron","unichain","worldchain","xlayer","zksync"]\',
+                                    "sector",
+                                    "stablecoins",
+                                    \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_balances.sql
@@ -5,7 +5,10 @@
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ expose_spells(\'["tron"]\',
+                                    "sector",
+                                    "stablecoins",
+                                    \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_balances.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_balances.sql
@@ -4,8 +4,11 @@
   config(
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
-    materialized = 'view'
-    , post_hook='{{ hide_spells() }}'
+    materialized = 'view',
+    post_hook = '{{ expose_spells(\'["solana"]\',
+                                    "sector",
+                                    "stablecoins",
+                                    \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_transfers.sql
+++ b/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_transfers.sql
@@ -4,8 +4,11 @@
   config(
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
-    materialized = 'view'
-    , post_hook='{{ hide_spells() }}'
+    materialized = 'view',
+    post_hook = '{{ expose_spells(\'["solana"]\',
+                                    "sector",
+                                    "stablecoins",
+                                    \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/tokens/models/stablecoins/evm/stablecoins_evm_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/stablecoins_evm_transfers.sql
@@ -42,7 +42,10 @@
     schema = 'stablecoins_evm',
     alias = 'transfers',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ expose_spells(blockchains = \'["' + chains | join('","') + '"]\',
+                                    spell_type = "sector",
+                                    spell_name = "stablecoins",
+                                    contributors = \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/tokens/models/stablecoins/tron/transfers/stablecoins_tron_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/tron/transfers/stablecoins_tron_transfers.sql
@@ -5,7 +5,10 @@
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ expose_spells(\'["tron"]\',
+                                    "sector",
+                                    "stablecoins",
+                                    \'["tomfutago"]\') }}'
   )
 }}
 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:
This PR exposes 7 stablecoin dataset tables for public launch, resolving [CUR2-1527](https://linear.app/dune/issue/CUR2-1527/expose-stablecoin-dataset-tables-for-launch).

The `hide_spells()` post_hook has been replaced with `expose_spells()` in the following models:
- `stablecoins_evm.transfers`
- `stablecoins_evm.balances`
- `stablecoins_solana.transfers`
- `stablecoins_solana.balances`
- `stablecoins_tron.transfers`
- `stablecoins_tron.balances`
- `stablecoins_multichain.balances`

All `expose_spells` calls are configured with `spell_type="sector"`, `spell_name="stablecoins"`, and `contributors="tomfutago"`. This change makes these tables visible in the data explorer.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
Linear Issue: [CUR2-1527](https://linear.app/dune/issue/CUR2-1527/expose-stablecoin-dataset-tables-for-launch)

<p><a href="https://cursor.com/agents/bc-b2a9a65a-215f-49e0-8e05-6a8ba168a045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2a9a65a-215f-49e0-8e05-6a8ba168a045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

