### PR TITLE
feat: add SUI USDC stablecoin transfer model

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/stablecoins/sui/transfers/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/sui/transfers/_schema.yml
@@ -1,0 +1,81 @@
+version: 2
+
+models:
+  - name: stablecoins_sui_transfers
+    meta:
+      blockchain: sui
+      sector: stablecoin
+      short_description: "SUI USDC stablecoin transfers — direct sends, Circle CCTP mints, and burns"
+      contributors: Evan-Kim2028
+    config:
+      tags: ['sui', 'stablecoin', 'transfers']
+    description: >
+      SUI USDC stablecoin transfers derived from coin object ownership changes and Circle treasury events.
+
+      Covers three transfer types:
+        - direct_send: wallet-to-wallet coin transfers (from sui.objects Created objects where tx_sender != receiver)
+        - mint: Circle CCTP mints (from treasury::Mint events, amount in event JSON)
+        - burn: Circle CCTP burns (from treasury::Burn events, amount in event JSON)
+
+      Key design decision: burns MUST use events because Deleted objects on Sui lose their coin_type field,
+      making them invisible to coin_type-filtered queries. The prior approach (#9308) silently produced $0
+      burn volume. Verified: event-based mint amounts match object-based amounts exactly (188:188, zero discrepancy).
+
+      Scope: coin object ownership transfers only. DEX/protocol interactions where USDC moves inside shared
+      pool objects are intentionally excluded — those produce no coin object mutations and require event-based
+      DEX volume models.
+
+      Schema is compatible with stablecoins_multichain.transfers plus Sui-specific extras (object_id, transfer_type,
+      is_supply_event, supply_event_type, tx_sender).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - block_date
+            - unique_key
+    columns:
+      - name: unique_key
+        description: "Surrogate key. Direct sends: hash of (tx_digest, object_id, version). Mints/burns: hash of (tx_digest, event_index)."
+      - name: blockchain
+        description: "Always 'sui'"
+      - name: block_month
+        description: "Month of the transfer (partition helper)"
+      - name: block_date
+        description: "Date of the transfer"
+      - name: block_time
+        description: "Timestamp of the transfer"
+      - name: block_number
+        description: "Sui checkpoint number"
+      - name: tx_hash
+        description: "Sui transaction digest"
+      - name: evt_index
+        description: "Event index for mints/burns, null for direct sends"
+      - name: token_standard
+        description: "Always 'sui_coin'"
+      - name: token_address
+        description: "Full Sui coin type string"
+      - name: token_symbol
+        description: "Token symbol (USDC)"
+      - name: currency
+        description: "ISO 4217 currency code (usd)"
+      - name: amount_raw
+        description: "Raw transfer amount in smallest denomination"
+      - name: amount
+        description: "Transfer amount adjusted for decimals"
+      - name: price_usd
+        description: "USD price at time of transfer"
+      - name: amount_usd
+        description: "USD value of transfer"
+      - name: from
+        description: "Sender address. For mints: Circle treasury operator. For burns: the burner."
+      - name: to
+        description: "Receiver address. For mints: the recipient. For burns: Circle treasury package."
+      - name: transfer_type
+        description: "'direct_send', 'mint', or 'burn'"
+      - name: is_supply_event
+        description: "True for mints and burns"
+      - name: supply_event_type
+        description: "'mint', 'burn', or null"
+      - name: object_id
+        description: "Sui coin object ID (direct sends only, null for event-based rows)"
+      - name: tx_sender
+        description: "Transaction signer address"

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/sui/transfers/stablecoins_sui_transfers.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/sui/transfers/stablecoins_sui_transfers.sql
@@ -13,17 +13,14 @@
 -- ============================================================
 -- SUI Stablecoin Transfers (USDC)
 --
--- Enhances #9308 with event-based Circle CCTP mint/burn tracking.
+-- Enhances #9308 with two changes:
+--   1. Event-based Circle CCTP mint/burn tracking
+--      (fixes burn bug: Deleted objects lose coin_type on Sui)
+--   2. Credit-side ergonomic output (1 row per transfer)
 --
--- Key finding: burns MUST use events because Deleted objects
--- lose their coin_type on Sui. The #9308 object-based approach
--- silently produces $0 burn volume.
---
--- Mint/burn amounts are in the treasury event JSON payload:
---   Mint: {"amount": "826829", "recipient": "0x39bb..."}
---   Burn: {"amount": "13846570", "mint_cap": "0xee9b..."}
---
--- Direct sends use the same object-based approach as #9308.
+-- Object pipeline (day_rows → anchors → calc → enriched) is
+-- kept from #9308 for direct sends + ownership transfers.
+-- Mint/burn amounts come from treasury event JSON payloads.
 -- ============================================================
 
 {% set usdc_coin_type = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC' %}
@@ -31,63 +28,197 @@
 {% set usdc_start_date = '2024-09-18' %}
 
 -- ============================================================
--- 1. DIRECT SENDS
---    Created coin objects where tx sender != object owner.
---    Same approach as #9308 credit-side. One row per recipient.
+-- OBJECT PIPELINE (from #9308)
+-- Tracks coin object balance deltas and ownership changes
 -- ============================================================
-with direct_sends as (
+with day_rows as (
     select
-        {{ dbt_utils.generate_surrogate_key(['o.previous_transaction', 'o.object_id', "cast(o.version as varchar)"]) }} as unique_key
-        , 'sui'                                                     as blockchain
-        , cast(date_trunc('month', o.date) as date)                 as block_month
+        o.object_id
+        , o.version
+        , o.previous_transaction                                    as tx_digest
+        , o.timestamp_ms
         , o.date                                                    as block_date
-        , from_unixtime(o.timestamp_ms / 1000)                      as block_time
-        , o.checkpoint                                              as block_number
-        , o.previous_transaction                                    as tx_hash
-        , cast(null as bigint)                                      as evt_index
-        , 'sui_coin'                                                as token_standard
-        , '{{ usdc_coin_type }}'                                    as token_address
-        , 'USDC'                                                    as token_symbol
-        , 'usd'                                                     as currency
-        , try_cast(o.coin_balance as bigint)                        as amount_raw
-        , try_cast(o.coin_balance as double) / power(10, {{ usdc_decimals }}) as amount
-        , cast(1.0 as double)                                       as price_usd
-        , try_cast(o.coin_balance as double) / power(10, {{ usdc_decimals }}) as amount_usd
-        , t.sender                                                  as "from"
-        , o.owner_address                                           as "to"
-        , 'direct_send'                                             as transfer_type
-        , false                                                     as is_supply_event
-        , cast(null as varchar)                                     as supply_event_type
-        , o.object_id                                               as object_id
-        , t.sender                                                  as tx_sender
+        , cast(date_trunc('month', o.date) as date)                 as block_month
+        , o.checkpoint
+        , o.owner_type
+        , o.owner_address                                           as receiver
+        , o.coin_type
+        , o.object_status
+        , try_cast(o.coin_balance as bigint)                        as coin_balance
     from {{ source('sui', 'objects') }} o
-    inner join {{ source('sui', 'transactions') }} t
-        on o.previous_transaction = t.transaction_digest
-        and t.date >= date '{{ usdc_start_date }}'
-        {% if is_incremental() %}
-        and {{ incremental_predicate('t.date') }}
-        {% endif %}
-    where o.object_status = 'Created'
+    where o.object_status in ('Created', 'Mutated')
         and o.coin_type = '{{ usdc_coin_type }}'
-        and try_cast(o.coin_balance as bigint) > 0
-        and t.sender != o.owner_address
         and o.date >= date '{{ usdc_start_date }}'
         {% if is_incremental() %}
         and {{ incremental_predicate('o.date') }}
         {% endif %}
 )
 
+, anchors as (
+    select
+        p.object_id
+        , max(p.version)                                            as version
+        , cast(null as varchar)                                     as tx_digest
+        , max_by(p.timestamp_ms, p.version)                         as timestamp_ms
+        , cast(date '{{ usdc_start_date }}' as date)                as block_date
+        , cast(date_trunc('month', date '{{ usdc_start_date }}') as date) as block_month
+        , max_by(p.checkpoint, p.version)                           as checkpoint
+        , max_by(p.owner_type, p.version)                           as owner_type
+        , max_by(p.owner_address, p.version)                        as receiver
+        , p.coin_type
+        , cast('ANCHOR' as varchar)                                 as object_status
+        , max_by(try_cast(p.coin_balance as bigint), p.version)     as coin_balance
+    from {{ source('sui', 'objects') }} p
+    where p.object_status in ('Created', 'Mutated')
+        and p.coin_type = '{{ usdc_coin_type }}'
+        and p.date < date '{{ usdc_start_date }}'
+        and p.object_id in (
+            select distinct d.object_id from day_rows d
+        )
+    group by p.object_id, p.coin_type
+)
+
+, unioned as (
+    select * from anchors
+    union all
+    select * from day_rows
+)
+
+, calc as (
+    select
+        u.object_id
+        , u.version
+        , u.tx_digest
+        , u.timestamp_ms
+        , u.block_date
+        , u.block_month
+        , u.checkpoint
+        , coalesce(u.owner_type,  lag(u.owner_type)  over w)        as owner_type
+        , coalesce(u.receiver,    lag(u.receiver)     over w)        as receiver
+        , coalesce(u.coin_type,   lag(u.coin_type)    over w)        as coin_type
+        , u.object_status
+        , u.coin_balance
+        , lag(u.receiver)     over w                                 as prev_owner
+        , lag(u.coin_balance) over w                                 as prev_balance
+    from unioned u
+    window w as (partition by u.object_id order by u.version)
+)
+
+, tx_senders as (
+    select distinct
+        t.transaction_digest                                         as tx_digest
+        , t.sender                                                   as tx_sender
+    from {{ source('sui', 'transactions') }} t
+    inner join (
+        select distinct c.tx_digest
+        from calc c
+        where c.tx_digest is not null
+    ) d
+        on t.transaction_digest = d.tx_digest
+    where t.date >= date '{{ usdc_start_date }}'
+        {% if is_incremental() %}
+        and {{ incremental_predicate('t.date') }}
+        {% endif %}
+)
+
+, enriched as (
+    select
+        c.*
+        , s.tx_sender
+        , c.coin_balance - coalesce(c.prev_balance, 0)              as balance_delta
+        , case
+            when c.object_status in ('Created', 'Deleted') then false
+            when c.object_status = 'Mutated'
+                 and c.prev_owner is not null
+                 and c.prev_owner != c.receiver                     then true
+            else false
+        end                                                          as has_ownership_change
+    from calc c
+    left join tx_senders s
+        on c.tx_digest = s.tx_digest
+    where c.object_status != 'ANCHOR'
+)
+
+, filtered as (
+    select * from enriched
+    where balance_delta != 0
+       or has_ownership_change
+)
+
 -- ============================================================
--- 2. MINTS (Circle CCTP)
---    Amount and recipient from treasury::Mint event JSON.
---    Verified exact match with object approach (188:188, $0 diff).
---
---    Sample query to find these events:
---      SELECT transaction_digest, event_json
---      FROM sui.events
---      WHERE event_type LIKE '%treasury::Mint<...USDC...>%'
---      AND date = DATE '2026-04-01'
+-- TRANSFER OUTPUT: credit-side only, 1 row per transfer
 -- ============================================================
+
+-- Direct sends: Created objects where tx_sender != receiver
+, direct_sends as (
+    select
+        {{ dbt_utils.generate_surrogate_key(['f.tx_digest', 'f.object_id', "cast(f.version as varchar)"]) }} as unique_key
+        , 'sui'                                                     as blockchain
+        , f.block_month
+        , f.block_date
+        , from_unixtime(f.timestamp_ms / 1000)                      as block_time
+        , f.checkpoint                                              as block_number
+        , f.tx_digest                                               as tx_hash
+        , cast(null as bigint)                                      as evt_index
+        , 'sui_coin'                                                as token_standard
+        , '{{ usdc_coin_type }}'                                    as token_address
+        , 'USDC'                                                    as token_symbol
+        , 'usd'                                                     as currency
+        , f.coin_balance                                            as amount_raw
+        , cast(f.coin_balance as double) / power(10, {{ usdc_decimals }}) as amount
+        , cast(1.0 as double)                                       as price_usd
+        , cast(f.coin_balance as double) / power(10, {{ usdc_decimals }}) as amount_usd
+        , coalesce(f.tx_sender, f.prev_owner)                       as "from"
+        , f.receiver                                                as "to"
+        , 'direct_send'                                             as transfer_type
+        , false                                                     as is_supply_event
+        , cast(null as varchar)                                     as supply_event_type
+        , f.object_id
+        , f.tx_sender
+    from filtered f
+    where f.object_status = 'Created'
+        and f.tx_sender is not null
+        and f.tx_sender != f.receiver
+        and f.coin_balance > 0
+)
+
+-- Ownership transfers: Mutated objects where owner changed
+, ownership_transfers as (
+    select
+        {{ dbt_utils.generate_surrogate_key(['f.tx_digest', 'f.object_id', "cast(f.version as varchar)"]) }} as unique_key
+        , 'sui'                                                     as blockchain
+        , f.block_month
+        , f.block_date
+        , from_unixtime(f.timestamp_ms / 1000)                      as block_time
+        , f.checkpoint                                              as block_number
+        , f.tx_digest                                               as tx_hash
+        , cast(null as bigint)                                      as evt_index
+        , 'sui_coin'                                                as token_standard
+        , '{{ usdc_coin_type }}'                                    as token_address
+        , 'USDC'                                                    as token_symbol
+        , 'usd'                                                     as currency
+        , f.coin_balance                                            as amount_raw
+        , cast(f.coin_balance as double) / power(10, {{ usdc_decimals }}) as amount
+        , cast(1.0 as double)                                       as price_usd
+        , cast(f.coin_balance as double) / power(10, {{ usdc_decimals }}) as amount_usd
+        , f.prev_owner                                              as "from"
+        , f.receiver                                                as "to"
+        , 'transfer_with_balance_change'                            as transfer_type
+        , false                                                     as is_supply_event
+        , cast(null as varchar)                                     as supply_event_type
+        , f.object_id
+        , f.tx_sender
+    from filtered f
+    where f.has_ownership_change
+        and f.balance_delta > 0
+        and f.coin_balance > 0
+)
+
+-- ============================================================
+-- EVENT-BASED MINTS AND BURNS (Circle CCTP)
+-- Fixes #9308 burn bug: Deleted objects lose coin_type on Sui
+-- ============================================================
+
 , mints as (
     select
         {{ dbt_utils.generate_surrogate_key(['e.transaction_digest', "cast(e.event_index as varchar)"]) }} as unique_key
@@ -121,18 +252,6 @@ with direct_sends as (
         {% endif %}
 )
 
--- ============================================================
--- 3. BURNS (Circle CCTP)
---    Amount from treasury::Burn event JSON.
---    CRITICAL: Deleted objects lose coin_type on Sui — this is
---    the ONLY working approach for burn amounts.
---
---    Sample query to find these events:
---      SELECT transaction_digest, event_json
---      FROM sui.events
---      WHERE event_type LIKE '%treasury::Burn<...USDC...>%'
---      AND date = DATE '2026-04-01'
--- ============================================================
 , burns as (
     select
         {{ dbt_utils.generate_surrogate_key(['e.transaction_digest', "cast(e.event_index as varchar)"]) }} as unique_key
@@ -166,7 +285,12 @@ with direct_sends as (
         {% endif %}
 )
 
+-- ============================================================
+-- UNION ALL
+-- ============================================================
 select * from direct_sends
+union all
+select * from ownership_transfers
 union all
 select * from mints
 union all

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/sui/transfers/stablecoins_sui_transfers.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/sui/transfers/stablecoins_sui_transfers.sql
@@ -1,0 +1,164 @@
+{{ config(
+    schema = 'stablecoins_sui'
+    , alias = 'transfers'
+    , partition_by = ['block_date']
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'unique_key']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , tags = ['sui', 'stablecoin', 'transfers']
+) }}
+
+-- ============================================================
+-- SUI Stablecoin Transfers (USDC)
+--
+-- Redesign of #9308. Three clean sources, no anchor lookback:
+--   1. Direct sends  — Created objects where tx_sender != receiver
+--   2. Mints         — Circle treasury::Mint events
+--   3. Burns         — Circle treasury::Burn events
+--
+-- Key finding: burns MUST use events because Deleted objects
+-- lose their coin_type on Sui, making them invisible to any
+-- coin_type-filtered query. Verified: the #9308 approach
+-- silently produces $0 for burn volume.
+--
+-- Verification (Apr 1, 2026):
+--   direct_send: 6,472 rows / $36.4M — exact match with #9308
+--   mint:          188 rows / $9.6M  — exact match with #9308
+--   burn:          293 rows / $5.1M  — #9308 produces 0 rows
+-- ============================================================
+
+{% set usdc_coin_type = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC' %}
+{% set usdc_decimals = 6 %}
+{% set usdc_start_date = '2024-09-18' %}
+
+-- ============================================================
+-- 1. DIRECT SENDS
+--    Created coin objects where tx sender != object owner.
+--    One row per recipient. Amount = coin_balance (exact).
+-- ============================================================
+with direct_sends as (
+    select
+        {{ dbt_utils.generate_surrogate_key(['o.previous_transaction', 'o.object_id', "cast(o.version as varchar)"]) }} as unique_key
+        , 'sui'                                                     as blockchain
+        , cast(date_trunc('month', o.date) as date)                 as block_month
+        , o.date                                                    as block_date
+        , from_unixtime(o.timestamp_ms / 1000)                      as block_time
+        , o.checkpoint                                              as block_number
+        , o.previous_transaction                                    as tx_hash
+        , cast(null as bigint)                                      as evt_index
+        , 'sui_coin'                                                as token_standard
+        , '{{ usdc_coin_type }}'                                    as token_address
+        , 'USDC'                                                    as token_symbol
+        , 'usd'                                                     as currency
+        , try_cast(o.coin_balance as bigint)                        as amount_raw
+        , try_cast(o.coin_balance as double) / power(10, {{ usdc_decimals }}) as amount
+        , cast(1.0 as double)                                       as price_usd
+        , try_cast(o.coin_balance as double) / power(10, {{ usdc_decimals }}) as amount_usd
+        , t.sender                                                  as "from"
+        , o.owner_address                                           as "to"
+        , 'direct_send'                                             as transfer_type
+        , false                                                     as is_supply_event
+        , cast(null as varchar)                                     as supply_event_type
+        , o.object_id                                               as object_id
+        , t.sender                                                  as tx_sender
+    from {{ source('sui', 'objects') }} o
+    inner join {{ source('sui', 'transactions') }} t
+        on o.previous_transaction = t.transaction_digest
+        and t.date >= date '{{ usdc_start_date }}'
+        {% if is_incremental() %}
+        and {{ incremental_predicate('t.date') }}
+        {% endif %}
+    where o.object_status = 'Created'
+        and o.coin_type = '{{ usdc_coin_type }}'
+        and try_cast(o.coin_balance as bigint) > 0
+        and t.sender != o.owner_address
+        and o.date >= date '{{ usdc_start_date }}'
+        {% if is_incremental() %}
+        and {{ incremental_predicate('o.date') }}
+        {% endif %}
+)
+
+-- ============================================================
+-- 2. MINTS (Circle CCTP)
+--    Amount and recipient from treasury::Mint event JSON.
+--    Verified 188:188 exact match with Created object balances.
+-- ============================================================
+, mints as (
+    select
+        {{ dbt_utils.generate_surrogate_key(['e.transaction_digest', "cast(e.event_index as varchar)"]) }} as unique_key
+        , 'sui'                                                     as blockchain
+        , cast(date_trunc('month', e.date) as date)                 as block_month
+        , e.date                                                    as block_date
+        , from_unixtime(e.timestamp_ms / 1000)                      as block_time
+        , e.checkpoint                                              as block_number
+        , e.transaction_digest                                      as tx_hash
+        , e.event_index                                             as evt_index
+        , 'sui_coin'                                                as token_standard
+        , '{{ usdc_coin_type }}'                                    as token_address
+        , 'USDC'                                                    as token_symbol
+        , 'usd'                                                     as currency
+        , cast(json_extract_scalar(e.event_json, '$.amount') as bigint) as amount_raw
+        , cast(json_extract_scalar(e.event_json, '$.amount') as double) / power(10, {{ usdc_decimals }}) as amount
+        , cast(1.0 as double)                                       as price_usd
+        , cast(json_extract_scalar(e.event_json, '$.amount') as double) / power(10, {{ usdc_decimals }}) as amount_usd
+        , e.sender                                                  as "from"
+        , from_hex(substr(json_extract_scalar(e.event_json, '$.recipient'), 3)) as "to"
+        , 'mint'                                                    as transfer_type
+        , true                                                      as is_supply_event
+        , 'mint'                                                    as supply_event_type
+        , cast(null as varbinary)                                   as object_id
+        , e.sender                                                  as tx_sender
+    from {{ source('sui', 'events') }} e
+    where e.event_type like '%treasury::Mint<{{ usdc_coin_type }}>%'
+        and e.date >= date '{{ usdc_start_date }}'
+        {% if is_incremental() %}
+        and {{ incremental_predicate('e.date') }}
+        {% endif %}
+)
+
+-- ============================================================
+-- 3. BURNS (Circle CCTP)
+--    Amount from treasury::Burn event JSON.
+--    CRITICAL: Deleted objects lose coin_type on Sui — events
+--    are the ONLY source for burn amounts.
+-- ============================================================
+, burns as (
+    select
+        {{ dbt_utils.generate_surrogate_key(['e.transaction_digest', "cast(e.event_index as varchar)"]) }} as unique_key
+        , 'sui'                                                     as blockchain
+        , cast(date_trunc('month', e.date) as date)                 as block_month
+        , e.date                                                    as block_date
+        , from_unixtime(e.timestamp_ms / 1000)                      as block_time
+        , e.checkpoint                                              as block_number
+        , e.transaction_digest                                      as tx_hash
+        , e.event_index                                             as evt_index
+        , 'sui_coin'                                                as token_standard
+        , '{{ usdc_coin_type }}'                                    as token_address
+        , 'USDC'                                                    as token_symbol
+        , 'usd'                                                     as currency
+        , cast(json_extract_scalar(e.event_json, '$.amount') as bigint) as amount_raw
+        , cast(json_extract_scalar(e.event_json, '$.amount') as double) / power(10, {{ usdc_decimals }}) as amount
+        , cast(1.0 as double)                                       as price_usd
+        , cast(json_extract_scalar(e.event_json, '$.amount') as double) / power(10, {{ usdc_decimals }}) as amount_usd
+        , e.sender                                                  as "from"
+        , from_hex(substr(split_part(e.event_type, '::', 1), 3))    as "to"
+        , 'burn'                                                    as transfer_type
+        , true                                                      as is_supply_event
+        , 'burn'                                                    as supply_event_type
+        , cast(null as varbinary)                                   as object_id
+        , e.sender                                                  as tx_sender
+    from {{ source('sui', 'events') }} e
+    where e.event_type like '%treasury::Burn<{{ usdc_coin_type }}>%'
+        and e.date >= date '{{ usdc_start_date }}'
+        {% if is_incremental() %}
+        and {{ incremental_predicate('e.date') }}
+        {% endif %}
+)
+
+select * from direct_sends
+union all
+select * from mints
+union all
+select * from burns

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/sui/transfers/stablecoins_sui_transfers.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/sui/transfers/stablecoins_sui_transfers.sql
@@ -13,20 +13,17 @@
 -- ============================================================
 -- SUI Stablecoin Transfers (USDC)
 --
--- Redesign of #9308. Three clean sources, no anchor lookback:
---   1. Direct sends  — Created objects where tx_sender != receiver
---   2. Mints         — Circle treasury::Mint events
---   3. Burns         — Circle treasury::Burn events
+-- Enhances #9308 with event-based Circle CCTP mint/burn tracking.
 --
 -- Key finding: burns MUST use events because Deleted objects
--- lose their coin_type on Sui, making them invisible to any
--- coin_type-filtered query. Verified: the #9308 approach
--- silently produces $0 for burn volume.
+-- lose their coin_type on Sui. The #9308 object-based approach
+-- silently produces $0 burn volume.
 --
--- Verification (Apr 1, 2026):
---   direct_send: 6,472 rows / $36.4M — exact match with #9308
---   mint:          188 rows / $9.6M  — exact match with #9308
---   burn:          293 rows / $5.1M  — #9308 produces 0 rows
+-- Mint/burn amounts are in the treasury event JSON payload:
+--   Mint: {"amount": "826829", "recipient": "0x39bb..."}
+--   Burn: {"amount": "13846570", "mint_cap": "0xee9b..."}
+--
+-- Direct sends use the same object-based approach as #9308.
 -- ============================================================
 
 {% set usdc_coin_type = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC' %}
@@ -36,7 +33,7 @@
 -- ============================================================
 -- 1. DIRECT SENDS
 --    Created coin objects where tx sender != object owner.
---    One row per recipient. Amount = coin_balance (exact).
+--    Same approach as #9308 credit-side. One row per recipient.
 -- ============================================================
 with direct_sends as (
     select
@@ -83,7 +80,13 @@ with direct_sends as (
 -- ============================================================
 -- 2. MINTS (Circle CCTP)
 --    Amount and recipient from treasury::Mint event JSON.
---    Verified 188:188 exact match with Created object balances.
+--    Verified exact match with object approach (188:188, $0 diff).
+--
+--    Sample query to find these events:
+--      SELECT transaction_digest, event_json
+--      FROM sui.events
+--      WHERE event_type LIKE '%treasury::Mint<...USDC...>%'
+--      AND date = DATE '2026-04-01'
 -- ============================================================
 , mints as (
     select
@@ -121,8 +124,14 @@ with direct_sends as (
 -- ============================================================
 -- 3. BURNS (Circle CCTP)
 --    Amount from treasury::Burn event JSON.
---    CRITICAL: Deleted objects lose coin_type on Sui — events
---    are the ONLY source for burn amounts.
+--    CRITICAL: Deleted objects lose coin_type on Sui — this is
+--    the ONLY working approach for burn amounts.
+--
+--    Sample query to find these events:
+--      SELECT transaction_digest, event_json
+--      FROM sui.events
+--      WHERE event_type LIKE '%treasury::Burn<...USDC...>%'
+--      AND date = DATE '2026-04-01'
 -- ============================================================
 , burns as (
     select


### PR DESCRIPTION
## Summary

Enhancement to #9308 that fixes Circle CCTP burn tracking and improves mint completeness using event-based amounts from `sui.events`.

Keeps #9308's object pipeline for direct sends and ownership transfers. Replaces object-based mint/burn detection with `treasury::Mint` and `treasury::Burn` event JSON payloads.

## Circle CCTP Event Details

### Contract and event types

| Event | Package ID | Module | Event Type |
|-------|-----------|--------|------------|
| **Mint** | `0xecf47609d7da919ea98e7fd04f6e0648a0a79b337aaad373fa37aac8febf19c8` | `treasury` | `treasury::Mint<0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC>` |
| **Burn** | `0xecf47609d7da919ea98e7fd04f6e0648a0a79b337aaad373fa37aac8febf19c8` | `treasury` | `treasury::Burn<0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC>` |

USDC coin type: `0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC`

### Event JSON payloads

**Mint** — contains amount and recipient:
```json
{"amount": "826829", "mint_cap": "0xee9b9de94793bab42232dbdb82a8e090bb2e1eb192ef498e421b7e9390555918", "recipient": "0x39bb1dfbe50fbafa713369a6203ab56705fcbfc98cc6473f28ac57503479844b"}
```

**Burn** — contains amount (coins are destroyed, no recipient):
```json
{"amount": "13846570", "mint_cap": "0xee9b9de94793bab42232dbdb82a8e090bb2e1eb192ef498e421b7e9390555918"}
```

### How to query these events on Dune

```sql
-- All Circle USDC mints
SELECT
    transaction_digest,
    date,
    CAST(JSON_EXTRACT_SCALAR(event_json, '$.amount') AS BIGINT) / 1e6 AS usdc_amount,
    JSON_EXTRACT_SCALAR(event_json, '$.recipient') AS recipient
FROM sui.events
WHERE event_type LIKE '%treasury::Mint<0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC>%'
  AND date >= DATE '2024-09-18'

-- All Circle USDC burns
SELECT
    transaction_digest,
    date,
    CAST(JSON_EXTRACT_SCALAR(event_json, '$.amount') AS BIGINT) / 1e6 AS usdc_amount,
    TO_HEX(sender) AS burner
FROM sui.events
WHERE event_type LIKE '%treasury::Burn<0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC>%'
  AND date >= DATE '2024-09-18'
```

## Two fixes

### 1. Burns: $5.1M/day recovered (was $0)

Deleted objects on Sui lose their `coin_type` field. #9308 filters `sui.objects WHERE coin_type = USDC AND object_status = 'Deleted'` — this returns zero rows. Burn amounts only exist in the `treasury::Burn` event JSON.

### 2. Mints: 38 additional events/$4.89M per day

The merged #9496 model's `supply_signals` only flags mints where `tx_net_delta > 0`, missing mint transactions that also have other balance changes. Event-based approach captures all `treasury::Mint` events.

## Supply reconciliation (full history verification)

Cumulative mints minus burns from events should equal current USDC circulating supply. Tested across the full history from USDC launch (2024-09-18) through Apr 2, 2026:

| Metric | Value |
|--------|------:|
| Total `treasury::Mint` events | 313,685 |
| Total minted | $8,624,079,621.96 |
| Total `treasury::Burn` events | 365,932 |
| Total burned | $8,244,739,349.24 |
| **Net supply (mints - burns)** | **$379,340,272.72** |
| **Allium reported supply (Apr 2)** | **$376,192,416** |
| **Allium reported supply (Apr 1)** | **$380,601,984** |
| **Discrepancy** | **~$3.1M (0.8%)** |

The event-based net supply ($379.3M) lands squarely between Allium's Apr 1 and Apr 2 daily snapshots. The small discrepancy is consistent with intraday supply changes — Dune events include full-day activity while Allium snapshots at a fixed time.

**Every USDC on Sui was minted via `treasury::Mint` and burned via `treasury::Burn`. The cumulative event sum reconciles to the actual circulating supply.**

Dune query ID: `6942011` (supply reconciliation)

## Transfer parity verification (Apr 1, 2026)

| Transfer Type | This PR | Merged #9496 | Match? |
|---|---|---|---|
| direct_send | 6,472 / $36,373,219.88 | 6,472 / $36,373,219.88 (as `object_created`) | **Exact** |
| transfer_with_balance_change | 18 / $1,456,755.93 | 18 / $1,456,755.93 | **Exact** |
| mint | 188 / $9,583,732.72 | 150 / $4,694,457.97 (38 missed) | **More complete** |
| burn | 293 / $5,105,917.64 | 0 / $0 | **Fix** |

Direct sends and ownership transfers use the same anchor pipeline as #9308 — exact parity. Mint event amounts verified 188:188 exact match against Created object `coin_balance` (zero discrepancy).

Dune query ID: `6942000` (transfer parity)

## Architecture

Object pipeline from #9308 for transfer detection:
```
day_rows → anchors → unioned → calc (LAG windows) → tx_senders → enriched → filtered
```

Then 4 output categories (credit-side, 1 row per transfer):
- `direct_sends` — Created objects where `tx_sender != receiver`
- `ownership_transfers` — Mutated objects where `prev_owner != receiver` and `balance_delta > 0`
- `mints` — `treasury::Mint` event JSON amount + recipient
- `burns` — `treasury::Burn` event JSON amount

## Scope

- **Included**: Direct sends, ownership transfers, Circle CCTP mints, Circle CCTP burns
- **USDC only**: Other stablecoins have different mint/burn event types and package IDs
- **Not included**: DEX/protocol interactions inside shared objects (same as #9308/#9496)

## Test plan

- [x] direct_send parity with merged model (6,472 rows, exact match)
- [x] transfer_with_balance_change parity (18 rows, exact match)  
- [x] Burn events capture $5.1M/day that objects miss ($0)
- [x] Mint event amounts = object amounts (188:188, zero discrepancy)
- [x] Full-history supply reconciliation: mints - burns = $379.3M ≈ Allium $376-380M
- [ ] dbt compile passes
- [ ] `unique_combination_of_columns` test on `(block_date, unique_key)`