### PR TITLE
CUR2-2282: GMX v2 hourly evt_tx columns and block_date merge keys

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_claimed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'claim_funds_claimed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -141,7 +148,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'amount' THEN value END) AS amount
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -169,6 +176,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -176,7 +184,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_claimed.sql
@@ -156,6 +156,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_claimed.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -154,8 +160,11 @@ WITH evt_data_1 AS (
         from_hex(token) AS token,
         from_hex(receiver) AS receiver,
         TRY_CAST(distribution_id AS VARCHAR) AS distribution_id,
-        TRY_CAST(amount AS DOUBLE) AS amount
+        TRY_CAST(amount AS DOUBLE) AS amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -183,8 +192,11 @@ WITH evt_data_1 AS (
             ERC20.decimals,
             MD.market_token_decimals,
             GLV.glv_token_decimals
-        )) AS amount
+        )) AS amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON ED.token = ERC20.contract_address
@@ -194,11 +206,6 @@ WITH evt_data_1 AS (
         ON ED.token = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_deposited.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_deposited.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -154,8 +160,11 @@ WITH evt_data_1 AS (
         from_hex(token) AS token,
         TRY_CAST(distribution_id AS VARCHAR) AS distribution_id,
         TRY_CAST(amount AS DOUBLE) AS amount,
-        TRY_CAST(next_amount AS DOUBLE) AS next_amount
+        TRY_CAST(next_amount AS DOUBLE) AS next_amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -187,8 +196,11 @@ WITH evt_data_1 AS (
             ERC20.decimals,
             MD.market_token_decimals,
             GLV.glv_token_decimals
-        )) AS next_amount
+        )) AS next_amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON ED.token = ERC20.contract_address
@@ -198,11 +210,6 @@ WITH evt_data_1 AS (
         ON ED.token = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_deposited.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_deposited.sql
@@ -156,6 +156,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_deposited.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_deposited.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'claim_funds_deposited',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'distributionId' THEN value END) AS distribution_id,
@@ -141,7 +148,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextAmount' THEN value END) AS next_amount
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -169,6 +176,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -176,7 +184,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_transferred.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_transferred.sql
@@ -157,6 +157,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_transferred.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_transferred.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -156,7 +162,10 @@ WITH evt_data_1 AS (
         from_hex(token) AS token,
         TRY_CAST(distribution_id AS VARCHAR) AS distribution_id,
         TRY_CAST(amount AS DOUBLE) AS amount,
-        TRY_CAST(next_amount AS DOUBLE) AS next_amount
+        TRY_CAST(next_amount AS DOUBLE) AS next_amount,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -190,8 +199,11 @@ WITH evt_data_1 AS (
             ERC20.decimals,
             MD.market_token_decimals,
             GLV.glv_token_decimals
-        )) AS next_amount
+        )) AS next_amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON ED.token = ERC20.contract_address
@@ -201,11 +213,6 @@ WITH evt_data_1 AS (
         ON ED.token = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_transferred.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_transferred.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'claim_funds_transferred',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'fromAccount' THEN value END) AS from_account,
         MAX(CASE WHEN key_name = 'toAccount' THEN value END) AS to_account,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
@@ -142,7 +149,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextAmount' THEN value END) AS next_amount
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -171,6 +178,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -178,7 +186,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_withdrawn.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_withdrawn.sql
@@ -156,6 +156,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_withdrawn.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_withdrawn.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'claim_funds_withdrawn',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -141,7 +148,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'amount' THEN value END) AS amount
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -169,6 +176,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -176,7 +184,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_withdrawn.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_funds_withdrawn.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -154,8 +160,11 @@ WITH evt_data_1 AS (
         from_hex(token) AS token,
         from_hex(receiver) AS receiver,
         TRY_CAST(distribution_id AS VARCHAR) AS distribution_id,
-        TRY_CAST(amount AS DOUBLE) AS amount
+        TRY_CAST(amount AS DOUBLE) AS amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -183,8 +192,11 @@ WITH evt_data_1 AS (
             ERC20.decimals,
             MD.market_token_decimals,
             GLV.glv_token_decimals
-        )) AS amount
+        )) AS amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON ED.token = ERC20.contract_address
@@ -194,11 +206,6 @@ WITH evt_data_1 AS (
         ON ED.token = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_terms_removed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_terms_removed.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -130,18 +136,16 @@ WITH evt_data_1 AS (
         ED.event_name,
         ED.msg_sender,
         
-        TRY_CAST(distribution_id AS VARCHAR) AS distribution_id
+        TRY_CAST(distribution_id AS VARCHAR) AS distribution_id,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_terms_removed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_terms_removed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'claim_terms_removed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
         evt_data
@@ -99,6 +103,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,10 +122,11 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'distributionId' THEN value END) AS distribution_id
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -128,7 +134,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -144,6 +150,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_terms_set.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_terms_set.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'claim_terms_set',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,11 +140,12 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'distributionId' THEN value END) AS distribution_id,
         MAX(CASE WHEN key_name = 'termsHash' THEN value END) AS terms_hash
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -146,7 +153,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -164,6 +171,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_terms_set.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claim_terms_set.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -149,7 +155,10 @@ WITH evt_data_1 AS (
         ED.msg_sender,
         
         TRY_CAST(distribution_id AS VARCHAR) AS distribution_id,
-        from_hex(terms_hash) AS terms_hash
+        from_hex(terms_hash) AS terms_hash,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -157,11 +166,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_collateral_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_collateral_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'claimable_collateral_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -40,6 +41,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -95,6 +98,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -104,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +122,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -138,6 +144,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
@@ -147,7 +154,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextPoolValue' THEN value END) AS next_pool_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -175,6 +182,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_collateral_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_collateral_updated.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -41,6 +43,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -62,6 +66,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -161,7 +167,10 @@ WITH evt_data_1 AS (
         CAST(time_key AS DOUBLE) AS time_key,
         CAST(delta AS DOUBLE) AS delta,
         CAST(next_value AS DOUBLE) AS next_value,
-        CAST(next_pool_value AS DOUBLE) AS next_pool_value
+        CAST(next_pool_value AS DOUBLE) AS next_pool_value,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -187,18 +196,16 @@ WITH evt_data_1 AS (
         ED.time_key / POWER(10, erc20.decimals) AS time_key,
         ED.delta / POWER(10, erc20.decimals) AS delta,
         ED.next_value / POWER(10, erc20.decimals) AS next_value,
-        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value
+        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS erc20
         ON erc20.contract_address = ED.token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_funding_amount_per_size_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_funding_amount_per_size_updated.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -152,8 +156,11 @@ WITH evt_data_1 AS (
         from_hex(collateral_token) AS collateral_token,
         TRY_CAST(delta AS DOUBLE) delta, 
         TRY_CAST("value" AS DOUBLE) "value",  
-        TRY_CAST(is_long AS BOOLEAN) AS is_long
+        TRY_CAST(is_long AS BOOLEAN) AS is_long,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -176,20 +183,16 @@ WITH evt_data_1 AS (
         ED.collateral_token,
         delta / POWER(10, CTD.collateral_token_decimals + 15) AS delta,
         "value" / POWER(10, CTD.collateral_token_decimals + 15) AS "value",
-        is_long
+        is_long,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_collateral_tokens_data') }} AS CTD
         ON ED.collateral_token = CTD.collateral_token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_funding_amount_per_size_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_funding_amount_per_size_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'claimable_funding_amount_per_size_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
@@ -137,7 +144,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -165,6 +172,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_funding_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_funding_updated.sql
@@ -160,6 +160,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_funding_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_funding_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'claimable_funding_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -40,6 +41,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -95,6 +98,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -104,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +122,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -138,6 +144,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
@@ -146,7 +153,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextPoolValue' THEN value END) AS next_pool_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -173,6 +180,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -180,7 +188,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_funding_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_claimable_funding_updated.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -41,6 +43,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -62,6 +66,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -159,7 +165,10 @@ WITH evt_data_1 AS (
         from_hex(account) AS account,
         CAST(delta AS DOUBLE) AS delta,
         CAST(next_value AS DOUBLE) AS next_value,
-        CAST(next_pool_value AS DOUBLE) AS next_pool_value
+        CAST(next_pool_value AS DOUBLE) AS next_pool_value,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -184,18 +193,16 @@ WITH evt_data_1 AS (
         ED.account,
         ED.delta / POWER(10, erc20.decimals) AS delta,
         ED.next_value / POWER(10, erc20.decimals) AS next_value,
-        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value
+        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS erc20
         ON erc20.contract_address = ED.token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_clear_pending_action.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_clear_pending_action.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'clear_pending_action',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -89,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.stringItems' OMIT QUOTES) AS string_items
     FROM
@@ -98,6 +102,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -110,6 +115,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,11 +135,12 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'actionKey' THEN value END) AS action_key,
         MAX(CASE WHEN key_name = 'actionLabel' THEN value END) AS action_label
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -159,6 +166,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_clear_pending_action.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_clear_pending_action.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -62,7 +62,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -150,20 +150,19 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(action_key) AS action_key,
-        action_label
+        action_label,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_collateral_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_collateral_claimed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'collateral_claimed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -40,6 +41,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -95,6 +98,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -104,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +122,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -138,6 +144,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
@@ -147,7 +154,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextPoolValue' THEN value END) AS next_pool_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -175,6 +182,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_collateral_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_collateral_claimed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -41,6 +43,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -62,6 +66,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -161,7 +167,10 @@ WITH evt_data_1 AS (
         from_hex(receiver) AS receiver,
         CAST(time_key AS DOUBLE) AS time_key,
         CAST(amount AS DOUBLE) AS amount,
-        CAST(next_pool_value AS DOUBLE) AS next_pool_value
+        CAST(next_pool_value AS DOUBLE) AS next_pool_value,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -187,18 +196,16 @@ WITH evt_data_1 AS (
         ED.receiver,
         ED.time_key / POWER(10, erc20.decimals) AS time_key,
         ED.amount / POWER(10, erc20.decimals) AS amount,
-        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value
+        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS erc20
         ON erc20.contract_address = ED.token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_cancelled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'deposit_cancelled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
@@ -103,6 +107,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -116,6 +121,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,6 +135,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -142,6 +149,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -169,6 +177,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key",
@@ -177,7 +186,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -204,6 +213,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_cancelled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -189,7 +195,10 @@ WITH evt_data_1 AS (
         from_hex(account) AS account,
         from_hex("key") AS "key",
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -197,13 +206,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'deposit_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -169,7 +177,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -211,6 +219,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_created.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -198,7 +202,10 @@ WITH evt_data_1 AS (
         
         TRY_CAST(should_unwrap_native_token AS BOOLEAN) AS should_unwrap_native_token,
         
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -239,20 +246,16 @@ WITH evt_data_1 AS (
         deposit_type,
         
         should_unwrap_native_token,
-        "key"
+        "key",
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
         ON ED.market = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_executed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -175,7 +181,10 @@ WITH evt_data_1 AS (
         TRY_CAST(short_token_amount AS DOUBLE) AS short_token_amount,
         TRY_CAST(received_market_tokens AS DOUBLE) AS received_market_tokens,
         TRY_CAST(swap_pricing_type AS INTEGER) AS swap_pricing_type,
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -200,8 +209,11 @@ WITH evt_data_1 AS (
         ED.short_token_amount / POWER(10, MD.short_token_decimals) AS short_token_amount,
         ED.received_market_tokens / POWER(10, 18) AS received_market_tokens,
         ED.swap_pricing_type,
-        ED."key"
+        ED."key",
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_deposit_created') }} AS DC
         ON ED."key" = DC."key"
@@ -209,13 +221,6 @@ WITH evt_data_1 AS (
         ON DC.market = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'deposit_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -102,6 +106,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -115,6 +120,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -152,6 +159,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'longTokenAmount' THEN value END) AS long_token_amount,
@@ -162,7 +170,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -190,13 +198,14 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_deposit_executed.sql
@@ -177,6 +177,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_event_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_event_schema.yml
@@ -17,6 +17,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -181,6 +182,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -229,6 +231,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -348,6 +351,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -486,6 +490,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -572,6 +577,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -794,6 +800,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -878,6 +885,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -927,6 +935,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -981,6 +990,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1040,6 +1050,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1105,6 +1116,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1161,6 +1173,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1220,6 +1233,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1273,6 +1287,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1314,6 +1329,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1355,6 +1371,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1398,6 +1415,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1467,6 +1485,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1514,6 +1533,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1563,6 +1583,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1606,6 +1627,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1681,6 +1703,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1724,6 +1747,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1765,6 +1789,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1814,6 +1839,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1853,6 +1879,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1898,6 +1925,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1967,6 +1995,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2008,6 +2037,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2065,6 +2095,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2106,6 +2137,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2149,6 +2181,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2214,6 +2247,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2254,6 +2288,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2297,6 +2332,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2340,6 +2376,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2397,6 +2434,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2436,6 +2474,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2481,6 +2520,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2525,6 +2565,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2561,6 +2602,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2607,6 +2649,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2651,6 +2694,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2687,6 +2731,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2723,6 +2768,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2759,6 +2805,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2799,6 +2846,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2835,6 +2883,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2871,6 +2920,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2913,6 +2963,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2949,6 +3000,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2985,6 +3037,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3021,6 +3074,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3057,6 +3111,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3097,6 +3152,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3133,6 +3189,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3169,6 +3226,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3211,6 +3269,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3269,6 +3328,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3309,6 +3369,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3349,6 +3410,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3389,6 +3451,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3432,6 +3495,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3472,6 +3536,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3514,6 +3579,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3556,6 +3622,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3596,6 +3663,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3638,6 +3706,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3680,6 +3749,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3722,6 +3792,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3766,6 +3837,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3808,6 +3880,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3842,6 +3915,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3879,6 +3953,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_event_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_event_schema.yml
@@ -452,16 +452,10 @@ models:
         description: The change in collateral amount
         data_tests:
           - not_null
-      - &price_impact_usd
-        name: price_impact_usd
-        description: The impact on price in USD
-        data_tests:
-          - not_null
-      - &price_impact_amount
-        name: price_impact_amount
-        description: The impact on price in index token amount
-        data_tests:
-          - not_null
+      - name: price_impact_usd
+        description: The impact on price in USD (nullable when the on-chain payload omits priceImpactUsd)
+      - name: price_impact_amount
+        description: The impact on price in index token amount (nullable when the payload omits priceImpactAmount)
       - *is_long
       - &order_key
         name: order_key
@@ -545,7 +539,10 @@ models:
       - &decreased_at_time
         name: decreased_at_time
         description: The block timestamp when the position was decreased             
-      - *price_impact_usd
+      - name: price_impact_usd
+        description: The impact on price in USD
+        data_tests:
+          - not_null
       - &base_pnl_usd
         name: base_pnl_usd
         description: The base profit and loss in USD for the position

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_execution_fee_refund.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_execution_fee_refund.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -128,7 +132,10 @@ WITH evt_data_1 AS (
         msg_sender,
         
         from_hex(EDP.receiver) AS receiver,
-        CAST(EDP.refund_fee_amount AS DOUBLE) / POWER(10, 18) AS refund_fee_amount
+        CAST(EDP.refund_fee_amount AS DOUBLE) / POWER(10, 18) AS refund_fee_amount,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -136,12 +143,6 @@ WITH evt_data_1 AS (
         AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_execution_fee_refund.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_execution_fee_refund.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'execution_fee_refund',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -111,11 +116,12 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
         MAX(CASE WHEN key_name = 'refundFeeAmount' THEN value END) AS refund_fee_amount
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -141,6 +147,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -39,7 +39,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -58,7 +58,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -148,8 +148,11 @@ WITH evt_data_1 AS (
         msg_sender,
         
         from_hex(market) AS market,
-        TRY_CAST(funding_factor_per_second AS DOUBLE) AS funding_factor_per_second
-        
+        TRY_CAST(funding_factor_per_second AS DOUBLE) AS funding_factor_per_second,
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -171,16 +174,17 @@ WITH evt_data_1 AS (
         ED.market,
         MD.market_name,
         ED.funding_factor_per_second AS funding_factor_per_second_raw,
-        ED.funding_factor_per_second / POWER(10, 30) AS funding_factor_per_second
+        ED.funding_factor_per_second / POWER(10, 30) AS funding_factor_per_second,
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
         ON ED.market = MD.market
 )
 
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding.sql
@@ -147,6 +147,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'funding',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -36,6 +37,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -55,6 +57,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -85,6 +88,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -95,6 +99,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -108,6 +113,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,11 +135,12 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'fundingFactorPerSecond' THEN value END) AS funding_factor_per_second
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -157,13 +164,14 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding_fee_amount_per_size_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding_fee_amount_per_size_updated.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -152,8 +156,11 @@ WITH evt_data_1 AS (
         from_hex(collateral_token) AS collateral_token,
         TRY_CAST(delta AS DOUBLE) delta, 
         TRY_CAST("value" AS DOUBLE) "value",  
-        TRY_CAST(is_long AS BOOLEAN) AS is_long
+        TRY_CAST(is_long AS BOOLEAN) AS is_long,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -176,20 +183,16 @@ WITH evt_data_1 AS (
         ED.collateral_token,
         delta / POWER(10, CTD.collateral_token_decimals + 15) AS delta,
         "value" / POWER(10, CTD.collateral_token_decimals + 15) AS "value",
-        is_long
+        is_long,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_collateral_tokens_data') }} AS CTD
         ON ED.collateral_token = CTD.collateral_token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding_fee_amount_per_size_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding_fee_amount_per_size_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'funding_fee_amount_per_size_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
@@ -137,7 +144,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -165,6 +172,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding_fees_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding_fees_claimed.sql
@@ -160,6 +160,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding_fees_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding_fees_claimed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'funding_fees_claimed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -40,6 +41,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -95,6 +98,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -104,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +122,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -138,6 +144,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
@@ -146,7 +153,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextPoolValue' THEN value END) AS next_pool_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -173,6 +180,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -180,7 +188,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding_fees_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_funding_fees_claimed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -41,6 +43,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -62,6 +66,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -159,7 +165,10 @@ WITH evt_data_1 AS (
         from_hex(account) AS account,
         from_hex(receiver) AS receiver,
         CAST(amount AS DOUBLE) AS amount,
-        CAST(next_pool_value AS DOUBLE) AS next_pool_value
+        CAST(next_pool_value AS DOUBLE) AS next_pool_value,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -184,18 +193,16 @@ WITH evt_data_1 AS (
         ED.account,
         ED.receiver,
         ED.amount / POWER(10, erc20.decimals) AS amount,
-        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value
+        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS erc20
         ON erc20.contract_address = ED.token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_created.sql
@@ -2,7 +2,7 @@
 	schema='gmx_v2_arbitrum',
 	alias='glv_created',
 	materialized='incremental',
-	unique_key=['tx_hash', 'index'],
+	unique_key=['block_date', 'tx_hash', 'index'],
 	incremental_strategy='merge',
 ) }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_deposit_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_deposit_cancelled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'glv_deposit_cancelled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key",
@@ -153,7 +161,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -180,6 +188,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_deposit_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_deposit_cancelled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -167,7 +171,10 @@ WITH evt_data_1 AS (
         from_hex(account) AS account,
         from_hex("key") AS "key",
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -175,13 +182,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_deposit_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_deposit_created.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -204,7 +208,10 @@ WITH evt_data_1 AS (
         TRY_CAST(should_unwrap_native_token AS BOOLEAN) AS should_unwrap_native_token,
         TRY_CAST(is_market_token_deposit AS BOOLEAN) AS is_market_token_deposit,
         
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -249,7 +256,10 @@ WITH evt_data_1 AS (
         should_unwrap_native_token,
         is_market_token_deposit,
         
-        "key"
+        "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
@@ -257,13 +267,6 @@ WITH evt_data_1 AS (
 )
 
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_deposit_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_deposit_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'glv_deposit_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -172,7 +180,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -217,6 +225,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_deposit_executed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -147,7 +151,10 @@ WITH evt_data_1 AS (
 
         from_hex(account) AS account,
         TRY_CAST(received_glv_tokens AS DOUBLE) received_glv_tokens,
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -169,18 +176,14 @@ WITH evt_data_1 AS (
 
         account,
         received_glv_tokens / POWER(10,18) AS received_glv_tokens,
-        "key"
+        "key",
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_deposit_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'glv_deposit_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receivedGlvTokens' THEN value END) AS received_glv_tokens,
@@ -135,7 +142,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -160,6 +167,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_shift_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_shift_cancelled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'glv_shift_cancelled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
         json_query(data, 'lax $.stringItems' OMIT QUOTES) AS string_items
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -103,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -127,13 +133,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key",
         MAX(CASE WHEN key_name = 'reasonBytes' THEN value END) AS reason_bytes,
         MAX(CASE WHEN key_name = 'reason' THEN value END) AS reason
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -160,6 +167,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_shift_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_shift_cancelled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -147,7 +151,10 @@ WITH evt_data_1 AS (
         
         from_hex("key") AS "key",
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -155,13 +162,6 @@ WITH evt_data_1 AS (
         AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_shift_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_shift_created.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -155,7 +159,10 @@ WITH evt_data_1 AS (
         TRY_CAST(market_token_amount AS DOUBLE) AS market_token_amount,
         TRY_CAST(min_market_tokens AS DOUBLE) AS min_market_tokens,
         TRY_CAST(updated_at_time AS DOUBLE) updated_at_time,
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -184,17 +191,13 @@ WITH evt_data_1 AS (
             WHEN updated_at_time = 0 THEN NULL
             ELSE updated_at_time
         END AS updated_at_time,
-        "key"
+        "key",
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_shift_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_shift_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'glv_shift_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'fromMarket' THEN value END) AS from_market,
         MAX(CASE WHEN key_name = 'toMarket' THEN value END) AS to_market,
@@ -139,7 +146,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -168,6 +175,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_shift_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_shift_executed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -128,7 +132,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         TRY_CAST(received_market_tokens AS DOUBLE) received_market_tokens, 
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -149,17 +156,13 @@ WITH evt_data_1 AS (
         msg_sender,
 
         received_market_tokens / POWER(10, 18) AS received_market_tokens,
-        "key"
+        "key",
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_shift_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_shift_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'glv_shift_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -111,13 +116,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'receivedMarketTokens' THEN value END) AS received_market_tokens,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key"
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -141,6 +147,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_withdrawal_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_withdrawal_cancelled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -167,7 +171,10 @@ WITH evt_data_1 AS (
         from_hex(account) AS account,
         from_hex("key") AS "key",
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -175,13 +182,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_withdrawal_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_withdrawal_cancelled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'glv_withdrawal_cancelled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key",
@@ -153,7 +161,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -180,6 +188,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_withdrawal_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_withdrawal_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'glv_withdrawal_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -168,7 +176,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -209,6 +217,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_withdrawal_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_withdrawal_created.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -196,7 +200,10 @@ WITH evt_data_1 AS (
 
         TRY_CAST(should_unwrap_native_token AS BOOLEAN) AS should_unwrap_native_token,
         
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -236,20 +243,16 @@ WITH evt_data_1 AS (
         callback_gas_limit,
 
         should_unwrap_native_token,
-        "key"
+        "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
         ON ED.market = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_withdrawal_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_withdrawal_executed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -129,7 +133,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(account) AS account,
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -137,13 +144,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_withdrawal_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_glv_withdrawal_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'glv_withdrawal_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -111,13 +116,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key"
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -142,6 +148,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_grant_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_grant_role.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(account) AS account,
-        from_hex(role_key) AS role_key
+        from_hex(role_key) AS role_key,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_grant_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_grant_role.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'grant_role',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'roleKey' THEN value END) AS role_key
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_increment_subaccount_action_count.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_increment_subaccount_action_count.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'increment_subaccount_action_count',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -102,6 +106,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -115,6 +120,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -152,13 +159,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'subaccount' THEN value END) AS subaccount,
         MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value,
         MAX(CASE WHEN key_name = 'actionType' THEN value END) AS action_type
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -183,6 +191,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_increment_subaccount_action_count.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_increment_subaccount_action_count.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -169,20 +175,16 @@ WITH evt_data_1 AS (
         from_hex(EDP.account) AS account,
         from_hex(EDP.subaccount) AS subaccount,
         TRY_CAST(EDP.next_value AS DOUBLE) AS next_value,
-        from_hex(EDP.action_type) AS action_type
+        from_hex(EDP.action_type) AS action_type,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_keeper_execution_fee.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_keeper_execution_fee.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'keeper_execution_fee',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -111,11 +116,12 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'keeper' THEN value END) AS keeper,
         MAX(CASE WHEN key_name = 'executionFeeAmount' THEN value END) AS execution_fee_amount
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -141,6 +147,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_keeper_execution_fee.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_keeper_execution_fee.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -128,7 +132,10 @@ WITH evt_data_1 AS (
         msg_sender,
         
         from_hex(EDP.keeper) AS keeper,
-        CAST(EDP.execution_fee_amount AS DOUBLE) / POWER(10, 18) AS execution_fee_amount
+        CAST(EDP.execution_fee_amount AS DOUBLE) / POWER(10, 18) AS execution_fee_amount,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -136,12 +143,6 @@ WITH evt_data_1 AS (
         AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_action.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_action.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'multichain_bridge_action',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,13 +140,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS provider,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'srcChainId' THEN value END) AS src_chain_id,
         MAX(CASE WHEN key_name = 'actionType' THEN value END) AS action_type
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -148,7 +155,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -167,6 +174,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_action.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_action.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -153,18 +159,16 @@ WITH evt_data_1 AS (
         from_hex(EDP.provider) AS provider,
         from_hex(EDP.account) AS account,
         TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id,
-        TRY_CAST(EDP.action_type AS DOUBLE) AS action_type
+        TRY_CAST(EDP.action_type AS DOUBLE) AS action_type,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_action_failed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_action_failed.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -172,18 +178,16 @@ WITH evt_data_1 AS (
         from_hex(EDP.account) AS account,
         TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id,
         TRY_CAST(EDP.action_type AS DOUBLE) AS action_type,
-        reason AS reason
+        reason AS reason,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_action_failed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_action_failed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'multichain_bridge_action_failed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.stringItems' OMIT QUOTES) AS string_items
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -127,6 +133,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -151,6 +158,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS provider,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'srcChainId' THEN value END) AS src_chain_id,
@@ -158,7 +166,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'reason' THEN value END) AS reason
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -166,7 +174,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -186,6 +194,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_in.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_in.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -159,7 +165,10 @@ WITH evt_data_1 AS (
             MD.market_token_decimals,
             GLV.glv_token_decimals
             )) AS amount,
-        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id
+        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -172,11 +181,6 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_in.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_in.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'multichain_bridge_in',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS provider,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
@@ -141,7 +148,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'srcChainId' THEN value END) AS src_chain_id
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -149,7 +156,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -173,6 +180,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_out.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_out.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -159,7 +165,10 @@ WITH evt_data_1 AS (
             MD.market_token_decimals,
             GLV.glv_token_decimals
             )) AS amount,
-        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id
+        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -172,11 +181,6 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_out.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_bridge_out.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'multichain_bridge_out',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS provider,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -141,7 +148,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'srcChainId' THEN value END) AS src_chain_id
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -149,7 +156,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -173,6 +180,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_transfer_in.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_transfer_in.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'multichain_transfer_in',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,13 +140,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'amount' THEN value END) AS amount,
         MAX(CASE WHEN key_name = 'srcChainId' THEN value END) AS src_chain_id
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -148,7 +155,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -171,6 +178,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_transfer_in.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_transfer_in.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -157,7 +163,10 @@ WITH evt_data_1 AS (
             MD.market_token_decimals,
             GLV.glv_token_decimals
             )) AS amount,
-        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id
+        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -170,11 +179,6 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_transfer_out.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_transfer_out.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -159,7 +165,10 @@ WITH evt_data_1 AS (
             MD.market_token_decimals,
             GLV.glv_token_decimals
             )) AS amount,
-        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id
+        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -172,11 +181,6 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_transfer_out.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_multichain_transfer_out.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'multichain_transfer_out',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -141,7 +148,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'srcChainId' THEN value END) AS src_chain_id
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -149,7 +156,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -173,6 +180,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_open_interest_in_tokens_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_open_interest_in_tokens_updated.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -39,7 +39,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -167,8 +167,11 @@ WITH evt_data_1 AS (
         from_hex(EDP.collateral_token) AS collateral_token,   
         CAST(EDP.is_long AS BOOLEAN) AS is_long,
         CAST(EDP.next_value AS DOUBLE) / POWER(10, MD.index_token_decimals) AS next_value,
-        CAST(EDP.delta AS DOUBLE) / POWER(10, MD.index_token_decimals) AS delta
+        CAST(EDP.delta AS DOUBLE) / POWER(10, MD.index_token_decimals) AS delta,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -177,11 +180,7 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.market) = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_open_interest_in_tokens_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_open_interest_in_tokens_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'open_interest_in_tokens_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -36,6 +37,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -62,6 +64,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
@@ -74,6 +77,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -87,6 +91,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -100,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -140,6 +147,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'isLong' THEN value END) AS is_long,
         MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
@@ -147,7 +155,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'delta' THEN value END) AS delta
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -176,6 +184,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
         ON from_hex(EDP.market) = MD.market
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_open_interest_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_open_interest_updated.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -39,7 +39,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -168,19 +168,18 @@ WITH evt_data_1 AS (
         from_hex(collateral_token) AS collateral_token,
         TRY_CAST(is_long AS BOOLEAN) AS is_long,
         TRY_CAST(delta AS DOUBLE) / POWER(10, 30) AS delta,
-        TRY_CAST(next_value AS DOUBLE) / POWER(10, 30) AS next_value
+        TRY_CAST(next_value AS DOUBLE) / POWER(10, 30) AS next_value,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_open_interest_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_open_interest_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'open_interest_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
   )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -36,6 +37,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
@@ -75,6 +78,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -88,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -101,6 +106,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +120,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -141,6 +148,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
         MAX(CASE WHEN key_name = 'isLong' THEN value END) AS is_long,
@@ -148,7 +156,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -177,6 +185,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_oracle_price_update.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_oracle_price_update.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'oracle_price_update',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -75,6 +78,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -87,6 +91,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -106,6 +111,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS provider,
         MAX(CASE WHEN key_name = 'minPrice' THEN value END) AS min_price,
@@ -113,7 +119,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'timestamp' THEN value END) AS "timestamp"    
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -145,6 +151,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_oracle_price_update.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_oracle_price_update.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -136,8 +136,11 @@ WITH evt_data_1 AS (
         CASE 
             WHEN TRY_CAST("timestamp" AS DOUBLE) = 0 THEN NULL
             ELSE TRY_CAST("timestamp" AS DOUBLE)
-        END AS "timestamp"
+        END AS "timestamp",
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -146,12 +149,8 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = ERC20.contract_address
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_cancelled.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -166,7 +170,10 @@ WITH evt_data_1 AS (
         from_hex(key) AS key,
         from_hex(account) AS account,
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -174,11 +181,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_cancelled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'order_cancelled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,13 +152,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS key,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'reasonBytes' THEN value END) AS reason_bytes,
         MAX(CASE WHEN key_name = 'reason' THEN value END) AS reason
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -179,6 +187,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_created.sql
@@ -4,7 +4,9 @@
     alias = 'order_created',
     materialized = 'incremental',
     unique_key = ['tx_hash', 'index'],
-    incremental_strategy = 'merge'
+    incremental_strategy = 'merge',
+    file_format = 'delta',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     )
 }}
 
@@ -19,6 +21,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +42,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +63,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -72,10 +80,10 @@ WITH evt_data_1 AS (
 , evt_data AS (
     SELECT * 
     FROM evt_data_1
-    UNION DISTINCT
+    UNION ALL
     SELECT *
     FROM evt_data_2
-    UNION 
+    UNION ALL
     SELECT *
     FROM evt_data_3
 )
@@ -269,8 +277,11 @@ WITH evt_data_1 AS (
         TRY_CAST(should_unwrap_native_token AS BOOLEAN) AS should_unwrap_native_token,
         TRY_CAST(auto_cancel AS BOOLEAN) AS auto_cancel,
         from_hex(key) AS key,
-        data_list
+        data_list,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -349,7 +360,10 @@ WITH evt_data_1 AS (
         END AS auto_cancel,
         
         key,
-        data_list
+        data_list,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
@@ -358,11 +372,6 @@ WITH evt_data_1 AS (
         ON ED.initial_collateral_token = CTD.collateral_token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'order_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge',
     file_format = 'delta',
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
@@ -18,6 +18,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -39,6 +40,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -60,6 +62,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -92,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -104,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +122,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_format(json_extract(CAST(item AS VARCHAR), '$.value')) AS value
     FROM 
@@ -130,6 +136,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -143,6 +150,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -156,6 +164,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -169,6 +178,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_format(json_extract(CAST(item AS VARCHAR), '$.value')) AS value
     FROM 
@@ -202,6 +212,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
         MAX(CASE WHEN key_name = 'callbackContract' THEN value END) AS callback_contract,
@@ -235,7 +246,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -286,6 +297,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'order_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -103,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,12 +134,13 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS key,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'secondaryOrderType' THEN value END) AS secondary_order_type
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -160,6 +167,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_executed.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -147,7 +151,10 @@ WITH evt_data_1 AS (
 
         from_hex(key) AS key,
         from_hex(account) AS account,
-        TRY_CAST(secondary_order_type AS INTEGER) AS secondary_order_type
+        TRY_CAST(secondary_order_type AS INTEGER) AS secondary_order_type,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -155,11 +162,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_frozen.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_frozen.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -166,7 +170,10 @@ WITH evt_data_1 AS (
         from_hex(key) AS key,
         from_hex(account) AS account,
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -174,11 +181,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_frozen.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_frozen.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'order_frozen',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,13 +152,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS key,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'reasonBytes' THEN value END) AS reason_bytes,
         MAX(CASE WHEN key_name = 'reason' THEN value END) AS reason
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -179,6 +187,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_updated.sql
@@ -173,6 +173,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_updated.sql
@@ -4,7 +4,9 @@
     alias = 'order_updated',
     materialized = 'incremental',
     unique_key = ['tx_hash', 'index'],
-    incremental_strategy = 'merge'
+    incremental_strategy = 'merge',
+    file_format = 'delta',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     )
 }}
 
@@ -19,6 +21,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +42,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -53,7 +59,7 @@ WITH evt_data_1 AS (
 , evt_data AS (
     SELECT * 
     FROM evt_data_1
-    UNION DISTINCT
+    UNION ALL
     SELECT *
     FROM evt_data_2
 )
@@ -174,8 +180,11 @@ WITH evt_data_1 AS (
         TRY_CAST(min_output_amount AS DOUBLE) AS min_output_amount,
         TRY_CAST(updated_at_time AS DOUBLE) AS updated_at_time,
         TRY_CAST(valid_from_time AS DOUBLE) AS valid_from_time,
-        TRY_CAST(auto_cancel AS BOOLEAN) AS auto_cancel
+        TRY_CAST(auto_cancel AS BOOLEAN) AS auto_cancel,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -215,7 +224,10 @@ WITH evt_data_1 AS (
             ELSE ED.updated_at_time
         END AS updated_at_time,
         ED.valid_from_time,
-        ED.auto_cancel
+        ED.auto_cancel,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_order_created') }} AS OC
@@ -225,11 +237,6 @@ WITH evt_data_1 AS (
         
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'order_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge',
     file_format = 'delta',
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
@@ -18,6 +18,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -39,6 +40,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -68,6 +70,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
@@ -80,6 +83,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -93,6 +97,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -106,6 +111,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -119,6 +125,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -146,6 +153,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS key,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'sizeDeltaUsd' THEN value END) AS size_delta_usd,
@@ -157,7 +165,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'autoCancel' THEN value END) AS auto_cancel
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -189,6 +197,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -196,7 +205,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_pool_amount_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_pool_amount_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'pool_amount_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -36,6 +37,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items
@@ -73,6 +76,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -85,6 +89,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -97,6 +102,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -119,13 +125,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'delta' THEN value END) AS delta,
         MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -153,6 +160,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_pool_amount_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_pool_amount_updated.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -39,7 +39,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -144,8 +144,11 @@ WITH evt_data_1 AS (
         from_hex(market) AS market,
         from_hex(token) AS token,
         TRY_CAST(next_value AS DOUBLE) / POWER(10, ERC20.decimals) AS next_value,
-        TRY_CAST(delta AS DOUBLE) / POWER(10, ERC20.decimals) AS delta
+        TRY_CAST(delta AS DOUBLE) / POWER(10, ERC20.decimals) AS delta,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -154,12 +157,8 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = ERC20.contract_address
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_decrease.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_decrease.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'position_decrease',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -131,6 +138,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -161,6 +169,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,        
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
@@ -191,7 +200,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -241,6 +250,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_decrease.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_decrease.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -228,8 +232,11 @@ WITH evt_data_1 AS (
         TRY_CAST(uncapped_base_pnl_usd AS DOUBLE) AS uncapped_base_pnl_usd,
         TRY_CAST(is_long AS BOOLEAN) AS is_long,
         from_hex(order_key) AS order_key,
-        from_hex(position_key) AS position_key
+        from_hex(position_key) AS position_key,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -289,8 +296,11 @@ WITH evt_data_1 AS (
         uncapped_base_pnl_usd / POWER(10, 30) AS uncapped_base_pnl_usd,    
         is_long,
         order_key,
-        position_key
+        position_key,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
         ON ED.market = MD.market
@@ -298,11 +308,6 @@ WITH evt_data_1 AS (
         ON ED.collateral_token = CTD.collateral_token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_fees_collected.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_fees_collected.sql
@@ -455,7 +455,9 @@ WITH evt_data_1 AS (
         COALESCE(liquidation_fee_receiver_factor, 0) AS liquidation_fee_receiver_factor,
         COALESCE(liquidation_fee_amount_for_fee_receiver, 0) AS liquidation_fee_amount_for_fee_receiver, 
     
-        is_increase
+        is_increase,
+        tx_from,
+        tx_to
     
     FROM full_data
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_fees_collected.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_fees_collected.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'position_fees_collected',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +123,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -144,6 +151,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'orderKey' THEN value END) AS order_key,
         MAX(CASE WHEN key_name = 'positionKey' THEN value END) AS position_key,
@@ -203,7 +211,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -281,6 +289,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_fees_collected.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_fees_collected.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -268,7 +272,10 @@ WITH evt_data_1 AS (
         TRY_CAST(liquidation_fee_receiver_factor AS DOUBLE) AS liquidation_fee_receiver_factor,
         TRY_CAST(liquidation_fee_amount_for_fee_receiver AS DOUBLE) AS liquidation_fee_amount_for_fee_receiver,
 
-        TRY_CAST(is_increase AS BOOLEAN) AS is_increase
+        TRY_CAST(is_increase AS BOOLEAN) AS is_increase,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -343,7 +350,10 @@ WITH evt_data_1 AS (
         liquidation_fee_receiver_factor / POWER(10, 30) AS liquidation_fee_receiver_factor,
         liquidation_fee_amount_for_fee_receiver / POWER(10, collateral_token_decimals) AS liquidation_fee_amount_for_fee_receiver,
 
-        is_increase
+        is_increase,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
@@ -441,11 +451,6 @@ WITH evt_data_1 AS (
     FROM full_data
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data_2'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data_2 AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_fees_info.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_fees_info.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'position_fees_info',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +123,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -144,6 +151,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'orderKey' THEN value END) AS order_key,
         MAX(CASE WHEN key_name = 'positionKey' THEN value END) AS position_key,
@@ -204,7 +212,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -282,6 +290,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_fees_info.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_fees_info.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -269,7 +273,10 @@ WITH evt_data_1 AS (
         TRY_CAST(liquidation_fee_receiver_factor AS DOUBLE) AS liquidation_fee_receiver_factor, 
         TRY_CAST(liquidation_fee_amount_for_fee_receiver AS DOUBLE) AS liquidation_fee_amount_for_fee_receiver, 
 
-        TRY_CAST(is_increase AS BOOLEAN) AS is_increase
+        TRY_CAST(is_increase AS BOOLEAN) AS is_increase,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -344,8 +351,11 @@ WITH evt_data_1 AS (
         liquidation_fee_receiver_factor / POWER(10, 30) AS liquidation_fee_receiver_factor, 
         liquidation_fee_amount_for_fee_receiver / POWER(10, collateral_token_decimals) AS liquidation_fee_amount_for_fee_receiver, 
 
-        is_increase
+        is_increase,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
         ON ED.market = MD.market
@@ -442,11 +452,6 @@ WITH evt_data_1 AS (
     FROM full_data
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data_2'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data_2 AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_fees_info.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_fees_info.sql
@@ -456,7 +456,9 @@ WITH evt_data_1 AS (
         COALESCE(liquidation_fee_receiver_factor, 0) AS liquidation_fee_receiver_factor,
         COALESCE(liquidation_fee_amount_for_fee_receiver, 0) AS liquidation_fee_amount_for_fee_receiver, 
     
-        is_increase
+        is_increase,
+        tx_from,
+        tx_to
     
     FROM full_data
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_impact_pool_amount_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_impact_pool_amount_updated.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -39,7 +39,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -58,7 +58,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -164,8 +164,11 @@ WITH evt_data_1 AS (
 
         from_hex(EDP.market) AS market,
         TRY_CAST(EDP.next_value AS DOUBLE) / POWER(10, MD.index_token_decimals) AS next_value,
-        TRY_CAST(EDP.delta AS DOUBLE) / POWER(10, MD.index_token_decimals) AS delta
-        
+        TRY_CAST(EDP.delta AS DOUBLE) / POWER(10, MD.index_token_decimals) AS delta,
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -174,12 +177,8 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.market) = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_impact_pool_amount_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_impact_pool_amount_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'position_impact_pool_amount_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -36,6 +37,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -55,6 +57,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -85,6 +88,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items
@@ -95,6 +99,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -107,6 +112,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -119,6 +125,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -141,12 +148,13 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'delta' THEN value END) AS delta,
         MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -173,6 +181,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
         ON from_hex(EDP.market) = MD.market
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_impact_pool_distributed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_impact_pool_distributed.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -129,8 +133,11 @@ WITH evt_data_1 AS (
 
         from_hex(market) AS market,
         TRY_CAST(distribution_amount AS DOUBLE) AS distribution_amount,
-        TRY_CAST(next_position_impact_pool_amount AS DOUBLE) AS next_position_impact_pool_amount
+        TRY_CAST(next_position_impact_pool_amount AS DOUBLE) AS next_position_impact_pool_amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -157,18 +164,16 @@ WITH evt_data_1 AS (
         CASE
             WHEN next_position_impact_pool_amount = 0 THEN 0
             ELSE next_position_impact_pool_amount / POWER(10, MD.index_token_decimals)
-        END AS next_position_impact_pool_amount
+        END AS next_position_impact_pool_amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
         ON ED.market = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_impact_pool_distributed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_impact_pool_distributed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'position_impact_pool_distributed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -76,6 +79,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -89,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -110,6 +115,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'distributionAmount' THEN value END) AS distribution_amount,
@@ -117,7 +123,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -142,6 +148,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_increase.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_increase.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'position_increase',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -131,6 +138,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -161,6 +169,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
@@ -189,7 +198,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -237,6 +246,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_increase.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_position_increase.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -224,8 +228,11 @@ WITH evt_data_1 AS (
         TRY_CAST(price_impact_amount AS DOUBLE) AS price_impact_amount,
         TRY_CAST(is_long AS BOOLEAN) AS is_long,
         from_hex(order_key) AS order_key,
-        from_hex(position_key) AS position_key
+        from_hex(position_key) AS position_key,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -283,8 +290,11 @@ WITH evt_data_1 AS (
         price_impact_amount / POWER(10, index_token_decimals) AS price_impact_amount,  
         is_long,
         order_key,
-        position_key
+        position_key,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
         ON ED.market = MD.market
@@ -292,11 +302,6 @@ WITH evt_data_1 AS (
         ON ED.collateral_token = CTD.collateral_token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_revoke_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_revoke_role.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(account) AS account,
-        from_hex(role_key) AS role_key
+        from_hex(role_key) AS role_key,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_revoke_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_revoke_role.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'revoke_role',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'roleKey' THEN value END) AS role_key
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_atomic_oracle_provider.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_atomic_oracle_provider.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'set_atomic_oracle_provider',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS "provider",
         MAX(CASE WHEN key_name = 'value' THEN value END) AS "value"
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_atomic_oracle_provider.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_atomic_oracle_provider.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex("provider") AS "provider",
-        TRY_CAST("value" AS BOOLEAN) AS "value"
+        TRY_CAST("value" AS BOOLEAN) AS "value",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_data_stream.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_data_stream.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'set_data_stream',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -89,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -99,6 +103,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -111,6 +116,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -123,6 +129,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,13 +152,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'feedId' THEN value END) AS feed_id,
         MAX(CASE WHEN key_name = 'dataStreamMultiplier' THEN value END) AS data_stream_multiplier,
         MAX(CASE WHEN key_name = 'dataStreamSpreadReductionFactor' THEN value END) AS data_stream_spread_reduction_factor
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -179,6 +187,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_data_stream.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_data_stream.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -62,7 +62,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -170,19 +170,19 @@ WITH evt_data_1 AS (
         from_hex(EDP.token) AS token,
         from_hex(EDP.feed_id) AS feed_id,
         TRY_CAST(EDP.data_stream_multiplier AS DOUBLE) / POWER(10, 30) AS data_stream_multiplier,
-        TRY_CAST(EDP.data_stream_spread_reduction_factor AS DOUBLE) / POWER(10, 30) AS data_stream_spread_reduction_factor
+        TRY_CAST(EDP.data_stream_spread_reduction_factor AS DOUBLE) / POWER(10, 30) AS data_stream_spread_reduction_factor,
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_oracle_provider_enabled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_oracle_provider_enabled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'set_oracle_provider_enabled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS "provider",
         MAX(CASE WHEN key_name = 'value' THEN value END) AS "value"
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_oracle_provider_enabled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_oracle_provider_enabled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex("provider") AS "provider",
-        TRY_CAST("value" AS BOOLEAN) AS "value"
+        TRY_CAST("value" AS BOOLEAN) AS "value",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_oracle_provider_for_token.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_oracle_provider_for_token.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -134,7 +140,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(token) AS token,
-        from_hex("provider") AS "provider"
+        from_hex("provider") AS "provider",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -142,13 +151,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_oracle_provider_for_token.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_oracle_provider_for_token.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'set_oracle_provider_for_token',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items
     FROM
         evt_data
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,20 +123,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS "provider"
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -149,6 +155,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_price_feed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_price_feed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'set_price_feed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -89,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -98,6 +102,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -110,6 +115,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,6 +135,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'priceFeed' THEN value END) AS price_feed,
         MAX(CASE WHEN key_name = 'priceFeedMultiplier' THEN value END) AS price_feed_multiplier,
@@ -136,7 +143,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'stablePrice' THEN value END) AS stable_price 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -165,6 +172,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_price_feed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_price_feed.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -62,7 +62,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -156,8 +156,11 @@ WITH evt_data_1 AS (
         from_hex(EDP.price_feed) AS price_feed,
         TRY_CAST(EDP.price_feed_multiplier AS DOUBLE) / POWER(10, 30) AS price_feed_multiplier,
         TRY_CAST(EDP.price_feed_heartbeat_duration AS DOUBLE) AS price_feed_heartbeat_duration,
-        TRY_CAST(EDP.stable_price AS DOUBLE) / POWER(10, 30 - ERC20.decimals) AS stable_price
+        TRY_CAST(EDP.stable_price AS DOUBLE) / POWER(10, 30 - ERC20.decimals) AS stable_price,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -166,12 +169,8 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = ERC20.contract_address
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_uint.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_uint.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -39,7 +39,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -147,19 +147,19 @@ WITH evt_data_1 AS (
 
         from_hex(EDP.base_key) AS base_key,
         from_hex(EDP."data") AS "data",
-        TRY_CAST(EDP."value" AS DOUBLE) AS "value_raw"
+        TRY_CAST(EDP."value" AS DOUBLE) AS "value_raw",
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_uint.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_set_uint.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'set_uint',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -36,6 +37,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
@@ -74,6 +77,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -87,6 +91,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -100,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -124,12 +130,13 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'baseKey' THEN value END) AS base_key,
         MAX(CASE WHEN key_name = 'data' THEN value END) AS "data",
         MAX(CASE WHEN key_name = 'value' THEN value END) AS "value"
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -156,6 +163,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_shift_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_shift_created.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -167,7 +171,10 @@ WITH evt_data_1 AS (
         TRY_CAST(execution_fee AS DOUBLE) AS execution_fee,
         TRY_CAST(callback_gas_limit AS DOUBLE) AS callback_gas_limit,
         
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -201,18 +208,14 @@ WITH evt_data_1 AS (
         END AS updated_at_time,
         execution_fee / POWER(10, 18) AS execution_fee,
         callback_gas_limit,
-        "key"
+        "key",
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_shift_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_shift_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'shift_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -145,7 +152,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -180,6 +187,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_shift_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_shift_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'shift_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receivedMarketTokens' THEN value END) AS received_market_tokens,
@@ -135,7 +142,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -161,6 +168,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_shift_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_shift_executed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -148,7 +152,10 @@ WITH evt_data_1 AS (
 
         from_hex(account) AS account,
         TRY_CAST(received_market_tokens AS DOUBLE) / POWER(10,18) AS received_market_tokens,
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -156,13 +163,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_grant_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_grant_role.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(account) AS account,
-        from_hex(role_key) AS role_key
+        from_hex(role_key) AS role_key,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_grant_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_grant_role.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'signal_grant_role',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'roleKey' THEN value END) AS role_key
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_pending_action.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_pending_action.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'signal_pending_action',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -89,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.stringItems' OMIT QUOTES) AS string_items
     FROM
@@ -98,6 +102,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -110,6 +115,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,11 +135,12 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'actionKey' THEN value END) AS action_key,
         MAX(CASE WHEN key_name = 'actionLabel' THEN value END) AS action_label
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -159,6 +166,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_pending_action.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_pending_action.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -62,7 +62,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -150,20 +150,19 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(action_key) AS action_key,
-        action_label
+        action_label,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_revoke_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_revoke_role.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(account) AS account,
-        from_hex(role_key) AS role_key
+        from_hex(role_key) AS role_key,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_revoke_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_revoke_role.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'signal_revoke_role',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'roleKey' THEN value END) AS role_key
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_atomic_oracle_provider.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_atomic_oracle_provider.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'signal_set_atomic_oracle_provider',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS "provider",
         MAX(CASE WHEN key_name = 'value' THEN value END) AS "value"
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_atomic_oracle_provider.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_atomic_oracle_provider.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex("provider") AS "provider",
-        TRY_CAST("value" AS BOOLEAN) AS "value"
+        TRY_CAST("value" AS BOOLEAN) AS "value",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_data_stream.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_data_stream.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -62,7 +62,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -170,19 +170,19 @@ WITH evt_data_1 AS (
         from_hex(EDP.token) AS token,
         from_hex(EDP.feed_id) AS feed_id,
         TRY_CAST(EDP.data_stream_multiplier AS DOUBLE) / POWER(10, 30) AS data_stream_multiplier,
-        TRY_CAST(EDP.data_stream_spread_reduction_factor AS DOUBLE) / POWER(10, 30) AS data_stream_spread_reduction_factor
+        TRY_CAST(EDP.data_stream_spread_reduction_factor AS DOUBLE) / POWER(10, 30) AS data_stream_spread_reduction_factor,
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_data_stream.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_data_stream.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'signal_set_data_stream',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -89,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -99,6 +103,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -111,6 +116,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -123,6 +129,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,13 +152,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'feedId' THEN value END) AS feed_id,
         MAX(CASE WHEN key_name = 'dataStreamMultiplier' THEN value END) AS data_stream_multiplier,
         MAX(CASE WHEN key_name = 'dataStreamSpreadReductionFactor' THEN value END) AS data_stream_spread_reduction_factor
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -179,6 +187,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_oracle_provider_enabled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_oracle_provider_enabled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'signal_set_oracle_provider_enabled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS "provider",
         MAX(CASE WHEN key_name = 'value' THEN value END) AS "value"
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_oracle_provider_enabled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_oracle_provider_enabled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex("provider") AS "provider",
-        TRY_CAST("value" AS BOOLEAN) AS "value"
+        TRY_CAST("value" AS BOOLEAN) AS "value",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_oracle_provider_for_token.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_oracle_provider_for_token.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -134,7 +140,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(token) AS token,
-        from_hex("provider") AS "provider"
+        from_hex("provider") AS "provider",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -142,13 +151,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_oracle_provider_for_token.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_oracle_provider_for_token.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'signal_set_oracle_provider_for_token',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items
     FROM
         evt_data
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,20 +123,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS "provider"
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -149,6 +155,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_price_feed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_price_feed.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -62,7 +62,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -156,8 +156,11 @@ WITH evt_data_1 AS (
         from_hex(EDP.price_feed) AS price_feed,
         TRY_CAST(EDP.price_feed_multiplier AS DOUBLE) / POWER(10, 30) AS price_feed_multiplier,
         TRY_CAST(EDP.price_feed_heartbeat_duration AS DOUBLE) AS price_feed_heartbeat_duration,
-        TRY_CAST(EDP.stable_price AS DOUBLE) / POWER(10, 30 - ERC20.decimals) AS stable_price
+        TRY_CAST(EDP.stable_price AS DOUBLE) / POWER(10, 30 - ERC20.decimals) AS stable_price,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -166,12 +169,8 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = ERC20.contract_address
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_price_feed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_signal_set_price_feed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'signal_set_price_feed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -89,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -98,6 +102,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -110,6 +115,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,6 +135,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'priceFeed' THEN value END) AS price_feed,
         MAX(CASE WHEN key_name = 'priceFeedMultiplier' THEN value END) AS price_feed_multiplier,
@@ -136,7 +143,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'stablePrice' THEN value END) AS stable_price 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -165,6 +172,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_swap_fees_collected.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_swap_fees_collected.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -166,8 +170,11 @@ WITH evt_data_1 AS (
         TRY_CAST(ui_fee_amount AS DOUBLE) ui_fee_amount,
 
         from_hex(trade_key) AS trade_key,
-        from_hex(swap_fee_type) AS swap_fee_type
+        from_hex(swap_fee_type) AS swap_fee_type,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -203,18 +210,16 @@ WITH evt_data_1 AS (
             WHEN swap_fee_type = 0x39226eb4fed85317aa310fa53f734c7af59274c49325ab568f9c4592250e8cc5 THEN 'deposit'
             WHEN swap_fee_type = 0xda1ac8fcb4f900f8ab7c364d553e5b6b8bdc58f74160df840be80995056f3838 THEN 'withdrawal'
             WHEN swap_fee_type = 0x7ad0b6f464d338ea140ff9ef891b4a69cf89f107060a105c31bb985d9e532214 THEN 'swap'
-        END AS action_type
+        END AS action_type,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20
         ON ED.token = ERC20.contract_address
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_swap_fees_collected.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_swap_fees_collected.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'swap_fees_collected',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -103,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -127,6 +133,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'uiFeeReceiver' THEN value END) AS ui_fee_receiver,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
@@ -144,7 +151,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -179,6 +186,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_swap_info.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_swap_info.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'swap_info',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -162,7 +170,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -197,6 +205,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_swap_info.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_swap_info.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -184,8 +188,11 @@ WITH evt_data_1 AS (
         TRY_CAST(price_impact_usd AS DOUBLE) AS price_impact_usd,
         TRY_CAST(price_impact_amount AS DOUBLE) AS price_impact_amount,
         TRY_CAST(token_in_price_impact_amount AS DOUBLE) AS token_in_price_impact_amount,
-        from_hex(order_key) AS order_key
+        from_hex(order_key) AS order_key,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -220,7 +227,10 @@ WITH evt_data_1 AS (
             ELSE price_impact_amount
         END AS price_impact_amount,
         token_in_price_impact_amount / POWER(10, ERC20_in.decimals) AS token_in_price_impact_amount,
-        order_key
+        order_key,
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_erc20') }} AS ERC20_in
         ON ED.token_in = ERC20_in.contract_address
@@ -228,11 +238,6 @@ WITH evt_data_1 AS (
         ON ED.token_out = ERC20_out.contract_address
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_sync_config.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_sync_config.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -155,18 +161,16 @@ WITH evt_data_1 AS (
         TRY_CAST(EDP.update_id AS DECIMAL(38,0)) AS update_id,
         TRY_CAST(EDP.prev_value AS DECIMAL(38,0)) AS prev_value_raw,
         TRY_CAST(EDP.next_value AS DECIMAL(38,0)) AS next_value_raw,
-        TRY_CAST(EDP.update_applied AS BOOLEAN) AS update_applied
+        TRY_CAST(EDP.update_applied AS BOOLEAN) AS update_applied,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_sync_config.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_sync_config.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'sync_config',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'updateId' THEN value END) AS update_id,
         MAX(CASE WHEN key_name = 'prevValue' THEN value END) AS prev_value,
@@ -142,7 +149,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -169,6 +176,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_cancelled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -189,7 +195,10 @@ WITH evt_data_1 AS (
         from_hex(account) AS account,
         from_hex("key") AS "key",
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -197,13 +206,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_cancelled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'withdrawal_cancelled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
@@ -103,6 +107,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -116,6 +121,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,6 +135,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -142,6 +149,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -169,6 +177,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key",
@@ -177,7 +186,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -204,6 +213,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'withdrawal_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -167,7 +175,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -207,6 +215,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_created.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -194,7 +198,10 @@ WITH evt_data_1 AS (
 
         TRY_CAST(should_unwrap_native_token AS BOOLEAN) AS should_unwrap_native_token,
         
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -233,20 +240,16 @@ WITH evt_data_1 AS (
         withdrawal_type,
         
         should_unwrap_native_token,
-        "key"
+        "key",
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
         ON ED.market = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_arbitrum',
     alias = 'withdrawal_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -103,6 +107,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -116,6 +121,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,6 +135,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -153,6 +160,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'swapPricingType' THEN value END) AS swap_pricing_type,
@@ -160,7 +168,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -186,6 +194,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_withdrawal_executed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -171,7 +177,10 @@ WITH evt_data_1 AS (
 
         from_hex(account) AS account,
         TRY_CAST(swap_pricing_type AS INTEGER) AS swap_pricing_type,
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -179,13 +188,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_claimed.sql
@@ -156,6 +156,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_claimed.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -154,8 +160,11 @@ WITH evt_data_1 AS (
         from_hex(token) AS token,
         from_hex(receiver) AS receiver,
         TRY_CAST(distribution_id AS VARCHAR) AS distribution_id,
-        TRY_CAST(amount AS DOUBLE) AS amount
+        TRY_CAST(amount AS DOUBLE) AS amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -183,8 +192,11 @@ WITH evt_data_1 AS (
             ERC20.decimals,
             MD.market_token_decimals,
             GLV.glv_token_decimals
-        )) AS amount
+        )) AS amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON ED.token = ERC20.contract_address
@@ -194,11 +206,6 @@ WITH evt_data_1 AS (
         ON ED.token = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_claimed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'claim_funds_claimed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -141,7 +148,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'amount' THEN value END) AS amount
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -169,6 +176,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -176,7 +184,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_deposited.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_deposited.sql
@@ -156,6 +156,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_deposited.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_deposited.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -154,8 +160,11 @@ WITH evt_data_1 AS (
         from_hex(token) AS token,
         TRY_CAST(distribution_id AS VARCHAR) AS distribution_id,
         TRY_CAST(amount AS DOUBLE) AS amount,
-        TRY_CAST(next_amount AS DOUBLE) AS next_amount
+        TRY_CAST(next_amount AS DOUBLE) AS next_amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -187,8 +196,11 @@ WITH evt_data_1 AS (
             ERC20.decimals,
             MD.market_token_decimals,
             GLV.glv_token_decimals
-        )) AS next_amount
+        )) AS next_amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON ED.token = ERC20.contract_address
@@ -198,11 +210,6 @@ WITH evt_data_1 AS (
         ON ED.token = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_deposited.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_deposited.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'claim_funds_deposited',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'distributionId' THEN value END) AS distribution_id,
@@ -141,7 +148,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextAmount' THEN value END) AS next_amount
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -169,6 +176,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -176,7 +184,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_transferred.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_transferred.sql
@@ -157,6 +157,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_transferred.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_transferred.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -156,7 +162,10 @@ WITH evt_data_1 AS (
         from_hex(token) AS token,
         TRY_CAST(distribution_id AS VARCHAR) AS distribution_id,
         TRY_CAST(amount AS DOUBLE) AS amount,
-        TRY_CAST(next_amount AS DOUBLE) AS next_amount
+        TRY_CAST(next_amount AS DOUBLE) AS next_amount,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -190,8 +199,11 @@ WITH evt_data_1 AS (
             ERC20.decimals,
             MD.market_token_decimals,
             GLV.glv_token_decimals
-        )) AS next_amount
+        )) AS next_amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON ED.token = ERC20.contract_address
@@ -201,11 +213,6 @@ WITH evt_data_1 AS (
         ON ED.token = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_transferred.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_transferred.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'claim_funds_transferred',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'fromAccount' THEN value END) AS from_account,
         MAX(CASE WHEN key_name = 'toAccount' THEN value END) AS to_account,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
@@ -142,7 +149,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextAmount' THEN value END) AS next_amount
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -171,6 +178,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -178,7 +186,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_withdrawn.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_withdrawn.sql
@@ -156,6 +156,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_withdrawn.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_withdrawn.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -154,8 +160,11 @@ WITH evt_data_1 AS (
         from_hex(token) AS token,
         from_hex(receiver) AS receiver,
         TRY_CAST(distribution_id AS VARCHAR) AS distribution_id,
-        TRY_CAST(amount AS DOUBLE) AS amount
+        TRY_CAST(amount AS DOUBLE) AS amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -183,8 +192,11 @@ WITH evt_data_1 AS (
             ERC20.decimals,
             MD.market_token_decimals,
             GLV.glv_token_decimals
-        )) AS amount
+        )) AS amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON ED.token = ERC20.contract_address
@@ -194,11 +206,6 @@ WITH evt_data_1 AS (
         ON ED.token = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_withdrawn.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_funds_withdrawn.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'claim_funds_withdrawn',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -141,7 +148,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'amount' THEN value END) AS amount
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -169,6 +176,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -176,7 +184,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_terms_removed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_terms_removed.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -130,18 +136,16 @@ WITH evt_data_1 AS (
         ED.event_name,
         ED.msg_sender,
         
-        TRY_CAST(distribution_id AS VARCHAR) AS distribution_id
+        TRY_CAST(distribution_id AS VARCHAR) AS distribution_id,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_terms_removed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_terms_removed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'claim_terms_removed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
         evt_data
@@ -99,6 +103,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,10 +122,11 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'distributionId' THEN value END) AS distribution_id
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -128,7 +134,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -144,6 +150,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_terms_set.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_terms_set.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -149,7 +155,10 @@ WITH evt_data_1 AS (
         ED.msg_sender,
         
         TRY_CAST(distribution_id AS VARCHAR) AS distribution_id,
-        from_hex(terms_hash) AS terms_hash
+        from_hex(terms_hash) AS terms_hash,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -157,11 +166,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_terms_set.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claim_terms_set.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'claim_terms_set',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,11 +140,12 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'distributionId' THEN value END) AS distribution_id,
         MAX(CASE WHEN key_name = 'termsHash' THEN value END) AS terms_hash
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -146,7 +153,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -164,6 +171,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_collateral_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_collateral_updated.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -41,6 +43,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -62,6 +66,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -161,7 +167,10 @@ WITH evt_data_1 AS (
         CAST(time_key AS DOUBLE) AS time_key,
         CAST(delta AS DOUBLE) AS delta,
         CAST(next_value AS DOUBLE) AS next_value,
-        CAST(next_pool_value AS DOUBLE) AS next_pool_value
+        CAST(next_pool_value AS DOUBLE) AS next_pool_value,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -187,18 +196,16 @@ WITH evt_data_1 AS (
         ED.time_key / POWER(10, erc20.decimals) AS time_key,
         ED.delta / POWER(10, erc20.decimals) AS delta,
         ED.next_value / POWER(10, erc20.decimals) AS next_value,
-        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value
+        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS erc20
         ON erc20.contract_address = ED.token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_collateral_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_collateral_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'claimable_collateral_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -40,6 +41,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -95,6 +98,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -104,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +122,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -138,6 +144,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
@@ -147,7 +154,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextPoolValue' THEN value END) AS next_pool_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -175,6 +182,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_funding_amount_per_size_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_funding_amount_per_size_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'claimable_funding_amount_per_size_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
@@ -137,7 +144,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -165,6 +172,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_funding_amount_per_size_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_funding_amount_per_size_updated.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -152,8 +156,11 @@ WITH evt_data_1 AS (
         from_hex(collateral_token) AS collateral_token,
         TRY_CAST(delta AS DOUBLE) delta, 
         TRY_CAST("value" AS DOUBLE) "value",  
-        TRY_CAST(is_long AS BOOLEAN) AS is_long
+        TRY_CAST(is_long AS BOOLEAN) AS is_long,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -176,20 +183,16 @@ WITH evt_data_1 AS (
         ED.collateral_token,
         delta / POWER(10, CTD.collateral_token_decimals + 15) AS delta,
         "value" / POWER(10, CTD.collateral_token_decimals + 15) AS "value",
-        is_long
+        is_long,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_collateral_tokens_data') }} AS CTD
         ON ED.collateral_token = CTD.collateral_token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_funding_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_funding_updated.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -41,6 +43,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -62,6 +66,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -159,7 +165,10 @@ WITH evt_data_1 AS (
         from_hex(account) AS account,
         CAST(delta AS DOUBLE) AS delta,
         CAST(next_value AS DOUBLE) AS next_value,
-        CAST(next_pool_value AS DOUBLE) AS next_pool_value
+        CAST(next_pool_value AS DOUBLE) AS next_pool_value,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -184,18 +193,16 @@ WITH evt_data_1 AS (
         ED.account,
         ED.delta / POWER(10, erc20.decimals) AS delta,
         ED.next_value / POWER(10, erc20.decimals) AS next_value,
-        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value
+        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS erc20
         ON erc20.contract_address = ED.token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_funding_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_funding_updated.sql
@@ -160,6 +160,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_funding_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_claimable_funding_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'claimable_funding_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -40,6 +41,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -95,6 +98,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -104,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +122,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -138,6 +144,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
@@ -146,7 +153,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextPoolValue' THEN value END) AS next_pool_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -173,6 +180,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -180,7 +188,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_clear_pending_action.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_clear_pending_action.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -62,7 +62,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -150,20 +150,19 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(action_key) AS action_key,
-        action_label
+        action_label,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_clear_pending_action.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_clear_pending_action.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'clear_pending_action',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -89,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.stringItems' OMIT QUOTES) AS string_items
     FROM
@@ -98,6 +102,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -110,6 +115,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,11 +135,12 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'actionKey' THEN value END) AS action_key,
         MAX(CASE WHEN key_name = 'actionLabel' THEN value END) AS action_label
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -159,6 +166,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_collateral_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_collateral_claimed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -41,6 +43,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -62,6 +66,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -161,7 +167,10 @@ WITH evt_data_1 AS (
         from_hex(receiver) AS receiver,
         CAST(time_key AS DOUBLE) AS time_key,
         CAST(amount AS DOUBLE) AS amount,
-        CAST(next_pool_value AS DOUBLE) AS next_pool_value
+        CAST(next_pool_value AS DOUBLE) AS next_pool_value,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -187,18 +196,16 @@ WITH evt_data_1 AS (
         ED.receiver,
         ED.time_key / POWER(10, erc20.decimals) AS time_key,
         ED.amount / POWER(10, erc20.decimals) AS amount,
-        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value
+        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS erc20
         ON erc20.contract_address = ED.token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_collateral_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_collateral_claimed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'collateral_claimed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -40,6 +41,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -95,6 +98,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -104,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +122,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -138,6 +144,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
@@ -147,7 +154,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextPoolValue' THEN value END) AS next_pool_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -175,6 +182,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_cancelled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -189,7 +195,10 @@ WITH evt_data_1 AS (
         from_hex(account) AS account,
         from_hex("key") AS "key",
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -197,13 +206,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_cancelled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'deposit_cancelled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
@@ -103,6 +107,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -116,6 +121,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,6 +135,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -142,6 +149,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -169,6 +177,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key",
@@ -177,7 +186,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -204,6 +213,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_created.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -198,7 +202,10 @@ WITH evt_data_1 AS (
         
         TRY_CAST(should_unwrap_native_token AS BOOLEAN) AS should_unwrap_native_token,
         
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -239,20 +246,16 @@ WITH evt_data_1 AS (
         deposit_type,
         
         should_unwrap_native_token,
-        "key"
+        "key",
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
         ON ED.market = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'deposit_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -169,7 +177,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -211,6 +219,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_executed.sql
@@ -177,6 +177,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'deposit_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -102,6 +106,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -115,6 +120,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -152,6 +159,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'longTokenAmount' THEN value END) AS long_token_amount,
@@ -162,7 +170,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -190,13 +198,14 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_deposit_executed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -175,7 +181,10 @@ WITH evt_data_1 AS (
         TRY_CAST(short_token_amount AS DOUBLE) AS short_token_amount,
         TRY_CAST(received_market_tokens AS DOUBLE) AS received_market_tokens,
         TRY_CAST(swap_pricing_type AS INTEGER) AS swap_pricing_type,
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -200,8 +209,11 @@ WITH evt_data_1 AS (
         ED.short_token_amount / POWER(10, MD.short_token_decimals) AS short_token_amount,
         ED.received_market_tokens / POWER(10, 18) AS received_market_tokens,
         ED.swap_pricing_type,
-        ED."key"
+        ED."key",
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_deposit_created') }} AS DC
         ON ED."key" = DC."key"
@@ -209,13 +221,6 @@ WITH evt_data_1 AS (
         ON DC.market = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_event_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_event_schema.yml
@@ -17,6 +17,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -181,6 +182,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -230,6 +232,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -349,6 +352,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -488,6 +492,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -574,6 +579,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -797,6 +803,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -881,6 +888,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
 
@@ -931,6 +939,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -985,6 +994,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1044,6 +1054,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1109,6 +1120,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1165,6 +1177,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1224,6 +1237,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1277,6 +1291,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1318,6 +1333,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1359,6 +1375,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1402,6 +1419,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1471,6 +1489,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1518,6 +1537,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1567,6 +1587,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1610,6 +1631,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1685,6 +1707,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1728,6 +1751,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1769,6 +1793,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1818,6 +1843,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1857,6 +1883,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1902,6 +1929,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -1971,6 +1999,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2012,6 +2041,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2069,6 +2099,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2110,6 +2141,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2153,6 +2185,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2218,6 +2251,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2257,6 +2291,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2300,6 +2335,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2343,6 +2379,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2400,6 +2437,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2439,6 +2477,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2484,6 +2523,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2528,6 +2568,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2564,6 +2605,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2610,6 +2652,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2654,6 +2697,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2690,6 +2734,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2726,6 +2771,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2762,6 +2808,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2802,6 +2849,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2838,6 +2886,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2874,6 +2923,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2916,6 +2966,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2952,6 +3003,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -2988,6 +3040,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3024,6 +3077,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3060,6 +3114,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3100,6 +3155,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3136,6 +3192,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3172,6 +3229,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3214,6 +3272,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3272,6 +3331,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3312,6 +3372,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3352,6 +3413,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3392,6 +3454,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3434,6 +3497,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3473,6 +3537,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3515,6 +3580,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3557,6 +3623,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:
@@ -3596,6 +3663,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3638,6 +3706,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3680,6 +3749,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3722,6 +3792,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3766,6 +3837,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3808,6 +3880,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3842,6 +3915,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     
@@ -3879,6 +3953,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_event_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_event_schema.yml
@@ -454,16 +454,10 @@ models:
         description: The change in collateral amount
         data_tests:
           - not_null
-      - &price_impact_usd
-        name: price_impact_usd
-        description: The impact on price in USD
-        data_tests:
-          - not_null
-      - &price_impact_amount
-        name: price_impact_amount
-        description: The impact on price in index token amount
-        data_tests:
-          - not_null
+      - name: price_impact_usd
+        description: The impact on price in USD (nullable when the on-chain payload omits priceImpactUsd)
+      - name: price_impact_amount
+        description: The impact on price in index token amount (nullable when the payload omits priceImpactAmount)
       - *is_long
       - &order_key
         name: order_key
@@ -547,7 +541,10 @@ models:
       - &decreased_at_time
         name: decreased_at_time
         description: The block timestamp when the position was decreased             
-      - *price_impact_usd
+      - name: price_impact_usd
+        description: The impact on price in USD
+        data_tests:
+          - not_null
       - &base_pnl_usd
         name: base_pnl_usd
         description: The base profit and loss in USD for the position

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_execution_fee_refund.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_execution_fee_refund.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -128,7 +132,10 @@ WITH evt_data_1 AS (
         msg_sender,
         
         from_hex(EDP.receiver) AS receiver,
-        CAST(EDP.refund_fee_amount AS DOUBLE) / POWER(10, 18) AS refund_fee_amount
+        CAST(EDP.refund_fee_amount AS DOUBLE) / POWER(10, 18) AS refund_fee_amount,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -136,12 +143,6 @@ WITH evt_data_1 AS (
         AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_execution_fee_refund.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_execution_fee_refund.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'execution_fee_refund',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -111,11 +116,12 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
         MAX(CASE WHEN key_name = 'refundFeeAmount' THEN value END) AS refund_fee_amount
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -141,6 +147,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'funding',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -36,6 +37,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -55,6 +57,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -85,6 +88,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -95,6 +99,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -108,6 +113,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,11 +135,12 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'fundingFactorPerSecond' THEN value END) AS funding_factor_per_second
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -157,13 +164,14 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding.sql
@@ -147,6 +147,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -39,7 +39,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -58,7 +58,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -148,8 +148,11 @@ WITH evt_data_1 AS (
         msg_sender,
         
         from_hex(market) AS market,
-        TRY_CAST(funding_factor_per_second AS DOUBLE) AS funding_factor_per_second
-        
+        TRY_CAST(funding_factor_per_second AS DOUBLE) AS funding_factor_per_second,
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -171,16 +174,17 @@ WITH evt_data_1 AS (
         ED.market,
         MD.market_name,
         ED.funding_factor_per_second AS funding_factor_per_second_raw,
-        ED.funding_factor_per_second / POWER(10, 30) AS funding_factor_per_second
+        ED.funding_factor_per_second / POWER(10, 30) AS funding_factor_per_second,
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
         ON ED.market = MD.market
 )
 
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding_fee_amount_per_size_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding_fee_amount_per_size_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'funding_fee_amount_per_size_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
@@ -137,7 +144,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -165,6 +172,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding_fee_amount_per_size_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding_fee_amount_per_size_updated.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -152,8 +156,11 @@ WITH evt_data_1 AS (
         from_hex(collateral_token) AS collateral_token,
         TRY_CAST(delta AS DOUBLE) delta, 
         TRY_CAST("value" AS DOUBLE) "value",  
-        TRY_CAST(is_long AS BOOLEAN) AS is_long
+        TRY_CAST(is_long AS BOOLEAN) AS is_long,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -176,20 +183,16 @@ WITH evt_data_1 AS (
         ED.collateral_token,
         delta / POWER(10, CTD.collateral_token_decimals + 15) AS delta,
         "value" / POWER(10, CTD.collateral_token_decimals + 15) AS "value",
-        is_long
+        is_long,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_collateral_tokens_data') }} AS CTD
         ON ED.collateral_token = CTD.collateral_token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding_fees_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding_fees_claimed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'funding_fees_claimed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -40,6 +41,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -95,6 +98,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -104,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +122,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -138,6 +144,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
@@ -146,7 +153,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextPoolValue' THEN value END) AS next_pool_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -173,6 +180,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -180,7 +188,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding_fees_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding_fees_claimed.sql
@@ -160,6 +160,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding_fees_claimed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_funding_fees_claimed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -41,6 +43,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -62,6 +66,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -159,7 +165,10 @@ WITH evt_data_1 AS (
         from_hex(account) AS account,
         from_hex(receiver) AS receiver,
         CAST(amount AS DOUBLE) AS amount,
-        CAST(next_pool_value AS DOUBLE) AS next_pool_value
+        CAST(next_pool_value AS DOUBLE) AS next_pool_value,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -184,18 +193,16 @@ WITH evt_data_1 AS (
         ED.account,
         ED.receiver,
         ED.amount / POWER(10, erc20.decimals) AS amount,
-        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value
+        ED.next_pool_value / POWER(10, erc20.decimals) AS next_pool_value,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS erc20
         ON erc20.contract_address = ED.token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_created.sql
@@ -2,7 +2,7 @@
 	schema='gmx_v2_avalanche_c',
 	alias='glv_created',
 	materialized='incremental',
-	unique_key=['tx_hash', 'index'],
+	unique_key=['block_date', 'tx_hash', 'index'],
 	incremental_strategy='merge',
 ) }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_deposit_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_deposit_cancelled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'glv_deposit_cancelled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key",
@@ -153,7 +161,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -180,6 +188,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_deposit_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_deposit_cancelled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -167,7 +171,10 @@ WITH evt_data_1 AS (
         from_hex(account) AS account,
         from_hex("key") AS "key",
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -175,13 +182,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_deposit_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_deposit_created.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -204,7 +208,10 @@ WITH evt_data_1 AS (
         TRY_CAST(should_unwrap_native_token AS BOOLEAN) AS should_unwrap_native_token,
         TRY_CAST(is_market_token_deposit AS BOOLEAN) AS is_market_token_deposit,
         
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -249,7 +256,10 @@ WITH evt_data_1 AS (
         should_unwrap_native_token,
         is_market_token_deposit,
         
-        "key"
+        "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
@@ -257,13 +267,6 @@ WITH evt_data_1 AS (
 )
 
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_deposit_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_deposit_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'glv_deposit_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -172,7 +180,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -217,6 +225,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_deposit_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'glv_deposit_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receivedGlvTokens' THEN value END) AS received_glv_tokens,
@@ -135,7 +142,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -160,6 +167,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_deposit_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_deposit_executed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -147,7 +151,10 @@ WITH evt_data_1 AS (
 
         from_hex(account) AS account,
         TRY_CAST(received_glv_tokens AS DOUBLE) received_glv_tokens,
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -169,18 +176,14 @@ WITH evt_data_1 AS (
 
         account,
         received_glv_tokens / POWER(10,18) AS received_glv_tokens,
-        "key"
+        "key",
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_shift_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_shift_cancelled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'glv_shift_cancelled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
         json_query(data, 'lax $.stringItems' OMIT QUOTES) AS string_items
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -103,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -127,13 +133,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key",
         MAX(CASE WHEN key_name = 'reasonBytes' THEN value END) AS reason_bytes,
         MAX(CASE WHEN key_name = 'reason' THEN value END) AS reason
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -160,6 +167,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_shift_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_shift_cancelled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -147,7 +151,10 @@ WITH evt_data_1 AS (
         
         from_hex("key") AS "key",
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -155,13 +162,6 @@ WITH evt_data_1 AS (
         AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_shift_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_shift_created.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -155,7 +159,10 @@ WITH evt_data_1 AS (
         TRY_CAST(market_token_amount AS DOUBLE) AS market_token_amount,
         TRY_CAST(min_market_tokens AS DOUBLE) AS min_market_tokens,
         TRY_CAST(updated_at_time AS DOUBLE) updated_at_time,
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -184,17 +191,13 @@ WITH evt_data_1 AS (
             WHEN updated_at_time = 0 THEN NULL
             ELSE updated_at_time
         END AS updated_at_time,
-        "key"
+        "key",
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_shift_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_shift_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'glv_shift_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'fromMarket' THEN value END) AS from_market,
         MAX(CASE WHEN key_name = 'toMarket' THEN value END) AS to_market,
@@ -139,7 +146,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -168,6 +175,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_shift_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_shift_executed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -128,7 +132,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         TRY_CAST(received_market_tokens AS DOUBLE) received_market_tokens, 
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -149,17 +156,13 @@ WITH evt_data_1 AS (
         msg_sender,
 
         received_market_tokens / POWER(10, 18) AS received_market_tokens,
-        "key"
+        "key",
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_shift_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_shift_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'glv_shift_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -111,13 +116,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'receivedMarketTokens' THEN value END) AS received_market_tokens,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key"
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -141,6 +147,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_withdrawal_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_withdrawal_cancelled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'glv_withdrawal_cancelled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key",
@@ -153,7 +161,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -180,6 +188,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_withdrawal_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_withdrawal_cancelled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -167,7 +171,10 @@ WITH evt_data_1 AS (
         from_hex(account) AS account,
         from_hex("key") AS "key",
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -175,13 +182,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_withdrawal_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_withdrawal_created.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -196,7 +200,10 @@ WITH evt_data_1 AS (
 
         TRY_CAST(should_unwrap_native_token AS BOOLEAN) AS should_unwrap_native_token,
         
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -236,20 +243,16 @@ WITH evt_data_1 AS (
         callback_gas_limit,
 
         should_unwrap_native_token,
-        "key"
+        "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
         ON ED.market = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_withdrawal_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_withdrawal_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'glv_withdrawal_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -168,7 +176,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -209,6 +217,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_withdrawal_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_withdrawal_executed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -129,7 +133,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(account) AS account,
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -137,13 +144,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_withdrawal_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_glv_withdrawal_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'glv_withdrawal_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -111,13 +116,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key"
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -142,6 +148,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_grant_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_grant_role.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(account) AS account,
-        from_hex(role_key) AS role_key
+        from_hex(role_key) AS role_key,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_grant_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_grant_role.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'grant_role',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'roleKey' THEN value END) AS role_key
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_increment_subaccount_action_count.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_increment_subaccount_action_count.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'increment_subaccount_action_count',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -102,6 +106,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -115,6 +120,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -152,13 +159,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'subaccount' THEN value END) AS subaccount,
         MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value,
         MAX(CASE WHEN key_name = 'actionType' THEN value END) AS action_type
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -183,6 +191,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_increment_subaccount_action_count.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_increment_subaccount_action_count.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -169,20 +175,16 @@ WITH evt_data_1 AS (
         from_hex(EDP.account) AS account,
         from_hex(EDP.subaccount) AS subaccount,
         TRY_CAST(EDP.next_value AS DOUBLE) AS next_value,
-        from_hex(EDP.action_type) AS action_type
+        from_hex(EDP.action_type) AS action_type,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_keeper_execution_fee.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_keeper_execution_fee.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -128,7 +132,10 @@ WITH evt_data_1 AS (
         msg_sender,
         
         from_hex(EDP.keeper) AS keeper,
-        CAST(EDP.execution_fee_amount AS DOUBLE) / POWER(10, 18) AS execution_fee_amount
+        CAST(EDP.execution_fee_amount AS DOUBLE) / POWER(10, 18) AS execution_fee_amount,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -136,12 +143,6 @@ WITH evt_data_1 AS (
         AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_keeper_execution_fee.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_keeper_execution_fee.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'keeper_execution_fee',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -111,11 +116,12 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'keeper' THEN value END) AS keeper,
         MAX(CASE WHEN key_name = 'executionFeeAmount' THEN value END) AS execution_fee_amount
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -141,6 +147,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_action.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_action.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'multichain_bridge_action',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,13 +140,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS provider,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'srcChainId' THEN value END) AS src_chain_id,
         MAX(CASE WHEN key_name = 'actionType' THEN value END) AS action_type
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -148,7 +155,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -167,6 +174,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_action.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_action.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -153,18 +159,16 @@ WITH evt_data_1 AS (
         from_hex(EDP.provider) AS provider,
         from_hex(EDP.account) AS account,
         TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id,
-        TRY_CAST(EDP.action_type AS DOUBLE) AS action_type
+        TRY_CAST(EDP.action_type AS DOUBLE) AS action_type,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_action_failed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_action_failed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'multichain_bridge_action_failed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.stringItems' OMIT QUOTES) AS string_items
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -127,6 +133,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -151,6 +158,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS provider,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'srcChainId' THEN value END) AS src_chain_id,
@@ -158,7 +166,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'reason' THEN value END) AS reason
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -166,7 +174,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -186,6 +194,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_action_failed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_action_failed.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -172,18 +178,16 @@ WITH evt_data_1 AS (
         from_hex(EDP.account) AS account,
         TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id,
         TRY_CAST(EDP.action_type AS DOUBLE) AS action_type,
-        reason AS reason
+        reason AS reason,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_in.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_in.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -159,7 +165,10 @@ WITH evt_data_1 AS (
             MD.market_token_decimals,
             GLV.glv_token_decimals
             )) AS amount,
-        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id
+        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -172,11 +181,6 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_in.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_in.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'multichain_bridge_in',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS provider,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
@@ -141,7 +148,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'srcChainId' THEN value END) AS src_chain_id
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -149,7 +156,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -173,6 +180,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_out.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_out.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -159,7 +165,10 @@ WITH evt_data_1 AS (
             MD.market_token_decimals,
             GLV.glv_token_decimals
             )) AS amount,
-        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id
+        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -172,11 +181,6 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_out.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_bridge_out.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'multichain_bridge_out',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS provider,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -141,7 +148,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'srcChainId' THEN value END) AS src_chain_id
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -149,7 +156,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -173,6 +180,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_transfer_in.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_transfer_in.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -157,7 +163,10 @@ WITH evt_data_1 AS (
             MD.market_token_decimals,
             GLV.glv_token_decimals
             )) AS amount,
-        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id
+        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -170,11 +179,6 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_transfer_in.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_transfer_in.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'multichain_transfer_in',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,13 +140,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'amount' THEN value END) AS amount,
         MAX(CASE WHEN key_name = 'srcChainId' THEN value END) AS src_chain_id
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -148,7 +155,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -171,6 +178,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_transfer_out.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_transfer_out.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -159,7 +165,10 @@ WITH evt_data_1 AS (
             MD.market_token_decimals,
             GLV.glv_token_decimals
             )) AS amount,
-        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id
+        TRY_CAST(EDP.src_chain_id AS DOUBLE) AS src_chain_id,
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -172,11 +181,6 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = GLV.glv
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_transfer_out.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_multichain_transfer_out.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'multichain_transfer_out',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -141,7 +148,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'srcChainId' THEN value END) AS src_chain_id
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -149,7 +156,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,
@@ -173,6 +180,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_open_interest_in_tokens_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_open_interest_in_tokens_updated.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -39,7 +39,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -167,8 +167,11 @@ WITH evt_data_1 AS (
         from_hex(EDP.collateral_token) AS collateral_token,   
         CAST(EDP.is_long AS BOOLEAN) AS is_long,
         CAST(EDP.next_value AS DOUBLE) / POWER(10, MD.index_token_decimals) AS next_value,
-        CAST(EDP.delta AS DOUBLE) / POWER(10, MD.index_token_decimals) AS delta
+        CAST(EDP.delta AS DOUBLE) / POWER(10, MD.index_token_decimals) AS delta,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -177,11 +180,7 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.market) = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_open_interest_in_tokens_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_open_interest_in_tokens_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'open_interest_in_tokens_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -36,6 +37,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -62,6 +64,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
@@ -74,6 +77,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -87,6 +91,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -100,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -140,6 +147,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'isLong' THEN value END) AS is_long,
         MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
@@ -147,7 +155,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'delta' THEN value END) AS delta
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -176,6 +184,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
         ON from_hex(EDP.market) = MD.market
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_open_interest_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_open_interest_updated.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -39,7 +39,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -168,20 +168,19 @@ WITH evt_data_1 AS (
         from_hex(collateral_token) AS collateral_token,
         TRY_CAST(is_long AS BOOLEAN) AS is_long,
         TRY_CAST(delta AS DOUBLE) / POWER(10, 30) AS delta,
-        TRY_CAST(next_value AS DOUBLE) / POWER(10, 30) AS next_value
+        TRY_CAST(next_value AS DOUBLE) / POWER(10, 30) AS next_value,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_open_interest_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_open_interest_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'open_interest_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -36,6 +37,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
@@ -75,6 +78,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -88,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -101,6 +106,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +120,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -141,6 +148,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
         MAX(CASE WHEN key_name = 'isLong' THEN value END) AS is_long,
@@ -148,7 +156,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -177,6 +185,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_oracle_price_update.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_oracle_price_update.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -136,8 +136,11 @@ WITH evt_data_1 AS (
         CASE 
             WHEN TRY_CAST("timestamp" AS DOUBLE) = 0 THEN NULL
             ELSE TRY_CAST("timestamp" AS DOUBLE)
-        END AS "timestamp"
-        
+        END AS "timestamp",
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -146,12 +149,8 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = ERC20.contract_address
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_oracle_price_update.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_oracle_price_update.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'oracle_price_update',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -75,6 +78,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -87,6 +91,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -106,6 +111,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS provider,
         MAX(CASE WHEN key_name = 'minPrice' THEN value END) AS min_price,
@@ -113,7 +119,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'timestamp' THEN value END) AS "timestamp"    
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -145,6 +151,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_cancelled.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -166,7 +170,10 @@ WITH evt_data_1 AS (
         from_hex(key) AS key,
         from_hex(account) AS account,
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -174,11 +181,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_cancelled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'order_cancelled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,13 +152,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS key,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'reasonBytes' THEN value END) AS reason_bytes,
         MAX(CASE WHEN key_name = 'reason' THEN value END) AS reason
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -179,6 +187,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_created.sql
@@ -4,7 +4,9 @@
     alias = 'order_created',
     materialized = 'incremental',
     unique_key = ['tx_hash', 'index'],
-    incremental_strategy = 'merge'
+    incremental_strategy = 'merge',
+    file_format = 'delta',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     )
 }}
 
@@ -19,6 +21,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +42,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +63,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -72,10 +80,10 @@ WITH evt_data_1 AS (
 , evt_data AS (
     SELECT * 
     FROM evt_data_1
-    UNION DISTINCT
+    UNION ALL
     SELECT *
     FROM evt_data_2
-    UNION 
+    UNION ALL
     SELECT *
     FROM evt_data_3
 )
@@ -269,8 +277,11 @@ WITH evt_data_1 AS (
         TRY_CAST(should_unwrap_native_token AS BOOLEAN) AS should_unwrap_native_token,
         TRY_CAST(auto_cancel AS BOOLEAN) AS auto_cancel,
         from_hex(key) AS key,
-        data_list
+        data_list,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -349,7 +360,10 @@ WITH evt_data_1 AS (
         END AS auto_cancel,
         
         key,
-        data_list
+        data_list,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
@@ -358,11 +372,6 @@ WITH evt_data_1 AS (
         ON ED.initial_collateral_token = CTD.collateral_token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'order_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge',
     file_format = 'delta',
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
@@ -18,6 +18,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -39,6 +40,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -60,6 +62,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -92,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -104,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +122,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_format(json_extract(CAST(item AS VARCHAR), '$.value')) AS value
     FROM 
@@ -130,6 +136,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -143,6 +150,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -156,6 +164,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -169,6 +178,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_format(json_extract(CAST(item AS VARCHAR), '$.value')) AS value
     FROM 
@@ -202,6 +212,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
         MAX(CASE WHEN key_name = 'callbackContract' THEN value END) AS callback_contract,
@@ -235,7 +246,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -286,6 +297,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_executed.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -147,7 +151,10 @@ WITH evt_data_1 AS (
         
         from_hex(key) AS key,
         from_hex(account) AS account,
-        TRY_CAST(secondary_order_type AS INTEGER) AS secondary_order_type
+        TRY_CAST(secondary_order_type AS INTEGER) AS secondary_order_type,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -155,11 +162,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'order_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -103,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,12 +134,13 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS key,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'secondaryOrderType' THEN value END) AS secondary_order_type
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -160,6 +167,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_frozen.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_frozen.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -166,7 +170,10 @@ WITH evt_data_1 AS (
         from_hex(key) AS key,
         from_hex(account) AS account,
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -174,11 +181,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_frozen.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_frozen.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'order_frozen',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,13 +152,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS key,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'reasonBytes' THEN value END) AS reason_bytes,
         MAX(CASE WHEN key_name = 'reason' THEN value END) AS reason
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -179,6 +187,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_updated.sql
@@ -4,7 +4,9 @@
     alias = 'order_updated',
     materialized = 'incremental',
     unique_key = ['tx_hash', 'index'],
-    incremental_strategy = 'merge'
+    incremental_strategy = 'merge',
+    file_format = 'delta',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
     )
 }}
 
@@ -19,6 +21,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +42,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -53,7 +59,7 @@ WITH evt_data_1 AS (
 , evt_data AS (
     SELECT * 
     FROM evt_data_1
-    UNION DISTINCT
+    UNION ALL
     SELECT *
     FROM evt_data_2
 )
@@ -174,8 +180,11 @@ WITH evt_data_1 AS (
         TRY_CAST(min_output_amount AS DOUBLE) AS min_output_amount,
         TRY_CAST(updated_at_time AS DOUBLE) AS updated_at_time,
         TRY_CAST(valid_from_time AS DOUBLE) AS valid_from_time,
-        TRY_CAST(auto_cancel AS BOOLEAN) AS auto_cancel
+        TRY_CAST(auto_cancel AS BOOLEAN) AS auto_cancel,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -215,7 +224,10 @@ WITH evt_data_1 AS (
             ELSE ED.updated_at_time
         END AS updated_at_time,
         ED.valid_from_time,
-        ED.auto_cancel
+        ED.auto_cancel,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_order_created') }} AS OC
@@ -225,11 +237,6 @@ WITH evt_data_1 AS (
         
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_updated.sql
@@ -173,6 +173,7 @@ WITH evt_data_1 AS (
     SELECT 
         blockchain,
         block_time,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_order_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'order_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge',
     file_format = 'delta',
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
@@ -18,6 +18,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -39,6 +40,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -68,6 +70,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
@@ -80,6 +83,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -93,6 +97,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -106,6 +111,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -119,6 +125,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -146,6 +153,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS key,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'sizeDeltaUsd' THEN value END) AS size_delta_usd,
@@ -157,7 +165,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'autoCancel' THEN value END) AS auto_cancel
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -189,6 +197,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 
@@ -196,7 +205,7 @@ WITH evt_data_1 AS (
     SELECT 
         ED.blockchain,
         ED.block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         ED.block_number,
         ED.tx_hash,
         ED.index,

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_pool_amount_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_pool_amount_updated.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -39,7 +39,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -144,8 +144,11 @@ WITH evt_data_1 AS (
         from_hex(market) AS market,
         from_hex(token) AS token,
         TRY_CAST(next_value AS DOUBLE) / POWER(10, ERC20.decimals) AS next_value,
-        TRY_CAST(delta AS DOUBLE) / POWER(10, ERC20.decimals) AS delta
+        TRY_CAST(delta AS DOUBLE) / POWER(10, ERC20.decimals) AS delta,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -154,12 +157,8 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = ERC20.contract_address
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_pool_amount_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_pool_amount_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'pool_amount_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -36,6 +37,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items
@@ -73,6 +76,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -85,6 +89,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -97,6 +102,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -119,13 +125,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'delta' THEN value END) AS delta,
         MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -153,6 +160,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_decrease.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_decrease.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'position_decrease',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -131,6 +138,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -161,6 +169,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account, 
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
@@ -191,7 +200,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -241,6 +250,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_decrease.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_decrease.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -228,8 +232,11 @@ WITH evt_data_1 AS (
         TRY_CAST(uncapped_base_pnl_usd AS DOUBLE) AS uncapped_base_pnl_usd,
         TRY_CAST(is_long AS BOOLEAN) AS is_long,
         from_hex(order_key) AS order_key,
-        from_hex(position_key) AS position_key
+        from_hex(position_key) AS position_key,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -289,8 +296,11 @@ WITH evt_data_1 AS (
         uncapped_base_pnl_usd / POWER(10, 30) AS uncapped_base_pnl_usd,    
         is_long,
         order_key,
-        position_key
+        position_key,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
         ON ED.market = MD.market
@@ -298,11 +308,6 @@ WITH evt_data_1 AS (
         ON ED.collateral_token = CTD.collateral_token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_fees_collected.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_fees_collected.sql
@@ -455,7 +455,9 @@ WITH evt_data_1 AS (
         COALESCE(liquidation_fee_receiver_factor, 0) AS liquidation_fee_receiver_factor,
         COALESCE(liquidation_fee_amount_for_fee_receiver, 0) AS liquidation_fee_amount_for_fee_receiver, 
     
-        is_increase
+        is_increase,
+        tx_from,
+        tx_to
     
     FROM full_data
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_fees_collected.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_fees_collected.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -268,7 +272,10 @@ WITH evt_data_1 AS (
         TRY_CAST(liquidation_fee_receiver_factor AS DOUBLE) AS liquidation_fee_receiver_factor,
         TRY_CAST(liquidation_fee_amount_for_fee_receiver AS DOUBLE) AS liquidation_fee_amount_for_fee_receiver,
 
-        TRY_CAST(is_increase AS BOOLEAN) AS is_increase
+        TRY_CAST(is_increase AS BOOLEAN) AS is_increase,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -343,7 +350,10 @@ WITH evt_data_1 AS (
         liquidation_fee_receiver_factor / POWER(10, 30) AS liquidation_fee_receiver_factor,
         liquidation_fee_amount_for_fee_receiver / POWER(10, collateral_token_decimals) AS liquidation_fee_amount_for_fee_receiver,
 
-        is_increase
+        is_increase,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
@@ -441,11 +451,6 @@ WITH evt_data_1 AS (
     FROM full_data
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data_2'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data_2 AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_fees_collected.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_fees_collected.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'position_fees_collected',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +123,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -144,6 +151,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'orderKey' THEN value END) AS order_key,
         MAX(CASE WHEN key_name = 'positionKey' THEN value END) AS position_key,
@@ -203,7 +211,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -281,6 +289,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_fees_info.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_fees_info.sql
@@ -456,7 +456,9 @@ WITH evt_data_1 AS (
         COALESCE(liquidation_fee_receiver_factor, 0) AS liquidation_fee_receiver_factor,
         COALESCE(liquidation_fee_amount_for_fee_receiver, 0) AS liquidation_fee_amount_for_fee_receiver, 
     
-        is_increase
+        is_increase,
+        tx_from,
+        tx_to
     
     FROM full_data
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_fees_info.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_fees_info.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'position_fees_info',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -117,6 +123,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -144,6 +151,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'orderKey' THEN value END) AS order_key,
         MAX(CASE WHEN key_name = 'positionKey' THEN value END) AS position_key,
@@ -204,7 +212,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -282,6 +290,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_fees_info.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_fees_info.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -269,7 +273,10 @@ WITH evt_data_1 AS (
         TRY_CAST(liquidation_fee_receiver_factor AS DOUBLE) AS liquidation_fee_receiver_factor, 
         TRY_CAST(liquidation_fee_amount_for_fee_receiver AS DOUBLE) AS liquidation_fee_amount_for_fee_receiver, 
 
-        TRY_CAST(is_increase AS BOOLEAN) AS is_increase
+        TRY_CAST(is_increase AS BOOLEAN) AS is_increase,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -344,8 +351,11 @@ WITH evt_data_1 AS (
         liquidation_fee_receiver_factor / POWER(10, 30) AS liquidation_fee_receiver_factor, 
         liquidation_fee_amount_for_fee_receiver / POWER(10, collateral_token_decimals) AS liquidation_fee_amount_for_fee_receiver, 
 
-        is_increase
+        is_increase,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
         ON ED.market = MD.market
@@ -442,11 +452,6 @@ WITH evt_data_1 AS (
     FROM full_data
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data_2'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data_2 AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_impact_pool_amount_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_impact_pool_amount_updated.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -39,7 +39,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -58,7 +58,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -164,8 +164,11 @@ WITH evt_data_1 AS (
 
         from_hex(EDP.market) AS market,
         TRY_CAST(EDP.next_value AS DOUBLE) / POWER(10, MD.index_token_decimals) AS next_value,
-        TRY_CAST(EDP.delta AS DOUBLE) / POWER(10, MD.index_token_decimals) AS delta
-        
+        TRY_CAST(EDP.delta AS DOUBLE) / POWER(10, MD.index_token_decimals) AS delta,
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -174,12 +177,8 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.market) = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_impact_pool_amount_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_impact_pool_amount_updated.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'position_impact_pool_amount_updated',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -36,6 +37,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -55,6 +57,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -85,6 +88,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items
@@ -95,6 +99,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -107,6 +112,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -119,6 +125,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -141,12 +148,13 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'delta' THEN value END) AS delta,
         MAX(CASE WHEN key_name = 'nextValue' THEN value END) AS next_value
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -173,6 +181,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
         ON from_hex(EDP.market) = MD.market
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_impact_pool_distributed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_impact_pool_distributed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'position_impact_pool_distributed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -76,6 +79,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -89,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -110,6 +115,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'distributionAmount' THEN value END) AS distribution_amount,
@@ -117,7 +123,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -142,6 +148,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_impact_pool_distributed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_impact_pool_distributed.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -129,8 +133,11 @@ WITH evt_data_1 AS (
 
         from_hex(market) AS market,
         TRY_CAST(distribution_amount AS DOUBLE) AS distribution_amount,
-        TRY_CAST(next_position_impact_pool_amount AS DOUBLE) AS next_position_impact_pool_amount
+        TRY_CAST(next_position_impact_pool_amount AS DOUBLE) AS next_position_impact_pool_amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -157,18 +164,16 @@ WITH evt_data_1 AS (
         CASE
             WHEN next_position_impact_pool_amount = 0 THEN 0
             ELSE next_position_impact_pool_amount / POWER(10, MD.index_token_decimals)
-        END AS next_position_impact_pool_amount
+        END AS next_position_impact_pool_amount,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
         ON ED.market = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_increase.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_increase.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'position_increase',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -131,6 +138,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -161,6 +169,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'collateralToken' THEN value END) AS collateral_token,
@@ -189,7 +198,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -237,6 +246,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 -- full data 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_increase.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_position_increase.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -224,8 +228,11 @@ WITH evt_data_1 AS (
         TRY_CAST(price_impact_amount AS DOUBLE) AS price_impact_amount,
         TRY_CAST(is_long AS BOOLEAN) AS is_long,
         from_hex(order_key) AS order_key,
-        from_hex(position_key) AS position_key
+        from_hex(position_key) AS position_key,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -283,8 +290,11 @@ WITH evt_data_1 AS (
         price_impact_amount / POWER(10, index_token_decimals) AS price_impact_amount,  
         is_long,
         order_key,
-        position_key
+        position_key,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
         ON ED.market = MD.market
@@ -292,11 +302,6 @@ WITH evt_data_1 AS (
         ON ED.collateral_token = CTD.collateral_token
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_revoke_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_revoke_role.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(account) AS account,
-        from_hex(role_key) AS role_key
+        from_hex(role_key) AS role_key,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_revoke_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_revoke_role.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'revoke_role',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'roleKey' THEN value END) AS role_key
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_atomic_oracle_provider.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_atomic_oracle_provider.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'set_atomic_oracle_provider',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS "provider",
         MAX(CASE WHEN key_name = 'value' THEN value END) AS "value"
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_atomic_oracle_provider.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_atomic_oracle_provider.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex("provider") AS "provider",
-        TRY_CAST("value" AS BOOLEAN) AS "value"
+        TRY_CAST("value" AS BOOLEAN) AS "value",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_data_stream.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_data_stream.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'set_data_stream',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -89,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -99,6 +103,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -111,6 +116,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -123,6 +129,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,13 +152,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'feedId' THEN value END) AS feed_id,
         MAX(CASE WHEN key_name = 'dataStreamMultiplier' THEN value END) AS data_stream_multiplier,
         MAX(CASE WHEN key_name = 'dataStreamSpreadReductionFactor' THEN value END) AS data_stream_spread_reduction_factor
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -179,6 +187,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_data_stream.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_data_stream.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -62,7 +62,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -170,19 +170,19 @@ WITH evt_data_1 AS (
         from_hex(EDP.token) AS token,
         from_hex(EDP.feed_id) AS feed_id,
         TRY_CAST(EDP.data_stream_multiplier AS DOUBLE) / POWER(10, 30) AS data_stream_multiplier,
-        TRY_CAST(EDP.data_stream_spread_reduction_factor AS DOUBLE) / POWER(10, 30) AS data_stream_spread_reduction_factor
+        TRY_CAST(EDP.data_stream_spread_reduction_factor AS DOUBLE) / POWER(10, 30) AS data_stream_spread_reduction_factor,
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_oracle_provider_enabled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_oracle_provider_enabled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'set_oracle_provider_enabled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS "provider",
         MAX(CASE WHEN key_name = 'value' THEN value END) AS "value"
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_oracle_provider_enabled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_oracle_provider_enabled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex("provider") AS "provider",
-        TRY_CAST("value" AS BOOLEAN) AS "value"
+        TRY_CAST("value" AS BOOLEAN) AS "value",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_oracle_provider_for_token.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_oracle_provider_for_token.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -134,7 +140,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(token) AS token,
-        from_hex("provider") AS "provider"
+        from_hex("provider") AS "provider",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -142,13 +151,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_oracle_provider_for_token.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_oracle_provider_for_token.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'set_oracle_provider_for_token',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items
     FROM
         evt_data
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,20 +123,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS "provider"
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -149,6 +155,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_price_feed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_price_feed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'set_price_feed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -89,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -98,6 +102,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -110,6 +115,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,6 +135,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'priceFeed' THEN value END) AS price_feed,
         MAX(CASE WHEN key_name = 'priceFeedMultiplier' THEN value END) AS price_feed_multiplier,
@@ -136,7 +143,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'stablePrice' THEN value END) AS stable_price 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -165,6 +172,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_price_feed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_price_feed.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -62,7 +62,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -156,8 +156,11 @@ WITH evt_data_1 AS (
         from_hex(EDP.price_feed) AS price_feed,
         TRY_CAST(EDP.price_feed_multiplier AS DOUBLE) / POWER(10, 30) AS price_feed_multiplier,
         TRY_CAST(EDP.price_feed_heartbeat_duration AS DOUBLE) AS price_feed_heartbeat_duration,
-        TRY_CAST(EDP.stable_price AS DOUBLE) / POWER(10, 30 - ERC20.decimals) AS stable_price
+        TRY_CAST(EDP.stable_price AS DOUBLE) / POWER(10, 30 - ERC20.decimals) AS stable_price,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -166,12 +169,8 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = ERC20.contract_address
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_uint.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_uint.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -39,7 +39,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -147,19 +147,19 @@ WITH evt_data_1 AS (
 
         from_hex(EDP.base_key) AS base_key,
         from_hex(EDP."data") AS "data",
-        TRY_CAST(EDP."value" AS DOUBLE) AS "value_raw"
+        TRY_CAST(EDP."value" AS DOUBLE) AS "value_raw",
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_uint.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_set_uint.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'set_uint',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -36,6 +37,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -63,6 +65,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
@@ -74,6 +77,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -87,6 +91,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -100,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -124,12 +130,13 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'baseKey' THEN value END) AS base_key,
         MAX(CASE WHEN key_name = 'data' THEN value END) AS "data",
         MAX(CASE WHEN key_name = 'value' THEN value END) AS "value"
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -156,6 +163,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_shift_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_shift_created.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -167,7 +171,10 @@ WITH evt_data_1 AS (
         TRY_CAST(execution_fee AS DOUBLE) AS execution_fee,
         TRY_CAST(callback_gas_limit AS DOUBLE) AS callback_gas_limit,
         
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -201,18 +208,14 @@ WITH evt_data_1 AS (
         END AS updated_at_time,
         execution_fee / POWER(10, 18) AS execution_fee,
         callback_gas_limit,
-        "key"
+        "key",
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_shift_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_shift_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'shift_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -145,7 +152,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -180,6 +187,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_shift_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_shift_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'shift_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -104,6 +109,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -128,6 +134,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receivedMarketTokens' THEN value END) AS received_market_tokens,
@@ -135,7 +142,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -161,6 +168,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_shift_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_shift_executed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -148,7 +152,10 @@ WITH evt_data_1 AS (
 
         from_hex(account) AS account,
         TRY_CAST(received_market_tokens AS DOUBLE) / POWER(10,18) AS received_market_tokens,
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -156,13 +163,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_grant_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_grant_role.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(account) AS account,
-        from_hex(role_key) AS role_key
+        from_hex(role_key) AS role_key,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_grant_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_grant_role.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'signal_grant_role',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'roleKey' THEN value END) AS role_key
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_pending_action.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_pending_action.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'signal_pending_action',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -89,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.stringItems' OMIT QUOTES) AS string_items
     FROM
@@ -98,6 +102,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -110,6 +115,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,11 +135,12 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'actionKey' THEN value END) AS action_key,
         MAX(CASE WHEN key_name = 'actionLabel' THEN value END) AS action_label
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -159,6 +166,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_pending_action.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_pending_action.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -62,7 +62,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -150,20 +150,19 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(action_key) AS action_key,
-        action_label
+        action_label,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_revoke_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_revoke_role.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(account) AS account,
-        from_hex(role_key) AS role_key
+        from_hex(role_key) AS role_key,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_revoke_role.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_revoke_role.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'signal_revoke_role',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'roleKey' THEN value END) AS role_key
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_atomic_oracle_provider.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_atomic_oracle_provider.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'signal_set_atomic_oracle_provider',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS "provider",
         MAX(CASE WHEN key_name = 'value' THEN value END) AS "value"
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_atomic_oracle_provider.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_atomic_oracle_provider.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex("provider") AS "provider",
-        TRY_CAST("value" AS BOOLEAN) AS "value"
+        TRY_CAST("value" AS BOOLEAN) AS "value",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_data_stream.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_data_stream.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'signal_set_data_stream',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -89,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -99,6 +103,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -111,6 +116,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -123,6 +129,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,13 +152,14 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'feedId' THEN value END) AS feed_id,
         MAX(CASE WHEN key_name = 'dataStreamMultiplier' THEN value END) AS data_stream_multiplier,
         MAX(CASE WHEN key_name = 'dataStreamSpreadReductionFactor' THEN value END) AS data_stream_spread_reduction_factor
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -179,6 +187,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_data_stream.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_data_stream.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -62,7 +62,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -170,19 +170,19 @@ WITH evt_data_1 AS (
         from_hex(EDP.token) AS token,
         from_hex(EDP.feed_id) AS feed_id,
         TRY_CAST(EDP.data_stream_multiplier AS DOUBLE) / POWER(10, 30) AS data_stream_multiplier,
-        TRY_CAST(EDP.data_stream_spread_reduction_factor AS DOUBLE) / POWER(10, 30) AS data_stream_spread_reduction_factor
+        TRY_CAST(EDP.data_stream_spread_reduction_factor AS DOUBLE) / POWER(10, 30) AS data_stream_spread_reduction_factor,
+
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_oracle_provider_enabled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_oracle_provider_enabled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'signal_set_oracle_provider_enabled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
     FROM
@@ -101,6 +105,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -114,6 +119,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -135,20 +141,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS "provider",
         MAX(CASE WHEN key_name = 'value' THEN value END) AS "value"
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -166,6 +173,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_oracle_provider_enabled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_oracle_provider_enabled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -151,7 +157,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex("provider") AS "provider",
-        TRY_CAST("value" AS BOOLEAN) AS "value"
+        TRY_CAST("value" AS BOOLEAN) AS "value",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -159,13 +168,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_oracle_provider_for_token.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_oracle_provider_for_token.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -134,7 +140,10 @@ WITH evt_data_1 AS (
         msg_sender,
 
         from_hex(token) AS token,
-        from_hex("provider") AS "provider"
+        from_hex("provider") AS "provider",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -142,13 +151,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'event_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM event_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_oracle_provider_for_token.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_oracle_provider_for_token.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'signal_set_oracle_provider_for_token',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items
     FROM
         evt_data
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,20 +123,21 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'provider' THEN value END) AS "provider"
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
     SELECT 
         blockchain,
         block_time,
-        DATE(ED.block_time) AS block_date,
+        ED.block_date AS block_date,
         block_number,
         ED.tx_hash,
         ED.index,
@@ -149,6 +155,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_price_feed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_price_feed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'signal_set_price_feed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -89,6 +92,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items
     FROM
@@ -98,6 +102,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -110,6 +115,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,6 +135,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         MAX(CASE WHEN key_name = 'token' THEN value END) AS token,
         MAX(CASE WHEN key_name = 'priceFeed' THEN value END) AS price_feed,
         MAX(CASE WHEN key_name = 'priceFeedMultiplier' THEN value END) AS price_feed_multiplier,
@@ -136,7 +143,7 @@ WITH evt_data_1 AS (
         MAX(CASE WHEN key_name = 'stablePrice' THEN value END) AS stable_price 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -165,6 +172,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON from_hex(EDP.token) = ERC20.contract_address
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_price_feed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_signal_set_price_feed.sql
@@ -20,7 +20,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -41,7 +41,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -62,7 +62,7 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
-        contract_address,
+        evt_tx_from AS tx_from,        evt_tx_to AS tx_to,        evt_tx_index AS tx_index,        contract_address,
         eventName AS event_name,
         eventData AS data,
         msgSender AS msg_sender
@@ -156,8 +156,11 @@ WITH evt_data_1 AS (
         from_hex(EDP.price_feed) AS price_feed,
         TRY_CAST(EDP.price_feed_multiplier AS DOUBLE) / POWER(10, 30) AS price_feed_multiplier,
         TRY_CAST(EDP.price_feed_heartbeat_duration AS DOUBLE) AS price_feed_heartbeat_duration,
-        TRY_CAST(EDP.stable_price AS DOUBLE) / POWER(10, 30 - ERC20.decimals) AS stable_price
+        TRY_CAST(EDP.stable_price AS DOUBLE) / POWER(10, 30 - ERC20.decimals) AS stable_price,
 
+        ED.tx_from,
+        ED.tx_to,
+        ED.tx_index
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -166,12 +169,8 @@ WITH evt_data_1 AS (
         ON from_hex(EDP.token) = ERC20.contract_address
 )
 
--- can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to', 'index']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd
+
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_swap_fees_collected.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_swap_fees_collected.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -166,8 +170,11 @@ WITH evt_data_1 AS (
         TRY_CAST(ui_fee_amount AS DOUBLE) ui_fee_amount,
 
         from_hex(trade_key) AS trade_key,
-        from_hex(swap_fee_type) AS swap_fee_type
+        from_hex(swap_fee_type) AS swap_fee_type,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -203,18 +210,16 @@ WITH evt_data_1 AS (
             WHEN swap_fee_type = 0x39226eb4fed85317aa310fa53f734c7af59274c49325ab568f9c4592250e8cc5 THEN 'deposit'
             WHEN swap_fee_type = 0xda1ac8fcb4f900f8ab7c364d553e5b6b8bdc58f74160df840be80995056f3838 THEN 'withdrawal'
             WHEN swap_fee_type = 0x7ad0b6f464d338ea140ff9ef891b4a69cf89f107060a105c31bb985d9e532214 THEN 'swap'
-        END AS action_type
+        END AS action_type,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20
         ON ED.token = ERC20.contract_address
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_swap_fees_collected.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_swap_fees_collected.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'swap_fees_collected',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -77,6 +80,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -90,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -103,6 +108,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -127,6 +133,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'uiFeeReceiver' THEN value END) AS ui_fee_receiver,
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
@@ -144,7 +151,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -179,6 +186,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_swap_info.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_swap_info.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'swap_info',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -66,6 +68,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.intItems' OMIT QUOTES) AS int_items,
@@ -78,6 +81,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -91,6 +95,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'market' THEN value END) AS market,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -162,7 +170,7 @@ WITH evt_data_1 AS (
         
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -197,6 +205,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
         AND ED.index = EDP.index
+        AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_swap_info.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_swap_info.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -184,8 +188,11 @@ WITH evt_data_1 AS (
         TRY_CAST(price_impact_usd AS DOUBLE) AS price_impact_usd,
         TRY_CAST(price_impact_amount AS DOUBLE) AS price_impact_amount,
         TRY_CAST(token_in_price_impact_amount AS DOUBLE) AS token_in_price_impact_amount,
-        from_hex(order_key) AS order_key
+        from_hex(order_key) AS order_key,
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
@@ -220,7 +227,10 @@ WITH evt_data_1 AS (
             ELSE price_impact_amount
         END AS price_impact_amount,
         token_in_price_impact_amount / POWER(10, ERC20_in.decimals) AS token_in_price_impact_amount,
-        order_key
+        order_key,
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_erc20') }} AS ERC20_in
         ON ED.token_in = ERC20_in.contract_address
@@ -228,11 +238,6 @@ WITH evt_data_1 AS (
         ON ED.token_out = ERC20_out.contract_address
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_sync_config.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_sync_config.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'sync_config',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -16,6 +16,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -37,6 +38,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -58,6 +60,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -90,6 +93,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index, 
+        block_date,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items
     FROM
@@ -100,6 +104,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -113,6 +118,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -134,6 +140,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'updateId' THEN value END) AS update_id,
         MAX(CASE WHEN key_name = 'prevValue' THEN value END) AS prev_value,
@@ -142,7 +149,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 -- full data 
@@ -170,6 +177,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_sync_config.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_sync_config.sql
@@ -19,6 +19,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -38,6 +40,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -57,6 +61,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -155,7 +161,10 @@ WITH evt_data_1 AS (
         TRY_CAST(EDP.update_id AS DECIMAL(38,0)) AS update_id,
         TRY_CAST(EDP.prev_value AS DECIMAL(38,0)) AS prev_value_raw,
         TRY_CAST(EDP.next_value AS DECIMAL(38,0)) AS next_value_raw,
-        TRY_CAST(EDP.update_applied AS BOOLEAN) AS update_applied
+        TRY_CAST(EDP.update_applied AS BOOLEAN) AS update_applied,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -163,11 +172,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_cancelled.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -189,7 +195,10 @@ WITH evt_data_1 AS (
         from_hex(account) AS account,
         from_hex("key") AS "key",
         from_hex(reason_bytes) AS reason_bytes,
-        reason
+        reason,
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -197,13 +206,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_cancelled.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_cancelled.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'withdrawal_cancelled',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items,
         json_query(data, 'lax $.bytesItems' OMIT QUOTES) AS bytes_items,
@@ -103,6 +107,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -116,6 +121,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,6 +135,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -142,6 +149,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -169,6 +177,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'key' THEN value END) AS "key",
@@ -177,7 +186,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -204,6 +213,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_created.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -194,7 +198,10 @@ WITH evt_data_1 AS (
 
         TRY_CAST(should_unwrap_native_token AS BOOLEAN) AS should_unwrap_native_token,
         
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -233,20 +240,16 @@ WITH evt_data_1 AS (
         withdrawal_type,
         
         should_unwrap_native_token,
-        "key"
+        "key",
         
+        ED.tx_from,
+        ED.tx_to
+
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_avalanche_c_markets_data') }} AS MD
         ON ED.market = MD.market
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_created.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'withdrawal_created',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -67,6 +69,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.boolItems' OMIT QUOTES) AS bool_items,
@@ -79,6 +82,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -92,6 +96,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -105,6 +110,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -118,6 +124,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -145,6 +152,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
 
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'receiver' THEN value END) AS receiver,
@@ -167,7 +175,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , event_data AS (
@@ -207,6 +215,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 , full_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_executed.sql
@@ -3,7 +3,7 @@
     schema = 'gmx_v2_avalanche_c',
     alias = 'withdrawal_executed',
     materialized = 'incremental',
-    unique_key = ['tx_hash', 'index'],
+    unique_key = ['block_date', 'tx_hash', 'index'],
     incremental_strategy = 'merge'
     )
 }}
@@ -17,6 +17,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -38,6 +39,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -59,6 +61,7 @@ WITH evt_data_1 AS (
         -- Main Variables
         '{{ blockchain_name }}' AS blockchain,
         evt_block_time AS block_time,
+        DATE(evt_block_time) AS block_date,
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
@@ -91,6 +94,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         json_query(data, 'lax $.addressItems' OMIT QUOTES) AS address_items,
         json_query(data, 'lax $.uintItems' OMIT QUOTES) AS uint_items,
         json_query(data, 'lax $.bytes32Items' OMIT QUOTES) AS bytes32_items
@@ -103,6 +107,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -116,6 +121,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -129,6 +135,7 @@ WITH evt_data_1 AS (
     SELECT 
         tx_hash,
         index,
+        block_date,
         json_extract_scalar(CAST(item AS VARCHAR), '$.key') AS key_name,
         json_extract_scalar(CAST(item AS VARCHAR), '$.value') AS value
     FROM 
@@ -153,6 +160,7 @@ WITH evt_data_1 AS (
     SELECT
         tx_hash,
         index,
+        block_date,
         
         MAX(CASE WHEN key_name = 'account' THEN value END) AS account,
         MAX(CASE WHEN key_name = 'swapPricingType' THEN value END) AS swap_pricing_type,
@@ -160,7 +168,7 @@ WITH evt_data_1 AS (
 
     FROM
         combined
-    GROUP BY tx_hash, index
+    GROUP BY tx_hash, index, block_date
 )
 
 , full_data AS (
@@ -186,6 +194,7 @@ WITH evt_data_1 AS (
     LEFT JOIN evt_data_parsed AS EDP
         ON ED.tx_hash = EDP.tx_hash
             AND ED.index = EDP.index
+            AND ED.block_date = EDP.block_date
 )
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_executed.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/avalanche_c/gmx_v2_avalanche_c_withdrawal_executed.sql
@@ -20,6 +20,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -39,6 +41,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -58,6 +62,8 @@ WITH evt_data_1 AS (
         evt_block_number AS block_number, 
         evt_tx_hash AS tx_hash,
         evt_index AS index,
+        evt_tx_from AS tx_from,
+        evt_tx_to AS tx_to,
         contract_address,
         eventName AS event_name,
         eventData AS data,
@@ -171,7 +177,10 @@ WITH evt_data_1 AS (
 
         from_hex(account) AS account,
         TRY_CAST(swap_pricing_type AS INTEGER) AS swap_pricing_type,
-        from_hex("key") AS "key"
+        from_hex("key") AS "key",
+
+        ED.tx_from,
+        ED.tx_to
 
     FROM evt_data AS ED
     LEFT JOIN evt_data_parsed AS EDP
@@ -179,13 +188,6 @@ WITH evt_data_1 AS (
             AND ED.index = EDP.index
 )
 
---can be removed once decoded tables are fully denormalized
-{{
-    add_tx_columns(
-        model_cte = 'full_data'
-        , blockchain = blockchain_name
-        , columns = ['from', 'to']
-    )
-}}
-
-
+SELECT
+    fd.*
+FROM full_data AS fd

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/gmx_v2_event_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/gmx_v2_event_schema.yml
@@ -17,6 +17,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
 
@@ -845,8 +846,9 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
-               - key
+               - index
 
     columns:
       - *blockchain

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/megaeth/gmx_v2_megaeth_event_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/megaeth/gmx_v2_megaeth_event_schema.yml
@@ -109,6 +109,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
            arguments:
              combination_of_columns:
+               - block_date
                - tx_hash
                - index
     columns:

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/megaeth/gmx_v2_megaeth_glv_created.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/megaeth/gmx_v2_megaeth_glv_created.sql
@@ -2,7 +2,7 @@
 	schema='gmx_v2_megaeth',
 	alias='glv_created',
 	materialized='incremental',
-	unique_key=['tx_hash', 'index'],
+	unique_key=['block_date', 'tx_hash', 'index'],
 	incremental_strategy='merge',
 ) }}
 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:

**CUR2-2282 — GMX v2 hourly event pipeline**

- Drop `add_tx_columns` / `transactions` joins from GMX v2 hourly **EventEmitter** event models on **Arbitrum** and **Avalanche C**. Use **`evt_tx_from`**, **`evt_tx_to`**, and **`evt_tx_index`** (as `tx_index` where needed) from decoded logs instead. **MegaETH** `market_created` / `glv_created` remain on the existing single-pass unnest pattern from prior work.
- For incremental merge models, include **`block_date`** in **`unique_key`** alongside **`tx_hash`** and **`index`**. Thread **`DATE(evt_block_time)`** through **`evt_data`** → parsing CTEs → **`evt_data_parsed`**, extend **`GROUP BY`**, and add **`AND ED.block_date = EDP.block_date`** wherever **`evt_data`** joins **`evt_data_parsed`** on **`tx_hash`/`index`**. Prefer **`ED.block_date`** over **`DATE(ED.block_time)`** where **`event_data`** selects from **`evt_data AS ED`**.
- Update **`unique_combination_of_columns`** in **`gmx_v2_*_event_schema.yml`** (and cross-chain **`gmx_v2_event_schema.yml`**) to **`block_date`, `tx_hash`, `index`**. Align **`gmx_v2_order_frozen`** uniqueness test with the SQL grain (**`tx_hash`/`index`**, not **`key`**).


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
