### PR TITLE
fix: use block_time instead of block_date in transfers_enrich incremental predicates

### DIFF
--- a/dbt_subprojects/tokens/macros/transfers/net_transfers.sql
+++ b/dbt_subprojects/tokens/macros/transfers/net_transfers.sql
@@ -12,7 +12,7 @@ with raw_transfers as (
     where
         blockchain = '{{blockchain}}'
         {% if is_incremental() %}
-        and {{ incremental_predicate('block_date') }}
+        and {{ incremental_predicate('block_time') }}
         {% endif %}
     group by
         blockchain
@@ -33,7 +33,7 @@ with raw_transfers as (
     where
         blockchain = '{{blockchain}}'
         {% if is_incremental() %}
-        and {{ incremental_predicate('block_date') }}
+        and {{ incremental_predicate('block_time') }}
         {% endif %}
     group by
         blockchain
@@ -119,7 +119,7 @@ with raw_transfers as (
     where
         blockchain = '{{blockchain}}'
         {% if is_incremental() %}
-        and {{ incremental_predicate('block_date') }}
+        and {{ incremental_predicate('block_time') }}
         {% endif %}
     group by
         blockchain
@@ -145,7 +145,7 @@ with raw_transfers as (
     where
         blockchain = '{{blockchain}}'
        {% if is_incremental() %}
-        and {{ incremental_predicate('block_date') }}
+        and {{ incremental_predicate('block_time') }}
         {% endif %}
     group by
         blockchain

--- a/dbt_subprojects/tokens/macros/transfers/transfers_enrich.sql
+++ b/dbt_subprojects/tokens/macros/transfers/transfers_enrich.sql
@@ -23,7 +23,7 @@ with base_transfers as (
 		{{ base_transfers }}
 	{% if is_incremental() -%}
 	where
-		{{ incremental_predicate('block_date') }}
+		{{ incremental_predicate('block_time') }}
 	{% elif transfers_start_date is not none and transfers_start_date | trim != '' -%}
 	where
 		block_date >= date '{{ transfers_start_date }}'

--- a/dbt_subprojects/tokens/models/transfers_and_balances/abstract/tokens_abstract_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/abstract/tokens_abstract_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
  }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/apechain/tokens_apechain_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/apechain/tokens_apechain_transfers.sql
@@ -7,7 +7,7 @@
      , incremental_strategy = 'merge'
      , merge_skip_unchanged = true
      , unique_key = ['block_date','unique_key']
-     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/b3/tokens_b3_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/b3/tokens_b3_transfers.sql
@@ -7,7 +7,7 @@
      , incremental_strategy = 'merge'
      , merge_skip_unchanged = true
      , unique_key = ['block_date','unique_key']
-     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/berachain/tokens_berachain_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/berachain/tokens_berachain_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/blast/tokens_blast_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/blast/tokens_blast_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     tags=['static'],
     post_hook='{{ hide_spells() }}'
     )

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bob/tokens_bob_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bob/tokens_bob_transfers.sql
@@ -7,7 +7,7 @@
      , incremental_strategy = 'merge'
      , merge_skip_unchanged = true
      , unique_key = ['block_date','unique_key']
-     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/boba/tokens_boba_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/boba/tokens_boba_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/celo/tokens_celo_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/celo/tokens_celo_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/corn/tokens_corn_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/corn/tokens_corn_transfers.sql
@@ -7,7 +7,7 @@
      , incremental_strategy = 'merge'
      , merge_skip_unchanged = true
      , unique_key = ['block_date','unique_key']
-     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/degen/tokens_degen_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/degen/tokens_degen_transfers.sql
@@ -7,7 +7,7 @@
      , incremental_strategy = 'merge'
      , merge_skip_unchanged = true
      , unique_key = ['block_date','unique_key']
-     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/fantom/tokens_fantom_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/fantom/tokens_fantom_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/flare/tokens_flare_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/flare/tokens_flare_transfers.sql
@@ -7,7 +7,7 @@
     , incremental_strategy = 'merge'
     , merge_skip_unchanged = true
     , unique_key = ['block_date','unique_key']
-    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/flow/tokens_flow_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/flow/tokens_flow_transfers.sql
@@ -7,7 +7,7 @@
     , incremental_strategy = 'merge'
     , merge_skip_unchanged = true
     , unique_key = ['block_date','unique_key']
-    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/gnosis/tokens_gnosis_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/gnosis/tokens_gnosis_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/goerli/tokens_goerli_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/goerli/tokens_goerli_transfers.sql
@@ -8,7 +8,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ hide_spells() }}'
 )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/hemi/tokens_hemi_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/hemi/tokens_hemi_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/henesys/tokens_henesys_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/henesys/tokens_henesys_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/hyperevm/tokens_hyperevm_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/hyperevm/tokens_hyperevm_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ink/tokens_ink_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ink/tokens_ink_transfers.sql
@@ -7,7 +7,7 @@
     , incremental_strategy = 'merge'
     , merge_skip_unchanged = true
     , unique_key = ['block_date','unique_key']
-    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_transfers.sql
@@ -7,7 +7,7 @@
     , incremental_strategy = 'merge'
     , merge_skip_unchanged = true
     , unique_key = ['block_date','unique_key']
-    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/katana/tokens_katana_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/katana/tokens_katana_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/lens/tokens_lens_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/lens/tokens_lens_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/mantle/tokens_mantle_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/mantle/tokens_mantle_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/megaeth/tokens_megaeth_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/megaeth/tokens_megaeth_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/mezo/tokens_mezo_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/mezo/tokens_mezo_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/monad/tokens_monad_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/monad/tokens_monad_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/nova/tokens_nova_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/nova/tokens_nova_transfers.sql
@@ -7,7 +7,7 @@
     , incremental_strategy = 'merge'
     , merge_skip_unchanged = true
     , unique_key = ['block_date','unique_key']
-    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/opbnb/tokens_opbnb_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/opbnb/tokens_opbnb_transfers.sql
@@ -7,7 +7,7 @@
      , incremental_strategy = 'merge'
      , merge_skip_unchanged = true
      , unique_key = ['block_date','unique_key']
-     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/peaq/tokens_peaq_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/peaq/tokens_peaq_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/plasma/tokens_plasma_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/plasma/tokens_plasma_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/plume/tokens_plume_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/plume/tokens_plume_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/rise/tokens_rise_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/rise/tokens_rise_transfers.sql
@@ -7,7 +7,7 @@
     , incremental_strategy = 'merge'
     , merge_skip_unchanged = true
     , unique_key = ['block_date','unique_key']
-    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ronin/tokens_ronin_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ronin/tokens_ronin_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sei/tokens_sei_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sei/tokens_sei_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sepolia/tokens_sepolia_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sepolia/tokens_sepolia_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/shape/tokens_shape_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/shape/tokens_shape_transfers.sql
@@ -7,7 +7,7 @@
      , incremental_strategy = 'merge'
      , merge_skip_unchanged = true
      , unique_key = ['block_date','unique_key']
-     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/somnia/tokens_somnia_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/somnia/tokens_somnia_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sonic/tokens_sonic_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sonic/tokens_sonic_transfers.sql
@@ -7,7 +7,7 @@
     , incremental_strategy = 'merge'
     , merge_skip_unchanged = true
     , unique_key = ['block_date','unique_key']
-    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sophon/tokens_sophon_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sophon/tokens_sophon_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/story/tokens_story_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/story/tokens_story_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_transfers.sql
@@ -7,7 +7,7 @@
     partition_by = ['block_date'],
     incremental_strategy = 'merge',
     unique_key = ['block_date', 'unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     merge_skip_unchanged = true,
     post_hook = '{{ hide_spells() }}',
   )
@@ -28,7 +28,7 @@ base_transfers as (
   from {{ ref('tokens_sui_base_transfers') }} t
   where t.block_date >= date '{{ sui_transfer_start_date }}'
     {% if is_incremental() %}
-    and {{ incremental_predicate('t.block_date') }}
+    and {{ incremental_predicate('t.block_time') }}
     {% endif %}
 ),
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/superseed/tokens_superseed_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/superseed/tokens_superseed_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/tac/tokens_tac_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/tac/tokens_tac_transfers.sql
@@ -7,7 +7,7 @@
      incremental_strategy = 'merge',
      merge_skip_unchanged = true,
      unique_key = ['block_date','unique_key'],
-     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/taiko/tokens_taiko_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/taiko/tokens_taiko_transfers.sql
@@ -7,7 +7,7 @@
      , incremental_strategy = 'merge'
      , merge_skip_unchanged = true
      , unique_key = ['block_date','unique_key']
-     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/tempo/tokens_tempo_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/tempo/tokens_tempo_transfers.sql
@@ -7,7 +7,7 @@
     , incremental_strategy = 'merge'
     , merge_skip_unchanged = true
     , unique_key = ['block_date','unique_key']
-    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/tron/tokens_tron_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/tron/tokens_tron_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}
@@ -22,7 +22,7 @@ WITH base_transfers as (
     WHERE
         1=1
         {% if is_incremental() -%}
-        AND {{ incremental_predicate('block_date') }}
+        AND {{ incremental_predicate('block_time') }}
         {% else -%}
         AND block_date >= date '{{ transfers_start_date }}'
         {% endif -%}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/unichain/tokens_unichain_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/unichain/tokens_unichain_transfers.sql
@@ -7,7 +7,7 @@
      , incremental_strategy = 'merge'
      , merge_skip_unchanged = true
      , unique_key = ['block_date','unique_key']
-     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
      , post_hook='{{ hide_spells() }}'
      )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/viction/tokens_viction_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/viction/tokens_viction_transfers.sql
@@ -7,7 +7,7 @@
     , incremental_strategy = 'merge'
     , merge_skip_unchanged = true
     , unique_key = ['block_date','unique_key']
-    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_transfers.sql
@@ -7,7 +7,7 @@
     , incremental_strategy = 'merge'
     , merge_skip_unchanged = true
     , unique_key = ['block_date','unique_key']
-    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/xlayer/tokens_xlayer_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/xlayer/tokens_xlayer_transfers.sql
@@ -7,7 +7,7 @@
     , incremental_strategy = 'merge'
     , merge_skip_unchanged = true
     , unique_key = ['block_date','unique_key']
-    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/zkevm/tokens_zkevm_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/zkevm/tokens_zkevm_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/zksync/tokens_zksync_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/zksync/tokens_zksync_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/zora/tokens_zora_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/zora/tokens_zora_transfers.sql
@@ -7,7 +7,7 @@
     incremental_strategy = 'merge',
     merge_skip_unchanged = true,
     unique_key = ['block_date','unique_key'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     , post_hook='{{ hide_spells() }}'
     )
 }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description:

Fixes missing ERC20 transfers in `tokens_monad.transfers` (and potentially all other chains) caused by a DATE vs TIMESTAMP type mismatch in incremental predicates.

**Root Cause:**

The `transfers_enrich` macro and all `tokens_*_transfers` model configs used `block_date` (DATE type) in their incremental predicates. The `incremental_predicate()` macro generates:

```sql
column >= date_trunc('<time_unit>', now() - interval '<n>' <time_unit>)
```

When the scheduler runs with hourly granularity (`DBT_ENV_INCREMENTAL_TIME_UNIT=hour`), this produces a non-midnight timestamp (e.g., `2025-10-15 11:00:00`). In Trino, comparing `block_date` (DATE, always midnight `00:00:00`) against this timestamp silently excludes valid rows from the current day — because `2025-10-15 00:00:00 >= 2025-10-15 11:00:00` evaluates to `FALSE`.

This was reported for Monad (664 missing ERC20 transfers across 46 contracts, Jul 8 – Oct 31, 2025, 94% in October), but the same issue affects all chains using the `transfers_enrich` macro.

**Two places the mismatch occurs:**

1. **Source CTE filter** (`transfers_enrich` macro line 26): `{{ incremental_predicate('block_date') }}` — drops source rows from `base_transfers`
2. **Config `incremental_predicates`** (merge window): `DBT_INTERNAL_DEST.block_date` — misaligns the merge scan window

**Changes:**

| File | Change |
|------|--------|
| `macros/transfers/transfers_enrich.sql` | Source CTE filter: `block_date` → `block_time` |
| `macros/transfers/net_transfers.sql` | Source reads filter: `block_date` → `block_time` (4 occurrences) |
| 60 `tokens_*_transfers.sql` model configs | `DBT_INTERNAL_DEST.block_date` → `DBT_INTERNAL_DEST.block_time` |
| `tokens_tron_transfers.sql` | Config + source CTE: `block_date` → `block_time` (inline SQL, not macro) |
| `tokens_sui_transfers.sql` | Config + source CTE: `block_date` → `block_time` (custom implementation) |

All models compile successfully. The upstream `base_transfers` models already correctly use `block_time` in their predicates, so this change aligns the downstream enrichment layer with the upstream.

**Note:** After merge, affected chains should be run with `--full-refresh` to backfill the 664+ missing Monad rows and any gaps on other chains.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CUR2-2046](https://linear.app/dune/issue/CUR2-2046/investigate-missing-erc20-transfers-in-tokens-monad-due-to-transfers)

<div><a href="https://cursor.com/agents/bc-5ac68704-c527-430b-828b-7c27a7ed2ada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ac68704-c527-430b-828b-7c27a7ed2ada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

