### PR TITLE
Solana sns domains view

### DIFF
--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_sns_domains.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_sns_domains.sql
@@ -1,9 +1,9 @@
- {{
-  config(
-        schema = 'solana_utils',
-        alias = 'sns_domains',
-        materialized='table'
-        , post_hook='{{ hide_spells() }}'
+{{
+ config(
+       schema = 'solana_utils',
+       alias = 'sns_domains',
+       materialized='view'
+       , post_hook='{{ hide_spells() }}'
 )
 }}
 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

This PR updates the `solana_utils_sns_domains` model from a `table` to a `view` materialization. This change addresses a production performance issue where the model was timing out after 1 hour 49 minutes due to an expensive full table rebuild on every run. Switching to a view will allow the model to execute queries on-demand, which is an acceptable tradeoff given its low usage.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
[Slack Thread](https://duneanalytics.slack.com/archives/C04E0CV1SG3/p1772016211959549?thread_ts=1772016211.959549&cid=C04E0CV1SG3)

<p><a href="https://cursor.com/agents/bc-550c1c43-7c2e-50fc-bd93-9d99b65ec9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-550c1c43-7c2e-50fc-bd93-9d99b65ec9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

