### PR TITLE
Migrate CI test tables to dune catalog with __tmp_ schemas

### DIFF
--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -19,9 +19,7 @@ jobs:
 
       - name: Setup variables
         run: |
-          GIT_SHA=$(echo ${{ github.sha }} | tr - _ | cut -c1-7)
-          echo "GIT_SHA=$GIT_SHA" >> $GITHUB_ENV
-          echo "DBT_CI_SCHEMA=dune_spellbook_ci__tmp_$GIT_SHA" >> $GITHUB_ENV
+          echo "DBT_CI_SCHEMA=dune_spellbook_ci__tmp_pr${{ github.event.number }}_${{ github.run_id }}_${{ github.run_attempt }}" >> $GITHUB_ENV
           echo "PROFILE=--profiles-dir $HOME/.dbt --profile dunesql --target ci" >> $GITHUB_ENV
           echo "S3_LOCATION=s3://manifest-spellbook-dunesql/${{inputs.project}}" >> $GITHUB_ENV
           PROJECT_DIR=dbt_subprojects/${{ inputs.project }}

--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -18,14 +18,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup variables
-        run: | # Spellbook is a special case because it's not a subdirectory
-          echo "GIT_SHA=$(echo ${{ github.sha }} | tr - _ | cut -c1-7)" >> $GITHUB_ENV
-          echo "PROFILE=--profiles-dir $HOME/.dbt --profile dunesql" >> $GITHUB_ENV
+        run: |
+          GIT_SHA=$(echo ${{ github.sha }} | tr - _ | cut -c1-7)
+          echo "GIT_SHA=$GIT_SHA" >> $GITHUB_ENV
+          echo "DBT_CI_SCHEMA=dune_spellbook_ci__tmp_$GIT_SHA" >> $GITHUB_ENV
+          echo "PROFILE=--profiles-dir $HOME/.dbt --profile dunesql --target ci" >> $GITHUB_ENV
           echo "S3_LOCATION=s3://manifest-spellbook-dunesql/${{inputs.project}}" >> $GITHUB_ENV
           PROJECT_DIR=dbt_subprojects/${{ inputs.project }}
           echo "PROJECT_DIR=$PROJECT_DIR" >> $GITHUB_ENV
-      - name: Add git_sha to schema
-        run: "/runner/change_schema.sh git_dunesql_$GIT_SHA"
 
       - name: Get latest manifest
         run: "aws s3 cp $S3_LOCATION/manifest.json $PROJECT_DIR/manifest.json"

--- a/dbt_macros/dune/adapters.sql
+++ b/dbt_macros/dune/adapters.sql
@@ -23,10 +23,12 @@
 {%- endmacro -%}
 
 {% macro create_table_properties(_properties, relation) %}
-  {%- set modified_identifier = relation.identifier | replace("__dbt_tmp", "") -%}
-  {%- set unique_location = modified_identifier ~ '_' ~ time_salted_md5_prefix() -%}
-  {%- set location= 's3a://%s/%s/%s' % (s3_bucket(), relation.schema, unique_location) -%}
-  {%- do _properties.update({'location': "'" + location + "'"}) -%}
+  {%- if target.database != 'dune' -%}
+    {%- set modified_identifier = relation.identifier | replace("__dbt_tmp", "") -%}
+    {%- set unique_location = modified_identifier ~ '_' ~ time_salted_md5_prefix() -%}
+    {%- set location= 's3a://%s/%s/%s' % (s3_bucket(), relation.schema, unique_location) -%}
+    {%- do _properties.update({'location': "'" + location + "'"}) -%}
+  {%- endif -%}
     {# temp fix to get latest dbt-trino version 1.8.3 working in dbt cloud #}
     {{ dune_properties(_properties) }} {# properties is a macro within the trino adapter #}
 {%- endmacro -%}

--- a/dbt_macros/dune/adapters.sql
+++ b/dbt_macros/dune/adapters.sql
@@ -23,7 +23,7 @@
 {%- endmacro -%}
 
 {% macro create_table_properties(_properties, relation) %}
-  {%- if target.database != 'dune' -%}
+  {%- if not (target.name == 'ci' and target.database == 'dune') -%}
     {%- set modified_identifier = relation.identifier | replace("__dbt_tmp", "") -%}
     {%- set unique_location = modified_identifier ~ '_' ~ time_salted_md5_prefix() -%}
     {%- set location= 's3a://%s/%s/%s' % (s3_bucket(), relation.schema, unique_location) -%}

--- a/dbt_macros/dune/generate_alias_name.sql
+++ b/dbt_macros/dune/generate_alias_name.sql
@@ -8,6 +8,10 @@
 
         {{ ( target.schema + '_' + node.name | trim ) | truncate(128,True,'',0)}}
 
+    {%- elif target.schema.startswith("dune_spellbook_ci__tmp_") -%}
+
+        {{ node.name | trim | truncate(128,True,'',0) }}
+
     {%- else -%}
 
         {%- if custom_alias_name is none -%}

--- a/dbt_macros/dune/generate_schema_name.sql
+++ b/dbt_macros/dune/generate_schema_name.sql
@@ -5,6 +5,10 @@
 
         {{ custom_schema_name | trim }}
 
+    {%- elif target.schema.startswith("dune_spellbook_ci__tmp_") -%}
+
+        {{ target.schema }}
+
     {%- elif target.schema.startswith("git_") -%}
 
         {{ 'test_schema' }}

--- a/dbt_macros/dune/schema.sql
+++ b/dbt_macros/dune/schema.sql
@@ -4,6 +4,10 @@
 
 {% macro trino__create_schema(relation) -%}
   {%- call statement('create_schema') -%}
-   CREATE SCHEMA {{ relation }} WITH (location = 's3a://{{s3_bucket()}}/')
+    {%- if target.database == 'dune' -%}
+      CREATE SCHEMA IF NOT EXISTS {{ relation }}
+    {%- else -%}
+      CREATE SCHEMA {{ relation }} WITH (location = 's3a://{{s3_bucket()}}/')
+    {%- endif -%}
   {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
Moves spellbook CI test table creation from `hive.test_schema.git_dunesql_<SHA>_<model>` to `dune.dune_spellbook_ci__tmp_<SHA>.<model>`. 

`generate_schema_name` macro gets a new condition: when the schema starts with `dune_spellbook_ci__tmp_`, all models are placed in that schema (same flat-schema behavior as the existing `git_`/`test_schema` pattern).

Towards DWH-421