### PR TITLE
Boost completors static tag

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/boost/boost_completors.sql
+++ b/dbt_subprojects/daily_spellbook/models/boost/boost_completors.sql
@@ -3,6 +3,7 @@
         schema='boost',
         alias='completors',
         materialized='table',
+        tags=['static'],
     )
 }}
 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Adds `tags=['static']` to the `boost_completors` model. This model is materialized as a table, making the `static` tag appropriate for its configuration.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
[Slack Thread](https://duneanalytics.slack.com/archives/C04E0CV1SG3/p1772175025162039?thread_ts=1772175025.162039&cid=C04E0CV1SG3)

<p><a href="https://cursor.com/agents/bc-3570f7bb-56ba-5f7f-9785-7d0cdd544f09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3570f7bb-56ba-5f7f-9785-7d0cdd544f09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

