### PR TITLE
fix: use varbinary_to_int256 for ekubo liquidity event amounts

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/ekubo_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/ekubo_compatible_liquidity.sql
@@ -20,8 +20,8 @@ swap_events as (
         el.block_number,
         el.tx_from,
         substr(el."data", 21, 32) AS id,
-        cast(varbinary_to_decimal(substr(el."data", 53, 16)) as decimal(38,0)) as amount0,
-        cast(varbinary_to_decimal(substr(el."data", 69, 16)) as decimal(38,0)) as amount1,
+        varbinary_to_int256(substr(el."data", 53, 16)) as amount0,
+        varbinary_to_int256(substr(el."data", 69, 16)) as amount1,
         el.tx_hash,
         el.index as evt_index,
         'swap' as event_type
@@ -61,8 +61,8 @@ liquidity_events as (
         evt_block_number as block_number,
         evt_tx_from as tx_from,
         poolId as id,
-        varbinary_to_decimal(substr(balanceUpdate, 1, 16)) as amount0,
-        varbinary_to_decimal(substr(balanceUpdate, 1+16, 16)) as amount1,
+        varbinary_to_int256(substr(balanceUpdate, 1, 16)) as amount0,
+        varbinary_to_int256(substr(balanceUpdate, 1+16, 16)) as amount1,
         evt_tx_hash as tx_hash,
         evt_index,
         'modify_liquidity' as event_type 


### PR DESCRIPTION
## Summary
- Ekubo's `Swapped` payload and `PositionUpdated.balanceUpdate` field pack signed `int128` deltas, which can reach `-2^127` (~-1.7e38) when liquidity is fully burned — below `decimal(38,0)`'s lower bound.
- Trino raises `NUMERIC_VALUE_OUT_OF_RANGE` and explicitly recommends `varbinary_to_int256`. Swap the four `varbinary_to_decimal` calls in `ekubo_compatible_liquidity_events` to `varbinary_to_int256`. Downstream `CAST(amount AS double)` is unchanged.
- Affects both `ekubo_v3_ethereum_base_liquidity_events` (the failing model) and `ekubo_ethereum_base_liquidity_events` (v1 — same swap_events parse).

Error from the scheduled dex run:
```
TrinoUserError(type=USER_ERROR, name=NUMERIC_VALUE_OUT_OF_RANGE,
  message="Overflow when converting varbinary to decimal(38,0) - number is smaller than expected:
  -170141183460469231731687303715884093082 < -99999999999999999999999999999999999999.
  Use varbinary_to_int256 instead.")
```

## Test plan
- [ ] CI compiles both `ekubo_v3_ethereum_base_liquidity_events` and `ekubo_ethereum_base_liquidity_events`
- [ ] Spot-check a recent swap with a large negative delta resolves without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)