### PR TITLE
fix(kalshi,polymarket): OHLCV hourly data quality fixes

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/kalshi/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_projects/kalshi/_schema.yml
@@ -268,7 +268,7 @@ models:
       - name: market_end_time
         description: "Market expiration time"
       - name: market_outcome
-        description: "Settled outcome of the market (yes/no/empty if unresolved)"
+        description: "Settled outcome of the market (yes/no/scalar/unresolved)"
       - name: event_market_name
         description: "Parent event title (event_title), falling back to market title — aligns with polymarket_polygon_ohlcv_hourly.event_market_name"
       - name: is_forward_filled

--- a/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_ohlcv_hourly.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_ohlcv_hourly.sql
@@ -157,7 +157,7 @@ with_settlement as (
 		f.trade_count,
 		m.category,
 		m.expiration_time as market_end_time,
-		m.result as market_outcome,
+		case when m.result = '' then 'unresolved' else m.result end as market_outcome,
 		coalesce(m.event_title, m.title) as event_market_name,
 		f.is_forward_filled,
 		case
@@ -214,6 +214,12 @@ select
 	r.is_forward_filled,
 	now() as _updated_at
 from with_resolution as r
+where not (
+	r.is_forward_filled
+	and r.market_end_time is not null
+	and r.hour > r.market_end_time
+	and r.market_outcome in ('yes', 'no')
+)
 {% if is_incremental() -%}
-where {{ incremental_predicate('r.hour') }}
+  and {{ incremental_predicate('r.hour') }}
 {%- endif %}

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/_schema.yml
@@ -487,7 +487,7 @@ models:
       - name: trade_count
         description: "Number of trades in the hour. Zero for forward-filled hours."
       - name: market_end_time
-        description: "Market end time from market details (raw varchar, ISO 8601)"
+        description: "Market end time from market details (timestamp, parsed from ISO 8601)"
       - name: market_outcome
         description: "Resolved outcome of the market (yes/no/null if unresolved)"
       - name: event_market_name

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
@@ -33,6 +33,7 @@ with base as (
         )                                       as rn_last
     from {{ ref('polymarket_polygon_market_trades') }}
     where token_outcome is not null
+      and price between 0 and 1  -- drop upstream bad-price trades (MINT/MERGE artefacts)
     {% if is_incremental() -%}
       and {{ incremental_predicate('block_time') }}
     {%- endif %}
@@ -172,13 +173,13 @@ with_settlement as (
         f.volume_usd,
         f.trade_count,
         m.category,
-        m.market_end_time,
+        m.market_end_time_ts                                                    as market_end_time,
         m.market_outcome,
         f.is_forward_filled,
         case
             when m.market_end_time_ts is not null
                  and f.hour > m.market_end_time_ts
-                 and m.market_outcome is not null
+                 and m.market_outcome in ('yes', 'no')
             then
                 case
                     when f.token_outcome = 'Yes' and m.market_outcome = 'yes' then 1.0
@@ -236,6 +237,12 @@ select
     r.is_forward_filled,
     now()                                                                       as _updated_at
 from with_resolution r
+where not (
+    r.is_forward_filled
+    and r.market_end_time is not null
+    and r.hour > r.market_end_time
+    and r.market_outcome in ('yes', 'no')
+)
 {% if is_incremental() -%}
-where {{ incremental_predicate('r.hour') }}
+  and {{ incremental_predicate('r.hour') }}
 {%- endif %}


### PR DESCRIPTION
## Summary
- Filter out 23 upstream bad-price trades (`price > 1`) in Polymarket `base` CTE — caused by MINT/MERGE artefacts (worst: `high = 7,812`)
- Cast Polymarket `market_end_time` from `varchar` to `timestamp` to match Kalshi's type
- Normalize Kalshi `market_outcome` from empty string `""` to `'unresolved'` for cross-table consistency with Polymarket
- Stop forward-filling past resolved market expiry in both tables (drops ~479 unnecessary FF rows in Kalshi)
- Tighten Polymarket settlement logic from `market_outcome is not null` to `market_outcome in ('yes', 'no')` — prevents applying terminal pricing to `'50/50'` or `'unresolved'` outcomes

## Test plan
- [ ] CI passes on both models
- [ ] Verify Polymarket `market_end_time` column type is now `timestamp` (requires `--full-refresh`)
- [ ] Verify no rows with `high > 1` in Polymarket after rebuild
- [ ] Verify Kalshi `market_outcome` has no empty strings, uses `'unresolved'` instead
- [ ] Verify no forward-filled rows past `market_end_time` for resolved markets in either table

🤖 Generated with [Claude Code](https://claude.com/claude-code)