### PR TITLE
re-add fix: materialise upstream views into tables to avoid stage limits

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/liquidity/balancer_liquidity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/liquidity/balancer_liquidity.sql
@@ -1,6 +1,8 @@
 {{ config(
         schema = 'balancer',
-        alias = 'liquidity'
+        alias = 'liquidity',
+        materialized = 'table',
+        file_format = 'delta'
         , post_hook='{{ hide_spells() }}'
         )
 }}
@@ -48,4 +50,3 @@ FROM (
     {% endif %}
     {% endfor %}
 )
-;

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/pools/balancer_pools_metrics_daily.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/pools/balancer_pools_metrics_daily.sql
@@ -1,5 +1,4 @@
 {{ config(
-    tags = ['prod_exclude'],
     schema = 'balancer',
     alias = 'pools_metrics_daily',
     materialized = 'incremental',

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/protocol_fee/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/protocol_fee/_schema.yml
@@ -24,9 +24,9 @@ models:
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
+            - day
             - blockchain
             - version
-            - day
             - pool_id
             - token_address
             - fee_type

--- a/dbt_subprojects/hourly_spellbook/models/_project/balancer/protocol_fee/balancer_protocol_fee.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/balancer/protocol_fee/balancer_protocol_fee.sql
@@ -1,6 +1,8 @@
 {{ config(
     schema = 'balancer',
-    alias = 'protocol_fee'
+    alias = 'protocol_fee',
+    materialized = 'table',
+    file_format = 'delta'
     , post_hook='{{ hide_spells() }}'
     )
 }}
@@ -46,4 +48,4 @@ FROM (
     {% endif %}
     {% endfor %}
 )
-;
+


### PR DESCRIPTION
## Summary
- Re-adds the reverted changes from #9338 by reverting #9462.
- Materializes `balancer_liquidity` and `balancer_protocol_fee` as Delta tables.
- Keeps the protocol fee uniqueness combination aligned (`day`, `blockchain`, `version`, `pool_id`, `token_address`, `fee_type`) and retains the `balancer_pools_metrics_daily` tag adjustment.

## Test plan
- [ ] Confirm CI passes for hourly subproject checks
- [ ] Spot-check model compile behavior in hourly spellbook

Made with [Cursor](https://cursor.com)