### PR TITLE
feat: add HEDGE token (Hedgehog Protocol) to Sonic price feeds

### DIFF
--- a/dbt_subprojects/tokens/models/prices/sonic/prices_sonic_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/sonic/prices_sonic_tokens.sql
@@ -66,4 +66,5 @@ FROM
     , ('usdc-usd-coin', 'metaUSD', 0x1111111199558661Bf7Ff27b4F1623dC6b91Aa3e, 18)
     , ('equal-equalizer-on-sonic', 'EQUAL', 0xddf26b42c1d903de8962d3f79a74a501420d5f19, 18)
     , ('fly-flytrade', 'FLY', 0x6c9B3A74ae4779da5Ca999371eE8950e8DB3407f, 18)
+    , ('hedge-hedge-token', 'HEDGE', 0x5cccEbCb0C0af721a6539aFDa1628EeaAF7d6C5c, 18)
 ) as temp (token_id, symbol, contract_address, decimals)


### PR DESCRIPTION
## Summary

Adds the HEDGE token from Hedgehog Protocol to the Sonic prices table so Dune can track its price.

**Token Details:**
- Name: Hedge Token
- Symbol: HEDGE
- Token ID: hedge-hedge-token
- Contract: `0x5cccEbCb0C0af721a6539aFDa1628EeaAF7d6C5c`
- Decimals: 18
- Chain: Sonic

**Protocol:** [Hedgehog Protocol](https://sonicpump.meme) — permissionless meme token launchpad on Sonic with bonding curve liquidity.

**Changes:**
- Added HEDGE to `prices_sonic_tokens.sql` VALUES list

**Links:**
- Website: https://sonicpump.meme
- DeFiLlama: PR merged (https://github.com/DefiLlama/DefiLlama-Adapters/pull/19202)
- SonicScan: https://sonicscan.org/token/0x5cccEbCb0C0af721a6539aFDa1628EeaAF7d6C5c