### PR TITLE
Apply private_data_explorer to prediction market spells (Polymarket + Kalshi)

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_market_details.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_market_details.sql
@@ -5,6 +5,9 @@
 	file_format = 'delta',
 	incremental_strategy = 'merge',
 	unique_key = ['ticker'],
+	post_hook = '{{ private_data_explorer(blockchains = \'[]\',
+	                spell_type = "project",
+	                spell_name = "kalshi") }}'
 ) }}
 
 -- volume_fp >= 100 drops 85% of dust while keeping 99.7% of volume.

--- a/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_market_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_market_trades.sql
@@ -7,6 +7,9 @@
 	partition_by = ['block_month'],
 	unique_key = ['block_month', 'trade_id'],
 	merge_skip_unchanged = true,
+	post_hook = '{{ private_data_explorer(blockchains = \'[]\',
+	                spell_type = "project",
+	                spell_name = "kalshi") }}'
 ) }}
 
 -- Source filter unions new trades with trades whose market_details.source_updated_at moved,

--- a/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_ohlcv_hourly.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/kalshi/kalshi_ohlcv_hourly.sql
@@ -7,6 +7,9 @@
 	partition_by = ['block_month'],
 	unique_key = ['block_month', 'hour', 'market_id', 'outcome'],
 	merge_skip_unchanged = true,
+	post_hook = '{{ private_data_explorer(blockchains = \'[]\',
+	                spell_type = "project",
+	                spell_name = "kalshi") }}'
 ) }}
 
 -- Merge target is NOT pruned by incremental_predicates: the source emits historical hours

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
@@ -8,6 +8,9 @@
     unique_key = ['block_month', 'hour', 'market_id', 'outcome'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.hour')],
     merge_skip_unchanged = true,
+    post_hook = '{{ private_data_explorer(blockchains = \'["polygon"]\',
+                    spell_type = "project",
+                    spell_name = "polymarket") }}'
   )
 }}
 

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions.sql
@@ -8,10 +8,9 @@
     partition_by = ['day'],
     unique_key = ['day', 'address', 'token_id'],
     merge_skip_unchanged = true,
-    post_hook = '{{ expose_spells(blockchains = \'["polygon"]\',
+    post_hook = '{{ private_data_explorer(blockchains = \'["polygon"]\',
                                   spell_type = "project",
-                                  spell_name = "polymarket",
-                                  contributors = \'["tomfutago"]\') }}'
+                                  spell_name = "polymarket") }}'
   )
 }}
 


### PR DESCRIPTION
towards CUR2-2428

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

Gate five prediction market spells with the `private_data_explorer` post-hook macro (introduced in c2358857 / #9661). The macro sets `dune.public=false` and `dune.visible=true` along with data explorer abstraction metadata, so these relations stay team-private but still surface in the data explorer for entitled users.

Tables gated (per the Linear thread):

- [x] `polymarket_polygon.ohlcv_hourly` — net new post-hook
- [x] `polymarket_polygon.positions` — overrides existing `expose_spells`
- [x] `kalshi.market_trades` — net new post-hook
- [x] `kalshi.ohlcv_hourly` — net new post-hook
- [x] `kalshi.market_details` — net new post-hook

Argument convention follows the reference commit:

- `blockchains = '["polygon"]'` for the Polymarket models
- `blockchains = '[]'` for Kalshi (off-chain regulated US futures exchange — same convention used in `scripts/dex-sep-gen.py` for non-chain-scoped project spells)
- `spell_type = "project"`, `spell_name = "polymarket"` / `"kalshi"`
- `contributors` arg dropped, matching the `private_data_explorer` signature

CI note: post-hook-only edits do not trigger CI per `ci-state-detection.mdc`, which is intentional for `expose_spells` / `private_data_explorer` swaps. Verified locally via `dbt compile` on all five models.

Reference: commit `c23588571103637c4da766a37e48364045d59550` (#9661).

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CUR2-2428](https://linear.app/dune/issue/CUR2-2428/make-spellbook-models-publicfalse)

<div><a href="https://cursor.com/agents/bc-3d082038-dc96-4a50-939f-6205b0cf726a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d082038-dc96-4a50-939f-6205b0cf726a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

