### PR TITLE
Anomalous tx_hash exclusion

### DIFF
--- a/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/transfers/stablecoins_ethereum_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/transfers/stablecoins_ethereum_core_transfers.sql
@@ -13,8 +13,21 @@
 }}
 
 -- core transfers: tracks transfers for stablecoins in the frozen core list
+-- wraps the macro output in a CTE to exclude anomalous exploit transactions
+-- context: https://github.com/duneanalytics/curated-stablecoins/pull/114
 
-{{ stablecoins_transfers(
-    blockchain = chain,
-    token_list = 'core'
-) }}
+with base as (
+    {{ stablecoins_transfers(
+        blockchain = chain,
+        token_list = 'core'
+    ) }}
+)
+
+select *
+from base
+where tx_hash not in (
+    0xaa532ae7f06cccdbdc226f59b68733ae8594464a98e128365f8170e305c34f4b
+    ,0xc45dd1a77c05d9ae5b2284eea5393ecce2ac8a7e88e973c6ba3fe7a18bf45634
+    ,0xb23aaecc086996f8059a0de67819b0e45d82e68c2581edf889b3177d7aa96ea6
+    ,0x06712214f077b5bfd9568ca0d32da8633e1ea12bf3522a86195daaa0defe3977
+)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Addresses ST-232 by moving the exclusion of 4 anomalous Ethereum transaction hashes from frontend queries to the `stablecoins_ethereum_core_transfers` dbt model. This centralizes the data cleaning, ensuring all downstream consumers receive a consistent, filtered dataset without needing to re-apply the exclusions. The `stablecoins_transfers` macro call is wrapped in a CTE, and the `tx_hash NOT IN (...)` filter is applied to its output.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
Linear Issue: [ST-232](https://linear.app/dune/issue/ST-232/remove-anomalous-tx-hashes-from-upstream-enriched-dataset)

<p><a href="https://cursor.com/agents/bc-ac10bfa1-8d7e-456a-b4f2-74d2f6c7302b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac10bfa1-8d7e-456a-b4f2-74d2f6c7302b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->