### PR TITLE
Add reCLAMM Pools to Balancer v3 pool labels

### DIFF
--- a/dbt_subprojects/dex/models/_projects/balancer/labels/arbitrum/labels_balancer_v3_pools_arbitrum.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/arbitrum/labels_balancer_v3_pools_arbitrum.sql
@@ -47,6 +47,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_arbitrum', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_arbitrum', 'StablePoolFactory_call_create') }} cc

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/base/labels_balancer_v3_pools_base.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/base/labels_balancer_v3_pools_base.sql
@@ -47,6 +47,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_base', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_base', 'StablePoolFactory_call_create') }} cc

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/ethereum/labels_balancer_v3_pools_ethereum.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/ethereum/labels_balancer_v3_pools_ethereum.sql
@@ -47,6 +47,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_ethereum', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_ethereum', 'StablePoolFactory_call_create') }} cc

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/gnosis/labels_balancer_v3_pools_gnosis.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/gnosis/labels_balancer_v3_pools_gnosis.sql
@@ -47,6 +47,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_gnosis', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_gnosis', 'StablePoolFactory_call_create') }} cc

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/hyperevm/labels_balancer_v3_pools_hyperevm.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/hyperevm/labels_balancer_v3_pools_hyperevm.sql
@@ -46,6 +46,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_hyperevm', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_hyperevm', 'StablePoolFactory_call_create') }} cc

--- a/dbt_subprojects/dex/models/_projects/balancer/labels/monad/labels_balancer_v3_pools_monad.sql
+++ b/dbt_subprojects/dex/models/_projects/balancer/labels/monad/labels_balancer_v3_pools_monad.sql
@@ -47,6 +47,19 @@ WITH token_data AS (
         t.tokens,
         0 AS weights,
         cc.symbol,
+        'reclamm' AS pool_type
+      FROM token_data c
+      INNER JOIN {{ source('balancer_v3_monad', 'ReclammPoolFactory_call_create') }} cc
+        ON c.pool = cc.output_pool
+      CROSS JOIN UNNEST(c.tokens) AS t(tokens)
+
+      UNION ALL
+
+      SELECT
+        c.pool AS pool_id,
+        t.tokens,
+        0 AS weights,
+        cc.symbol,
         'stable' AS pool_type
       FROM token_data c
       INNER JOIN {{ source('balancer_v3_monad', 'StablePoolFactory_call_create') }} cc


### PR DESCRIPTION
# Add Reclamm Balancer v3 pool sources and label coverage

## Summary

This PR wires **Reclamm** Balancer v3 pools end-to-end for the supported chains: dbt **sources** declare `ReclammPoolFactory_call_create`, and the **labels** models union in those pools with `pool_type = 'reclamm'`.

## Changes

### Sources

- Register `ReclammPoolFactory_call_create` under the existing Balancer v3 source definitions (per-chain `sources/balancer/*/balancer_*_sources.yml`), so `source('balancer_v3_<chain>', 'ReclammPoolFactory_call_create')` resolves in dbt.

### Labels

- Extend `labels_balancer_v3_pools_*` with a `UNION ALL` branch that joins `token_data` to `ReclammPoolFactory_call_create` on `output_pool`, sets `pool_type = 'reclamm'`, and follows the same non-weighted factory pattern as other stable-style branches.

## Chains touched in this branch

- Arbitrum  
- Base  
- Ethereum  
- Gnosis  
- HyperEVM  
- Monad  

## Notes

- Scope is limited to chains where both the source entry and the label model change are included in this PR; other chains can follow the same pattern if/when decoded tables are available and needed downstream.