### PR TITLE
Solfi models partitioned joins

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/solfi/solfi_solana_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/solfi/solfi_solana_base_trades.sql
@@ -8,6 +8,7 @@
     , incremental_strategy = 'merge'
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , unique_key = ['block_month', 'surrogate_key']
+    , pre_hook='{{ enforce_join_distribution("PARTITIONED") }}'
   )
 }}
 

--- a/dbt_subprojects/solana/models/_sector/dex/solfi/solfi_solana_token_transfers.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/solfi/solfi_solana_token_transfers.sql
@@ -8,6 +8,7 @@
     , incremental_strategy = 'merge'
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , unique_key = ['block_date', 'unique_instruction_key']
+    , pre_hook='{{ enforce_join_distribution("PARTITIONED") }}'
   )
 }}
 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Adds `pre_hook='{{ enforce_join_distribution("PARTITIONED") }}'` to the `solfi_solana_base_trades` and `solfi_solana_token_transfers` models. This change is intended to optimize performance for partitioned joins within these models, as requested in Linear issue CUR2-1583.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
Linear Issue: [CUR2-1583](https://linear.app/dune/issue/CUR2-1583/rebuild-solfi-solana-base-trades)

<p><a href="https://cursor.com/agents/bc-cd9074d8-4b9b-4c73-9dd8-3cca7ad3cf50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd9074d8-4b9b-4c73-9dd8-3cca7ad3cf50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

