### PR TITLE
Add MegaUSD (USDm) to megaeth price tokens

### DIFF
--- a/dbt_subprojects/tokens/models/prices/megaeth/prices_megaeth_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/megaeth/prices_megaeth_tokens.sql
@@ -28,6 +28,6 @@ FROM
     , ('usdt0-usdt0', 'USDT0', 0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb, 6)
     --, ('wbtc-wrapped-bitcoin', 'WBTC', 0x32090fB1399a31cC095e6341a6353b7c09ba84FB, 8) seems like wrong address, excluding for now
     , ('wrseth-wrapped-rseth', 'wrsETH', 0x4Fc44BE15e9B6E30C1E774E2C87A21D3E8b5403F, 18)
-    , ('usdc-usd-coin', 'MegaUSD', 0xfafddbb3fc7688494971a79cc65dca3ef82079e7, 18)
+    , ('usdc-usd-coin', 'MegaUSD', 0xfafddbb3fc7688494971a79cc65dca3ef82079e7, 18) -- TODO: replace token_id with USDm once integrated to coinpaprika
     , ('wsteth-wrapped-liquid-staked-ether-20', 'wstETH', 0x601aC63637933D88285A025C685AC4e9a92a98dA, 18)
 ) as temp (token_id, symbol, contract_address, decimals)


### PR DESCRIPTION
## Summary
- Add MegaUSD (USDm) token to `prices_megaeth_tokens` for price feed support
- Contract address: `0xfafddbb3fc7688494971a79cc65dca3ef82079e7` (18 decimals)
- Uses `usdc-usd-coin` coinpaprika token-id for the price feed

## Test plan
- [ ] CI passes `dbt slim ci` on the modified model
- [ ] Verify `prices_megaeth_tokens` compiles correctly
- [ ] Confirm token appears in test table with correct metadata


Made with [Cursor](https://cursor.com)