### PR TITLE
solana stablecoins: split non-circulating helper tables

### DIFF
--- a/dbt_subprojects/solana/models/stablecoins/balances/_schema.yml
+++ b/dbt_subprojects/solana/models/stablecoins/balances/_schema.yml
@@ -205,6 +205,43 @@ models:
       - name: observed_owners
         description: "Observed owner addresses for the inventory token account (historical)"
 
+  - name: stablecoins_solana_core_non_circulating_inventory_accounts
+    meta:
+      blockchain: solana
+      sector: stablecoins
+      contributors: tomfutago
+    config:
+      tags: ['stablecoin', 'balances']
+    description: >
+      Solana SPL stablecoin inventory token accounts used as a helper list for core circulating balance exclusions,
+      with source classification and observed owners derived from stablecoin transfers.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - token_mint_address
+            - token_account
+    columns:
+      - *blockchain
+      - <<: *token_mint_address
+        data_tests:
+          - not_null
+      - name: token_account
+        description: "SPL token account tracked in the non-circulating inventory helper list"
+        data_tests:
+          - not_null
+      - name: source_class
+        description: "Classification of the inventory token account source (official Circle premint or legacy inventory)"
+        data_tests:
+          - not_null
+          - accepted_values:
+              values: ['official_circle_premint', 'legacy_inventory']
+      - name: excluded
+        description: "Whether this token account is excluded from circulating balance computations"
+        data_tests:
+          - not_null
+      - name: observed_owners
+        description: "Observed owner addresses for the inventory token account (historical)"
+
   - name: stablecoins_solana_extended_non_circulating_inventory_accounts
     meta:
       blockchain: solana

--- a/dbt_subprojects/solana/models/stablecoins/balances/_schema.yml
+++ b/dbt_subprojects/solana/models/stablecoins/balances/_schema.yml
@@ -204,3 +204,40 @@ models:
           - not_null
       - name: observed_owners
         description: "Observed owner addresses for the inventory token account (historical)"
+
+  - name: stablecoins_solana_extended_non_circulating_inventory_accounts
+    meta:
+      blockchain: solana
+      sector: stablecoins
+      contributors: tomfutago
+    config:
+      tags: ['stablecoin', 'balances']
+    description: >
+      Solana SPL stablecoin inventory token accounts used as a helper list for extended circulating balance exclusions,
+      with source classification and observed owners derived from extended stablecoin transfers.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - token_mint_address
+            - token_account
+    columns:
+      - *blockchain
+      - <<: *token_mint_address
+        data_tests:
+          - not_null
+      - name: token_account
+        description: "SPL token account tracked in the non-circulating inventory helper list"
+        data_tests:
+          - not_null
+      - name: source_class
+        description: "Classification of the inventory token account source (official Circle premint or legacy inventory)"
+        data_tests:
+          - not_null
+          - accepted_values:
+              values: ['official_circle_premint', 'legacy_inventory']
+      - name: excluded
+        description: "Whether this token account is excluded from circulating balance computations"
+        data_tests:
+          - not_null
+      - name: observed_owners
+        description: "Observed owner addresses for the inventory token account (historical)"

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_core_non_circulating_inventory_accounts.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_core_non_circulating_inventory_accounts.sql
@@ -1,0 +1,88 @@
+{% set chain = 'solana' %}
+{% set owners_observation_start_date = '2020-10-01' %}
+
+{{
+  config(
+    schema = 'stablecoins_' ~ chain,
+    alias = 'core_non_circulating_inventory_accounts',
+    materialized = 'table',
+    file_format = 'delta',
+    tags = ['static'],
+    unique_key = ['token_mint_address', 'token_account']
+  )
+}}
+
+-- non-circulating inventory token accounts for spl stablecoins on solana core lineage
+-- approach:
+-- 1) curate known non-circulating token accounts inline via values() (not dbt seed-backed)
+-- 2) derive observed owners from stablecoin transfer history via from/to token-account matches
+-- this keeps exclusions generic in runtime logic (no stale-age/threshold heuristics)
+-- source: https://github.com/solana-labs/token-list/blob/main/src/tokens/solana.tokenlist.json
+-- ref: https://www.circle.com/blog/gateway-new-pre-mint-address-for-usdc-on-solana
+
+with token_accounts as (
+  select token_mint_address, token_account, source_class
+  from (
+    values
+      -- usdc mint
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '27T5c11dNMXjcRuko9CeUy3Wq41nFdH3tz9Qt4REzZMM', 'official_circle_premint'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '28VqfqsUUBx59i8ruG2TuC5RekW5ZY3tsK4bSV59sXjn', 'official_circle_premint'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa', 'official_circle_premint'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'FSxJ85FXVsXSr51SeWf9ciJWTcRnqKFSmBgRDeL3KyWw', 'official_circle_premint'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '6xTBTqJMBr5m7BKqVxmW2x11DfqUwtD3TJsqpxELx72L', 'official_circle_premint'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'CkzX3bvAt9PcjCh2QoQdM9ENzUVwH229hFe4dB7Y8qZK', 'official_circle_premint'),
+      -- legacy usdc non-circulating inventory token accounts
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'fMx1JWj55yTMv4CFLm5ZRWjo16TnbsQDsVuCbkBDnYe', 'legacy_inventory'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '5nGMuvwbZdZZtXQdGhCnGfu6oCDmikXi3yChmdb4GBrV', 'legacy_inventory'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '5tFhdTCzTYMvfVTZnczZEL36YjFnkDTSaoQ7XAZvS7LR', 'legacy_inventory'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'FYAFDcQsZCgJJdj5YJNLPsWazYyqDTWmgyX7hFk4mM95', 'legacy_inventory'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'fBQG6bx8SFgAVcS3vtr3rJDFKHnVcKw4CpbL3o7obBu', 'legacy_inventory'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '9tKZxccYcSGDYTTgkme8mG2XbZpaYJaKK6DmrT8ZHy9R', 'legacy_inventory')
+  ) as t(token_mint_address, token_account, source_class)
+),
+
+owner_candidates as (
+  select
+    a.token_mint_address,
+    a.token_account,
+    t.from_owner as address
+  from token_accounts as a
+  inner join {{ ref('stablecoins_' ~ chain ~ '_transfers') }} as t
+    on t.token_mint_address = a.token_mint_address
+    and a.token_account = t.from_token_account
+  where t.block_date >= date '{{ owners_observation_start_date }}'
+
+  union all
+
+  select
+    a.token_mint_address,
+    a.token_account,
+    t.to_owner as address
+  from token_accounts as a
+  inner join {{ ref('stablecoins_' ~ chain ~ '_transfers') }} as t
+    on t.token_mint_address = a.token_mint_address
+    and a.token_account = t.to_token_account
+  where t.block_date >= date '{{ owners_observation_start_date }}'
+),
+
+observed_owners as (
+  select
+    token_mint_address,
+    token_account,
+    array_join(array_sort(array_agg(distinct address)), ', ') as observed_owners
+  from owner_candidates
+  where address is not null
+  group by 1, 2
+)
+
+select
+  '{{ chain }}' as blockchain,
+  a.token_mint_address,
+  a.token_account,
+  a.source_class,
+  cast(a.source_class = 'legacy_inventory' as boolean) as excluded,
+  o.observed_owners
+from token_accounts as a
+left join observed_owners as o
+  on o.token_mint_address = a.token_mint_address
+  and o.token_account = a.token_account

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_core_non_circulating_inventory_accounts.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_core_non_circulating_inventory_accounts.sql
@@ -15,7 +15,7 @@
 -- non-circulating inventory token accounts for spl stablecoins on solana core lineage
 -- approach:
 -- 1) curate known non-circulating token accounts inline via values() (not dbt seed-backed)
--- 2) derive observed owners from stablecoin transfer history via from/to token-account matches
+-- 2) derive observed owners from core stablecoin transfer history via from/to token-account matches
 -- this keeps exclusions generic in runtime logic (no stale-age/threshold heuristics)
 -- source: https://github.com/solana-labs/token-list/blob/main/src/tokens/solana.tokenlist.json
 -- ref: https://www.circle.com/blog/gateway-new-pre-mint-address-for-usdc-on-solana
@@ -41,13 +41,23 @@ with token_accounts as (
   ) as t(token_mint_address, token_account, source_class)
 ),
 
+relevant_token_accounts as (
+  select
+    a.token_mint_address,
+    a.token_account,
+    a.source_class
+  from token_accounts as a
+  inner join {{ ref('tokens_' ~ chain ~ '_spl_stablecoins_core') }} as s
+    on s.token_mint_address = a.token_mint_address
+),
+
 owner_candidates as (
   select
     a.token_mint_address,
     a.token_account,
     t.from_owner as address
-  from token_accounts as a
-  inner join {{ ref('stablecoins_' ~ chain ~ '_transfers') }} as t
+  from relevant_token_accounts as a
+  inner join {{ ref('stablecoins_' ~ chain ~ '_core_transfers') }} as t
     on t.token_mint_address = a.token_mint_address
     and a.token_account = t.from_token_account
   where t.block_date >= date '{{ owners_observation_start_date }}'
@@ -58,8 +68,8 @@ owner_candidates as (
     a.token_mint_address,
     a.token_account,
     t.to_owner as address
-  from token_accounts as a
-  inner join {{ ref('stablecoins_' ~ chain ~ '_transfers') }} as t
+  from relevant_token_accounts as a
+  inner join {{ ref('stablecoins_' ~ chain ~ '_core_transfers') }} as t
     on t.token_mint_address = a.token_mint_address
     and a.token_account = t.to_token_account
   where t.block_date >= date '{{ owners_observation_start_date }}'
@@ -82,7 +92,7 @@ select
   a.source_class,
   cast(a.source_class = 'legacy_inventory' as boolean) as excluded,
   o.observed_owners
-from token_accounts as a
+from relevant_token_accounts as a
 left join observed_owners as o
   on o.token_mint_address = a.token_mint_address
   and o.token_account = a.token_account

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_extended_non_circulating_inventory_accounts.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_extended_non_circulating_inventory_accounts.sql
@@ -14,7 +14,7 @@
 
 -- non-circulating inventory token accounts for spl stablecoins on solana extended lineage
 -- approach:
--- 1) curate known non-circulating token accounts inline via values() (not dbt seed-backed)
+-- 1) curate non-circulating token accounts for extended stablecoins inline via values() (currently none)
 -- 2) derive observed owners from extended stablecoin transfer history via from/to token-account matches
 -- this keeps exclusions generic in runtime logic (no stale-age/threshold heuristics)
 -- source: https://github.com/solana-labs/token-list/blob/main/src/tokens/solana.tokenlist.json
@@ -24,21 +24,9 @@ with token_accounts as (
   select token_mint_address, token_account, source_class
   from (
     values
-      -- usdc mint
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '27T5c11dNMXjcRuko9CeUy3Wq41nFdH3tz9Qt4REzZMM', 'official_circle_premint'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '28VqfqsUUBx59i8ruG2TuC5RekW5ZY3tsK4bSV59sXjn', 'official_circle_premint'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa', 'official_circle_premint'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'FSxJ85FXVsXSr51SeWf9ciJWTcRnqKFSmBgRDeL3KyWw', 'official_circle_premint'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '6xTBTqJMBr5m7BKqVxmW2x11DfqUwtD3TJsqpxELx72L', 'official_circle_premint'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'CkzX3bvAt9PcjCh2QoQdM9ENzUVwH229hFe4dB7Y8qZK', 'official_circle_premint'),
-      -- legacy usdc non-circulating inventory token accounts
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'fMx1JWj55yTMv4CFLm5ZRWjo16TnbsQDsVuCbkBDnYe', 'legacy_inventory'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '5nGMuvwbZdZZtXQdGhCnGfu6oCDmikXi3yChmdb4GBrV', 'legacy_inventory'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '5tFhdTCzTYMvfVTZnczZEL36YjFnkDTSaoQ7XAZvS7LR', 'legacy_inventory'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'FYAFDcQsZCgJJdj5YJNLPsWazYyqDTWmgyX7hFk4mM95', 'legacy_inventory'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'fBQG6bx8SFgAVcS3vtr3rJDFKHnVcKw4CpbL3o7obBu', 'legacy_inventory'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '9tKZxccYcSGDYTTgkme8mG2XbZpaYJaKK6DmrT8ZHy9R', 'legacy_inventory')
+      (cast(null as varchar), cast(null as varchar), cast(null as varchar))
   ) as t(token_mint_address, token_account, source_class)
+  where false
 ),
 
 relevant_token_accounts as (

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_extended_non_circulating_inventory_accounts.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_extended_non_circulating_inventory_accounts.sql
@@ -14,31 +14,18 @@
 
 -- non-circulating inventory token accounts for spl stablecoins on solana extended lineage
 -- approach:
--- 1) curate known non-circulating token accounts inline via values() (not dbt seed-backed)
+-- 1) reuse canonical non-circulating token accounts from the base helper table
 -- 2) derive observed owners from extended stablecoin transfer history via from/to token-account matches
 -- this keeps exclusions generic in runtime logic (no stale-age/threshold heuristics)
 -- source: https://github.com/solana-labs/token-list/blob/main/src/tokens/solana.tokenlist.json
 -- ref: https://www.circle.com/blog/gateway-new-pre-mint-address-for-usdc-on-solana
 
 with token_accounts as (
-  select token_mint_address, token_account, source_class
-  from (
-    values
-      -- usdc mint
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '27T5c11dNMXjcRuko9CeUy3Wq41nFdH3tz9Qt4REzZMM', 'official_circle_premint'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '28VqfqsUUBx59i8ruG2TuC5RekW5ZY3tsK4bSV59sXjn', 'official_circle_premint'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa', 'official_circle_premint'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'FSxJ85FXVsXSr51SeWf9ciJWTcRnqKFSmBgRDeL3KyWw', 'official_circle_premint'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '6xTBTqJMBr5m7BKqVxmW2x11DfqUwtD3TJsqpxELx72L', 'official_circle_premint'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'CkzX3bvAt9PcjCh2QoQdM9ENzUVwH229hFe4dB7Y8qZK', 'official_circle_premint'),
-      -- legacy usdc non-circulating inventory token accounts
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'fMx1JWj55yTMv4CFLm5ZRWjo16TnbsQDsVuCbkBDnYe', 'legacy_inventory'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '5nGMuvwbZdZZtXQdGhCnGfu6oCDmikXi3yChmdb4GBrV', 'legacy_inventory'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '5tFhdTCzTYMvfVTZnczZEL36YjFnkDTSaoQ7XAZvS7LR', 'legacy_inventory'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'FYAFDcQsZCgJJdj5YJNLPsWazYyqDTWmgyX7hFk4mM95', 'legacy_inventory'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'fBQG6bx8SFgAVcS3vtr3rJDFKHnVcKw4CpbL3o7obBu', 'legacy_inventory'),
-      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '9tKZxccYcSGDYTTgkme8mG2XbZpaYJaKK6DmrT8ZHy9R', 'legacy_inventory')
-  ) as t(token_mint_address, token_account, source_class)
+  select
+    token_mint_address,
+    token_account,
+    source_class
+  from {{ ref('stablecoins_' ~ chain ~ '_non_circulating_inventory_accounts') }}
 ),
 
 relevant_token_accounts as (

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_extended_non_circulating_inventory_accounts.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_extended_non_circulating_inventory_accounts.sql
@@ -14,18 +14,31 @@
 
 -- non-circulating inventory token accounts for spl stablecoins on solana extended lineage
 -- approach:
--- 1) reuse canonical non-circulating token accounts from the base helper table
+-- 1) curate known non-circulating token accounts inline via values() (not dbt seed-backed)
 -- 2) derive observed owners from extended stablecoin transfer history via from/to token-account matches
 -- this keeps exclusions generic in runtime logic (no stale-age/threshold heuristics)
 -- source: https://github.com/solana-labs/token-list/blob/main/src/tokens/solana.tokenlist.json
 -- ref: https://www.circle.com/blog/gateway-new-pre-mint-address-for-usdc-on-solana
 
 with token_accounts as (
-  select
-    token_mint_address,
-    token_account,
-    source_class
-  from {{ ref('stablecoins_' ~ chain ~ '_non_circulating_inventory_accounts') }}
+  select token_mint_address, token_account, source_class
+  from (
+    values
+      -- usdc mint
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '27T5c11dNMXjcRuko9CeUy3Wq41nFdH3tz9Qt4REzZMM', 'official_circle_premint'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '28VqfqsUUBx59i8ruG2TuC5RekW5ZY3tsK4bSV59sXjn', 'official_circle_premint'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa', 'official_circle_premint'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'FSxJ85FXVsXSr51SeWf9ciJWTcRnqKFSmBgRDeL3KyWw', 'official_circle_premint'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '6xTBTqJMBr5m7BKqVxmW2x11DfqUwtD3TJsqpxELx72L', 'official_circle_premint'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'CkzX3bvAt9PcjCh2QoQdM9ENzUVwH229hFe4dB7Y8qZK', 'official_circle_premint'),
+      -- legacy usdc non-circulating inventory token accounts
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'fMx1JWj55yTMv4CFLm5ZRWjo16TnbsQDsVuCbkBDnYe', 'legacy_inventory'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '5nGMuvwbZdZZtXQdGhCnGfu6oCDmikXi3yChmdb4GBrV', 'legacy_inventory'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '5tFhdTCzTYMvfVTZnczZEL36YjFnkDTSaoQ7XAZvS7LR', 'legacy_inventory'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'FYAFDcQsZCgJJdj5YJNLPsWazYyqDTWmgyX7hFk4mM95', 'legacy_inventory'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'fBQG6bx8SFgAVcS3vtr3rJDFKHnVcKw4CpbL3o7obBu', 'legacy_inventory'),
+      ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', '9tKZxccYcSGDYTTgkme8mG2XbZpaYJaKK6DmrT8ZHy9R', 'legacy_inventory')
+  ) as t(token_mint_address, token_account, source_class)
 ),
 
 relevant_token_accounts as (

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_extended_non_circulating_inventory_accounts.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_extended_non_circulating_inventory_accounts.sql
@@ -4,7 +4,7 @@
 {{
   config(
     schema = 'stablecoins_' ~ chain,
-    alias = 'non_circulating_inventory_accounts',
+    alias = 'extended_non_circulating_inventory_accounts',
     materialized = 'table',
     file_format = 'delta',
     tags = ['static'],
@@ -12,10 +12,10 @@
   )
 }}
 
--- non-circulating inventory token accounts for spl stablecoins on solana
+-- non-circulating inventory token accounts for spl stablecoins on solana extended lineage
 -- approach:
 -- 1) curate known non-circulating token accounts inline via values() (not dbt seed-backed)
--- 2) derive observed owners from core stablecoin transfer history via from/to token-account matches
+-- 2) derive observed owners from extended stablecoin transfer history via from/to token-account matches
 -- this keeps exclusions generic in runtime logic (no stale-age/threshold heuristics)
 -- source: https://github.com/solana-labs/token-list/blob/main/src/tokens/solana.tokenlist.json
 -- ref: https://www.circle.com/blog/gateway-new-pre-mint-address-for-usdc-on-solana
@@ -47,7 +47,7 @@ relevant_token_accounts as (
     a.token_account,
     a.source_class
   from token_accounts as a
-  inner join {{ ref('tokens_' ~ chain ~ '_spl_stablecoins_core') }} as s
+  inner join {{ ref('tokens_' ~ chain ~ '_spl_stablecoins_extended') }} as s
     on s.token_mint_address = a.token_mint_address
 ),
 
@@ -57,7 +57,7 @@ owner_candidates as (
     a.token_account,
     t.from_owner as address
   from relevant_token_accounts as a
-  inner join {{ ref('stablecoins_' ~ chain ~ '_core_transfers') }} as t
+  inner join {{ ref('stablecoins_' ~ chain ~ '_extended_transfers') }} as t
     on t.token_mint_address = a.token_mint_address
     and a.token_account = t.from_token_account
   where t.block_date >= date '{{ owners_observation_start_date }}'
@@ -69,7 +69,7 @@ owner_candidates as (
     a.token_account,
     t.to_owner as address
   from relevant_token_accounts as a
-  inner join {{ ref('stablecoins_' ~ chain ~ '_core_transfers') }} as t
+  inner join {{ ref('stablecoins_' ~ chain ~ '_extended_transfers') }} as t
     on t.token_mint_address = a.token_mint_address
     and a.token_account = t.to_token_account
   where t.block_date >= date '{{ owners_observation_start_date }}'

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_non_circulating_inventory_accounts.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_non_circulating_inventory_accounts.sql
@@ -15,7 +15,7 @@
 -- non-circulating inventory token accounts for spl stablecoins on solana
 -- approach:
 -- 1) curate known non-circulating token accounts inline via values() (not dbt seed-backed)
--- 2) derive observed owners from core stablecoin transfer history via from/to token-account matches
+-- 2) derive observed owners from stablecoin transfer history via from/to token-account matches
 -- this keeps exclusions generic in runtime logic (no stale-age/threshold heuristics)
 -- source: https://github.com/solana-labs/token-list/blob/main/src/tokens/solana.tokenlist.json
 -- ref: https://www.circle.com/blog/gateway-new-pre-mint-address-for-usdc-on-solana
@@ -41,23 +41,13 @@ with token_accounts as (
   ) as t(token_mint_address, token_account, source_class)
 ),
 
-relevant_token_accounts as (
-  select
-    a.token_mint_address,
-    a.token_account,
-    a.source_class
-  from token_accounts as a
-  inner join {{ ref('tokens_' ~ chain ~ '_spl_stablecoins_core') }} as s
-    on s.token_mint_address = a.token_mint_address
-),
-
 owner_candidates as (
   select
     a.token_mint_address,
     a.token_account,
     t.from_owner as address
-  from relevant_token_accounts as a
-  inner join {{ ref('stablecoins_' ~ chain ~ '_core_transfers') }} as t
+  from token_accounts as a
+  inner join {{ ref('stablecoins_' ~ chain ~ '_transfers') }} as t
     on t.token_mint_address = a.token_mint_address
     and a.token_account = t.from_token_account
   where t.block_date >= date '{{ owners_observation_start_date }}'
@@ -68,8 +58,8 @@ owner_candidates as (
     a.token_mint_address,
     a.token_account,
     t.to_owner as address
-  from relevant_token_accounts as a
-  inner join {{ ref('stablecoins_' ~ chain ~ '_core_transfers') }} as t
+  from token_accounts as a
+  inner join {{ ref('stablecoins_' ~ chain ~ '_transfers') }} as t
     on t.token_mint_address = a.token_mint_address
     and a.token_account = t.to_token_account
   where t.block_date >= date '{{ owners_observation_start_date }}'
@@ -92,7 +82,7 @@ select
   a.source_class,
   cast(a.source_class = 'legacy_inventory' as boolean) as excluded,
   o.observed_owners
-from relevant_token_accounts as a
+from token_accounts as a
 left join observed_owners as o
   on o.token_mint_address = a.token_mint_address
   and o.token_account = a.token_account


### PR DESCRIPTION
## Summary
- Add `stablecoins_solana_extended_non_circulating_inventory_accounts` so extended lineage has its own helper table.
- Restrict the existing core helper table to core token-list mints and derive owners from `core_transfers` only.
- This is the normal-deploy base PR required before forward-only lineage wiring.