### PR TITLE
fix(kalshi): drive settlement updates from markets_lifecycle_raw

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/kalshi/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_projects/kalshi/_schema.yml
@@ -53,13 +53,13 @@ models:
       - name: expected_expiration_time
         description: "Expected expiration time"
       - name: settlement_ts
-        description: "When the market was settled (null if unsettled)"
+        description: "When the market was settled (null if unsettled). Sourced from markets_lifecycle_raw event_type='settled' when available, else from markets_raw."
       - name: status
         description: "Market lifecycle state (active, finalized, closed, etc.)"
       - name: result
-        description: "Settlement outcome (yes, no, or empty if unresolved)"
+        description: "Settlement outcome (yes, no, scalar). Sourced from markets_lifecycle_raw event_type='determined' when available, else from markets_raw."
       - name: settlement_value_dollars
-        description: "Payout value per contract at settlement"
+        description: "Payout value per contract at settlement. Sourced from markets_lifecycle_raw event_type='determined' (cast from varchar) when available, else from markets_raw."
       - name: expiration_value
         description: "Expiration outcome value"
       - name: can_close_early
@@ -138,9 +138,9 @@ models:
         description: "Series-level fee scalar applied on top of Kalshi's standard 0.07 taker / 0.0175 maker coefficients (1.0 = standard rate)."
       - name: source_updated_at
         description: >
-          Greatest of markets_raw.updated_time, market_details_raw.last_updated_ts, and
-          series_raw.last_updated_ts. Used by downstream spells to detect refreshed dimension
-          columns on rows whose own updated_time did not move.
+          Greatest of markets_raw.updated_time, market_details_raw.last_updated_ts,
+          series_raw.last_updated_ts, and markets_lifecycle_raw.received_ts. Used by downstream
+          spells to detect refreshed dimension columns on rows whose own updated_time did not move.
         data_tests:
           - not_null
       - name: _updated_at

--- a/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_market_details.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_market_details.sql
@@ -86,6 +86,13 @@ with markets as (
 							{{ incremental_predicate('sr.last_updated_ts') }}
 					)
 			)
+			-- Late-arriving settlements: markets_raw.updated_time can lag ingest by weeks; lifecycle.received_ts is real ingest time.
+			or m.ticker in (
+				select lc.market_ticker
+				from {{ source('kalshi', 'markets_lifecycle_raw') }} as lc
+				where {{ incremental_predicate('lc.received_ts') }}
+					and lc.event_type in ('determined', 'settled')
+			)
 		)
 	{% endif -%}
 )
@@ -145,6 +152,23 @@ with markets as (
 		{{ source('kalshi', 'series_raw') }}
 )
 
+-- Lifecycle events stream: settlement-relevant fields populated per event_type.
+, lifecycle as (
+	select
+		market_ticker as ticker
+		, max_by(result, received_ts) filter (where event_type = 'determined') as result
+		, max_by(settlement_value, received_ts) filter (where event_type = 'determined') as settlement_value
+		, max_by(determination_ts, received_ts) filter (where event_type = 'determined') as determination_ts
+		, max_by(settled_ts, received_ts) filter (where event_type = 'settled') as settled_ts
+		, max(received_ts) as last_event_received_ts
+	from
+		{{ source('kalshi', 'markets_lifecycle_raw') }}
+	where
+		event_type in ('determined', 'settled')
+	group by
+		market_ticker
+)
+
 select
 	m.ticker
 	, m.event_ticker
@@ -160,10 +184,11 @@ select
 	, m.expiration_time
 	, m.latest_expiration_time
 	, m.expected_expiration_time
-	, m.settlement_ts
+	-- Lifecycle wins when present: markets_raw settlement fields can lag ingest by weeks.
+	, coalesce(lc.settled_ts, m.settlement_ts) as settlement_ts
 	, m.status
-	, m.result
-	, m.settlement_value_dollars
+	, coalesce(lc.result, m.result) as result
+	, coalesce(try_cast(lc.settlement_value as double), m.settlement_value_dollars) as settlement_value_dollars
 	, m.expiration_value
 	, m.can_close_early
 	, m.early_close_condition
@@ -207,7 +232,8 @@ select
 	, greatest(
 		m.updated_time,
 		coalesce(ed.last_updated_ts, m.updated_time),
-		coalesce(s.series_last_updated_ts, m.updated_time)
+		coalesce(s.series_last_updated_ts, m.updated_time),
+		coalesce(lc.last_event_received_ts, m.updated_time)
 	) as source_updated_at
 	, now() as _updated_at
 from
@@ -216,3 +242,5 @@ left join event_details as ed
 	on m.event_ticker = ed.event_ticker
 left join series as s
 	on s.series_ticker = ed.series_ticker
+left join lifecycle as lc
+	on m.ticker = lc.ticker

--- a/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_market_details.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_market_details.sql
@@ -87,11 +87,15 @@ with markets as (
 					)
 			)
 			-- Late-arriving settlements: markets_raw.updated_time can lag ingest by weeks; lifecycle.received_ts is real ingest time.
+			-- Filter on field population, not event_type label, so new Kalshi event_types carrying these fields are picked up automatically.
 			or m.ticker in (
 				select lc.market_ticker
 				from {{ source('kalshi', 'markets_lifecycle_raw') }} as lc
 				where {{ incremental_predicate('lc.received_ts') }}
-					and lc.event_type in ('determined', 'settled')
+					and (lc.result is not null
+						or lc.settled_ts is not null
+						or lc.determination_ts is not null
+						or lc.settlement_value is not null)
 			)
 		)
 	{% endif -%}
@@ -152,19 +156,23 @@ with markets as (
 		{{ source('kalshi', 'series_raw') }}
 )
 
--- Lifecycle events stream: settlement-relevant fields populated per event_type.
+-- Lifecycle events stream. Filter on column population, not event_type label,
+-- so new Kalshi event_types that carry these fields are picked up automatically.
 , lifecycle as (
 	select
 		market_ticker as ticker
-		, max_by(result, received_ts) filter (where event_type = 'determined') as result
-		, max_by(settlement_value, received_ts) filter (where event_type = 'determined') as settlement_value
-		, max_by(determination_ts, received_ts) filter (where event_type = 'determined') as determination_ts
-		, max_by(settled_ts, received_ts) filter (where event_type = 'settled') as settled_ts
-		, max(received_ts) as last_event_received_ts
+		, max_by(result, received_ts) filter (where result is not null) as result
+		, max_by(settlement_value, received_ts) filter (where settlement_value is not null) as settlement_value
+		, max_by(determination_ts, received_ts) filter (where determination_ts is not null) as determination_ts
+		, max_by(settled_ts, received_ts) filter (where settled_ts is not null) as settled_ts
+		, max(received_ts) filter (
+			where result is not null
+				or settled_ts is not null
+				or determination_ts is not null
+				or settlement_value is not null
+		) as last_event_received_ts
 	from
 		{{ source('kalshi', 'markets_lifecycle_raw') }}
-	where
-		event_type in ('determined', 'settled')
 	group by
 		market_ticker
 )

--- a/sources/kalshi/_sources.yml
+++ b/sources/kalshi/_sources.yml
@@ -21,3 +21,19 @@ sources:
         description: "Series-level metadata from Kalshi API (one row per series_ticker). Carries canonical category, frequency, fee structure, and other series-stable fields."
       - name: markets_lifecycle_raw
         description: "Per-market lifecycle events (created, determined, settled, deactivated) streamed from Kalshi WebSocket. received_ts is reliable ingest time; event_type='determined' carries result/settlement_value/determination_ts, event_type='settled' carries settled_ts."
+        columns:
+          - name: event_type
+            description: "Lifecycle transition label from Kalshi WS. Allowlist tripwires when Kalshi adds a new value: investigate whether it carries settlement-relevant fields, then extend this list."
+            data_tests:
+              - accepted_values:
+                  arguments:
+                    values:
+                      - created
+                      - activated
+                      - deactivated
+                      - close_date_updated
+                      - determined
+                      - settled
+                      - fractional_trading_updated
+                      - price_level_structure_updated
+                      - metadata_updated

--- a/sources/kalshi/_sources.yml
+++ b/sources/kalshi/_sources.yml
@@ -19,3 +19,5 @@ sources:
         description: "Event-level metadata from Kalshi API"
       - name: series_raw
         description: "Series-level metadata from Kalshi API (one row per series_ticker). Carries canonical category, frequency, fee structure, and other series-stable fields."
+      - name: markets_lifecycle_raw
+        description: "Per-market lifecycle events (created, determined, settled, deactivated) streamed from Kalshi WebSocket. received_ts is reliable ingest time; event_type='determined' carries result/settlement_value/determination_ts, event_type='settled' carries settled_ts."


### PR DESCRIPTION
## Summary

Stacked on #9644 (`feat/kalshi-series-integration`). Targets that branch, not `main`, so the diff stays minimal once the parent merges.

`kalshi_market_details` reads `kalshi.markets_raw` and uses `m.updated_time >= now() - 3 days` as its incremental predicate. Problem: `markets_raw.updated_time` is Kalshi's own `last_modified` field, not ingest time. Settlement updates often arrive in `markets_raw` with `updated_time` already weeks old, so they fall outside the 3-day window and never land in the spell. We measured ~962K markets where `markets_raw.result` is populated but the spell still shows them as unsettled, which produced a journalist-visible cliff in `settled_share` from ~95% to ~0% after 2026-04-15.

This PR routes settlement signal through `kalshi.markets_lifecycle_raw` (new ingest table, forward-only WebSocket stream from 2026-05-07) where `received_ts` is real ingest time:

- New `lifecycle` CTE aggregates per-market: `result`, `settlement_value`, `determination_ts` from `event_type='determined'` rows; `settled_ts` from `event_type='settled'` rows.
- New OR-branch in the incremental selector: any ticker with a fresh lifecycle event (`received_ts` in window) is pulled into the merge.
- Final SELECT now coalesces `result`, `settlement_ts`, and `settlement_value_dollars` from lifecycle first, falling back to `markets_raw`. `settlement_value` is varchar in lifecycle ("0.0000"/"1.0000"), cast to double via `try_cast` to align with the existing `markets_raw.settlement_value_dollars` type.
- `source_updated_at` extended to include `lifecycle.last_event_received_ts` so downstream `kalshi_market_trades` (which already pulls `result`/`status` via `ref('kalshi_market_details')`) reprocesses tickers whose lifecycle row updated.

`kalshi_market_trades.sql` is unchanged: it inherits the fix automatically through the ref.

## Scope

- Lifecycle is forward-only since 2026-05-07; there is no historical backfill in `markets_lifecycle_raw`. The 962K-row historical backlog is fixed by the auto full-refresh that happens when #9644 merges (since the parent PR introduces a new column, dbt will rebuild from scratch and pick up settlement state from `markets_raw` directly).
- This PR fixes the **structural future bug** only: from now on, late-arriving settlements ride the lifecycle stream and land within one incremental tick.

## Validation

- `uv run dbt compile --select kalshi_market_details` succeeds.
- Compiled SQL run through Dune (full-refresh shape, `LIMIT 100`): parses, returns rows, `source_updated_at` non-null on every row, lifecycle coalesce produces the expected `result` (yes/no/scalar) and `settlement_value_dollars` (0.0/1.0 doubles).

Generated with [Claude Code](https://claude.com/claude-code)
