### PR TITLE
Pin uv exclude-newer to a rolling 3-day window

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,5 @@ dependencies = [
 ]
 
 [tool.uv]
+exclude-newer = "3 days"
 package = false

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = "==3.13.*"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "agate"
 version = "1.9.1"


### PR DESCRIPTION
## Summary

Adds `exclude-newer = "3 days"` to `[tool.uv]` so dependency resolution enforces a rolling minimum-release-age cooldown. Blocks fresh PyPI package versions for 3 days, neutralizing Shai-Hulud-style supply-chain worms that publish malicious versions and rely on victims auto-installing within hours.

## Context

Part of the local + CI supply-chain defense rollout. See:
- duneanalytics/ai-first-engineering#26 (uv config + agent policy)
- duneanalytics/spellbook-sqlmesh#381 (same pattern)

Lockfile change is metadata-only — no package version changes. Requires uv ≥ 0.9.17 (the `"3 days"` friendly-duration syntax). CI uses `astral-sh/setup-uv` which installs a recent enough version by default.