### PR TITLE
megaeth: remove hardcoded date filter in daily project

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_core_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'core_transfers'),
-    start_date = '2026-01-30'
+    start_date = '2025-11-01'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-30'
+    start_date = '2025-11-01'
 ) }}


### PR DESCRIPTION
Change start_date from '2026-01-30' to '2025-11-01' to include all megaeth history including pre-public-mainnet activity (e.g. USDM mint/burn transfers).

Resolves CUR2-1633