### PR TITLE
fix: short-circuit list_schemas to skip ~500x storm in before_run

### DIFF
--- a/dbt_macros/dune/no-relation-listing.sql
+++ b/dbt_macros/dune/no-relation-listing.sql
@@ -13,11 +13,11 @@
 {%- endmacro %}
 
 {% macro list_schemas(database) -%}
-  {% do log(target) %}
   {%- if (var('no-relation-listing', 'false').lower() == 'true') or (target.profile_name == 'spellbook-local') -%}
     {{ return([]) }}
   {%- else -%}
-    {{ return(adapter.dispatch('list_schemas')(database)) }}
+    {# Workaround for https://github.com/dbt-labs/dbt-adapters/issues/1929 -- drop once fixed. #}
+    {{ return([]) }}
   {%- endif -%}
 {%- endmacro %}
 

--- a/dbt_macros/dune/schema.sql
+++ b/dbt_macros/dune/schema.sql
@@ -7,7 +7,7 @@
     {%- if target.database == 'dune' -%}
       CREATE SCHEMA IF NOT EXISTS {{ relation }}
     {%- else -%}
-      CREATE SCHEMA {{ relation }} WITH (location = 's3a://{{s3_bucket()}}/')
+      CREATE SCHEMA IF NOT EXISTS {{ relation }} WITH (location = 's3a://{{s3_bucket()}}/')
     {%- endif -%}
   {% endcall %}
 {% endmacro %}

--- a/dbt_subprojects/tokens/models/_dev/tokens_dev_table.sql
+++ b/dbt_subprojects/tokens/models/_dev/tokens_dev_table.sql
@@ -4,5 +4,5 @@
     file_format = 'delta'
 ) }}
 
---stamp 1
-select 1 as stamp
+--stamp 2
+select 2 as stamp

--- a/dbt_subprojects/tokens/models/_dev/tokens_dev_view.sql
+++ b/dbt_subprojects/tokens/models/_dev/tokens_dev_view.sql
@@ -3,5 +3,5 @@
     materialized = 'view'
 ) }}
 
---stamp 1
-select 1 as stamp
+--stamp 2
+select 2 as stamp


### PR DESCRIPTION
## Summary

Every `dbt run` against `prod` issues ~500 identical `select schema_name from hive.INFORMATION_SCHEMA.schemata` queries during `before_run` (~5 min wall time on hourly). Root cause is a `Set[BaseRelation]` dedup bug in `dbt-adapters` — `__hash__` is render-based but `__eq__` is `to_dict`-based, and `.include(schema=False, identifier=False)` doesn't clear the underlying path fields, so the set keeps every entry instead of one per unique database.

Upstream fix: https://github.com/dbt-labs/dbt-adapters/pull/1930. This PR is a project-side workaround until that lands and ships.

## Change

- `dbt_macros/dune/no-relation-listing.sql`: `list_schemas` now always returns `[]`. dbt-core falls through to dispatching `create_schema` for each unique `(db, schema)` *string tuple* (that dedup is native string sets, not `BaseRelation`, and works correctly).
- `dbt_macros/dune/schema.sql`: add `IF NOT EXISTS` to the hive branch of `trino__create_schema` so the fallback dispatch is a metastore-cheap no-op (single `getDatabase` Thrift call) on already-existing schemas instead of a full `information_schema.schemata` scan.

## Expected effect

Before:
```
~525 identical `select schema_name from hive.INFORMATION_SCHEMA.schemata`
~5 min wall time on `before_run`
```

After:
```
0 `list_schemas` queries
~50 `CREATE SCHEMA IF NOT EXISTS` calls (one per unique (db, schema))
~3 s on `before_run`
```

Pulled from production `debug.log` (`dbt_cloud_run_id=70471878875888`).

## Risk

`list_schemas` returning `[]` would lie to any other caller that depends on knowing which schemas exist. Spellbook has no such caller (grep against `sources/`, `dbt_subprojects/`, `dbt_macros/` is empty). The only Python caller in dbt-core is `RunTask.create_schemas`, which is precisely the path we want to short-circuit.

`CREATE SCHEMA IF NOT EXISTS ... WITH (location=...)` is valid Trino syntax (the `WITH` clause is ignored for existing schemas).

Once `dbt-labs/dbt-adapters#1930` ships in our pinned dbt-adapters version, this macro should be reverted to the dispatched form.