### PR TITLE
Add missing Bybit address to cex_evms_addresses

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/cex/addresses/chains/cex_evms_addresses.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/cex/addresses/chains/cex_evms_addresses.sql
@@ -219,6 +219,7 @@ FROM (VALUES
     , (0xc3350595ed42ebe94556277bc77d257c76065291, 'Bybit', 'Bybit 42', 'hildobby', date '2025-08-01')
     , (0x79ae8c1b31b1e61c4b9d1040217a051f954d4433, 'Bybit', 'Bybit 43', 'hildobby', date '2025-08-01')
     , (0x3fb00e38602c6a501e19eda24787f40bccef0432, 'Bybit', 'Bybit 44', 'muh_raf', date '2025-08-18')
+    , (0xe46620553d6b28e5d2520b366942990d8654f243, 'Bybit', 'Bybit 45', 'ModestusOkoye', date '2026-03-14')
     , (0xab97925eb84fe0260779f58b7cb08d77dcb1ee2b, 'Bybit', 'Bybit Gas Supplier 1', 'hildobby', date '2023-11-15')
     , (0xa95b83af96d0b8a90bd507f2bd82ad8f3dbb86bc, 'Bybit', 'Bybit Gas Supplier 2', 'hildobby', date '2023-11-20')
     , (0xf65d698d18bc37bf36e4c8d4fe4f051ef570e2b6, 'Bybit', 'Bybit Gas Supplier 3', 'hildobby', date '2023-11-23')


### PR DESCRIPTION
## Description

While building a CEX flow analysis dashboard for MNT token on Ethereum, I noticed unusually large CEX inflow volumes that didn't match outflows.

Tracing the transactions on Etherscan, I found that address 0xe46620553d6b28e5d2520b366942990d8654f243 received 356M MNT from 0x828424517f9f04015db02169f4026d57b2b07229 (already labeled as Bybit 22 in this repo).

Arkham confirms this address is Bybit-controlled; however, it was being misclassified as a retail wallet, inflating CEX inflow metrics in onchain analysis.

<img width="1942" height="1125" alt="Screenshot 2026-03-15 020022" src="https://github.com/user-attachments/assets/3498621e-77fb-47e4-928d-3b7a6bdbd839" />
