### PR TITLE
fix(polymarket): drop forward-fill post-expiration for any resolved market

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
@@ -188,6 +188,10 @@ with_settlement as (
         m.market_end_time_ts                                                    as market_end_time,
         m.market_outcome,
         f.is_forward_filled,
+        -- Pin only Yes/No-tokenized binary markets where market_outcome is yes/no.
+        -- Multi-outcome markets (sports teams, Up/Down, Over/Under, 50/50) cannot be pinned
+        -- here because market_details.outcome is the binary "yes/no" representation, not the
+        -- winning token name. Per-token resolution would need a separate upstream source.
         case
             when m.market_end_time_ts is not null
                  and f.hour > m.market_end_time_ts
@@ -249,11 +253,18 @@ select
     r.is_forward_filled,
     now()                                                                       as _updated_at
 from with_resolution r
+-- Drop forward-filled rows past expiration for any resolved market. Today this filter only
+-- fires for market_outcome IN ('yes','no'); the wider condition closes the gap where
+-- multi-outcome markets (Rays/Red Sox, Up/Down, Over/Under, 50/50) keep stale forward-filled
+-- prices indefinitely after resolution. We can't pin them to a terminal value without a
+-- per-token resolution source, so we drop the noise.
 where not (
     r.is_forward_filled
     and r.market_end_time is not null
     and r.hour > r.market_end_time
-    and r.market_outcome in ('yes', 'no')
+    and r.market_outcome is not null
+    and r.market_outcome != ''
+    and r.market_outcome != 'unresolved'
 )
 {% if is_incremental() -%}
   and {{ incremental_predicate('r.hour') }}


### PR DESCRIPTION
## Summary

Closes the multi-outcome settlement-pin gap surfaced by the [internal audit](#audit-9-may): \`polymarket_polygon.ohlcv_hourly\` carries ~87k forward-filled rows past expiration for ~1,083 \`50/50\` markets, with stale prices that never get pinned or dropped.

## Root cause

\`with_settlement.settled_price\` only fires for \`market_outcome IN ('yes','no')\` and the bottom output filter drops forward-fill post-expiration only for those same outcomes. \`50/50\` markets land in neither branch: \`settled_price\` stays NULL (no pin), filter doesn't drop them (no cleanup). Stale forward-filled prices accumulate indefinitely.

## Fix considered: extend settlement-pin to multi-outcome (rejected)

The intuitive fix is to pin every resolved market: winning token = 1.0, losers = 0.0. Verified on deployed data that this is **not implementable** with the current upstream surface:

- \`market_details.outcome\` is the binary \`'yes'\`/\`'no'\`/\`'50/50'\`/\`'unresolved'\` representation, NOT the winning token name.
- For e.g. \"Rays vs Red Sox\" the tokens are \`'Rays'\` / \`'Red Sox'\` but \`outcome='no'\`. Without per-token resolution data, we can't tell which side won.
- Distinct \`market_outcome\` values across 90d on \`ohlcv_hourly\`: only \`null\`, \`'yes'\`, \`'no'\`, \`'unresolved'\`, \`'50/50'\`. No other multi-outcome values exist; all 1,083 audit-flagged markets are \`50/50\`.

A future PR can add per-token pinning if/when an upstream resolution source is wired up.

## Fix landed: drop forward-fill post-expiration for any resolved market

Single change in the bottom filter. Drops the noise rather than pinning it. Real-trade post-expiration rows are untouched (filter retains the \`is_forward_filled\` clause).

## Validation against deployed \`polymarket_polygon.ohlcv_hourly\`

| Cohort | Rows past expiration (90d) | Effect |
|---|---:|---|
| \`market_outcome='yes'\` real-trade | 1,384,871 | kept (no change) |
| \`market_outcome='no'\` real-trade | 2,310,968 | kept (no change) |
| \`market_outcome='50/50'\` real-trade | 16,983 | kept (no change) |
| \`market_outcome='50/50'\` forward-fill | **87,383** | **DROPPED by new filter** |

Matches the audit's 88,555 / 1,083 markets within the 90-day window.

## Note on existing stale rows

The bottom filter is forward-only: it prevents NEW stale rows from being emitted, but historical 87k stale rows already in the target stay until a one-time \`dbt build --full-refresh --select polymarket_polygon_ohlcv_hourly\`. Recommend running it after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)