### PR TITLE
fix(dex): join tokens.erc20 in oneinch LOP dex trades passthrough

### DIFF
--- a/dbt_subprojects/dex/macros/models/oneinch_lop_dex_trades_passthrough.sql
+++ b/dbt_subprojects/dex/macros/models/oneinch_lop_dex_trades_passthrough.sql
@@ -14,9 +14,12 @@ SELECT
 	, o.block_date
 	, o.block_time
 	, o.block_number
-	, o.token_bought_symbol
-	, o.token_sold_symbol
-	, o.token_pair
+	, coalesce(tb.symbol, o.token_bought_symbol) as token_bought_symbol
+	, coalesce(ts.symbol, o.token_sold_symbol) as token_sold_symbol
+	, case
+		when lower(coalesce(tb.symbol, o.token_bought_symbol)) > lower(coalesce(ts.symbol, o.token_sold_symbol)) then concat(coalesce(ts.symbol, o.token_sold_symbol), '-', coalesce(tb.symbol, o.token_bought_symbol))
+		else concat(coalesce(tb.symbol, o.token_bought_symbol), '-', coalesce(ts.symbol, o.token_sold_symbol))
+	end as token_pair
 	, o.token_bought_amount
 	, o.token_sold_amount
 	, o.token_bought_amount_raw
@@ -32,6 +35,12 @@ SELECT
 	, o.tx_to
 	, o.evt_index
 FROM {{ ref('oneinch_lop_own_trades') }} AS o
+LEFT JOIN {{ source('tokens', 'erc20') }} AS tb
+	ON tb.blockchain = '{{ blockchain }}'
+	AND tb.contract_address = o.token_bought_address
+LEFT JOIN {{ source('tokens', 'erc20') }} AS ts
+	ON ts.blockchain = '{{ blockchain }}'
+	AND ts.contract_address = o.token_sold_address
 WHERE o.blockchain = '{{ blockchain }}'
 {% if var('dev_dates', false) -%}
 	AND o.block_date > current_date - interval '3' day -- dev_dates mode for dev, to prevent full scan


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Updates `oneinch_lop_dex_trades_passthrough` to **left join** `tokens.erc20` on each chain for both `token_bought_address` and `token_sold_address`, and uses **`coalesce(tokens.erc20.symbol, oneinch symbol)`** so catalog metadata wins when present. Recomputes **`token_pair`** from the resolved bought/sold symbols so pairs stay consistent.

This addresses inconsistent `token_*_symbol` values from OneInch transfer parsing (same contract, different labels), which was contributing to duplicate merge keys downstream in token volume rollups.

Includes an empty commit to refresh CI/UI from an earlier push.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

Made with [Cursor](https://cursor.com)