### PR TITLE
fix(ekubo): sign-extend int128 deltas before varbinary_to_int256

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/ekubo_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/ekubo_compatible_liquidity.sql
@@ -20,8 +20,19 @@ swap_events as (
         el.block_number,
         el.tx_from,
         substr(el."data", 21, 32) AS id,
-        varbinary_to_int256(substr(el."data", 53, 16)) as amount0,
-        varbinary_to_int256(substr(el."data", 69, 16)) as amount1,
+        -- amount0/amount1 are signed int128 deltas packed into 16 bytes each.
+        -- varbinary_to_int256 zero-pads shorter inputs, so a negative int128 (high bit set)
+        -- comes back as ~2^128 unless we sign-extend with 0xFF*16 first.
+        case
+            when bitwise_and(varbinary_to_bigint(substr(el."data", 53, 1)), from_base('80', 16)) = from_base('80', 16)
+            then varbinary_to_int256(varbinary_concat(from_hex('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'), substr(el."data", 53, 16)))
+            else varbinary_to_int256(varbinary_concat(from_hex('0x00000000000000000000000000000000'), substr(el."data", 53, 16)))
+        end as amount0,
+        case
+            when bitwise_and(varbinary_to_bigint(substr(el."data", 69, 1)), from_base('80', 16)) = from_base('80', 16)
+            then varbinary_to_int256(varbinary_concat(from_hex('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'), substr(el."data", 69, 16)))
+            else varbinary_to_int256(varbinary_concat(from_hex('0x00000000000000000000000000000000'), substr(el."data", 69, 16)))
+        end as amount1,
         el.tx_hash,
         el.index as evt_index,
         'swap' as event_type
@@ -61,8 +72,16 @@ liquidity_events as (
         evt_block_number as block_number,
         evt_tx_from as tx_from,
         poolId as id,
-        varbinary_to_int256(substr(balanceUpdate, 1, 16)) as amount0,
-        varbinary_to_int256(substr(balanceUpdate, 1+16, 16)) as amount1,
+        case
+            when bitwise_and(varbinary_to_bigint(substr(balanceUpdate, 1, 1)), from_base('80', 16)) = from_base('80', 16)
+            then varbinary_to_int256(varbinary_concat(from_hex('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'), substr(balanceUpdate, 1, 16)))
+            else varbinary_to_int256(varbinary_concat(from_hex('0x00000000000000000000000000000000'), substr(balanceUpdate, 1, 16)))
+        end as amount0,
+        case
+            when bitwise_and(varbinary_to_bigint(substr(balanceUpdate, 1+16, 1)), from_base('80', 16)) = from_base('80', 16)
+            then varbinary_to_int256(varbinary_concat(from_hex('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'), substr(balanceUpdate, 1+16, 16)))
+            else varbinary_to_int256(varbinary_concat(from_hex('0x00000000000000000000000000000000'), substr(balanceUpdate, 1+16, 16)))
+        end as amount1,
         evt_tx_hash as tx_hash,
         evt_index,
         'modify_liquidity' as event_type 


### PR DESCRIPTION
## Summary

Follow-up to #9617. That PR switched the Ekubo swap and `PositionUpdated.balanceUpdate` parses to `varbinary_to_int256` to avoid `decimal(38,0)` overflow on negative int128 values — but `varbinary_to_int256` zero-pads inputs shorter than 32 bytes, so a negative int128 (high bit set in the first byte) comes back as `~2^128` instead of its true negative value.

As a result every Ekubo swap in `dex.trades` since the deploy has either `token_bought_amount_raw` or `token_sold_amount_raw` stuck at `340282366920938463463374607431768211455` on whichever side of the swap was negative — exactly the bogus values customers are reporting.

This applies the same sign-extension pattern already used in [`uniswap_compatible_liquidity.sql:324-348`](https://github.com/duneanalytics/spellbook/blob/main/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql#L324-L348) and [`pancakeswap_compatible_liquidity.sql:156-180`](https://github.com/duneanalytics/spellbook/blob/main/dbt_subprojects/dex/macros/models/_project/pancakeswap_compatible_liquidity.sql#L156-L180): inspect the high bit of the first byte, then prepend either `0xFF*16` (negative) or `0x00*16` (positive) before calling `varbinary_to_int256`. Applied at all four parse sites in `ekubo_compatible_liquidity.sql` (swap_events.amount0/1, liquidity_events.amount0/1).

## Verification

Ran current vs proposed parse on 6 recent v3 Ethereum swaps ([dune.com/queries/7404761](https://dune.com/queries/7404761)):

| tx | side | hex (16B) | current | **fixed** |
|---|---|---|---:|---:|
| [0x9ee074…](https://etherscan.io/tx/0x9ee074e381f0c70400512e445ba1f619ebe33c420d70f42055ac186c40c4c933) | a0 | `FFFF…CA5DDEE9` | 3.40e38 | **−899,817,751** |
| | a1 | `0000…35A4E900` | 900,000,000 | 900,000,000 |
| [0x0dc490…](https://etherscan.io/tx/0x0dc49007b766ff1d0d37ca993409911eeaf43988f7e6f543b75984865b721a96) | a0 | `0000…11C1332443D800` | 4.9975e15 | 4.9975e15 |
| | a1 | `FFFF…FF53ADBD` | 3.40e38 | **−11,293,251** |
| [0x551d33…](https://etherscan.io/tx/0x551d334c6922f45598d8210e6912e3ac6e4413f3d837694734a83fe5254d39ce) | a0 | `0000…02F71FF0` | 49,750,000 | 49,750,000 |
| | a1 | `FFFF…FD08B9B6` | 3.40e38 | **−49,759,818** |

Magnitudes line up across the swap pair — stable/stable pairs match within fee, ETH/USDC pairs match at ~$2,260/ETH. Every row had exactly one negative side and one positive side, as expected for signed-int128 swap deltas.

## Post-merge action

The bogus rows that landed in `ekubo_v{1,3}_ethereum_base_liquidity_events` since #9617 was deployed need to be rewritten. After merge:

1. Full-refresh (or window-refresh covering 2026-04-29 17:46 UTC → now) on:
   - `ekubo_v3_ethereum_base_liquidity_events`
   - `ekubo_ethereum_base_liquidity_events`
2. Downstream `ekubo_v{1,3}_*_base_trades` and `dex.trades` will catch up on the next incremental merge (unique key `tx_hash + evt_index` will overwrite the bad rows).

## Test plan

- [ ] CI: `dbt slim ci` for the dex sub-project compiles and tests the two ekubo base liquidity events models cleanly
- [ ] Spot-check a few historical tx hashes from the customer report against the rebuilt `dex.trades` rows post-refresh
- [ ] Confirm no `amount*_raw` value `≈ 3.4028e38` remains in the rebuilt window

🤖 Generated with [Claude Code](https://claude.com/claude-code)