### PR TITLE
Optimize Lido other income joins

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_other_income.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_other_income.sql
@@ -1,12 +1,11 @@
 {{ config(
 	schema='lido_accounting_ethereum',
 	alias='other_income',
-	materialized='incremental',
+	materialized='table',
 	file_format='delta',
-	incremental_strategy='merge',
-	unique_key=['blockchain', 'period', 'evt_tx_hash', 'token', 'amount_token'],
-	incremental_predicates=[incremental_predicate('DBT_INTERNAL_DEST.period')],
 ) }}
+
+-- ci-stamp: 1
 
 {% set project_start_date = '2020-12-17' %}
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_other_income.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_other_income.sql
@@ -145,6 +145,44 @@ with tokens as (
     ) as list(address)    
 )
 
+, income_recipient_multisigs as (
+	select distinct
+		address
+	from
+		multisigs_list
+	where
+		chain = 'Ethereum'
+		and name in ('Aragon', 'FinanceOpsMsig')
+)
+
+, aragon_multisig as (
+	select distinct
+		address
+	from
+		multisigs_list
+	where
+		chain = 'Ethereum'
+		and name = 'Aragon'
+)
+
+, excluded_income_senders as (
+	select address from multisigs_list
+	union all
+	select address from ldo_referral_payments_addr
+	union all
+	select address from dai_referral_payments_addr
+	union all
+	select address from steth_referral_payments_addr
+	union all
+	select address from diversifications_addresses
+)
+
+, excluded_eth_income_senders as (
+	select address from multisigs_list
+	union all
+	select address from diversifications_addresses
+)
+
 , stonks_orders as (
 	select
 		cast(replace(l.topic1, 0x000000000000000000000000, 0x) as varbinary) as order_addr
@@ -174,13 +212,14 @@ with tokens as (
 	inner join stonks_orders as s
 		on tr."from" = s.order_addr
 		and tr.contract_address = s.token_out
+	inner join cow_settlement as c
+		on c.address = tr.to
 	where
 		{% if not is_incremental() -%}
 		tr.evt_block_time >= timestamp '{{ project_start_date }}'
 		{% else -%}
 		{{ incremental_predicate('tr.evt_block_time') }}
 		{% endif -%}
-		and exists (select 1 from cow_settlement as c where c.address = tr.to)
 )
 
 , stonks_to_treasury as (
@@ -191,24 +230,20 @@ with tokens as (
 	inner join stonks_orders_txns as s
 		on tr.evt_tx_hash = s.evt_tx_hash
 		and tr.contract_address = s.token_in
-		and exists (select 1 from tokens as tok where tok.address = tr.contract_address)
+	inner join tokens as tok
+		on tok.address = tr.contract_address
+	inner join aragon_multisig as m
+		on m.address = tr.to
+	inner join cow_settlement as c
+		on c.address = tr."from"
 	where
 		{% if not is_incremental() -%}
 		tr.evt_block_time >= timestamp '{{ project_start_date }}'
 		{% else -%}
 		{{ incremental_predicate('tr.evt_block_time') }}
 		{% endif -%}
-		and exists (
-			select
-				1
-			from
-				multisigs_list as m
-			where
-				m.address = tr.to
-				and m.name = 'Aragon'
-				and m.chain = 'Ethereum'
-		)
-		and exists (select 1 from cow_settlement as c where c.address = tr."from")
+	group by
+		tr.evt_tx_hash
 )
 
 
@@ -222,30 +257,23 @@ with tokens as (
 		, 'ethereum' as blockchain
 	from
 		{{ source('erc20_ethereum', 'evt_Transfer') }} as t
+	inner join tokens as tok
+		on tok.address = t.contract_address
+	inner join income_recipient_multisigs as m
+		on m.address = t.to
+	left join excluded_income_senders as excluded
+		on excluded.address = t."from"
+	left join stonks_to_treasury as st
+		on st.evt_tx_hash = t.evt_tx_hash
 	where
 		{% if not is_incremental() -%}
 		t.evt_block_time >= timestamp '{{ project_start_date }}'
 		{% else -%}
 		{{ incremental_predicate('t.evt_block_time') }}
 		{% endif -%}
-		and exists (select 1 from tokens as tok where tok.address = t.contract_address)
-		and exists (
-			select
-				1
-			from
-				multisigs_list as m
-			where
-				m.address = t.to
-				and m.name in ('Aragon', 'FinanceOpsMsig')
-				and m.chain = 'Ethereum'
-		)
-		and not exists (select 1 from multisigs_list as m where m.address = t."from")
-		and not exists (select 1 from ldo_referral_payments_addr as l where l.address = t."from")
-		and not exists (select 1 from dai_referral_payments_addr as d where d.address = t."from")
-		and not exists (select 1 from steth_referral_payments_addr as s where s.address = t."from")
 		and t."from" != 0x0000000000000000000000000000000000000000
-		and not exists (select 1 from diversifications_addresses as d where d.address = t."from")
-		and not exists (select 1 from stonks_to_treasury as st where st.evt_tx_hash = t.evt_tx_hash)
+		and excluded.address is null
+		and st.evt_tx_hash is null
 
 	union all
 
@@ -262,6 +290,8 @@ with tokens as (
 		on t.evt_tx_hash = s.evt_tx_hash
 		and t.evt_block_time = s.evt_block_time
 		and t.evt_block_number = s.evt_block_number
+	inner join aragon_multisig as m
+		on m.address = t.to
 	where
 		{% if not is_incremental() -%}
 		t.evt_block_time >= timestamp '{{ project_start_date }}'
@@ -269,7 +299,6 @@ with tokens as (
 		{{ incremental_predicate('t.evt_block_time') }}
 		{% endif -%}
 		and t.contract_address = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84
-		and exists (select 1 from multisigs_list as m where m.address = t.to and m.chain = 'Ethereum' and m.name = 'Aragon')
 		and t."from" = 0x0000000000000000000000000000000000000000
 )
 
@@ -335,6 +364,10 @@ from
 			, cast(tr.value as double) as amount_token
 		from
 			{{ source('ethereum', 'traces') }} as tr
+		inner join income_recipient_multisigs as m
+			on m.address = tr.to
+		left join excluded_eth_income_senders as excluded
+			on excluded.address = tr."from"
 		where
 			{% if not is_incremental() -%}
 			tr.block_time >= timestamp '{{ project_start_date }}'
@@ -342,18 +375,7 @@ from
 			{{ incremental_predicate('tr.block_time') }}
 			{% endif -%}
 			and tr.success = true
-			and exists (
-				select
-					1
-				from
-					multisigs_list as m
-				where
-					m.address = tr.to
-					and m.name in ('Aragon', 'FinanceOpsMsig')
-					and m.chain = 'Ethereum'
-			)
-			and not exists (select 1 from multisigs_list as m where m.address = tr."from")
-			and not exists (select 1 from diversifications_addresses as d where d.address = tr."from")
+			and excluded.address is null
 			and tr.type = 'call'
 			and (tr.call_type not in ('delegatecall', 'callcode', 'staticcall') or tr.call_type is null)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:

Refactors `lido_accounting_ethereum_other_income` to replace repeated semi/anti-join filters with explicit include/exclude CTEs and joins, then materializes the small accounting output as a Delta table instead of incremental merge. The CI initial build produced 9,070 rows in ~4.8 minutes, while the incremental merge path still hit Trino's `DetermineJoinDistributionType` optimizer timeout; table materialization matches neighboring Lido accounting models and removes the failing merge plan.

Validation:
- `dbt compile -s lido_accounting_ethereum_other_income` from `dbt_subprojects/hourly_spellbook`
- PR CI revision `244af472f`: initial build + initial test passed; incremental merge failed with the original optimizer timeout, motivating the table materialization change
- PR CI revision `d662d4a9`: Hourly Spellbook `dbt-run / dbt-test` passed successfully

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duneanalytics.slack.com/archives/C04E0CV1SG3/p1778483083308999?thread_ts=1778483083.308999&cid=C04E0CV1SG3)

<div><a href="https://cursor.com/agents/bc-a4b62962-9af4-5338-b439-df2ffa19de75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4b62962-9af4-5338-b439-df2ffa19de75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

