### PR TITLE
Goosefx trades pre_hook

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/goosefx/goosefx_ssl_v2_solana_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/goosefx/goosefx_ssl_v2_solana_base_trades.sql
@@ -7,7 +7,8 @@
         file_format = 'delta',
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-        unique_key = ['tx_id', 'outer_instruction_index', 'inner_instruction_index', 'tx_index','block_month']
+        unique_key = ['tx_id', 'outer_instruction_index', 'inner_instruction_index', 'tx_index','block_month'],
+        pre_hook='{{ enforce_join_distribution("PARTITIONED") }}'
         )
 }}
 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Adds `pre_hook='{{ enforce_join_distribution("PARTITIONED") }}'` to the `goosefx_ssl_v2_solana_base_trades` model config. This change enforces partitioned join session properties, aligning the model with best practices used by other Solana DEX models and addressing tech debt (CUR2-1565).


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
Linear Issue: [CUR2-1565](https://linear.app/dune/issue/CUR2-1565/rebuild-goosefx-ssl-v2-solana-base-trades)

<p><a href="https://cursor.com/agents/bc-3f8cda6b-4932-47e6-939f-8876b51212a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f8cda6b-4932-47e6-939f-8876b51212a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

