### PR TITLE
Add CASH stablecoin support on Solana

### DIFF
--- a/dbt_subprojects/solana/models/stablecoins/_list/tokens_solana_spl_stablecoins_extended.sql
+++ b/dbt_subprojects/solana/models/stablecoins/_list/tokens_solana_spl_stablecoins_extended.sql
@@ -28,5 +28,6 @@ from (values
     ('AhhdRu5YZdjVkKR3wbnUDaymVQL2ucjMQ63sZ3LFHsch', 'CHF'),  -- VCHF
     ('A94X2fRy3wydNShU4dRaDyap2UuoeWJGWyATtyp61WZf', 'TRY'),  -- TRYB
     ('A9mUU4qviSctJVPJdBJWkb28deg915LYJKrzQ19ji3FM', 'USD'),  -- USDC (Wormhole from Ethereum)
-    ('Ejqkht2dyN1BaaEtK92zBKY6S8HbVH8APB5sDK9Rmokt', 'USD')   -- rUSD
+    ('Ejqkht2dyN1BaaEtK92zBKY6S8HbVH8APB5sDK9Rmokt', 'USD'),  -- rUSD
+    ('CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH', 'USD')   -- CASH (Bridge Open Issuance)
 ) as temp_table (token_mint_address, currency)

--- a/dbt_subprojects/solana/models/stablecoins/tokens_spl_stablecoins_metadata.sql
+++ b/dbt_subprojects/solana/models/stablecoins/tokens_spl_stablecoins_metadata.sql
@@ -34,7 +34,8 @@ from (values
 ('solana', 'FrBfWJ4qE5sCzKm3k3JaAtqZcXUh4LvJygDeketsrsH4', 'Fiat-backed stablecoin', 'ZUSD', 6, 'GMO-Z'),
 ('solana', 'Ea5SjE2Y6yvCeW5dYTn7PYMuW5ikXkvbGdcmSnXeaLjS', 'Crypto-backed stablecoin', 'PAI', 6, 'Parrot'),
 ('solana', 'A9mUU4qviSctJVPJdBJWkb28deg915LYJKrzQ19ji3FM', 'Fiat-backed stablecoin', 'USDC', 6, 'USD Coin (Wormhole)'),
-('solana', 'Ejqkht2dyN1BaaEtK92zBKY6S8HbVH8APB5sDK9Rmokt', '', 'rUSD', 18, '')
+('solana', 'Ejqkht2dyN1BaaEtK92zBKY6S8HbVH8APB5sDK9Rmokt', '', 'rUSD', 18, ''),
+('solana', 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH', 'Fiat-backed stablecoin', 'CASH', 6, 'Bridge')
 
 ) as temp_table (blockchain, token_mint_address, backing, symbol, decimals, name)
 

--- a/dbt_subprojects/solana/models/tokens/solana/tokens_solana_stablecoins.sql
+++ b/dbt_subprojects/solana/models/tokens/solana/tokens_solana_stablecoins.sql
@@ -20,4 +20,5 @@ from (Values
     , ('solana', 'ZUSD','FrBfWJ4qE5sCzKm3k3JaAtqZcXUh4LvJygDeketsrsH4', 6,'Dollar-Pegged','GMO-Z')
     , ('solana', 'PAI', 'Ea5SjE2Y6yvCeW5dYTn7PYMuW5ikXkvbGdcmSnXeaLjS', 6,'Crypto Stablecoin', 'Parrot')
     , ('solana', 'FDUSD', '9zNQRsGLjNKwCUU5Gq5LR8beUCPzQMVMqKAi3SSZh54u', 6,'Fiat Stablecoin', 'First Digital Labs')
+    , ('solana', 'CASH', 'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH', 6,'Fiat Stablecoin', 'Bridge')
 ) as t(blockchain, symbol, address, decimals, backing, name)

--- a/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
@@ -423,6 +423,7 @@ FROM
         ('haku-haku-ryujin','solana','HAKU','CXrdC7JiLKvpa6CshEskorEDqkbZJjb3LJV3KUVVEiMs',9),
         ('buffet-worried','solana','BUFFET','4teD1Evq7yBo5ud2LDbCVG7XgrM54ep2ndWFnBZe1DVP',1),
         ('cash-solnado-cash','solana','CASH','AAap4178s62oehYMyoPJSvkaXcCauTwb2cpkWTvtQSnk',9),
+        ('cash-bridge-open-issuance-solana','solana','CASH','CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH',6),
         ('crew-crew-inu','solana','CREW','E3zHh59yurhKr97U9yGYnUyAZNwUmciEB53j7t4s3Aph',9),
         ('chili-chili','solana','CHILI','GPyzPHuFFGvN4yWWixt6TYUtDG49gfMdFFi2iniTmCkh',2),
         ('wealth-generational-wealth','solana','WEALTH','2YuSzANgyU9rkFJn5aiAPJqN1kHgtZVQb4nWs1JLjLCw',5),


### PR DESCRIPTION
## Summary
- add the Solana CASH mint (`CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH`) to the Solana stablecoin extended list
- add CASH metadata to the Solana stablecoin metadata table
- add CASH to the legacy Solana stablecoins table for parity
- add a separate `prices_solana.tokens` entry for this CASH mint, distinct from the existing Solnado CASH token

## Related issue
- Related: #9527

## Notes
- CASH went live on `2025-08-29 16:33:32 UTC`
- Upstream: please ensure mint `CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH` is present in `tokens_solana.fungible` (symbol/decimals/metadata). `tokens.spl_stablecoins` depends on that table.

## Testing
- compiled modified Solana models with `dbt compile`
- compiled `prices_solana_tokens` in the `tokens` subproject after `dbt deps`