### PR TITLE
Fix Pepe Boost Solana bot trades optimizer timeout

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
@@ -19,8 +19,7 @@ WITH
     SELECT
       tx_id,
       block_time,
-      'SOL' AS feeTokenType,
-      balance_change / 1e9 AS fee_token_amount,
+      SUM(balance_change) / 1e9 AS fee_token_amount,
       '{{wsol_token}}' AS fee_token_mint_address
     FROM
       {{ source('solana','account_activity') }}
@@ -34,6 +33,24 @@ WITH
       AND balance_change > 0
       AND address = '{{fee_receiver}}'
       AND NOT signed -- Exclude transactions signed by the fee wallet.
+    GROUP BY
+      tx_id,
+      block_time
+  ),
+  wsolPrices AS (
+    SELECT
+      minute,
+      price
+    FROM
+      {{ source('prices', 'usd') }}
+    WHERE
+      blockchain = 'solana'
+      AND contract_address = from_base58('{{wsol_token}}')
+      {% if is_incremental() %}
+      AND {{ incremental_predicate('minute') }}
+      {% else %}
+      AND minute >= TIMESTAMP '{{project_start_date}}'
+      {% endif %}
   ),
   botTrades AS (
     SELECT
@@ -55,7 +72,7 @@ WITH
       token_sold_mint_address AS token_sold_address,
       fee_token_amount * price AS fee_usd,
       fee_token_amount,
-      IF(feeTokenType = 'SOL', 'SOL', symbol) AS fee_token_symbol,
+      'SOL' AS fee_token_symbol,
       fee_token_mint_address AS fee_token_address,
       project,
       trades.version,
@@ -72,15 +89,8 @@ WITH
         trades.tx_id = feePayments.tx_id
         AND trades.block_time = feePayments.block_time
       )
-      LEFT JOIN {{ source('prices', 'usd') }} AS feeTokenPrices ON (
-        feeTokenPrices.blockchain = 'solana'
-        AND feeTokenPrices.contract_address = from_base58(fee_token_mint_address)
-        AND date_trunc('minute', trades.block_time) = minute
-        {% if is_incremental() %}
-        AND {{ incremental_predicate('minute') }}
-        {% else %}
-        AND minute >= TIMESTAMP '{{project_start_date}}'
-        {% endif %}
+      LEFT JOIN wsolPrices ON (
+        date_trunc('minute', trades.block_time) = wsolPrices.minute
       )
     WHERE
       trades.trader_id != '{{fee_receiver}}' -- Exclude trades signed by FeeWallet

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
@@ -6,8 +6,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-    unique_key = ['blockchain', 'tx_id', 'tx_index', 'outer_instruction_index', 'inner_instruction_index'],
-    pre_hook = '{{ set_trino_session_property(true, "join_reordering_strategy", "ELIMINATE_CROSS_JOINS") }}'
+    unique_key = ['blockchain', 'tx_id', 'tx_index', 'outer_instruction_index', 'inner_instruction_index']
    )
 }}
 
@@ -19,6 +18,7 @@ WITH
   allFeePayments AS (
     SELECT
       tx_id,
+      block_time,
       IF(balance_change > 0, 'SOL', 'SPL') AS feeTokenType,
       IF(
         balance_change > 0,
@@ -75,10 +75,13 @@ WITH
       inner_instruction_index
     FROM
       {{ source('dex_solana', 'trades') }} AS trades
-      JOIN allFeePayments AS feePayments ON trades.tx_id = feePayments.tx_id
+      JOIN allFeePayments AS feePayments ON (
+        trades.tx_id = feePayments.tx_id
+        AND trades.block_time = feePayments.block_time
+      )
       LEFT JOIN {{ source('prices', 'usd') }} AS feeTokenPrices ON (
         feeTokenPrices.blockchain = 'solana'
-        AND fee_token_mint_address = toBase58 (feeTokenPrices.contract_address)
+        AND feeTokenPrices.contract_address = from_base58(fee_token_mint_address)
         AND date_trunc('minute', trades.block_time) = minute
         {% if is_incremental() %}
         AND {{ incremental_predicate('minute') }}
@@ -88,6 +91,7 @@ WITH
       )
       JOIN {{ source('solana','transactions') }} AS transactions ON (
         trades.tx_id = id
+        AND trades.block_time = transactions.block_time
         {% if is_incremental() %}
         AND {{ incremental_predicate('transactions.block_time') }}
         {% else %}

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
@@ -19,17 +19,9 @@ WITH
     SELECT
       tx_id,
       block_time,
-      IF(balance_change > 0, 'SOL', 'SPL') AS feeTokenType,
-      IF(
-        balance_change > 0,
-        balance_change / 1e9,
-        token_balance_change
-      ) AS fee_token_amount,
-      IF(
-        balance_change > 0,
-        '{{wsol_token}}',
-        token_mint_address
-      ) AS fee_token_mint_address
+      'SOL' AS feeTokenType,
+      balance_change / 1e9 AS fee_token_amount,
+      '{{wsol_token}}' AS fee_token_mint_address
     FROM
       {{ source('solana','account_activity') }}
     WHERE
@@ -41,6 +33,7 @@ WITH
       AND tx_success
       AND balance_change > 0
       AND address = '{{fee_receiver}}'
+      AND NOT signed -- Exclude transactions signed by the fee wallet.
   ),
   botTrades AS (
     SELECT
@@ -89,18 +82,8 @@ WITH
         AND minute >= TIMESTAMP '{{project_start_date}}'
         {% endif %}
       )
-      JOIN {{ source('solana','transactions') }} AS transactions ON (
-        trades.tx_id = id
-        AND trades.block_time = transactions.block_time
-        {% if is_incremental() %}
-        AND {{ incremental_predicate('transactions.block_time') }}
-        {% else %}
-        AND transactions.block_time >= TIMESTAMP '{{project_start_date}}'
-        {% endif %}
-      )
     WHERE
       trades.trader_id != '{{fee_receiver}}' -- Exclude trades signed by FeeWallet
-      AND transactions.signer != '{{fee_receiver}}' -- Exclude trades signed by FeeWallet
       {% if is_incremental() %}
       AND {{ incremental_predicate('trades.block_time') }}
       {% else %}

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
@@ -6,7 +6,8 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-    unique_key = ['blockchain', 'tx_id', 'tx_index', 'outer_instruction_index', 'inner_instruction_index']
+    unique_key = ['blockchain', 'tx_id', 'tx_index', 'outer_instruction_index', 'inner_instruction_index'],
+    pre_hook = '{{ set_trino_session_property(true, "join_reordering_strategy", "ELIMINATE_CROSS_JOINS") }}'
    )
 }}
 
@@ -78,7 +79,7 @@ WITH
       LEFT JOIN {{ source('prices', 'usd') }} AS feeTokenPrices ON (
         feeTokenPrices.blockchain = 'solana'
         AND fee_token_mint_address = toBase58 (feeTokenPrices.contract_address)
-        AND date_trunc('minute', block_time) = minute
+        AND date_trunc('minute', trades.block_time) = minute
         {% if is_incremental() %}
         AND {{ incremental_predicate('minute') }}
         {% else %}
@@ -101,17 +102,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -141,18 +131,11 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (
+      PARTITION BY botTrades.tx_id, botTrades.outer_instruction_index
+    ),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
-ORDER BY
-  block_time DESC,
-  tx_index DESC,
-  outer_instruction_index DESC,
-  inner_instruction_index DESC


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:

- Removes the self-join over `botTrades` in `pepe_boost_solana_bot_trades` by calculating `is_last_trade_in_transaction` with a window aggregate.
- Removes the final unbounded `ORDER BY` and qualifies the price join timestamp.
- Carries fee-payment `block_time` into the join against `dex_solana.trades` to tighten historical execution.
- Removes the `solana.transactions` join by using `account_activity.signed` to exclude fee-wallet-signed transactions.
- Simplifies Pepe Boost fee extraction to SOL-only, pre-aggregates fee rows by transaction/time, and pre-filters `prices.usd` to WSOL prices before joining.

### Validation:

- `uv run dbt deps`
- `uv run dbt compile -s pepe_boost_solana_bot_trades`
- CI reported `spilling failed` on earlier revisions; follow-ups removed the forced join-reordering hook, removed the large transactions join, and narrowed fee/price joins. Local compile still passes.

Execution-level Dune query validation was not run because `DUNE_API_KEY` is not available in this environment.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duneanalytics.slack.com/archives/C04E0CV1SG3/p1778217407673809?thread_ts=1778217407.673809&cid=C04E0CV1SG3)

<div><a href="https://cursor.com/agents/bc-caee1cd0-dc25-5a25-85c3-2c4f2343adce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caee1cd0-dc25-5a25-85c3-2c4f2343adce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

