### PR TITLE
fix(kalshi): propagate lifecycle settlement to ohlcv_hourly historical rows

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_ohlcv_hourly.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_ohlcv_hourly.sql
@@ -29,7 +29,16 @@ with base as (
 		) as rn_last
 	from {{ ref('kalshi_market_trades') }} as t
 	{% if is_incremental() -%}
-	where {{ incremental_predicate('t.created_time') }}
+	where
+		{{ incremental_predicate('t.created_time') }}
+		-- Late-arriving settlements: pull historical trades for tickers whose market_details
+		-- dim columns (result, category, event_title, ...) refreshed via lifecycle, so old
+		-- hours can be re-emitted with the current market_outcome.
+		or t.ticker in (
+			select md.ticker
+			from {{ ref('kalshi_market_details') }} as md
+			where {{ incremental_predicate('md.source_updated_at') }}
+		)
 	{%- endif %}
 ),
 
@@ -68,7 +77,9 @@ new_sparse as (
 ),
 
 {% if is_incremental() -%}
--- pre-window sparse anchor from {{ this }} so market_bounds and asof forward-fill stay correct across the window boundary
+-- pre-window sparse anchor from {{ this }} so market_bounds and asof forward-fill stay correct across the window boundary.
+-- Excludes tickers being re-aggregated from base (refreshed market_details), since their hours are
+-- already coming through new_sparse and double-emitting them here would break the merge unique key.
 prior_sparse as (
 	select
 		t.hour,
@@ -86,6 +97,11 @@ prior_sparse as (
 	from {{ this }} as t
 	where t.is_forward_filled = false
 		and not {{ incremental_predicate('t.hour') }}
+		and t.market_id not in (
+			select md.ticker
+			from {{ ref('kalshi_market_details') }} as md
+			where {{ incremental_predicate('md.source_updated_at') }}
+		)
 ),
 {% endif %}
 
@@ -239,5 +255,15 @@ where not (
 	and r.market_outcome in ('yes', 'no')
 )
 {% if is_incremental() -%}
-  and {{ incremental_predicate('r.hour') }}
+  and (
+    {{ incremental_predicate('r.hour') }}
+    -- Late-arriving settlements: when a ticker's market_details refreshed via lifecycle,
+    -- emit all its hours so historical rows pick up the new market_outcome / category /
+    -- event_market_name. Pairs with the OR-branch in the base CTE.
+    or r.market_id in (
+      select md.ticker
+      from {{ ref('kalshi_market_details') }} as md
+      where {{ incremental_predicate('md.source_updated_at') }}
+    )
+  )
 {%- endif %}

--- a/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_ohlcv_hourly.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_ohlcv_hourly.sql
@@ -6,9 +6,15 @@
 	incremental_strategy = 'merge',
 	partition_by = ['block_month'],
 	unique_key = ['block_month', 'hour', 'market_id', 'outcome'],
-	incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.hour')],
 	merge_skip_unchanged = true,
 ) }}
+
+-- Merge target is NOT pruned by incremental_predicates: the source emits historical hours
+-- for tickers whose market_details refreshed via lifecycle, and a destination predicate on
+-- DBT_INTERNAL_DEST.hour would hide their existing target rows from the ON clause, sending
+-- them through the INSERT branch and breaking unique(block_month, hour, market_id, outcome).
+-- Same reasoning as kalshi_market_details. Trades the destination-pruning speedup for
+-- correctness on late-arriving settlements.
 
 with base as (
 	select


### PR DESCRIPTION
## Summary

Stacked on #9647 (\`feat/kalshi-lifecycle-patch\`). Targets that branch, not \`main\`, so the diff stays minimal once the parent merges.

Cursor surfaced this on #9647: \`kalshi_market_details.source_updated_at\` now moves when lifecycle events land, and \`kalshi_market_trades\` propagates the change to historical trade rows. \`kalshi_ohlcv_hourly\` did not, because its incremental selectors (\`t.created_time\` in \`base\`, \`r.hour\` in the final emit) keyed only on time-of-trade. A market that settles today with old trades would update \`market_details\`/\`market_trades\` while \`ohlcv_hourly\` kept stale \`market_outcome\` / \`event_market_name\` / \`category\` until full refresh.

## Changes

Three coordinated edits to \`kalshi_ohlcv_hourly.sql\`. Coordinated because changing only the \`base\` filter would produce duplicate \`(block_month, hour, market_id, outcome)\` keys and break the merge unique constraint, and changing only the bottom filter would not actually surface the refreshed dim cols.

1. \`base\` CTE: widen the incremental WHERE with the same OR-branch \`kalshi_market_trades\` already uses, pulling historical trades for tickers whose \`market_details.source_updated_at\` is in window.
2. \`prior_sparse\` CTE: exclude refreshed tickers entirely. Otherwise their hours come through twice (new_sparse re-aggregates, prior_sparse re-emits from \`{{ this }}\`), and the merge fails uniqueness.
3. Final emit: widen the bottom \`incremental_predicate('r.hour')\` with an OR on refreshed \`market_id\`s so the merge actually writes to those old hours.

## Validation

- \`uv run dbt compile --select kalshi_ohlcv_hourly\` succeeds.
- End-to-end source-uniqueness check on the production target with a 3-day window: simulated post-fix \`sparse_ohlcv\` produces **0 duplicate (hour, market_id, outcome) keys** across new_sparse + prior_sparse. Refreshed cohort = 446k tickers in 3 days.

## Notes

- No schema change; existing \`unique_combination_of_columns(block_month, hour, market_id, outcome)\` test continues to enforce the post-fix invariant.
- Performance: the OR-branch in \`base\` widens the \`market_trades\` scan to include refreshed tickers' full history. Bounded by lifecycle event volume in the window. The merge uses \`merge_skip_unchanged = true\`, so unchanged columns on re-emitted rows do not trigger writes.
- Forward-filled post-expiration rows for resolved markets remain excluded from output by the existing \`where not (...)\` filter. Spine bounds (\`last_hour = least(max trade hour, now())\`) mean those rows are rarely generated in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)