### PR TITLE
Fix MERGE duplicate matches in polygon ERC-4337 v0.6 userops basics

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/account_abstraction/erc4337/polygon/account_abstraction_erc4337_polygon_v0_6_userops_basics.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/account_abstraction/erc4337/polygon/account_abstraction_erc4337_polygon_v0_6_userops_basics.sql
@@ -18,11 +18,48 @@
 {% set deployed_date = '2023-02-15' %}
 
 -- macros/models/sector/erc4337
-{{
-    erc4337_userops_basics(
-        blockchain = 'polygon',
-        version = 'v0.6',
-        userops_evt_model = source('erc4337_polygon','EntryPoint_v0_6_evt_UserOperationEvent'),
-        handleops_call_model = source('erc4337_polygon', 'EntryPoint_v0_6_call_handleOps')
-    )
-}}
+with base as (
+    {{
+        erc4337_userops_basics(
+            blockchain = 'polygon',
+            version = 'v0.6',
+            userops_evt_model = source('erc4337_polygon','EntryPoint_v0_6_evt_UserOperationEvent'),
+            handleops_call_model = source('erc4337_polygon', 'EntryPoint_v0_6_call_handleOps')
+        )
+    }}
+)
+, deduped as (
+    select
+          blockchain
+        , version
+        , block_month
+        , block_time
+        , entrypoint_contract
+        , tx_hash
+        , sender
+        , userop_hash
+        , success
+        , paymaster
+        , op_fee
+        , beneficiary
+        , row_number() over (
+            partition by userop_hash, tx_hash
+            order by (beneficiary is not null) desc, beneficiary desc
+        ) as _row_num
+    from base
+)
+select
+      blockchain
+    , version
+    , block_month
+    , block_time
+    , entrypoint_contract
+    , tx_hash
+    , sender
+    , userop_hash
+    , success
+    , paymaster
+    , op_fee
+    , beneficiary
+from deduped
+where _row_num = 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

- Applies a minimal, model-local fix to `account_abstraction_erc4337_polygon_v0_6_userops_basics`.
- Wraps the existing `erc4337_userops_basics` macro output in a CTE and deduplicates rows with:
  - `row_number() over (partition by userop_hash, tx_hash order by (beneficiary is not null) desc, beneficiary desc)`
  - `where _row_num = 1`
- This guarantees one source row per incremental `unique_key` (`userop_hash`, `tx_hash`) and prevents Trino MERGE errors:
  - `MERGE_TARGET_ROW_MULTIPLE_MATCHES`

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duneanalytics.slack.com/archives/C04E0CV1SG3/p1773735027265729?thread_ts=1773735027.265729&cid=C04E0CV1SG3)

<div><a href="https://cursor.com/agents/bc-8ab92df1-7b7f-51d4-98e5-8423693a8bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ab92df1-7b7f-51d4-98e5-8423693a8bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

