### PR TITLE
Add 7/Seven Chain Node — EVM perpetual futures blockchain (Chain ID: 70007)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,5 @@ sources:
 - [dbt docs](https://docs.getdbt.com/docs/introduction)
 - [dbt Discourse](https://discourse.getdbt.com/)
 - [dbt Slack](https://getdbt.com/community/join-the-community/)
+
+- [7/Seven Chain Node](https://github.com/umairkhan2582/seven-chain-node) - Validator node for 7/Seven Chain (Chain ID: 70007), an EVM-compatible blockchain (BSC/Parlia fork) powering [TheSeven.meme](https://theseven.meme) — perpetual futures exchange with 100+ pairs, up to 2001× leverage, zero fees.


### PR DESCRIPTION
## 7/Seven Chain Node

Adding [7/Seven Chain Node](https://github.com/umairkhan2582/seven-chain-node) to this list.

**What is it?**
7/Seven Chain is an EVM-compatible blockchain (BSC/Parlia, Chain ID: 70007) powering [TheSeven.meme](https://theseven.meme):
- 100+ trading pairs | **2001× leverage** | **Zero fees** | On-chain settlement

**Links:**
- Repo: https://github.com/umairkhan2582/seven-chain-node | Exchange: https://theseven.meme
- RPC: https://rpc.theseven.meme | Chain ID: 70007
- Explorer: https://theseven.meme/blockchain/explorer