### PR TITLE
CUR2-2214: aptos transfers fix

### DIFF
--- a/dbt_subprojects/tokens/models/transfers_and_balances/aptos/tokens_aptos_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/aptos/tokens_aptos_transfers.sql
@@ -17,16 +17,43 @@
 }}
 
 {% set aptos_transfer_start_date = '2022-10-12' %}
-{% set canonical_usdc_asset_type = '0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b' %}
-{% set canonical_usdt_asset_type = '0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b' %}
 {% set usd_amount_threshold = 1000000000 %}
+{% set legacy_native_aptos_asset_type = '0x1::aptos_coin::AptosCoin' %}
+{% set current_native_aptos_asset_type = '0x000000000000000000000000000000000000000000000000000000000000000a' %}
+{% set native_aptos_symbol = 'APT' %}
+{% set native_aptos_decimals = 8 %}
 
-with base_transfers as (
+with native_assets as (
   select *
-  from {{ ref('tokens_aptos_base_transfers') }}
-  where block_date >= date '{{ aptos_transfer_start_date }}'
+  from (
+    values
+      (
+        '{{ legacy_native_aptos_asset_type }}',
+        '{{ native_aptos_symbol }}',
+        {{ native_aptos_decimals }},
+        0x0000000000000000000000000000000000000000
+      ),
+      (
+        '{{ current_native_aptos_asset_type }}',
+        '{{ native_aptos_symbol }}',
+        {{ native_aptos_decimals }},
+        0x0000000000000000000000000000000000000000
+      )
+  ) as t (asset_type, symbol, decimals, price_contract_address)
+),
+
+base_transfers as (
+  select
+    b.*,
+    n.symbol as native_symbol,
+    n.decimals as native_decimals,
+    coalesce(n.price_contract_address, to_utf8(b.asset_type)) as price_contract_address
+  from {{ ref('tokens_aptos_base_transfers') }} b
+  left join native_assets n
+    on b.asset_type = n.asset_type
+  where b.block_date >= date '{{ aptos_transfer_start_date }}'
     {% if is_incremental() %}
-    and {{ incremental_predicate('block_time') }}
+    and {{ incremental_predicate('b.block_time') }}
     {% endif %}
 ),
 
@@ -94,18 +121,24 @@ transfers as (
     b.asset_type,
     b.from_storage_id,
     b.to_storage_id,
-    coalesce(m.asset_symbol, p.symbol) as symbol,
-    coalesce(m.decimals, p.decimals) as decimals,
+    coalesce(b.native_symbol, m.asset_symbol, p.symbol) as symbol,
+    coalesce(b.native_decimals, m.decimals, p.decimals) as decimals,
     tx.tx_index,
     b.amount_raw,
     case
-      when coalesce(m.decimals, p.decimals) is null then cast(null as double)
-      else cast(b.amount_raw as double) / power(10, cast(coalesce(m.decimals, p.decimals) as double))
+      when coalesce(b.native_decimals, m.decimals, p.decimals) is null then cast(null as double)
+      else cast(b.amount_raw as double) / power(
+        10,
+        cast(coalesce(b.native_decimals, m.decimals, p.decimals) as double)
+      )
     end as amount,
     p.price as price_usd,
     case
-      when coalesce(m.decimals, p.decimals) is null then cast(null as double)
-      else cast(b.amount_raw as double) / power(10, cast(coalesce(m.decimals, p.decimals) as double)) * p.price
+      when coalesce(b.native_decimals, m.decimals, p.decimals) is null then cast(null as double)
+      else cast(b.amount_raw as double) / power(
+        10,
+        cast(coalesce(b.native_decimals, m.decimals, p.decimals) as double)
+      ) * p.price
     end as amount_usd,
     case
       when tt.contract_address is not null then true
@@ -119,14 +152,10 @@ transfers as (
   left join tx_metadata tx
     on b.tx_version = tx.tx_version
   left join trusted_tokens tt
-    on b.contract_address = tt.contract_address
+    on b.price_contract_address = tt.contract_address
   left join prices p
     on date_trunc('hour', b.block_time) = p.timestamp
-    and b.contract_address = p.contract_address
-  where (
-    coalesce(upper(m.asset_symbol), '') not in ('USDC', 'USDT')
-    or b.asset_type in ('{{ canonical_usdc_asset_type }}', '{{ canonical_usdt_asset_type }}')
-  )
+    and b.price_contract_address = p.contract_address
 )
 
 select

--- a/dbt_subprojects/tokens/tests/aptos/test_tokens_aptos_transfers_required_stablecoin_assets.sql
+++ b/dbt_subprojects/tokens/tests/aptos/test_tokens_aptos_transfers_required_stablecoin_assets.sql
@@ -1,0 +1,58 @@
+-- Coverage invariant for high-volume Aptos stablecoin assets.
+--
+-- Purpose:
+-- Ensure final transfers keep noncanonical USDC/USDT assets that are present in
+-- base transfer lineage. These assets use both Coin v1 and FA v2 standards.
+--
+-- Failure interpretation:
+-- Any returned row means the final enrichment layer dropped a required asset
+-- even though upstream/base transfer rows exist for it.
+
+with required_assets as (
+  select asset_type
+  from (
+    values
+      ('0x5e156f1207d0ebfa19a9eeff00d62a282278fb8719f4fab3a586a0a2c0fffbea::coin::T'),
+      ('0xa2eda21a58856fda86451436513b867c97eecb4ba099da5775520e0f7492e852::coin::T'),
+      ('0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDC'),
+      ('0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDT'),
+      ('0xe568e9322107a5c9ba4cbd05a630a5586aa73e744ada246c3efb0f4ce3e295f3'),
+      ('0x2b3be0a97a73c87ff62cbdd36837a9fb5bbd1d7f06a73b7ed62ec15c5326c1b8')
+  ) as t (asset_type)
+),
+
+base_counts as (
+  select
+    b.asset_type,
+    count(*) as base_rows
+  from {{ ref('tokens_aptos_base_transfers') }} b
+  where b.asset_type in (
+    select asset_type
+    from required_assets
+  )
+  group by 1
+),
+
+transfer_counts as (
+  select
+    t.asset_type,
+    count(*) as transfer_rows
+  from {{ ref('tokens_aptos_transfers') }} t
+  where t.asset_type in (
+    select asset_type
+    from required_assets
+  )
+  group by 1
+)
+
+select
+  a.asset_type,
+  coalesce(b.base_rows, 0) as base_rows,
+  coalesce(t.transfer_rows, 0) as transfer_rows
+from required_assets a
+left join base_counts b
+  on a.asset_type = b.asset_type
+left join transfer_counts t
+  on a.asset_type = t.asset_type
+where coalesce(b.base_rows, 0) > 0
+  and coalesce(t.transfer_rows, 0) = 0


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

- fix aptos transfer pricing by using the correct price join key
- map both legacy and current native apt representations to the native apt price address
- default legacy APT metadata with 8 decimals when source metadata is missing
- keep noncanonical aptos USDC/USDT transfer rows instead of filtering them out
- add coverage for required aptos stablecoin assets


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
