### PR TITLE
fix(dex): correct token_bought_address decimal mismatch in 1inch-LOP trades

### DIFF
--- a/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_lop_own_trades.sql
@@ -31,8 +31,8 @@ select
     , src_executed_amount as token_bought_amount_raw
     , dst_executed_amount as token_sold_amount_raw
     , amount_usd
-    , src_token_address as token_bought_address
-    , dst_token_address as token_sold_address
+    , coalesce(src_executed_address, src_token_address) as token_bought_address
+    , coalesce(dst_executed_address, dst_token_address) as token_sold_address
     , call_from as taker
     , user as maker
     , call_to as project_contract_address


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Description:

**Bug:** After #9538 moved 1inch-LOP into the chain-level `enrich_dex_trades` pipeline, `amount_usd` became wildly inflated for some trades (~19/day, totalling ~$5.7 quadrillion/day). Repro: https://dune.com/queries/6977516

**Root cause:** `token_bought_amount_raw` holds the raw amount of the *actually executed* transfer token (`src_executed_address`), but `token_bought_address` was set to `src_token_address` (= `maker_asset` from the order). These can differ in the fallback path — e.g. when no transfer of `maker_asset` is found, the fallback picks the largest transfer from the maker, often WETH (18 dec). `enrich_dex_trades` then divides by `token_bought_address` decimals (USDT = 6 dec), causing 10^12x inflation:

```
WETH_raw / 10^6  →  2.56 WETH raw = $2.56 trillion (should be ~$7,680)
```

The old `as_is_model` pipeline (pre-#9538) was unaffected because it used `complement.src_decimals` (actual transfer decimals) for scaling.

**Fix:** Align `token_bought_address` with the actual executed transfer address:

```sql
-- Before
, src_token_address as token_bought_address
, dst_token_address as token_sold_address

-- After
, coalesce(src_executed_address, src_token_address) as token_bought_address
, coalesce(dst_executed_address, dst_token_address) as token_sold_address
```

In the normal case `src_executed_address = src_token_address`, so no behaviour change. Only the fallback path is fixed. `token_bought_symbol` already used `src_executed_symbol` — this aligns the address to match.

**Validation:** https://dune.com/queries/6977801 — confirms inflated amounts resolve to correct WETH-scale values after the fix.

**Impacted model:** `oneinch.lop_own_trades` (shared across all chains via the per-chain base_trades wrappers introduced in #9538)