### PR TITLE
Fix PancakeSwap v3 Solana merge duplicate matches

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/pancakeswap/pancakeswap_v3_solana_stg_swaps.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/pancakeswap/pancakeswap_v3_solana_stg_swaps.sql
@@ -32,6 +32,7 @@ WITH pools AS (
         , call_outer_executing_account
         , call_tx_signer
         , call_tx_index
+        , 2 AS source_priority
     FROM {{ source('pancakeswap_solana', 'amm_v3_call_swap') }}
     WHERE 1=1
         {% if is_incremental() %}
@@ -53,6 +54,7 @@ WITH pools AS (
         , call_outer_executing_account
         , call_tx_signer
         , call_tx_index
+        , 1 AS source_priority
     FROM {{ source('pancakeswap_solana', 'amm_v3_call_swap_v2') }}
     WHERE 1=1
         {% if is_incremental() %}
@@ -60,6 +62,41 @@ WITH pools AS (
         {% else %}
         AND call_block_time >= TIMESTAMP '{{ project_start_date }}'
         {% endif %}
+)
+
+, swaps AS (
+    -- swap + swap_v2 can overlap during decoder migrations; keep one source row per merge key.
+    SELECT
+          account_pool_state
+        , call_is_inner
+        , call_outer_instruction_index
+        , call_inner_instruction_index
+        , call_tx_id
+        , call_block_time
+        , call_block_slot
+        , call_outer_executing_account
+        , call_tx_signer
+        , call_tx_index
+    FROM (
+        SELECT
+              sr.*
+            , row_number() OVER (
+                PARTITION BY
+                      CAST(date_trunc('month', sr.call_block_time) AS DATE)
+                    , CAST(date_trunc('day', sr.call_block_time) AS DATE)
+                    , {{ solana_instruction_key(
+                          'sr.call_block_slot'
+                        , 'sr.call_tx_index'
+                        , 'sr.call_outer_instruction_index'
+                        , 'COALESCE(sr.call_inner_instruction_index, 0)'
+                      ) }}
+                ORDER BY
+                      sr.source_priority ASC
+                    , sr.call_block_time DESC
+              ) AS duplicate_rank
+        FROM swaps_raw sr
+    ) ranked_swaps
+    WHERE duplicate_rank = 1
 )
 
 SELECT
@@ -81,7 +118,7 @@ SELECT
         , 'sp.call_outer_instruction_index'
         , 'COALESCE(sp.call_inner_instruction_index, 0)'
       ) }} AS surrogate_key
-FROM swaps_raw sp
+FROM swaps sp
 INNER JOIN pools p
     ON sp.account_pool_state = p.pool_id
     AND p.recent_init = 1

--- a/dbt_subprojects/solana/models/_sector/dex/pancakeswap/pancakeswap_v3_solana_stg_swaps.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/pancakeswap/pancakeswap_v3_solana_stg_swaps.sql
@@ -64,61 +64,78 @@ WITH pools AS (
         {% endif %}
 )
 
-, swaps AS (
-    -- swap + swap_v2 can overlap during decoder migrations; keep one source row per merge key.
+, swaps_projected AS (
     SELECT
-          account_pool_state
-        , call_is_inner
-        , call_outer_instruction_index
-        , call_inner_instruction_index
-        , call_tx_id
-        , call_block_time
-        , call_block_slot
-        , call_outer_executing_account
-        , call_tx_signer
-        , call_tx_index
+          sp.call_block_slot AS block_slot
+        , CAST(date_trunc('month', sp.call_block_time) AS DATE) AS block_month
+        , CAST(date_trunc('day', sp.call_block_time) AS DATE) AS block_date
+        , sp.call_block_time AS block_time
+        , COALESCE(sp.call_inner_instruction_index, 0) AS inner_instruction_index
+        , sp.call_outer_instruction_index AS outer_instruction_index
+        , sp.call_outer_executing_account AS outer_executing_account
+        , sp.call_is_inner AS is_inner
+        , sp.call_tx_id AS tx_id
+        , sp.call_tx_signer AS tx_signer
+        , sp.call_tx_index AS tx_index
+        , sp.account_pool_state AS pool_id
+        , {{ solana_instruction_key(
+              'sp.call_block_slot'
+            , 'sp.call_tx_index'
+            , 'sp.call_outer_instruction_index'
+            , 'COALESCE(sp.call_inner_instruction_index, 0)'
+          ) }} AS surrogate_key
+        , sp.source_priority
+    FROM swaps_raw sp
+    INNER JOIN pools p
+        ON sp.account_pool_state = p.pool_id
+        AND p.recent_init = 1
+)
+
+, swaps AS (
+    -- swap + swap_v2 can overlap during decoder migrations; keep one projected row per merge key.
+    SELECT
+          block_slot
+        , block_month
+        , block_date
+        , block_time
+        , inner_instruction_index
+        , outer_instruction_index
+        , outer_executing_account
+        , is_inner
+        , tx_id
+        , tx_signer
+        , tx_index
+        , pool_id
+        , surrogate_key
     FROM (
         SELECT
-              sr.*
+              sp.*
             , row_number() OVER (
                 PARTITION BY
-                      CAST(date_trunc('month', sr.call_block_time) AS DATE)
-                    , CAST(date_trunc('day', sr.call_block_time) AS DATE)
-                    , {{ solana_instruction_key(
-                          'sr.call_block_slot'
-                        , 'sr.call_tx_index'
-                        , 'sr.call_outer_instruction_index'
-                        , 'COALESCE(sr.call_inner_instruction_index, 0)'
-                      ) }}
+                      sp.block_month
+                    , sp.block_date
+                    , sp.surrogate_key
                 ORDER BY
-                      sr.source_priority ASC
-                    , sr.call_block_time DESC
+                      sp.source_priority ASC
+                    , sp.block_time DESC
               ) AS duplicate_rank
-        FROM swaps_raw sr
+        FROM swaps_projected sp
     ) ranked_swaps
     WHERE duplicate_rank = 1
 )
 
 SELECT
-      sp.call_block_slot AS block_slot
-    , CAST(date_trunc('month', sp.call_block_time) AS DATE) AS block_month
-    , CAST(date_trunc('day', sp.call_block_time) AS DATE) AS block_date
-    , sp.call_block_time AS block_time
-    , COALESCE(sp.call_inner_instruction_index, 0) AS inner_instruction_index
-    , sp.call_outer_instruction_index AS outer_instruction_index
-    , sp.call_outer_executing_account AS outer_executing_account
-    , sp.call_is_inner AS is_inner
-    , sp.call_tx_id AS tx_id
-    , sp.call_tx_signer AS tx_signer
-    , sp.call_tx_index AS tx_index
-    , sp.account_pool_state AS pool_id
-    , {{ solana_instruction_key(
-          'sp.call_block_slot'
-        , 'sp.call_tx_index'
-        , 'sp.call_outer_instruction_index'
-        , 'COALESCE(sp.call_inner_instruction_index, 0)'
-      ) }} AS surrogate_key
-FROM swaps sp
-INNER JOIN pools p
-    ON sp.account_pool_state = p.pool_id
-    AND p.recent_init = 1
+      s.block_slot
+    , s.block_month
+    , s.block_date
+    , s.block_time
+    , s.inner_instruction_index
+    , s.outer_instruction_index
+    , s.outer_executing_account
+    , s.is_inner
+    , s.tx_id
+    , s.tx_signer
+    , s.tx_index
+    , s.pool_id
+    , s.surrogate_key
+FROM swaps s


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:

This PR fixes a production failure in `pancakeswap_v3_solana_stg_swaps`:

- Error: `MERGE_TARGET_ROW_MULTIPLE_MATCHES`
- Cause: overlapping rows can arrive from both decoded sources (`amm_v3_call_swap` and `amm_v3_call_swap_v2`), producing duplicate source rows for the same merge key (`block_month`, `block_date`, `surrogate_key`).
- Fix: add a deduplication CTE (`swaps`) that keeps one deterministic row per merge key via `row_number()`.
  - Prefer `swap_v2` rows using `source_priority`
  - Fall back deterministically on `call_block_time DESC`

This guarantees one source row per target key during incremental `merge` operations and prevents the multi-match merge failure.

### Validation:

- Manual SQL diff review completed.
- Could not run local `dbt compile` in this cloud runner because `pipenv`/`dbt` are not installed in the environment.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duneanalytics.slack.com/archives/C04E0CV1SG3/p1776152915562169?thread_ts=1776152915.562169&cid=C04E0CV1SG3)

<div><a href="https://cursor.com/agents/bc-5f26253e-3436-5836-9579-2b7a47584bb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f26253e-3436-5836-9579-2b7a47584bb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

