### PR TITLE
Solana microbatch lookback period

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/meteora/meteora_v1_solana_base_trades_backfill.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/meteora/meteora_v1_solana_base_trades_backfill.sql
@@ -10,7 +10,7 @@
        event_time = 'block_time',
        begin = '2022-07-27',
        batch_size = var('meteora_v1_batch_size', 'day'),
-       lookback = 3,
+       lookback = 1,
        unique_key = ['block_month', 'surrogate_key'],
        pre_hook='{{ enforce_join_distribution("PARTITIONED") }}'
        )

--- a/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v3_base_trades_backfill.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v3_base_trades_backfill.sql
@@ -10,7 +10,7 @@
        event_time = 'block_time',
        begin = '2022-08-17',
        batch_size = var('raydium_v3_batch_size', 'day'),
-       lookback = 3,
+       lookback = 1,
        unique_key = ['tx_id', 'outer_instruction_index', 'inner_instruction_index', 'tx_index','block_month'],
        pre_hook='{{ enforce_join_distribution("PARTITIONED") }}'
        )

--- a/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v4_base_trades_backfill.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v4_base_trades_backfill.sql
@@ -10,7 +10,7 @@
     , event_time = 'block_time'
     , begin = '2021-03-21'
     , batch_size = var('raydium_v4_batch_size', 'day')
-    , lookback = 3
+    , lookback = 1
     , unique_key = ['block_month', 'surrogate_key']
     , pre_hook='{{ enforce_join_distribution("PARTITIONED") }}'
   )

--- a/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v5_base_trades_backfill.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/raydium/raydium_v5_base_trades_backfill.sql
@@ -10,7 +10,7 @@
     , event_time = 'block_time'
     , begin = '2024-05-16'
     , batch_size = var('raydium_v5_batch_size', 'day')
-    , lookback = 3
+    , lookback = 1
     , unique_key = ['block_month', 'block_date', 'surrogate_key']
     , pre_hook='{{ enforce_join_distribution("PARTITIONED") }}'
   )

--- a/dbt_subprojects/solana/models/_sector/dex/stabble/stabble_solana_base_trades_backfill.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/stabble/stabble_solana_base_trades_backfill.sql
@@ -10,7 +10,7 @@
     , event_time = 'block_time'
     , begin = '2024-06-05'
     , batch_size = var('stabble_batch_size', 'day')
-    , lookback = 3
+    , lookback = 1
     , unique_key = ['block_month', 'surrogate_key']
     , pre_hook='{{ enforce_join_distribution("PARTITIONED") }}'
   )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

This PR updates the lookback period for Solana microbatch models to 1 day, as requested in Linear issue CUR2-1608. The `lookback` parameter was changed from `3` to `1` in the following models:
- `meteora_v1_solana_base_trades_backfill.sql`
- `raydium_v3_base_trades_backfill.sql`
- `raydium_v4_base_trades_backfill.sql`
- `raydium_v5_base_trades_backfill.sql`
- `stabble_solana_base_trades_backfill.sql`

Other Solana microbatch models (stablecoins core/extended transfers and goosefx) already had `lookback = 1` and therefore required no changes. All models compiled successfully after the updates.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

---
Linear Issue: [CUR2-1608](https://linear.app/dune/issue/CUR2-1608/update-solana-microbatch-models-lookback-period-to-1-day)

<p><a href="https://cursor.com/agents/bc-57df22ca-c21b-4910-bfea-673fc84f127a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57df22ca-c21b-4910-bfea-673fc84f127a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->