### PR TITLE
fix: point erc4626 to correct model, receiving all missing data that …

### DIFF
--- a/dbt_macros/shared/balancer/balancer_bpt_prices_macro.sql
+++ b/dbt_macros/shared/balancer/balancer_bpt_prices_macro.sql
@@ -406,7 +406,7 @@ WITH pool_labels AS (
             decimals,
             APPROX_PERCENTILE(median_price, 0.5) AS price,
             LEAD(DATE_TRUNC('day', minute), 1, CURRENT_DATE + INTERVAL '1' day) OVER (PARTITION BY wrapped_token ORDER BY date_trunc('day', minute)) AS next_change
-        FROM {{ source('balancer_v3' , 'erc4626_token_prices') }}
+        FROM {{ ref('balancer_v3_erc4626_token_prices') }}
         WHERE blockchain = '{{blockchain}}'
         GROUP BY 1, 2, 3
     ),

--- a/dbt_macros/shared/balancer/balancer_liquidity_macro.sql
+++ b/dbt_macros/shared/balancer/balancer_liquidity_macro.sql
@@ -391,7 +391,7 @@ WITH pool_labels AS (
             decimals,
             APPROX_PERCENTILE(median_price, 0.5) AS price,
             LEAD(DATE_TRUNC('day', minute), 1, CURRENT_DATE + INTERVAL '1' day) OVER (PARTITION BY wrapped_token ORDER BY date_trunc('day', minute)) AS next_change
-        FROM {{ source('balancer_v3', 'erc4626_token_prices') }}
+        FROM {{ ref('balancer_v3_erc4626_token_prices') }}
         WHERE blockchain = '{{blockchain}}'
         GROUP BY 1, 2, 3
     ),

--- a/dbt_macros/shared/balancer/balancer_protocol_fee_macro.sql
+++ b/dbt_macros/shared/balancer/balancer_protocol_fee_macro.sql
@@ -289,7 +289,7 @@ WITH pool_labels AS (
             decimals,
             APPROX_PERCENTILE(median_price, 0.5) AS price,
             LEAD(DATE_TRUNC('day', minute), 1, CURRENT_DATE + INTERVAL '1' day) OVER (PARTITION BY wrapped_token ORDER BY date_trunc('day', minute)) AS next_change
-        FROM {{ source('balancer_v3' , 'erc4626_token_prices') }}
+        FROM {{ ref('balancer_v3_erc4626_token_prices') }}
         WHERE blockchain = '{{blockchain}}'
         GROUP BY 1, 2, 3
     ),    

--- a/dbt_macros/shared/balancer/balancer_token_balance_changes_daily_agg_macro.sql
+++ b/dbt_macros/shared/balancer/balancer_token_balance_changes_daily_agg_macro.sql
@@ -276,7 +276,7 @@ WITH
             decimals,
             APPROX_PERCENTILE(median_price, 0.5) AS price,
             LEAD(DATE_TRUNC('day', minute), 1, CURRENT_DATE + INTERVAL '1' day) OVER (PARTITION BY wrapped_token ORDER BY date_trunc('day', minute)) AS next_change
-        FROM {{ source('balancer_v3' , 'erc4626_token_prices') }}
+        FROM {{ ref('balancer_v3_erc4626_token_prices') }}
         WHERE blockchain = '{{blockchain}}'
         GROUP BY 1, 2, 3
     ),    


### PR DESCRIPTION
…was not available on previous ref

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

This PR ports the Balancer V3 ERC4626 pricing fix to Spellbook so protocol fee/liquidity/BPT pricing paths use the internal modeled ERC4626 prices table.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
