### PR TITLE
feat: deploy lock guardrail

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,3 +17,9 @@
 "dbt: tokens":
 - changed-files:
     - any-glob-to-any-file: 'dbt_subprojects/tokens/**'
+
+"dbt: shared":
+- changed-files:
+    - any-glob-to-any-file:
+        - 'sources/**'
+        - 'dbt_macros/**'

--- a/.github/scripts/deploy_lock_status.sh
+++ b/.github/scripts/deploy_lock_status.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Post the deploy-lock commit status for one PR.
+# Usage: deploy_lock_status.sh <pr_number>
+set -euo pipefail
+
+PR="${1:?pr number required}"
+STATE_LABEL="${STATE_LABEL:-deploy-lock-state}"
+BYPASS_LABEL="${BYPASS_LABEL:-hotfix}"
+CONTEXT="deploy-lock"
+
+pr_json=$(gh pr view "$PR" --json headRefOid,labels,url)
+sha=$(jq -r '.headRefOid' <<<"$pr_json")
+url=$(jq -r '.url' <<<"$pr_json")
+labels=$(jq -r '.labels[].name' <<<"$pr_json")
+
+if [ -n "${STATE_JSON:-}" ]; then
+  state="$STATE_JSON"
+else
+  state_num=$(gh issue list --label "$STATE_LABEL" --state open --json number --jq '.[0].number // empty')
+  if [ -z "$state_num" ]; then
+    state='{"locked":false}'
+  else
+    state=$(gh issue view "$state_num" --json body --jq '.body')
+  fi
+fi
+
+locked=$(jq -r '.locked // false' <<<"$state" 2>/dev/null || echo false)
+
+if [ "$locked" = 'true' ]; then
+  expires=$(jq -r '.expires_at // empty' <<<"$state")
+  if [ -n "$expires" ]; then
+    now_ts=$(date -u +%s)
+    exp_ts=$(python3 -c "import datetime,sys; print(int(datetime.datetime.strptime(sys.argv[1],'%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=datetime.timezone.utc).timestamp()))" "$expires")
+    if [ "$now_ts" -ge "$exp_ts" ]; then
+      locked=false
+    fi
+  fi
+fi
+
+post_status() {
+  local st="$1" desc="$2"
+  desc="${desc:0:140}"
+  gh api "repos/${GH_REPO}/statuses/${sha}" \
+    -f "state=${st}" \
+    -f "context=${CONTEXT}" \
+    -f "description=${desc}" \
+    -f "target_url=${url}" >/dev/null
+}
+
+if [ "$locked" != 'true' ]; then
+  post_status success 'No active deploy lock'
+  exit 0
+fi
+
+if grep -qx "$BYPASS_LABEL" <<<"$labels"; then
+  post_status success "hotfix label: bypassing lock"
+  exit 0
+fi
+
+scope=$(jq -r '.scope' <<<"$state")
+reason=$(jq -r '.reason // ""' <<<"$state")
+
+in_scope=false
+if [ "$scope" = 'all' ]; then
+  in_scope=true
+elif grep -qx "dbt: $scope" <<<"$labels"; then
+  in_scope=true
+fi
+
+if [ "$in_scope" = 'true' ]; then
+  post_status pending "Locked ($scope): $reason"
+else
+  post_status success "Lock active ($scope), PR not in scope"
+fi

--- a/.github/workflows/deploy_lock.yml
+++ b/.github/workflows/deploy_lock.yml
@@ -1,0 +1,108 @@
+name: Deploy Lock
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: lock or unlock
+        required: true
+        type: choice
+        options:
+          - lock
+          - unlock
+      scope:
+        description: Scope to lock (ignored on unlock)
+        required: false
+        type: choice
+        options:
+          - all
+          - dex
+          - daily
+          - hourly
+          - solana
+          - tokens
+          - shared
+        default: all
+      reason:
+        description: Why are you locking?
+        required: false
+        type: string
+        default: ''
+      ttl_hours:
+        description: Auto-release after N hours
+        required: false
+        type: number
+        default: 4
+
+permissions:
+  issues: write
+  pull-requests: read
+  statuses: write
+  contents: read
+
+concurrency:
+  group: deploy-lock
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      STATE_LABEL: deploy-lock-state
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Find or create state issue
+        id: state
+        run: |
+          num=$(gh issue list --label "$STATE_LABEL" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$num" ]; then
+            url=$(gh issue create \
+              --title 'Deploy Lock: unlocked' \
+              --label "$STATE_LABEL" \
+              --body '{"locked":false}')
+            num="${url##*/}"
+          fi
+          echo "num=$num" >> "$GITHUB_OUTPUT"
+
+      - name: Write new state
+        run: |
+          if [ "${{ inputs.action }}" = 'lock' ]; then
+            ttl=${{ inputs.ttl_hours }}
+            now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            expires=$(python3 -c "import datetime; print((datetime.datetime.utcnow() + datetime.timedelta(hours=${ttl})).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+            jq -n \
+              --arg scope "${{ inputs.scope }}" \
+              --arg reason "${{ inputs.reason }}" \
+              --arg owner "${{ github.actor }}" \
+              --arg now "$now" \
+              --arg expires "$expires" \
+              '{locked:true, scope:$scope, reason:$reason, owner:$owner, created_at:$now, expires_at:$expires}' > /tmp/state.json
+            title="Deploy Lock: LOCKED (scope=${{ inputs.scope }}, expires $expires)"
+          else
+            echo '{"locked":false}' > /tmp/state.json
+            title='Deploy Lock: unlocked'
+          fi
+          gh issue edit "${{ steps.state.outputs.num }}" --title "$title" --body-file /tmp/state.json
+
+      - name: Slack notify
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: env.SLACK_WEBHOOK_URL != ''
+        run: |
+          if [ "${{ inputs.action }}" = 'lock' ]; then
+            text=":lock: Deploy lock ACTIVE by ${{ github.actor }}. Scope: \`${{ inputs.scope }}\`. Expires in ${{ inputs.ttl_hours }}h. Reason: ${{ inputs.reason }}. PRs labeled \`hotfix\` still mergeable."
+          else
+            text=":unlock: Deploy lock RELEASED by ${{ github.actor }}."
+          fi
+          jq -n --arg t "$text" '{text:$t}' | curl -sS -X POST -H 'content-type: application/json' --data @- "$SLACK_WEBHOOK_URL"
+
+      - name: Refresh statuses on open PRs
+        run: |
+          STATE_JSON="$(cat /tmp/state.json)"
+          export STATE_JSON
+          for pr in $(gh pr list --state open --json number --jq '.[].number'); do
+            ./.github/scripts/deploy_lock_status.sh "$pr" || echo "status refresh failed for PR #$pr"
+          done

--- a/.github/workflows/deploy_lock_check.yml
+++ b/.github/workflows/deploy_lock_check.yml
@@ -1,0 +1,27 @@
+name: Deploy Lock Check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  issues: read
+  pull-requests: read
+  statuses: write
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Post deploy-lock status
+        run: ./.github/scripts/deploy_lock_status.sh "${{ github.event.pull_request.number }}"

--- a/.github/workflows/deploy_lock_expiry.yml
+++ b/.github/workflows/deploy_lock_expiry.yml
@@ -1,0 +1,59 @@
+name: Deploy Lock Expiry
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: read
+  statuses: write
+  contents: read
+
+jobs:
+  expire:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      STATE_LABEL: deploy-lock-state
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Release expired lock
+        id: release
+        run: |
+          echo "released=false" >> "$GITHUB_OUTPUT"
+          num=$(gh issue list --label "$STATE_LABEL" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$num" ]; then exit 0; fi
+          body=$(gh issue view "$num" --json body --jq '.body')
+          locked=$(jq -r '.locked // false' <<<"$body" 2>/dev/null || echo false)
+          if [ "$locked" != 'true' ]; then exit 0; fi
+          expires=$(jq -r '.expires_at // empty' <<<"$body")
+          if [ -z "$expires" ]; then exit 0; fi
+          now_ts=$(date -u +%s)
+          exp_ts=$(python3 -c "import datetime,sys; print(int(datetime.datetime.strptime(sys.argv[1],'%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=datetime.timezone.utc).timestamp()))" "$expires")
+          if [ "$now_ts" -lt "$exp_ts" ]; then
+            echo "Not yet expired ($expires)"; exit 0
+          fi
+          scope=$(jq -r '.scope' <<<"$body")
+          gh issue edit "$num" --title 'Deploy Lock: unlocked (auto-released)' --body '{"locked":false}'
+          echo "released=true" >> "$GITHUB_OUTPUT"
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
+
+      - name: Refresh statuses on open PRs
+        if: steps.release.outputs.released == 'true'
+        run: |
+          export STATE_JSON='{"locked":false}'
+          for pr in $(gh pr list --state open --json number --jq '.[].number'); do
+            ./.github/scripts/deploy_lock_status.sh "$pr" || echo "status refresh failed for PR #$pr"
+          done
+
+      - name: Slack notify auto-release
+        if: steps.release.outputs.released == 'true' && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          text=":hourglass: Deploy lock auto-released (scope \`${{ steps.release.outputs.scope }}\`, TTL expired)."
+          jq -n --arg t "$text" '{text:$t}' | curl -sS -X POST -H 'content-type: application/json' --data @- "$SLACK_WEBHOOK_URL"

--- a/docs/deploy_lock.md
+++ b/docs/deploy_lock.md
@@ -1,0 +1,49 @@
+# Deploy lock
+
+Manual guardrail for holding merges while someone debugs a prod issue. Not automated. Only works if people use it.
+
+## When to use it
+
+You're fixing a broken model or running a backfill and want a quiet window on `main` for a scope you care about. Lock the scope, fix, unlock. If you forget, the lock auto-releases after its TTL.
+
+## Lock
+
+1. Actions tab, pick **Deploy Lock**, run workflow.
+2. Inputs:
+   - `action`: `lock`
+   - `scope`: one of `all`, `dex`, `daily`, `hourly`, `solana`, `tokens`, `shared`
+   - `reason`: what you're doing. Shows in the PR check, Slack, and the pinned state issue.
+   - `ttl_hours`: auto-release after N hours (default 4)
+3. Confirm. The workflow updates the pinned Deploy Lock issue, posts to Slack, and refreshes `deploy-lock` on every open PR so stale statuses don't linger.
+
+In-scope PRs show `deploy-lock` as pending. Merge button greys out.
+
+## Unlock
+
+Same workflow, `action: unlock`. Or do nothing. A cron releases expired locks every 15 minutes.
+
+## Hotfix bypass
+
+Add the `hotfix` label to the PR. `deploy-lock` flips to success and the PR is mergeable. Remove the label to re-block.
+
+Use this when you're the lock holder fixing forward.
+
+## Scope semantics
+
+- `all` blocks every non-hotfix PR.
+- Any other scope blocks PRs carrying the matching `dbt: <scope>` label (applied by the labeler based on changed paths). PRs outside that scope merge normally.
+- `shared` covers `sources/**` and `dbt_macros/**`.
+
+## State
+
+Source of truth is a pinned GitHub issue labeled `deploy-lock-state`. Body is a JSON blob:
+
+```json
+{"locked": true, "scope": "dex", "reason": "fixing microbatch gap", "owner": "someone", "created_at": "...", "expires_at": "..."}
+```
+
+One lock at a time. Relocking overwrites.
+
+## Admin bypass
+
+Repo admins can bypass branch protection as usual. Use sparingly. The guardrail only works if people respect it.


### PR DESCRIPTION
## Summary

Manual guardrail to hold merges to main while someone debugs a prod issue. Lock a scope, fix, unlock. Auto-releases after the TTL.

## Files

- .github/workflows/deploy_lock.yml: lock/unlock via workflow_dispatch
- .github/workflows/deploy_lock_check.yml: posts deploy-lock status on PR events
- .github/workflows/deploy_lock_expiry.yml: cron every 15 min, auto-release
- .github/scripts/deploy_lock_status.sh: shared status logic
- .github/labeler.yml: adds dbt: shared for sources/ and dbt_macros/
- docs/deploy_lock.md: usage

## One-time setup

- Add deploy-lock to required status checks in branch protection
- Create the hotfix PR label
- Add SLACK_WEBHOOK_URL secret (optional, step no-ops if absent)

## Verification

Tested in a private sandbox mirroring spellbook's labeler and directory layout.

| # | Case | Observed |
|---|---|---|
| 1 | No lock, in-scope PR | success |
| 2 | Lock dex, in-scope PR | pending |
| 3 | Lock dex, out-of-scope PR | success |
| 4 | hotfix under active lock | success (bypass) |
| 5 | Remove hotfix | pending |
| 6 | Lock all, any PR | pending |
| 7 | Unlock | all refreshed to success |
| 8 | TTL expiry | auto-released, refreshed |
| 9 | Merge API while locked | HTTP 405, "Required status check 'deploy-lock' is pending" |
| 10 | Merge API after unlock | succeeds |

## Post-merge

- [ ] Run one-time setup above
- [ ] Test lock on dex, confirm state issue + in-scope PRs flip to pending
- [ ] hotfix bypass
- [ ] Unlock refresh