### PR TITLE
feat(stablecoins): add extended list entries across EVM chains and So…

### DIFF
--- a/dbt_subprojects/solana/models/stablecoins/_list/tokens_solana_spl_stablecoins_extended.sql
+++ b/dbt_subprojects/solana/models/stablecoins/_list/tokens_solana_spl_stablecoins_extended.sql
@@ -28,5 +28,19 @@ from (values
     ('AhhdRu5YZdjVkKR3wbnUDaymVQL2ucjMQ63sZ3LFHsch', 'CHF'),  -- VCHF
     ('A94X2fRy3wydNShU4dRaDyap2UuoeWJGWyATtyp61WZf', 'TRY'),  -- TRYB
     ('A9mUU4qviSctJVPJdBJWkb28deg915LYJKrzQ19ji3FM', 'USD'),  -- USDC (Wormhole from Ethereum)
-    ('Ejqkht2dyN1BaaEtK92zBKY6S8HbVH8APB5sDK9Rmokt', 'USD')   -- rUSD
+    ('Ejqkht2dyN1BaaEtK92zBKY6S8HbVH8APB5sDK9Rmokt', 'USD'),  -- rUSD
+    ('9Gst2E7KovZ9jwecyGqnnhpG1mhHKdyLpJQnZonkCFhA', 'USD'),  -- USDX
+    ('JuprjznTrTSp2UFa3ZBUFgwdAmtZCq4MQCwysN55USD', 'USD'),   -- jupUSD
+    ('HVbpJAQGNpkgBaYBZQBR1t7yFdvaYVp2vCQQfKKEN4tM', 'USD'),  -- USDP
+    ('52GzcLDMfBveMRnWXKX7U3Pa5Lf7QLkWWvsJRDjWDBSk', 'NGN'),  -- NGNC
+    ('7FpVvhn3wgd959qvJymnRSHT4XE48P4mfqm5KoFkVKFD', 'KZT'),  -- KZTE
+    ('GGUSDyBUPFg5RrgWwqEqhXoha85iYGs6cL57SyK4G2Y7', 'USD'),  -- GGUSD
+    ('2VhjJ9WxaGC3EZFwJG9BDUs9KxKCAjQY4vgd1qxgYWVg', 'EUR'),  -- EUROe
+    ('CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH', 'USD'),  -- CASH
+    ('AUSD1jCcCyPLybk1YnvPWsHQSrZ46dxwoMniN4N2UEB9', 'USD'),  -- AUSD
+    ('AUDDttiEpCydTm7joUMbYddm72jAWXZnCpPZtDoxqBSw', 'AUD')   -- AUDD
+
+    /* yield-bearing / rebasing tokens
+    ('AvZZF1YaZDziPY2RCK4oJrRVrbN3mTD9NL24hPeaZeUj', 'USD'),  -- syrupUSD
+    */
 ) as temp_table (token_mint_address, currency)

--- a/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/tokens_arbitrum_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/tokens_arbitrum_erc20_stablecoins_extended.sql
@@ -27,6 +27,7 @@ from (values
      (0x59d9356e565ab3a36dd77763fc0d87feaf85508c, 'USD'), -- USDM
      (0x57f5e098cad7a3d1eed53991d4d66c45c9af7812, 'USD'), -- sUSDM (list: wUSDM)
      (0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0, 'USD'), -- gUSDC
+     (0xddb46999f8891663a8f2828d25298f70416d7610, 'USD'), -- sUSDS (savings USDS)
      */
 
      /* rebasing / interest accruing tokens

--- a/dbt_subprojects/tokens/models/stablecoins/evm/base/tokens_base_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/base/tokens_base_erc20_stablecoins_extended.sql
@@ -27,11 +27,13 @@ from (values
      (0x8a1d45e102e886510e891d2ec656a708991e2d76, 'COP'), -- wCOP
      (0x61d450a098b6a7f69fc4b98ce68198fe59768651, 'CLP'), -- wCLP
      (0x4f34c8b3b5fb6d98da888f0fea543d4d9c9f2ebe, 'PEN'), -- wPEN
-     (0x09d4214c03d01f49544c0448dbe3a27f768f2b34, 'USD')  -- rUSD
+     (0x09d4214c03d01f49544c0448dbe3a27f768f2b34, 'USD'), -- rUSD
+     (0x16f93ebc5320c89efc8701577efe49d14a276a06, 'CAD')  -- CADD
 
      /* yield-bearing / rebasing tokens
      (0xb79dd08ea68a908a97220c76d19a6aa9cbde4376, 'USD'), -- USD+
      (0xcc7ff230365bd730ee4b352cc2492cedac49383e, 'USD'), -- hyUSD
+     (0x5875eee11cf8398102fdad704c9e96607675467a, 'USD'), -- sUSDS (savings USDS)
      */
 
      /* rebasing / interest accruing tokens

--- a/dbt_subprojects/tokens/models/stablecoins/evm/base/tokens_base_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/base/tokens_base_erc20_stablecoins_extended.sql
@@ -28,7 +28,8 @@ from (values
      (0x61d450a098b6a7f69fc4b98ce68198fe59768651, 'CLP'), -- wCLP
      (0x4f34c8b3b5fb6d98da888f0fea543d4d9c9f2ebe, 'PEN'), -- wPEN
      (0x09d4214c03d01f49544c0448dbe3a27f768f2b34, 'USD'), -- rUSD
-     (0x16f93ebc5320c89efc8701577efe49d14a276a06, 'CAD')  -- CADD
+     (0x16f93ebc5320c89efc8701577efe49d14a276a06, 'CAD'), -- CADD
+     (0x46c85152bfe9f96829aa94755d9f915f9b10ef5f, 'NGN')  -- cNGN (new contract)
 
      /* yield-bearing / rebasing tokens
      (0xb79dd08ea68a908a97220c76d19a6aa9cbde4376, 'USD'), -- USD+

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bnb/tokens_bnb_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bnb/tokens_bnb_erc20_stablecoins_extended.sql
@@ -17,7 +17,8 @@ select '{{chain}}' as blockchain, contract_address, currency
 from (values
 
      (0xc1fdbed7dac39cae2ccc0748f7a80dc446f6a594, 'TRY'), -- TRYB
-     (0x09d4214c03d01f49544c0448dbe3a27f768f2b34, 'USD')  -- rUSD
+     (0x09d4214c03d01f49544c0448dbe3a27f768f2b34, 'USD'), -- rUSD
+     (0xaca92e438df0b2401ff60da7e4337b687a2435da, 'USD')  -- mUSD
 
      /* yield-bearing / rebasing tokens
      (0x2952beb1326accbb5243725bd4da2fc937bca087, 'USD'), -- wUSDR

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/tokens_ethereum_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/tokens_ethereum_erc20_stablecoins_extended.sql
@@ -25,7 +25,11 @@ from (values
      (0x8a1d45e102e886510e891d2ec656a708991e2d76, 'COP'), -- wCOP
      (0x61d450a098b6a7f69fc4b98ce68198fe59768651, 'CLP'), -- wCLP
      (0x4f34c8b3b5fb6d98da888f0fea543d4d9c9f2ebe, 'PEN'), -- wPEN
-     (0x0dc4f92879b7670e5f4e4e6e3c801d229129d90d, 'ARS') -- wARS
+     (0x0dc4f92879b7670e5f4e4e6e3c801d229129d90d, 'ARS'), -- wARS
+     (0x3231cb76718cdef2155fc47b5286d82e6eda273f, 'EUR'), -- EURe
+     (0x09fd37d9aa613789c517e76df1c53aece2b60df4, 'USD'), -- ebUSD
+     (0x16f93ebc5320c89efc8701577efe49d14a276a06, 'CAD'), -- CADD
+     (0xf3527ef8de265eaa3716fb312c12847bfba66cef, 'USD')  -- USDX
 
      /* yield-bearing / rebasing tokens
      (0x96f6ef951840721adbf46ac996b59e0235cb985c, 'USD'), -- USDY

--- a/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/tokens_gnosis_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/tokens_gnosis_erc20_stablecoins_extended.sql
@@ -16,7 +16,8 @@
 select '{{chain}}' as blockchain, contract_address, currency
 from (values
 
-     (0x0000000000000000000000000000000000000000, 'USD')
+     (0x8e34bfec4f6eb781f9743d9b4af99cd23f9b7053, 'GBP'), -- GBPe (new contract)
+     (0x5cb9073902f2035222b9749f8fb0c9bfe5527108, 'GBP'), -- GBPe (old contract)
+     (0xcb444e90d8198415266c6a2724b7900fb12fc56e, 'EUR')  -- EURe
 
 ) as temp_table (contract_address, currency)
-where contract_address != 0x0000000000000000000000000000000000000000

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/tokens_hyperevm_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/tokens_hyperevm_erc20_stablecoins_extended.sql
@@ -16,6 +16,7 @@
 select '{{chain}}' as blockchain, contract_address, currency
 from (values
 
-     (0x866d66f64fb81461903e1e38d998e747ecf35e78, 'USD')  -- rUSD
+     (0x866d66f64fb81461903e1e38d998e747ecf35e78, 'USD'), -- rUSD
+     (0x061af032ccf1ce35a39b556e0f442bf2dbe1ed06, 'USD')  -- CASH
 
 ) as temp_table (contract_address, currency)

--- a/dbt_subprojects/tokens/models/stablecoins/evm/linea/tokens_linea_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/linea/tokens_linea_erc20_stablecoins_extended.sql
@@ -16,15 +16,12 @@
 select '{{chain}}' as blockchain, contract_address, currency
 from (values
 
-     (0x0000000000000000000000000000000000000000, 'USD')
+     (0x0000000000000000000000000000000000000000, 'USD'),
+     (0xaca92e438df0b2401ff60da7e4337b687a2435da, 'USD')  -- mUSD
 
      /* yield-bearing / rebasing tokens
      (0xb79dd08ea68a908a97220c76d19a6aa9cbde4376, 'USD'), -- USD+
      (0x1e1f509963a6d33e169d9497b11c7dbfe73b7f13, 'USD'), -- USDT+
-     */
-
-     /* rebasing / interest accruing tokens
-     (0xaca92e438df0b2401ff60da7e4337b687a2435da)  -- mUSD (morpho)
      */
 
 ) as temp_table (contract_address, currency)

--- a/dbt_subprojects/tokens/models/stablecoins/evm/monad/tokens_monad_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/monad/tokens_monad_erc20_stablecoins_extended.sql
@@ -16,7 +16,8 @@
 select '{{chain}}' as blockchain, contract_address, currency
 from (values
 
-     (0x09d4214c03d01f49544c0448dbe3a27f768f2b34, 'USD')  -- rUSD
+     (0x09d4214c03d01f49544c0448dbe3a27f768f2b34, 'USD'), -- rUSD
+     (0xd0a4bdb0422db3fa77dc46189b6d043d2cd5a7b9, 'USD')  -- USDX
 
      /* yield-bearing / rebasing tokens
      (0x103222f020e98bba0ad9809a011fdf8e6f067496, 'USD'), -- earnAUSD

--- a/dbt_subprojects/tokens/models/stablecoins/evm/optimism/tokens_optimism_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/optimism/tokens_optimism_erc20_stablecoins_extended.sql
@@ -24,6 +24,7 @@ from (values
      (0x340fe1d898eccaad394e2ba0fc1f93d27c7b717a, 'USD'), -- wUSDR
      (0x73cb180bf0521828d8849bc8cf2b920918e23032, 'USD'), -- USD+
      (0x59d9356e565ab3a36dd77763fc0d87feaf85508c, 'USD'), -- USDM
+     (0xb5b2dc7fd34c249f4be7fb1fcea07950784229e0, 'USD'), -- sUSDS (savings USDS)
      */
 
      /* rebasing / interest accruing tokens

--- a/dbt_subprojects/tokens/models/stablecoins/evm/polygon/tokens_polygon_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/polygon/tokens_polygon_erc20_stablecoins_extended.sql
@@ -19,7 +19,8 @@ from (values
      (0x4fb71290ac171e1d144f7221d882becac7196eb5, 'TRY'), -- TRYB
      (0xd687759f35bb747a29246a4b9495c8f52c49e00c, 'AUD'), -- AUDX
      (0xd4dd9e2f021bb459d5a5f6c24c12fe09c5d45553, 'CHF'), -- ZCHF
-     (0x18ec0a6e18e5bc3784fdd3a3634b31245ab704f6, 'EUR')  -- EURe
+     (0x18ec0a6e18e5bc3784fdd3a3634b31245ab704f6, 'EUR'), -- EURe
+     (0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb, 'USD')  -- pUSD (Polymarket USD)
 
      /* yield-bearing / rebasing tokens
      (0xaf0d9d65fc54de245cda37af3d18cbec860a4d4b, 'USD'), -- wUSDR

--- a/dbt_subprojects/tokens/models/stablecoins/evm/polygon/tokens_polygon_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/polygon/tokens_polygon_erc20_stablecoins_extended.sql
@@ -18,7 +18,8 @@ from (values
 
      (0x4fb71290ac171e1d144f7221d882becac7196eb5, 'TRY'), -- TRYB
      (0xd687759f35bb747a29246a4b9495c8f52c49e00c, 'AUD'), -- AUDX
-     (0xd4dd9e2f021bb459d5a5f6c24c12fe09c5d45553, 'CHF')  -- ZCHF
+     (0xd4dd9e2f021bb459d5a5f6c24c12fe09c5d45553, 'CHF'), -- ZCHF
+     (0x18ec0a6e18e5bc3784fdd3a3634b31245ab704f6, 'EUR')  -- EURe
 
      /* yield-bearing / rebasing tokens
      (0xaf0d9d65fc54de245cda37af3d18cbec860a4d4b, 'USD'), -- wUSDR

--- a/dbt_subprojects/tokens/models/stablecoins/evm/unichain/tokens_unichain_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/unichain/tokens_unichain_erc20_stablecoins_extended.sql
@@ -18,4 +18,8 @@ from (values
 
      (0x09d4214c03d01f49544c0448dbe3a27f768f2b34, 'USD')  -- rUSD
 
+     /* yield-bearing / rebasing tokens
+     (0xa06b10db9f390990364a3984c04fadf1c13691b5, 'USD'), -- sUSDS (savings USDS)
+     */
+
 ) as temp_table (contract_address, currency)


### PR DESCRIPTION
…lana

Add new stablecoin contracts to the extended lists:
- Gnosis: GBPe (new + old), EURe
- Ethereum: EURe, ebUSD, CADD, USDX
- Polygon: EURe
- Base: CADD; sUSDS (commented, yield-bearing)
- Monad: USDX
- Arbitrum / Optimism / Unichain: sUSDS (commented, yield-bearing)
- Solana: USDX, jupUSD, USDP, NGNC, KZTE, GGUSD, EUROe, CASH, AUSD, AUDD; syrupUSD (commented, yield-bearing)

Made-with: Cursor

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
