### PR TITLE
Use ci target in dbt compile and remove no-op change_schema.sh

### DIFF
--- a/.github/workflows/commit_manifest.yml
+++ b/.github/workflows/commit_manifest.yml
@@ -25,9 +25,6 @@ jobs:
       with:
         ref: main
 
-    - name: Add git_sha to schema
-      run: "/runner/change_schema.sh wizard"
-
     - name: Setup variables
       run: |
         echo "GIT_SHA=$(echo ${{ github.sha }} | tr - _ | cut -c1-7)" >> $GITHUB_ENV

--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -37,8 +37,7 @@ jobs:
         run: "./scripts/ensure_cluster.sh"
 
       - name: dbt compile to create manifest to compare to
-        working-directory: ${{env.PROJECT_DIR}}
-        run: "dbt --warn-error compile"
+        run: "dbt --warn-error compile $PROFILE --project-dir ${PROJECT_DIR}"
 
       - name: check schemas
         run: "./scripts/check_schema.sh"


### PR DESCRIPTION
The `dbt compile` step in `dbt_run.yml` wasn't passing `$PROFILE`, so it ran against the runner's default `dev` target (`database=hive, schema=wizard`). With `target.schema == 'wizard'`, `generate_schema_name` returns the model's custom schema as-is (e.g., `kalshi`), and that gets baked into `target/manifest.json`. The subsequent `dbt run $PROFILE --target ci` step reuses that cached manifest, combines the model's `schema=kalshi` with the runtime `database=dune`, and tries `CREATE SCHEMA dune.kalshi` — which the ACL correctly denies because only `dune.dune_spellbook_ci__tmp_.*` is allowed.

The earlier test run hid this because it had zero modified models selected.

Also drops the `/runner/change_schema.sh wizard` step from `commit_manifest.yml` — the baked runner profile already has `dev.schema=wizard`, so this was a no-op sed-replace.

Fixes DWH-421