### PR TITLE
fix(dex): remove redundant wrapper in raw pool initializations

### DIFF
--- a/dbt_subprojects/dex/models/pools/_raw/dex_raw_pool_initializations.sql
+++ b/dbt_subprojects/dex/models/pools/_raw/dex_raw_pool_initializations.sql
@@ -10,23 +10,21 @@
 
 
 
-select * from (
-    -- only uni v2. re-initialization is restricted on v3
-    select
-        blockchain
-        , 'uniswap_compatible' as type
-        , 'v2' as version
-        , block_time
-        , "to" as pool
-        , substr(input, 17, 20) token0
-        , substr(input, 49, 20) token1
-        , tx_hash
-        , trace_address call_trace_address
-    from {{ ref('dex_raw_pool_pre_materialized_traces') }}
-    where 
-        substr(input, 1, 4) = 0x485cc955 
-        {% if is_incremental() %}
-            and {{ incremental_predicate('block_time') }}
-        {% endif %}
-)
+-- only uni v2. re-initialization is restricted on v3
+select
+    blockchain
+    , 'uniswap_compatible' as type
+    , 'v2' as version
+    , block_time
+    , "to" as pool
+    , substr(input, 17, 20) token0
+    , substr(input, 49, 20) token1
+    , tx_hash
+    , trace_address call_trace_address
+from {{ ref('dex_raw_pool_pre_materialized_traces') }}
+where 
+    substr(input, 1, 4) = 0x485cc955 
+    {% if is_incremental() %}
+        and {{ incremental_predicate('block_time') }}
+    {% endif %}
 


### PR DESCRIPTION
Why was this change needed?
dex_raw_pool_initializations had an extra outer SELECT * FROM (...) around a single query block. It added no filtering or transformation and made the model unnecessarily noisy.

What was changed?
Removed the redundant outer wrapper and kept the same inner SELECT logic, columns, and incremental predicate as-is.
This is a cleanup-only change with no intended data output change.