### PR TITLE
stablecoins: align extended_balances start_date with core per chain

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/abstract/balances/stablecoins_abstract_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/abstract/balances/stablecoins_abstract_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-12-20'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/apechain/balances/stablecoins_apechain_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/apechain/balances/stablecoins_apechain_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-11-04'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/arbitrum/balances/stablecoins_arbitrum_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/arbitrum/balances/stablecoins_arbitrum_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2025-01-01'
+    start_date = '2021-05-26'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/avalanche_c/balances/stablecoins_avalanche_c_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/avalanche_c/balances/stablecoins_avalanche_c_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2021-05-27'
+    start_date = '2021-01-27'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/b3/balances/stablecoins_b3_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/b3/balances/stablecoins_b3_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-08-13'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/base/balances/stablecoins_base_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/base/balances/stablecoins_base_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2025-07-03'
+    start_date = '2023-07-20'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/berachain/balances/stablecoins_berachain_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/berachain/balances/stablecoins_berachain_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2025-01-23'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bnb/balances/stablecoins_bnb_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bnb/balances/stablecoins_bnb_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2021-05-26'
+    start_date = '2020-09-01'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bob/balances/stablecoins_bob_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bob/balances/stablecoins_bob_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-04-11'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/boba/balances/stablecoins_boba_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/boba/balances/stablecoins_boba_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2021-11-01'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/celo/balances/stablecoins_celo_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/celo/balances/stablecoins_celo_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2020-04-22'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/corn/balances/stablecoins_corn_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/corn/balances/stablecoins_corn_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-11-01'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/degen/balances/stablecoins_degen_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/degen/balances/stablecoins_degen_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-03-28'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ethereum/balances/stablecoins_ethereum_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ethereum/balances/stablecoins_ethereum_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2025-12-24'
+    start_date = '2017-11-28'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/fantom/balances/stablecoins_fantom_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/fantom/balances/stablecoins_fantom_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2020-09-18'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flare/balances/stablecoins_flare_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flare/balances/stablecoins_flare_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-07-16'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flow/balances/stablecoins_flow_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flow/balances/stablecoins_flow_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-07-15'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/gnosis/balances/stablecoins_gnosis_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/gnosis/balances/stablecoins_gnosis_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2020-08-19'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hemi/balances/stablecoins_hemi_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hemi/balances/stablecoins_hemi_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-12-18'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/henesys/balances/stablecoins_henesys_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/henesys/balances/stablecoins_henesys_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-12-09'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hyperevm/balances/stablecoins_hyperevm_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hyperevm/balances/stablecoins_hyperevm_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2025-03-14'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ink/balances/stablecoins_ink_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ink/balances/stablecoins_ink_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-12-18'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/kaia/balances/stablecoins_kaia_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/kaia/balances/stablecoins_kaia_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-12-06'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/katana/balances/stablecoins_katana_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/katana/balances/stablecoins_katana_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2025-05-27'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/linea/balances/stablecoins_linea_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/linea/balances/stablecoins_linea_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2023-07-13'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/mantle/balances/stablecoins_mantle_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/mantle/balances/stablecoins_mantle_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2023-07-12'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/monad/balances/stablecoins_monad_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/monad/balances/stablecoins_monad_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2025-10-08'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/nova/balances/stablecoins_nova_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/nova/balances/stablecoins_nova_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2022-08-09'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/opbnb/balances/stablecoins_opbnb_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/opbnb/balances/stablecoins_opbnb_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2023-08-15'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/optimism/balances/stablecoins_optimism_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/optimism/balances/stablecoins_optimism_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2021-11-11'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/peaq/balances/stablecoins_peaq_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/peaq/balances/stablecoins_peaq_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2025-01-17'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plasma/balances/stablecoins_plasma_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plasma/balances/stablecoins_plasma_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2025-09-12'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plume/balances/stablecoins_plume_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plume/balances/stablecoins_plume_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2025-03-12'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/polygon/balances/stablecoins_polygon_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/polygon/balances/stablecoins_polygon_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2021-11-20'
+    start_date = '2020-09-15'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ronin/balances/stablecoins_ronin_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ronin/balances/stablecoins_ronin_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2021-10-21'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/scroll/balances/stablecoins_scroll_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/scroll/balances/stablecoins_scroll_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2023-10-01'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sei/balances/stablecoins_sei_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sei/balances/stablecoins_sei_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-05-28'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sepolia/balances/stablecoins_sepolia_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sepolia/balances/stablecoins_sepolia_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2022-09-06'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/shape/balances/stablecoins_shape_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/shape/balances/stablecoins_shape_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-08-06'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/somnia/balances/stablecoins_somnia_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/somnia/balances/stablecoins_somnia_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2025-08-27'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sonic/balances/stablecoins_sonic_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sonic/balances/stablecoins_sonic_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-12-17'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sophon/balances/stablecoins_sophon_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sophon/balances/stablecoins_sophon_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-12-18'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/story/balances/stablecoins_story_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/story/balances/stablecoins_story_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2025-02-12'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/superseed/balances/stablecoins_superseed_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/superseed/balances/stablecoins_superseed_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-12-09'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/tac/balances/stablecoins_tac_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/tac/balances/stablecoins_tac_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2025-01-15'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/taiko/balances/stablecoins_taiko_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/taiko/balances/stablecoins_taiko_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-05-27'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/unichain/balances/stablecoins_unichain_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/unichain/balances/stablecoins_unichain_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-11-14'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/viction/balances/stablecoins_viction_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/viction/balances/stablecoins_viction_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2019-01-10'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/worldchain/balances/stablecoins_worldchain_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/worldchain/balances/stablecoins_worldchain_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-08-27'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/xlayer/balances/stablecoins_xlayer_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/xlayer/balances/stablecoins_xlayer_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2024-03-31'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zkevm/balances/stablecoins_zkevm_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zkevm/balances/stablecoins_zkevm_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2023-03-24'
 ) }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zksync/balances/stablecoins_zksync_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zksync/balances/stablecoins_zksync_extended_balances.sql
@@ -18,5 +18,5 @@
 
 {{ stablecoins_balances_from_transfers(
     transfers = source('stablecoins_' ~ chain, 'extended_transfers'),
-    start_date = '2026-01-01'
+    start_date = '2023-03-20'
 ) }}


### PR DESCRIPTION
## Summary

Each `stablecoins_<chain>_extended_balances` model was passing an arbitrary forward-dated `start_date` (mostly `2026-01-01`) to the `stablecoins_balances_from_transfers` macro. That argument controls the lower bound of the `days` calendar used to forward-fill balances, so an `extended_balances` table whose `start_date` was after the chain's launch had a narrower history floor than the corresponding `stablecoins_<chain>_core_balances` on the same chain.

This PR sets `start_date` on every daily_spellbook EVM `extended_balances` model to exactly match the `start_date` of its `core_balances` counterpart, so the two tables share the same lower date bound and any downstream join/union over them is consistent.

- 52 files updated (one chain per file).
- `tron` is intentionally skipped.
- `megaeth` was already aligned, so no change there.
- No macro / config changes — the only diff per file is the date string in the macro call, which is in the model body and therefore picked up by `state:modified.body` in CI.

## Test plan

- [x] `dbt compile -s stablecoins_ethereum_extended_balances stablecoins_polygon_extended_balances stablecoins_arbitrum_extended_balances` — succeeds, compiled SQL contains the new core-aligned `start_date` literals (`2017-11-28`, `2020-09-15`, `2021-05-26`).
- [ ] CI green on all 52 modified models via `dbt slim ci`.

Made with [Cursor](https://cursor.com)