### PR TITLE
fix(dex): dedupe token_volumes_daily rows per merge key

### DIFF
--- a/dbt_subprojects/dex/macros/models/dex_token_volumes_daily.sql
+++ b/dbt_subprojects/dex/macros/models/dex_token_volumes_daily.sql
@@ -60,7 +60,7 @@ sums AS (
   , block_month
   , block_date
   , token_address
-  , symbol
+  , max(symbol) AS symbol
   , SUM(bought_volume_raw) AS bought_volume_raw_sum
   , SUM(sold_volume_raw) AS sold_volume_raw_sum
   , SUM(bought_volume) AS bought_volume_sum
@@ -68,7 +68,7 @@ sums AS (
   , SUM(bought_volume_usd) AS bought_volume_usd_sum
   , SUM(sold_volume_usd) AS sold_volume_usd_sum
   FROM daily_flows
-  GROUP BY blockchain, block_month, block_date, token_address, symbol
+  GROUP BY blockchain, block_month, block_date, token_address
 )
 
 SELECT

--- a/dbt_subprojects/dex/macros/models/dex_token_volumes_daily.sql
+++ b/dbt_subprojects/dex/macros/models/dex_token_volumes_daily.sql
@@ -60,7 +60,7 @@ sums AS (
   , block_month
   , block_date
   , token_address
-  , max(symbol) AS symbol
+  , symbol
   , SUM(bought_volume_raw) AS bought_volume_raw_sum
   , SUM(sold_volume_raw) AS sold_volume_raw_sum
   , SUM(bought_volume) AS bought_volume_sum
@@ -68,7 +68,7 @@ sums AS (
   , SUM(bought_volume_usd) AS bought_volume_usd_sum
   , SUM(sold_volume_usd) AS sold_volume_usd_sum
   FROM daily_flows
-  GROUP BY blockchain, block_month, block_date, token_address
+  GROUP BY blockchain, block_month, block_date, token_address, symbol
 )
 
 SELECT


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Updates `dex_token_volumes_daily` so the **`sums`** aggregate is grouped only by **`blockchain`**, **`block_month`**, **`block_date`**, and **`token_address`**, matching the incremental **`unique_key`**. **`symbol`** is collapsed with **`max(symbol)`** after summing volumes across all `daily_flows` rows for that token-day.

This fixes **`MERGE_TARGET_ROW_MULTIPLE_MATCHES`** on `dex_*_token_volumes_daily` when `dex_*_trades` emits inconsistent `token_*_symbol` values (including empty vs non-empty) for the same contract on the same day. Volumes were already summed correctly in spirit; the extra `symbol` grain produced duplicate source rows per merge key.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

Made with [Cursor](https://cursor.com)