### PR TITLE
Add balances_bitcoin_daily model

### DIFF
--- a/dbt_subprojects/tokens/models/transfers_and_balances/bitcoin/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bitcoin/_schema.yml
@@ -65,6 +65,39 @@ models:
       - *total_asset
       - *updated_at
 
+  - name: balances_bitcoin_daily
+    meta:
+      blockchain: bitcoin
+      sector: balances
+      contributors: florianklages
+    config:
+      tags: ['balances', 'bitcoin', 'daily']
+    description: >
+      Daily cumulative Bitcoin balance per wallet address, forward-filled across
+      inactive days. Follows the stablecoin balance pattern: outputs = deposits,
+      inputs = withdrawals. Properly converts satoshis to BTC and prices in USD.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - wallet_address
+    columns:
+      - *blockchain
+      - *day
+      - *wallet_address
+      - name: balance_satoshi
+        description: "Cumulative balance in satoshis (forward-filled)"
+        tests:
+          - not_null
+      - name: balance_btc
+        description: "Cumulative balance in BTC (balance_satoshi / 1e8)"
+      - name: btc_price_usd
+        description: "BTC price in USD on this day"
+      - name: balance_usd
+        description: "Balance valued in USD (balance_btc * btc_price_usd)"
+      - name: last_updated
+        description: "Block time of the most recent transaction affecting this balance"
+
   - name: tokens_bitcoin_net_transfers_daily
     meta:
       blockchain: bitcoin

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bitcoin/balances_bitcoin_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bitcoin/balances_bitcoin_daily.sql
@@ -1,0 +1,164 @@
+{{ config(
+    schema = 'balances_bitcoin'
+    , alias = 'daily'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , partition_by = ['day']
+    , unique_key = ['day', 'wallet_address']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
+    , post_hook = '{{ hide_spells() }}'
+) }}
+
+-- Follows the forward-fill balance pattern from stablecoins_tron_balances_from_transfers.
+-- Adapted for Bitcoin UTXO model: outputs = deposits, inputs = withdrawals.
+
+with
+
+deposits as (
+    select
+        o.block_date as day
+        , o.block_time
+        , o.address as wallet_address
+        , cast(o.value as double) as inflow
+        , 0e0 as outflow
+    from {{ source('bitcoin', 'outputs') }} as o
+    where o.address is not null
+        and o.value > 0
+    {% if is_incremental() %}
+        and {{ incremental_predicate('o.block_time') }}
+    {% endif %}
+)
+
+, withdrawals as (
+    select
+        i.block_date as day
+        , i.block_time
+        , i.address as wallet_address
+        , 0e0 as inflow
+        , cast(i.value as double) as outflow
+    from {{ source('bitcoin', 'inputs') }} as i
+    where i.address is not null
+        and i.value > 0
+    {% if is_incremental() %}
+        and {{ incremental_predicate('i.block_time') }}
+    {% endif %}
+)
+
+, all_flows as (
+    select * from deposits
+    union all
+    select * from withdrawals
+)
+
+, daily_aggregated as (
+    select
+        f.day
+        , f.wallet_address
+        , max(f.block_time) as last_updated
+        , sum(f.inflow) as daily_inflow
+        , sum(f.outflow) as daily_outflow
+    from all_flows as f
+    group by 1, 2
+)
+
+{% if is_incremental() %}
+, prior_balances as (
+    select
+        wallet_address
+        , max(day) as day
+        , max_by(last_updated, day) as last_updated
+        , max_by(balance_satoshi, day) as balance_satoshi
+    from {{ this }}
+    where not {{ incremental_predicate('day') }}
+    group by 1
+)
+{% endif %}
+
+, changed_balances as (
+    select
+        day
+        , last_updated
+        , wallet_address
+        , balance_satoshi
+        , lead(cast(day as timestamp)) over (
+            partition by wallet_address
+            order by day
+        ) as next_update_day
+    from (
+        select
+            d.day
+            , d.last_updated
+            , d.wallet_address
+            , greatest(0e0,
+                {% if is_incremental() %}
+                coalesce(p.balance_satoshi, 0e0) +
+                {% endif %}
+                sum(d.daily_inflow - d.daily_outflow) over (
+                    partition by d.wallet_address
+                    order by d.day
+                    rows between unbounded preceding and current row
+                )
+            ) as balance_satoshi
+        from daily_aggregated as d
+        {% if is_incremental() %}
+        left join prior_balances as p
+            on d.wallet_address = p.wallet_address
+        {% endif %}
+        {% if is_incremental() %}
+        union all
+        select
+            p.day
+            , p.last_updated
+            , p.wallet_address
+            , p.balance_satoshi
+        from prior_balances as p
+        {% endif %}
+    )
+)
+
+, days as (
+    select *
+    from unnest(
+        sequence(
+            date '2009-01-03'
+            , date(date_trunc('day', now()))
+            , interval '1' day
+        )
+    ) as foo(day)
+    {% if is_incremental() %}
+    where {{ incremental_predicate('cast(day as timestamp)') }}
+    {% endif %}
+)
+
+, forward_fill as (
+    select
+        d.day
+        , b.wallet_address
+        , b.balance_satoshi
+        , b.last_updated
+    from days as d
+    left join changed_balances as b
+        on d.day >= b.day
+        and (b.next_update_day is null or cast(d.day as timestamp) < b.next_update_day)
+)
+
+select
+    'bitcoin' as blockchain
+    , f.day
+    , f.wallet_address
+    , f.balance_satoshi
+    , f.balance_satoshi / 1e8 as balance_btc
+    , p.price as btc_price_usd
+    , f.balance_satoshi / 1e8 * coalesce(p.price, 0) as balance_usd
+    , f.last_updated
+from forward_fill as f
+left join {{ source('prices', 'usd') }} as p
+    on f.day = p.minute
+    and p.symbol = 'BTC'
+    and p.blockchain is null
+where f.balance_satoshi > 0
+    and f.wallet_address is not null
+{% if is_incremental() %}
+    and {{ incremental_predicate('f.day') }}
+{% endif %}


### PR DESCRIPTION
## Summary

- Adds a new `balances_bitcoin_daily` incremental model that tracks daily BTC balances per wallet address
- Follows the established forward-fill pattern from `stablecoins_tron_balances_from_transfers` — the same architecture used across all stablecoin balance models
- Replaces the broken approach in `balances_bitcoin_satoshi_day` which had a missing satoshi→BTC conversion, bogus "profit"/"total_asset" columns, and unmaterialized views that couldn't execute at scale

### How it works

1. **UTXO flow extraction** — `bitcoin.outputs` as deposits (credit), `bitcoin.inputs` as withdrawals (debit)
2. **Daily aggregation** — Net daily inflow/outflow per wallet
3. **Incremental prior balances** — On incremental runs, fetches last known balance from `{{ this }}` to avoid recomputing from genesis
4. **Forward-fill gap join** — Carries the last known balance forward across inactive days using `lead(day)` + date spine
5. **USD pricing** — Proper `satoshi / 1e8 * BTC price` at the final layer

### Output columns

| Column | Description |
|---|---|
| `blockchain` | Always `'bitcoin'` |
| `day` | Date |
| `wallet_address` | Bitcoin address |
| `balance_satoshi` | Cumulative balance in satoshis (forward-filled) |
| `balance_btc` | Balance in BTC (`balance_satoshi / 1e8`) |
| `btc_price_usd` | BTC price on this day |
| `balance_usd` | USD value of holdings |
| `last_updated` | Block time of most recent transaction affecting this balance |

### Config

- `materialized = 'incremental'` with `merge` strategy
- `partition_by = ['day']`
- `unique_key = ['day', 'wallet_address']`
- `incremental_predicates` for partition pruning
- Schema tests: `unique_combination_of_columns` + `not_null` on `balance_satoshi`

## Test plan

- [ ] Model compiles cleanly (`dbt compile --select balances_bitcoin_daily` ✅ verified locally)
- [ ] CI runs the model against Dune API
- [ ] Verify output data quality: spot-check known wallet balances
- [ ] Verify incremental runs produce consistent results with full refresh


Made with [Cursor](https://cursor.com)