### PR TITLE
APP-8165: add decoding_enabled field to blockchain schema and query

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/dune/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/dune/_schema.yml
@@ -24,3 +24,5 @@ models:
         description: "The token symbol of the native token"
       - name: token_decimals
         description: "The token decimals of the native token"
+      - name: decoding_enabled
+        description: "Whether the decoding of this blockchain is enabled"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/dune/dune_blockchains.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/dune/dune_blockchains.sql
@@ -17,5 +17,6 @@ select
         ,token_address
         ,token_symbol
         ,token_decimals
+        ,decoding_enabled
         ,start_date
 from {{ source("dune", "dataset_core_blockchains", database="dune") }}


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Adds the `decoding_enabled` column to the `dune_blockchains` model, exposing whether decoding is enabled for a given blockchain. The field is selected from the `dataset_core_blockchains` source and documented in the schema.


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)