### PR TITLE
Stablecoin post-hook update

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/aptos/stablecoins/aptos_usdc_transfers.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/stablecoins/aptos_usdc_transfers.sql
@@ -9,7 +9,7 @@
     partition_by = ['block_month'],
     post_hook='{{ expose_spells(blockchains = \'["aptos"]\',
         spell_type = "project",
-        spell_name = "stablecoins",
+        spell_name = "aptos_stablecoins",
         contributors = \'["ying-w"]\') }}'
 ) }}
 WITH events AS (

--- a/dbt_subprojects/daily_spellbook/models/aptos/stablecoins/aptos_usdt_transfers.sql
+++ b/dbt_subprojects/daily_spellbook/models/aptos/stablecoins/aptos_usdt_transfers.sql
@@ -9,7 +9,7 @@
     partition_by = ['block_month'],
     post_hook='{{ expose_spells(blockchains = \'["aptos"]\',
         spell_type = "project",
-        spell_name = "stablecoins",
+        spell_name = "aptos_stablecoins",
         contributors = \'["ying-w"]\') }}'
 ) }}
 -- usdt is minted to a reserve account

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/stablecoins_evm_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/stablecoins_evm_balances.sql
@@ -45,7 +45,7 @@
     materialized = 'view',
     post_hook = '{{ expose_spells(blockchains = \'["' ~ chains | join('","') ~ '"]\',
         spell_type = "sector",
-        spell_name = "stablecoins",
+        spell_name = "stablecoins_evm",
         contributors = \'["tomfutago"]\') }}'
   )
 }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_multichain_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_multichain_balances.sql
@@ -47,7 +47,7 @@
     materialized = 'view',
     post_hook = '{{ expose_spells(blockchains = \'["' ~ chains | join('","') ~ '"]\',
         spell_type = "sector",
-        spell_name = "stablecoins",
+        spell_name = "stablecoins_multichain",
         contributors = \'["tomfutago"]\') }}'
   )
 }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_balances.sql
@@ -8,7 +8,7 @@
     materialized = 'view',
     post_hook = '{{ expose_spells(\'["tron"]\',
         "sector",
-        "stablecoins",
+        "stablecoins_tron",
         \'["tomfutago"]\') }}'
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_balances.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_balances.sql
@@ -7,7 +7,7 @@
     materialized = 'view'
     , post_hook='{{ expose_spells(\'["solana"]\',
         "sector",
-        "stablecoins",
+        "stablecoins_solana",
         \'["tomfutago"]\') }}'
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_transfers.sql
+++ b/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_transfers.sql
@@ -7,7 +7,7 @@
     materialized = 'view'
     , post_hook='{{ expose_spells(\'["solana"]\',
         "sector",
-        "stablecoins",
+        "stablecoins_solana",
         \'["tomfutago"]\') }}'
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/stablecoins_evm_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/stablecoins_evm_transfers.sql
@@ -44,7 +44,7 @@
     materialized = 'view',
     post_hook = '{{ expose_spells(blockchains = \'["' ~ chains | join('","') ~ '"]\',
         spell_type = "sector",
-        spell_name = "stablecoins",
+        spell_name = "stablecoins_evm",
         contributors = \'["tomfutago"]\') }}'
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/tron/transfers/stablecoins_tron_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/tron/transfers/stablecoins_tron_transfers.sql
@@ -7,7 +7,7 @@
     materialized = 'view',
     post_hook = '{{ expose_spells(\'["tron"]\',
         "sector",
-        "stablecoins",
+        "stablecoins_tron",
         \'["tomfutago"]\') }}'
   )
 }}


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:
Addresses `CUR2-1555`. This PR updates the `expose_spells` post_hook configuration in stablecoin models. The `project` parameter was previously hardcoded to `"stablecoins"`, leading to incorrect display and categorization in the data explorer. This change updates the `project` parameter to use the model's specific schema name (e.g., `stablecoins_tron`, `stablecoins_evm`), ensuring proper data explorer functionality.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
Linear Issue: [CUR2-1555](https://linear.app/dune/issue/CUR2-1555/fix-stablecoin-display-on-data-explorer)

<p><a href="https://cursor.com/agents/bc-40f2a0da-fb1f-4fd4-90e2-3697222a62f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40f2a0da-fb1f-4fd4-90e2-3697222a62f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

