### PR TITLE
ci(prices): use uv to install requests for token checker

### DIFF
--- a/.github/workflows/prices_check.yml
+++ b/.github/workflows/prices_check.yml
@@ -20,10 +20,18 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v6
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
       - name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --locked
 
       - name: Fetch base commit
         run: git fetch origin ${{ github.event.pull_request.base.sha }}
@@ -38,4 +46,4 @@ jobs:
 
       - name: Run validations
         id: validations
-        run: python scripts/check_tokens.py --file_name scripts/new_lines.txt
+        run: uv run python scripts/check_tokens.py --file_name scripts/new_lines.txt

--- a/.github/workflows/prices_check.yml
+++ b/.github/workflows/prices_check.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Get prices diff
         shell: bash
         run: |
-          git diff ${{ github.event.pull_request.base.sha}}..${{ github.event.pull_request.head.sha }} dbt_subprojects/tokens/models/prices/**/*.sql | grep '^\+ ' > scripts/new_lines.txt
+          git diff ${{ github.event.pull_request.base.sha}}..${{ github.event.pull_request.head.sha }} dbt_subprojects/tokens/models/prices/**/*.sql | { grep '^\+ ' || true; } > scripts/new_lines.txt
 
       - name: Run validations
         id: validations

--- a/.github/workflows/prices_check.yml
+++ b/.github/workflows/prices_check.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - 'dbt_subprojects/tokens/models/prices/*/*.sql'
+      - '.github/workflows/prices_check.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- The uv migration PR (#9594) converted every workflow to \`uv sync --locked\` + \`uv run\` **except** \`prices_check.yml\`. As a result, \`python scripts/check_tokens.py\` now runs against the ubuntu-latest system Python without \`requests\` installed and fails with \`ModuleNotFoundError: No module named 'requests'\` on every PR that adds a token to the prices feed (e.g. #9616).
- Mirrors the pattern already in [\`pytest_automations.yml\`](.github/workflows/pytest_automations.yml): set up uv → set up Python → \`uv sync --locked\` → \`uv run\`.

## Test plan
- [ ] CI for this PR is green (the workflow itself doesn't run on this PR since the path filter is \`dbt_subprojects/tokens/models/prices/*/*.sql\`, but the YAML is parsed).
- [ ] After merge, retrigger CI on #9616 and confirm the \`Run validations\` step passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)