### PR TITLE
megaeth: remove hardcoded date filter in dex project

### DIFF
--- a/dbt_subprojects/dex/models/_projects/sushiswap/megaeth/sushiswap_agg_megaeth_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/sushiswap/megaeth/sushiswap_agg_megaeth_trades.sql
@@ -22,5 +22,3 @@ select
     *
 from
     raw
-where
-    block_time >= timestamp '2026-01-30'

--- a/dbt_subprojects/dex/models/trades/megaeth/platforms/kumbaya_megaeth_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/megaeth/platforms/kumbaya_megaeth_base_trades.sql
@@ -28,10 +28,9 @@ dexs as (
         t.evt_index
     from {{ source('kumbaya_megaeth', 'v3pool_evt_swap') }} as t
     inner join {{ source('kumbaya_megaeth', 'v3factory_evt_poolcreated') }} as f on f.pool = t.contract_address
-    where t.evt_block_time >= timestamp '2026-01-30' -- exclude stress test trades (3B+ rows)
-        {% if is_incremental() %}
-        and {{ incremental_predicate('t.evt_block_time') }}
-        {% endif %}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('t.evt_block_time') }}
+    {% endif %}
 )
 
 select

--- a/dbt_subprojects/dex/models/trades/megaeth/platforms/prismfi_megaeth_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/megaeth/platforms/prismfi_megaeth_base_trades.sql
@@ -26,5 +26,3 @@ select
     *
 from
     raw
-where
-    block_time >= timestamp '2026-01-30'


### PR DESCRIPTION
Remove date filters from prismfi, kumbaya, and sushiswap aggregator megaeth base trades models. Full history will now be read on non-incremental runs.

Resolves CUR2-1633
