### PR TITLE
feat(solana): add executing_account_prefix predicates for instruction_calls partition pruning

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/opensea/solana/opensea_solana_token_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/opensea/solana/opensea_solana_token_trades.sql
@@ -14,6 +14,7 @@ WITH opensea_tx_ids AS (
     SELECT DISTINCT(tx_id) AS tx_id
     FROM {{ source('solana', 'instruction_calls') }}
     WHERE CONTAINS(log_messages, 'Program log: Memo (len 8): "865d8597"')
+        AND executing_account_prefix = 'Me'
         AND executing_account = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'
         AND block_time > TRY_CAST('2025-05-26 00:00' AS TIMESTAMP)
         {% if is_incremental() %}

--- a/dbt_subprojects/solana/macros/_sector/dex/solana_amm_stg_raw_swaps.sql
+++ b/dbt_subprojects/solana/macros/_sector/dex/solana_amm_stg_raw_swaps.sql
@@ -27,6 +27,7 @@ WITH swaps AS (
           ) }} AS surrogate_key
     FROM {{ source('solana', 'instruction_calls') }}
     WHERE 1=1
+        AND executing_account_prefix = '{{ program_id[:2] }}'
         AND executing_account = '{{ program_id }}'
         AND tx_success = true
         AND {{ discriminator_filter }}

--- a/dbt_subprojects/solana/models/_sector/dex/humidifi/humidifi_solana_stg_raw_swaps.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/humidifi/humidifi_solana_stg_raw_swaps.sql
@@ -36,6 +36,7 @@ WITH swaps AS (
     FROM {{ source('solana', 'instruction_calls') }}
     WHERE 1=1
         AND executing_account = '9H6tua7jkLhdm3w8BvgpTn5LZNU7g4ZynDmCiNN3q6Rp'
+        AND executing_account_prefix = '9H'
         AND tx_success = true
         AND cardinality(account_arguments) > 8
         {% if is_incremental() -%}

--- a/dbt_subprojects/solana/models/_sector/dex/orca_whirlpool/orca_whirlpool_v2_stg_swaps.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/orca_whirlpool/orca_whirlpool_v2_stg_swaps.sql
@@ -273,6 +273,7 @@ FROM (
         AND ((sp.call_is_inner = false AND memo.inner_instruction_index = 1)
             OR (sp.call_is_inner = true AND memo.inner_instruction_index = sp.call_inner_instruction_index + 1))
         AND memo.executing_account = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'
+        AND memo.executing_account_prefix = 'Me'
         {% if is_incremental() -%}
         AND {{ incremental_predicate('memo.block_time') }}
         {% else -%}

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_addresses.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_addresses.sql
@@ -27,6 +27,7 @@ FROM (
     , account_arguments[4] AS referraltokenaccount
     FROM {{ source('solana','instruction_calls') }}
     WHERE executing_account = 'REFER4ZgmyYx9c6He5XfaTMiGfdLwRnkV4RPp9t9iF3'
+    AND executing_account_prefix = 'RE'
     AND account_arguments[2] = '45ruCyfdRkWpRNGEqWzjCiXRHkZs8WXCLQ67Pnpye7Hp'
     AND TRY_CAST(data AS VARCHAR) like '%7d12465f%'
     AND block_time >= TIMESTAMP '2023-11-30' -- First date phantom ReferralTokenAccount created

--- a/dbt_subprojects/solana/models/_sector/dex/pumpdotfun/solana/pumpdotfun_solana_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/pumpdotfun/solana/pumpdotfun_solana_base_trades.sql
@@ -22,6 +22,7 @@ with
             , account_arguments[4] as bonding_curve_vault
         FROM {{ source('solana','instruction_calls') }}
         WHERE executing_account = '6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P'
+            AND executing_account_prefix = '6E'
             AND bytearray_substring(data,1,8) = 0x181ec828051c0777 --Create https://solscan.io/tx/2Vfq4gS9nq2jvpmZSxVXJ3uHGeheENXetwUus6KnhBzFu23Brqbt5EoNiTLds6jr72yZYGJ9YbMDG1BYKMRe3hSQ
             and tx_success = true
         {% if is_incremental() %}
@@ -52,6 +53,7 @@ with
             , outer_executing_account
         FROM {{ source('solana','instruction_calls') }}
         WHERE executing_account = '6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P'
+        AND executing_account_prefix = '6E'
         AND bytearray_substring(data,1,16) = 0xe445a52e51cb9a1dbddb7fd34ee661ee --SwapEvent
         and tx_success = true
         {% if is_incremental() %}

--- a/dbt_subprojects/solana/models/_sector/dex/pumpswap/pumpswap_solana_pools.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/pumpswap/pumpswap_solana_pools.sql
@@ -26,6 +26,7 @@ WITH pool_creation AS (
     FROM {{ source('solana','instruction_calls') }}
     WHERE varbinary_starts_with(data, 0xe445a52e51cb9a1db1310cd2a076a774)
         AND executing_account = 'pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA'
+        AND executing_account_prefix = 'pA'
         AND tx_success = true
     {% if is_incremental() %}
     AND {{incremental_predicate('block_time')}}

--- a/dbt_subprojects/solana/models/_sector/dex/sanctum_router/sanctum_router_base_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/sanctum_router/sanctum_router_base_trades.sql
@@ -163,6 +163,7 @@ token_amounts AS (
         AND ic.block_slot = b.block_slot
     WHERE 1=1
         AND ic.executing_account = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+        AND ic.executing_account_prefix = 'To'
         AND (
             (b.amount_type = 'mintTo' AND bytearray_substring(ic.data, 1, 1) = 0x07 AND ELEMENT_AT(ic.account_arguments, 1) = b.token_bought_mint_address)
             OR

--- a/dbt_subprojects/solana/models/_sector/gas/gas_solana_compute_limit.sql
+++ b/dbt_subprojects/solana/models/_sector/gas/gas_solana_compute_limit.sql
@@ -24,6 +24,7 @@ SELECT
     ) as compute_limit
 FROM {{ source('solana', 'instruction_calls') }}
 WHERE executing_account = 'ComputeBudget111111111111111111111111111111'
+AND executing_account_prefix = 'Co'
 AND bytearray_substring(data,1,1) = 0x02
 AND inner_instruction_index is null
 {% if is_incremental() %}

--- a/dbt_subprojects/solana/models/_sector/gas/gas_solana_compute_unit_price.sql
+++ b/dbt_subprojects/solana/models/_sector/gas/gas_solana_compute_unit_price.sql
@@ -24,6 +24,7 @@ SELECT
     ) AS compute_unit_price
 FROM {{ source('solana', 'instruction_calls') }}
 WHERE executing_account = 'ComputeBudget111111111111111111111111111111'
+AND executing_account_prefix = 'Co'
 AND bytearray_substring(data,1,1) = 0x03
 AND inner_instruction_index is null
 {% if is_incremental() %}

--- a/dbt_subprojects/solana/models/jupiter/jupiter_solana_perp_events.sql
+++ b/dbt_subprojects/solana/models/jupiter/jupiter_solana_perp_events.sql
@@ -38,6 +38,7 @@ SELECT
     , tx_id
 FROM {{ source('solana','instruction_calls') }}
 WHERE executing_account = 'PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu'
+AND executing_account_prefix = 'PE'
 AND bytearray_substring(data,1+8,8) = 0xf5715534d6bb9984 -- IncreasePosition
 AND tx_success = true
 {% if is_incremental() %}
@@ -73,6 +74,7 @@ SELECT
     , tx_id
 FROM {{ source('solana','instruction_calls') }}
 WHERE executing_account = 'PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu'
+AND executing_account_prefix = 'PE'
 AND bytearray_substring(data,1+8,8) = 0x409c2b4a6d83107f -- DecreasePosition
 AND tx_success = true
 {% if is_incremental() %}
@@ -104,6 +106,7 @@ SELECT
     , tx_id
 FROM {{ source('solana','instruction_calls') }}
 WHERE executing_account = 'PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu'
+AND executing_account_prefix = 'PE'
 AND bytearray_substring(data,1+8,8) IN (0x68452084d423bf2f, 0x806547a880485654) --LiquidatePosition, LiquidateFullPosition
 AND tx_success = true
 {% if is_incremental() %}

--- a/dbt_subprojects/solana/models/jupiter/jupiter_v6_solana_aggregator_swaps.sql
+++ b/dbt_subprojects/solana/models/jupiter/jupiter_v6_solana_aggregator_swaps.sql
@@ -52,6 +52,7 @@ with
             FROM {{ source('solana','instruction_calls') }}
             WHERE
                 executing_account = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
+                AND executing_account_prefix = 'JU'
                 AND bytearray_substring(data,1+8,8) = 0x40c6cde8260871e2 --SwapEvent https://solscan.io/account/JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4#anchorProgramIDL
                 and tx_success = true
                 {% if is_incremental() -%}

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_sns_domains.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_sns_domains.sql
@@ -28,6 +28,7 @@ with
                   --0x11 https://solscan.io/tx/325dGEvxPLdMJgQH62ea89EJcaRSEuJtrd761Xhxadj1ZtirPhJmLvgx2ENaSodU74tXwzQk8ShvFsZQ1qw3T53E
         FROM {{ source('solana','instruction_calls') }}
         WHERE executing_account = 'jCebN34bUfdeUYJT13J1yG16XWQpt5PDx6Mse9GUqhR'
+        AND executing_account_prefix = 'jC'
         and bytearray_substring(data,1,1) IN (0x01, 0x09, 0x0d, 0x00, 0x11) --different register instructions
     )
     
@@ -41,6 +42,7 @@ with
             , tx_id
         FROM {{ source('solana','instruction_calls') }}
         WHERE executing_account = 'namesLPneVptA9Z5rqUDD9tMTWEJwofgaYwp8cawRkX'
+        AND executing_account_prefix = 'na'
         and bytearray_substring(data,1,1) = 0x02
     )
     
@@ -74,6 +76,7 @@ with
             , row_number() OVER (partition by account_arguments[1] order by block_time desc) as latest_by_domain
         FROM {{ source('solana','instruction_calls') }}
         WHERE executing_account = '85iDfUvr3HJyLM2zcq5BXSiDvUWfw6cSE1FfNBo8Ap29'
+        AND executing_account_prefix = '85'
         and bytearray_substring(data,1,1) = 0x06
         ) f
         LEFT JOIN names n ON n.domain_account = f.domain_account


### PR DESCRIPTION
`solana.instruction_calls` is partitioned by `(year, month, executing_account_prefix)` where `executing_account_prefix = substring(executing_account, 1, 2)`. Trino 479 cannot derive this predicate from `executing_account = '<literal>'`.

Every spellbook model that reads `instruction_calls` already filters on a known program address (pump.fun, Compute Budget, Jupiter v6, Phantom referral, etc.), so the prefix is trivially derivable at compile time. This inlines an explicit `executing_account_prefix = 'XX'` predicate in 11 models / 15 call sites:

- `pumpdotfun_solana_base_trades` (`6E`, x2)
- `pumpswap_solana_pools` (`pA`)
- `solana_utils_sns_domains` (`jC`, `na`, `85`)
- `jupiter_solana_perp_events` (`PE`, x3)
- `jupiter_v6_solana_aggregator_swaps` (`JU`)
- `gas_solana_compute_limit` (`Co`)
- `gas_solana_compute_unit_price` (`Co`)
- `sanctum_router_base_trades` (`To`)
- `phantom_swapper_solana_fee_addresses` (`RE`)
- `humidifi_solana_stg_raw_swaps` (`9H`)
- `orca_whirlpool_v2_stg_swaps` (`Me`, LEFT JOIN ON clause)

One model is intentionally excluded: `jupiter_v6_solana_swapsevent_aggregator_swaps` joins `instruction_calls` against a dynamic `amm_list` CTE derived from `jupiter_evt_swapevent`. The AMM set is unbounded and likely covers most prefixes, so a compile-time prefix list would either be wrong or saturated.

Same mechanical pattern as #9670, expected to provide a comparable ~2x speedup on planning time for the affected models.

Towards DWH-642