### PR TITLE
fix(eigenlayer): cast scaledShares as UINT256 to avoid DECIMAL(38,0) overflow

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_slashing_withdrawal_queued_flattened.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_slashing_withdrawal_queued_flattened.sql
@@ -25,7 +25,7 @@ SELECT
     t.evt_block_number,
     t.withdrawalRoot,
     from_hex(substr(u.strategy, 3)) AS strategy,
-    CAST(v.shares AS DECIMAL(38,0)) AS shares
+    CAST(v.shares AS UINT256) AS shares
 FROM
     parsed_data AS t
     CROSS JOIN UNNEST (


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Description:

**Bug:** Production run of `eigenlayer_ethereum_slashing_withdrawal_queued_flattened` failed with:

```
TrinoUserError(type=USER_ERROR, name=INVALID_CAST_ARGUMENT,
  message="Cannot cast VARCHAR '116468516031183163565269914560259104622' to DECIMAL(38, 0). Value too large.")
```

That value is 39 digits — `DECIMAL(38,0)` maxes out at 38 nines.

**Why it happens:** The model extracts EigenLayer's `scaledShares` (uint256) from the `withdrawal` struct JSON. `scaledShares = operatorShares × cumulativeScalingFactor`, and the scaling factor compounds with every slashing event, so scaled shares routinely grow past the 10^38 ceiling of DECIMAL(38,0).

**Fix:** Cast to `UINT256` instead of `DECIMAL(38,0)`. This matches the ABI type and the established pattern elsewhere in the repo (e.g., `jarvis_network_polygon_all_transactions.sql`).

**Notes for reviewers:**
- The cast is still required even though the on-chain type is uint256, because the source column `withdrawal` is a JSON-serialized struct — `JSON_EXTRACT(..., '$.scaledShares') AS ARRAY(VARCHAR)` yields strings, not native uint256.
- The non-slashing variant (`eigenlayer_ethereum_withdrawal_queued_v2_flattened`) uses the same DECIMAL(38,0) cast but reads unscaled `shares`, which haven't overflowed — leaving it untouched.
- Downstream `eigenlayer_ethereum_slashing_withdrawal_completed_enriched` passes `shares` through unchanged, so the type change propagates cleanly. The shared `&shares` schema anchor declares no type, so no schema update needed.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)