### PR TITLE
Consolidate spell explorer post-hooks (public/private)

### DIFF
--- a/dbt_macros/dune/macros_schema.yml
+++ b/dbt_macros/dune/macros_schema.yml
@@ -30,7 +30,22 @@ macros:
   - name: mark_as_spell
     description: >
       Catch all macro to mark all models as spells even if they are not exposed in the data explorer
-  
+
+  - name: private_data_explorer
+    description: >
+      Prod post-hook: set dune.public false and dune.visible true with data explorer abstraction metadata
+      (no contributors). For team-private relations that should still appear in the explorer for entitled users.
+    arguments:
+      - name: blockchains
+        type: string
+        description: "JSON array string of blockchains, e.g. '[\"ethereum\"]'"
+      - name: spell_type
+        type: string
+        description: "dune.data_explorer.abstraction.type value"
+      - name: spell_name
+        type: string
+        description: "dune.data_explorer.abstraction.name value"
+
   - name: source
     description: >
       Change source database.

--- a/dbt_macros/dune/private_data_explorer.sql
+++ b/dbt_macros/dune/private_data_explorer.sql
@@ -1,0 +1,23 @@
+{% macro private_data_explorer(blockchains, spell_type, spell_name) %}
+  {%- if target.name == 'prod' -%}
+    {%- set properties = {
+            'dune.created_by': 'dbt_spellbook',
+            'dune.public': 'false',
+            'dune.visible': 'true',
+            'dune.data_explorer.blockchains':  blockchains | as_text,
+            'dune.data_explorer.category': 'abstraction',
+            'dune.data_explorer.abstraction.type': spell_type,
+            'dune.data_explorer.abstraction.name': spell_name,
+            'dune.data_explorer.freshness': var('freshness'),
+            'dune.vacuum': '{"enabled":true}'
+          } -%}
+    {%- if model.config.materialized == "view" -%}
+      CALL {{ model.database }}._internal.alter_view_properties('{{ model.schema }}', '{{ model.alias }}',
+        {{ trino_properties(properties) }}
+      )
+    {%- else -%}
+      ALTER TABLE {{ this }}
+        SET PROPERTIES extra_properties = {{ trino_properties(properties) }}
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro -%}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/aptos/tokens_aptos_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/aptos/tokens_aptos_transfers.sql
@@ -9,10 +9,9 @@
     unique_key = ['block_date', 'unique_key'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     merge_skip_unchanged = true,
-    post_hook = '{{ expose_spells(blockchains = \'["aptos"]\',
+    post_hook = '{{ private_data_explorer(blockchains = \'["aptos"]\',
                     spell_type = "sector",
-                    spell_name = "tokens_aptos",
-                    contributors = \'["tomfutago"]\') }}'
+                    spell_name = "tokens_aptos") }}'
   )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/stellar/tokens_stellar_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/stellar/tokens_stellar_transfers.sql
@@ -9,10 +9,9 @@
     unique_key = ['block_date', 'unique_key'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     merge_skip_unchanged = true,
-    post_hook = '{{ expose_spells(blockchains = \'["stellar"]\',
+    post_hook = '{{ private_data_explorer(blockchains = \'["stellar"]\',
                     spell_type = "sector",
-                    spell_name = "tokens_stellar",
-                    contributors = \'["tomfutago"]\') }}'
+                    spell_name = "tokens_stellar") }}'
 
   )
 }}

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_transfers.sql
@@ -9,10 +9,9 @@
     unique_key = ['block_date', 'unique_key'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')],
     merge_skip_unchanged = true,
-    post_hook = '{{ expose_spells(blockchains = \'["sui"]\',
+    post_hook = '{{ private_data_explorer(blockchains = \'["sui"]\',
                     spell_type = "sector",
-                    spell_name = "tokens_sui",
-                    contributors = \'["tomfutago"]\') }}'
+                    spell_name = "tokens_sui") }}'
   )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/tokens_multichain_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/tokens_multichain_transfers.sql
@@ -67,10 +67,9 @@
     schema = 'tokens_multichain',
     alias = 'transfers',
     materialized = 'view',
-    post_hook = '{{ expose_spells(blockchains = \'["' + chains | join('","') + '"]\',
+    post_hook = '{{ private_data_explorer(blockchains = \'["' + chains | join('","') + '"]\',
                     spell_type = "sector",
-                    spell_name = "tokens_multichain",
-                    contributors = \'["kryptaki", "tomfutago"]\') }}'
+                    spell_name = "tokens_multichain") }}'
   )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/xrpl/tokens_xrpl_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/xrpl/tokens_xrpl_transfers.sql
@@ -9,10 +9,9 @@
     unique_key = ['block_date', 'unique_key'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')],
     merge_skip_unchanged = true,
-    post_hook = '{{ expose_spells(blockchains = \'["xrpl"]\',
+    post_hook = '{{ private_data_explorer(blockchains = \'["xrpl"]\',
                     spell_type = "sector",
-                    spell_name = "tokens_xrpl",
-                    contributors = \'["krishhh", "tomfutago"]\') }}'
+                    spell_name = "tokens_xrpl") }}'
   )
 }}
 


### PR DESCRIPTION
## Summary
Tighten Trino `extra_properties` post-hooks: drop redundant macros, rename the public explorer hook, add a private explorer hook, and adopt it on five non-EVM transfers models.

## Macros
- **Removed `expose_dataset`** — only one consumer remained; align on the shared spell metadata macros instead of a separate third-party helper.
  - **1** model updated (`reservoir.tokens` post_hook removed) and macro deleted.
- **Removed `hide_spells`** — same `public`/`visible` defaults as global `mark_as_spell`; removed duplicate `post_hook` calls to avoid double-setting properties.
  - **1,717** models under `dbt_subprojects` dropped `hide_spells` from `config`.
- **Renamed `expose_spells` → `public_data_explorer`** — name matches “public + data explorer” behavior (`dune.public` true, `dune.visible` true, contributors required).
  - **172** models under `dbt_subprojects` plus generators/docs/rules updated for the new macro name.
- **Added `private_data_explorer`** — explorer-visible but not broadly public (`dune.public` false, `dune.visible` true); mirrors public hook minus contributors JSON.
  - **5** models wired to the new hook:
    - `tokens_aptos.transfers`
    - `tokens_sui.transfers`
    - `tokens_stellar.transfers`
    - `tokens_xrpl.transfers`
    - `tokens_multichain.transfers`

Made with [Cursor](https://cursor.com)