### PR TITLE
fix(polymarket): capture ~387k missing market resolutions

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_outcomes.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_outcomes.sql
@@ -11,54 +11,97 @@
   )
 }}
 
+with all_outcomes as (
+  select
+    evt_block_time as block_time,
+    evt_block_number as block_number,
+    'uma-v1' as source,
+    questionID as question_id,
+    case settledPrice / 1e18
+      when 1 then 'yes'
+      when 0.5 then '50/50'
+      else 'no'
+    end as outcome,
+    evt_index,
+    evt_tx_hash as tx_hash
+  from {{ source('minereum_polygon', 'UmaConditionalTokensBinaryAdapter_evt_QuestionSettled') }}
+  {% if is_incremental() %}
+  where {{ incremental_predicate('evt_block_time') }}
+  {% endif %}
+
+  union all
+
+  select
+    evt_block_time as block_time,
+    evt_block_number as block_number,
+    'uma-v2' as source,
+    questionID as question_id,
+    case settledPrice / 1e18
+      when 1 then 'yes'
+      when 0.5 then '50/50'
+      else 'no'
+    end as outcome,
+    evt_index,
+    evt_tx_hash as tx_hash
+  from {{ source('polymarket_polygon', 'UmaCtfAdapter_evt_QuestionResolved') }}
+  {% if is_incremental() %}
+  where {{ incremental_predicate('evt_block_time') }}
+  {% endif %}
+
+  union all
+
+  select
+    evt_block_time as block_time,
+    evt_block_number as block_number,
+    'polymarket' as source,
+    questionId as question_id,
+    if(outcome, 'yes', 'no') as outcome,
+    evt_index,
+    evt_tx_hash as tx_hash
+  from {{ source('polymarket_polygon', 'NegRiskAdapter_evt_OutcomeReported') }}
+  {% if is_incremental() %}
+  where {{ incremental_predicate('evt_block_time') }}
+  {% endif %}
+
+  union all
+
+  -- CTF-level ConditionResolution catches resolutions from ALL oracle adapters,
+  -- including newer contracts (v3+) not tracked by the adapter-specific tables above
+  select
+    cr.evt_block_time as block_time,
+    cr.evt_block_number as block_number,
+    'ctf' as source,
+    cr.questionId as question_id,
+    case
+      when cr.payoutNumerators[1] = 1 and cr.payoutNumerators[2] = 0 then 'yes'
+      when cr.payoutNumerators[1] = 0 and cr.payoutNumerators[2] = 1 then 'no'
+      when cr.payoutNumerators[1] = 1 and cr.payoutNumerators[2] = 1 then '50/50'
+      else 'unknown'
+    end as outcome,
+    cr.evt_index,
+    cr.evt_tx_hash as tx_hash
+  from {{ source('polymarket_polygon', 'ctf_evt_ConditionResolution') }} cr
+  {% if is_incremental() %}
+  where {{ incremental_predicate('cr.evt_block_time') }}
+  {% endif %}
+)
+
+-- Deduplicate: prefer adapter-specific sources over CTF for consistent outcome derivation
 select
-  evt_block_time as block_time,
-  evt_block_number as block_number,
-  'uma-v1' as source,
-  questionID as question_id,
-  case settledPrice / 1e18
-    when 1 then 'yes'
-    when 0.5 then '50/50'
-    else 'no'
-  end as outcome,
+  block_time,
+  block_number,
+  source,
+  question_id,
+  outcome,
   evt_index,
-  evt_tx_hash as tx_hash
-from {{ source('minereum_polygon', 'UmaConditionalTokensBinaryAdapter_evt_QuestionSettled') }}
-{% if is_incremental() %}
-where {{ incremental_predicate('evt_block_time') }}
-{% endif %}
-
-union all
-
-select
-  evt_block_time as block_time,
-  evt_block_number as block_number,
-  'uma-v2' as source,
-  questionID as question_id,
-  case settledPrice / 1e18
-    when 1 then 'yes'
-    when 0.5 then '50/50'
-    else 'no'
-  end as outcome,
-  evt_index,
-  evt_tx_hash as tx_hash
-from {{ source('polymarket_polygon', 'UmaCtfAdapter_evt_QuestionResolved') }}
-{% if is_incremental() %}
-where {{ incremental_predicate('evt_block_time') }}
-{% endif %}
-
-union all
-
-select
-  evt_block_time as block_time,
-  evt_block_number as block_number,
-  'polymarket' as source,
-  --marketId as market_id,
-  questionId as question_id,
-  if(outcome, 'yes', 'no') as outcome,
-  evt_index,
-  evt_tx_hash as tx_hash
-from {{ source('polymarket_polygon', 'NegRiskAdapter_evt_OutcomeReported') }}
-{% if is_incremental() %}
-where {{ incremental_predicate('evt_block_time') }}
-{% endif %}
+  tx_hash
+from (
+  select
+    *,
+    row_number() over (
+      partition by question_id
+      order by case source when 'ctf' then 1 else 0 end, block_time
+    ) as rn
+  from all_outcomes
+)
+where rn = 1

--- a/sources/polymarket/polygon/_sources.yml
+++ b/sources/polymarket/polygon/_sources.yml
@@ -19,6 +19,7 @@ sources:
       - name: NegRiskAdapter_evt_QuestionPrepared
       - name: NegRiskAdapter_evt_OutcomeReported
       - name: ctf_evt_ConditionPreparation
+      - name: ctf_evt_ConditionResolution
       - name: CTFExchange_evt_TokenRegistered
       - name: NegRiskCtfExchange_evt_TokenRegistered
       - name: FixedProductMarketMaker_evt_FPMMSell


### PR DESCRIPTION
## Summary

- **~387,000 resolved Polymarket markets appear as "unresolved"** in Dune tables because the `market_outcomes` model only tracked 3 specific oracle adapter event tables (UMA v1, UMA v2, NegRiskAdapter)
- Since mid-2025, Polymarket deployed new oracle adapter contracts (v3+) whose resolution events are not captured by any of the existing sources
- Adds `ctf_evt_ConditionResolution` as a 4th union source — this CTF-level event fires for **all** oracle adapters, making it future-proof against new oracle deployments
- Keeps existing adapter sources (109k UMA v2 entries lack corresponding CTF events) with `ROW_NUMBER` deduplication preferring adapter-specific sources

## Investigation details

| Oracle contract | Missing resolutions | Active period |
|----------------|--------------------:|---------------|
| `0x65070b...` | 228,374 | Aug 2025 – present |
| `0x58e174...` | 136,212 | Aug 2025 – present |
| `0x157ce2...` | 12,929 | Jul 2025 – Feb 2026 |
| + 39 others | ~10,000+ | various |

Payout mapping (`payoutNumerators → outcome`) cross-validated against 27,441 UMA v2 markets with **100% match** (0 mismatches).

## Changes

- `polymarket_polygon_market_outcomes.sql` — added CTF `ConditionResolution` as 4th source + dedup logic
- `sources/polymarket/polygon/_sources.yml` — added `ctf_evt_ConditionResolution` source declaration

## Test plan

- [x] dbt compile succeeds
- [x] Payout mapping validated: `[1,0]→yes`, `[0,1]→no`, `[1,1]→50/50` — 100% match vs UMA v2
- [x] Example market ("Khamenei out as Supreme Leader of Iran by January 31?") now correctly resolves as `no`
- [ ] CI: `dbt slim ci` on PR (triggered automatically)
- [ ] Post-merge: verify `market_details` table shows resolved status for previously missing markets


Made with [Cursor](https://cursor.com)