### PR TITLE
Skip empty WITH clause in dune_properties to avoid CI syntax errors

### DIFF
--- a/dbt_macros/dune/adapters.sql
+++ b/dbt_macros/dune/adapters.sql
@@ -12,7 +12,7 @@
 
 {# temp fix to get latest dbt-trino version 1.8.3 working in dbt cloud #}
 {% macro dune_properties(properties) %}
-  {%- if properties is not none -%}
+  {%- if properties is not none and properties | length > 0 -%}
       WITH (
           {%- for key, value in properties.items() -%}
             {{ key }} = {{ value }}


### PR DESCRIPTION
After the DWH-421 migration, `create_table_properties` skips setting an explicit `location` when running on the `ci` target with the `dune` catalog. For models without `partition_by`, the properties dict ends up empty, and `dune_properties({})` emitted `WITH ( )` which is a Trino syntax error (`mismatched input ')'`).

Trivial guard: only emit the `WITH` clause when the properties dict has entries.

Towards DWH-421