### PR TITLE
Optimize Pepe Boost Solana bot trades

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
@@ -44,6 +44,7 @@ WITH
       AND tx_success
       AND balance_change > 0
       AND address = '{{fee_receiver}}'
+      AND NOT signed -- Exclude trades signed by FeeWallet
   ),
   botTrades AS (
     SELECT
@@ -89,17 +90,8 @@ WITH
         AND minute >= TIMESTAMP '{{project_start_date}}'
         {% endif %}
       )
-      JOIN {{ source('solana','transactions') }} AS transactions ON (
-        trades.tx_id = id
-        {% if is_incremental() %}
-        AND {{ incremental_predicate('transactions.block_time') }}
-        {% else %}
-        AND transactions.block_time >= TIMESTAMP '{{project_start_date}}'
-        {% endif %}
-      )
     WHERE
       trades.trader_id != '{{fee_receiver}}' -- Exclude trades signed by FeeWallet
-      AND transactions.signer != '{{fee_receiver}}' -- Exclude trades signed by FeeWallet
       {% if is_incremental() %}
       AND {{ incremental_predicate('trades.block_time') }}
       {% else %}

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
@@ -6,7 +6,10 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-    pre_hook = '{{ set_trino_session_property(true, "join_reordering_strategy", "NONE") }}',
+    pre_hook = [
+      '{{ set_trino_session_property(true, "join_reordering_strategy", "NONE") }}',
+      '{{ enforce_join_distribution("PARTITIONED") }}'
+    ],
     unique_key = ['blockchain', 'tx_id', 'tx_index', 'outer_instruction_index', 'inner_instruction_index']
    )
 }}

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
@@ -9,7 +9,7 @@
     pre_hook = [
       '{{ set_trino_session_property(true, "join_reordering_strategy", "NONE") }}',
       '{{ enforce_join_distribution("PARTITIONED") }}',
-      '{{ set_trino_session_property(true, "join_partitioned_build_min_row_count", 0) }}'
+      'SET SESSION join_partitioned_build_min_row_count=0'
     ],
     unique_key = ['blockchain', 'tx_id', 'tx_index', 'outer_instruction_index', 'inner_instruction_index']
    )

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
@@ -6,6 +6,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    pre_hook = '{{ set_trino_session_property(true, "join_reordering_strategy", "NONE") }}',
     unique_key = ['blockchain', 'tx_id', 'tx_index', 'outer_instruction_index', 'inner_instruction_index']
    )
 }}

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
@@ -8,7 +8,8 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     pre_hook = [
       '{{ set_trino_session_property(true, "join_reordering_strategy", "NONE") }}',
-      '{{ enforce_join_distribution("PARTITIONED") }}'
+      '{{ enforce_join_distribution("PARTITIONED") }}',
+      '{{ set_trino_session_property(true, "join_partitioned_build_min_row_count", 0) }}'
     ],
     unique_key = ['blockchain', 'tx_id', 'tx_index', 'outer_instruction_index', 'inner_instruction_index']
    )

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
@@ -101,17 +101,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -136,23 +125,18 @@ SELECT
   token_pair,
   project_contract_address,
   user,
-  botTrades.tx_id,
+  tx_id,
   tx_index,
-  botTrades.outer_instruction_index,
+  outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (
+      PARTITION BY
+        tx_id,
+        outer_instruction_index
+    ),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
-ORDER BY
-  block_time DESC,
-  tx_index DESC,
-  outer_instruction_index DESC,
-  inner_instruction_index DESC


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Optimizes `pepe_boost_solana_bot_trades` to avoid the Trino optimizer timeout seen in prod by:

- replacing the self-join used for `is_last_trade_in_transaction` with an equivalent windowed `max(inner_instruction_index)` expression
- removing the final unbounded `ORDER BY`
- disabling Trino join reordering for this model via a pre-hook
- pinning join distribution to `PARTITIONED` via the existing `enforce_join_distribution` macro
- removing the separate `solana.transactions` join by filtering fee-receiver account activity rows with `NOT signed`, preserving the fee-wallet-signed transaction exclusion intent with a smaller join graph
- disabling the non-partitioned join lookup optimization for this model by setting `join_partitioned_build_min_row_count = 0`

Validation:
- `uv run dbt compile -s pepe_boost_solana_bot_trades` passed locally after the latest pre-hook update
- PR CI iteration 1 still timed out in `ReorderJoins`
- PR CI iteration 2 moved past join reordering but timed out in `DetermineJoinDistributionType`
- PR CI iteration 3 moved past distribution choice but timed out in `UseNonPartitionedJoinLookupSource`
- PR CI iteration 4 still timed out in `UseNonPartitionedJoinLookupSource` after removing the transactions join
- PR CI iteration 5 failed because the shared session-property macro quoted numeric `0` as varchar
- PR CI iteration 6 is pending with raw `SET SESSION join_partitioned_build_min_row_count=0`

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duneanalytics.slack.com/archives/C04E0CV1SG3/p1778467679938939?thread_ts=1778467679.938939&cid=C04E0CV1SG3)

<div><a href="https://cursor.com/agents/bc-2c670ff1-fdb9-549b-a318-3f33ef7e51a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c670ff1-fdb9-549b-a318-3f33ef7e51a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

