### PR TITLE
perf(polymarket): narrow positions changed_markets trigger; parse market_details timestamps

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/_schema.yml
@@ -535,6 +535,8 @@ models:
               - address
               - token_id
     columns:
+      - name: block_month
+        description: "UTC month derived from day (date_trunc('month', day)); used for partitioning"
       - name: day
         description: "The date of the position"
         data_tests:

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/_schema.yml
@@ -426,9 +426,9 @@ models:
       - name: polymarket_link
         description: "Link to the Polymarket event page"
       - name: market_start_time
-        description: "Start time of the market"
+        description: "Timestamp when the market started accepting orders (parsed from API ISO-8601 string)"
       - name: market_end_time
-        description: "End time of the market"
+        description: "Timestamp when the market closed to new orders (parsed from API ISO-8601 string)"
       - name: market_outcome
         description: "Outcome of the market"
       - name: resolved_on_timestamp
@@ -576,9 +576,9 @@ models:
       - name: polymarket_link
         description: "Link to the Polymarket event page"
       - name: market_start_time
-        description: "Start time of the market"
+        description: "Timestamp when the market started accepting orders (parsed from API ISO-8601 string)"
       - name: market_end_time
-        description: "End time of the market"
+        description: "Timestamp when the market closed to new orders (parsed from API ISO-8601 string)"
       - name: market_outcome
         description: "Outcome of the market"
       - name: resolved_on_timestamp

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/_schema.yml
@@ -426,9 +426,9 @@ models:
       - name: polymarket_link
         description: "Link to the Polymarket event page"
       - name: market_start_time
-        description: "Timestamp when the market started accepting orders (parsed from API ISO-8601 string)"
+        description: "Start time of the market"
       - name: market_end_time
-        description: "Timestamp when the market closed to new orders (parsed from API ISO-8601 string)"
+        description: "End time of the market"
       - name: market_outcome
         description: "Outcome of the market"
       - name: resolved_on_timestamp
@@ -531,6 +531,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
+              - block_month
               - day
               - address
               - token_id
@@ -576,9 +577,9 @@ models:
       - name: polymarket_link
         description: "Link to the Polymarket event page"
       - name: market_start_time
-        description: "Timestamp when the market started accepting orders (parsed from API ISO-8601 string)"
+        description: "Start time of the market"
       - name: market_end_time
-        description: "Timestamp when the market closed to new orders (parsed from API ISO-8601 string)"
+        description: "End time of the market"
       - name: market_outcome
         description: "Outcome of the market"
       - name: resolved_on_timestamp

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_details.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_details.sql
@@ -93,8 +93,8 @@ SELECT
     WHEN lower(neg_risk) = 'false' THEN get_href('https://polymarket.com/event/' || market_slug, market_slug)
     WHEN lower(neg_risk) = 'true'  THEN  get_href('https://polymarket.com/event/' || replace(replace(replace(lower(neg_risk_market_name), ' ', '-'), '$', ''), '''',''), neg_risk_market_name)
   END AS polymarket_link,
-  from_iso8601_timestamp(accepting_order_timestamp) as market_start_time,
-  from_iso8601_timestamp(end_date_iso) as market_end_time,
+  accepting_order_timestamp as market_start_time,
+  end_date_iso as market_end_time,
   game_start_time,
   seconds_delay,
   fpmm,

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_details.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_details.sql
@@ -93,8 +93,8 @@ SELECT
     WHEN lower(neg_risk) = 'false' THEN get_href('https://polymarket.com/event/' || market_slug, market_slug)
     WHEN lower(neg_risk) = 'true'  THEN  get_href('https://polymarket.com/event/' || replace(replace(replace(lower(neg_risk_market_name), ' ', '-'), '$', ''), '''',''), neg_risk_market_name)
   END AS polymarket_link,
-  accepting_order_timestamp as market_start_time,
-  end_date_iso as market_end_time,
+  from_iso8601_timestamp(accepting_order_timestamp) as market_start_time,
+  from_iso8601_timestamp(end_date_iso) as market_end_time,
   game_start_time,
   seconds_delay,
   fpmm,

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions.sql
@@ -6,7 +6,7 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     partition_by = ['block_month'],
-    unique_key = ['day', 'address', 'token_id'],
+    unique_key = ['block_month', 'day', 'address', 'token_id'],
     merge_skip_unchanged = true,
     post_hook = '{{ private_data_explorer(blockchains = \'["polygon"]\',
                                   spell_type = "project",
@@ -21,12 +21,11 @@
 with changed_markets as (
   select distinct
     mm_check.token_id,
-    mm_check.market_start_time,
-    mm_check.resolved_on_timestamp
+    mm_check.market_start_time
   from {{ ref('polymarket_polygon_market_details') }} as mm_check
   inner join {{ this }} as existing
     on mm_check.token_id = existing.token_id
-    and existing.day >= cast(mm_check.market_start_time as date)
+    and existing.day >= cast(try_cast(mm_check.market_start_time as timestamp) as date)
   where existing.market_outcome is distinct from mm_check.outcome
     or existing.resolved_on_timestamp is distinct from mm_check.resolved_on_timestamp
 ),
@@ -42,9 +41,10 @@ positions_to_emit as (
 
   union all
 
-  -- Per-token between-bounds via dynamic filter on token_id; no global min_day scalar
-  -- subquery because referencing changed_markets a second time made Trino re-scan
-  -- {{ this }} a second time (10 B-row scan duplicated, ~50 % of incremental cost).
+  -- Lower-bound on market_start_time partition-prunes positions_raw to the
+  -- affected markets' lifespans (no upper bound: positions_raw forward-fills
+  -- non-zero balances past resolved_on_timestamp for unredeemed holders, and
+  -- those post-resolution rows still need the outcome propagated to them).
   select
     p.day,
     p.address,
@@ -53,8 +53,7 @@ positions_to_emit as (
   from {{ ref('polymarket_polygon_positions_raw') }} as p
   inner join changed_markets as cm
     on p.token_id = cm.token_id
-    and p.day between cast(cm.market_start_time as date)
-                  and cast(cm.resolved_on_timestamp as date)
+    and p.day >= cast(try_cast(cm.market_start_time as timestamp) as date)
   where not ({{ incremental_predicate('p.day') }})
 )
 

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions.sql
@@ -31,12 +31,6 @@ with changed_markets as (
     or existing.resolved_on_timestamp is distinct from mm_check.resolved_on_timestamp
 ),
 
--- Scalar bound pushed as a partition predicate; per-row day-range can't be.
-changed_markets_day_bounds as (
-  select min(cast(market_start_time as date)) as min_day
-  from changed_markets
-),
-
 positions_to_emit as (
   select
     p.day,
@@ -48,6 +42,9 @@ positions_to_emit as (
 
   union all
 
+  -- Per-token between-bounds via dynamic filter on token_id; no global min_day scalar
+  -- subquery because referencing changed_markets a second time made Trino re-scan
+  -- {{ this }} a second time (10 B-row scan duplicated, ~50 % of incremental cost).
   select
     p.day,
     p.address,
@@ -59,7 +56,6 @@ positions_to_emit as (
     and p.day between cast(cm.market_start_time as date)
                   and cast(cm.resolved_on_timestamp as date)
   where not ({{ incremental_predicate('p.day') }})
-    and p.day >= (select min_day from changed_markets_day_bounds)
 )
 
 select

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions.sql
@@ -41,10 +41,11 @@ positions_to_emit as (
 
   union all
 
-  -- Lower-bound on market_start_time partition-prunes positions_raw to the
-  -- affected markets' lifespans (no upper bound: positions_raw forward-fills
-  -- non-zero balances past resolved_on_timestamp for unredeemed holders, and
-  -- those post-resolution rows still need the outcome propagated to them).
+  -- Bounded by market_start_time (lower) and current_date (upper) — two-sided
+  -- range so Trino can push both bounds as join dynamic filters. The upper
+  -- bound of current_date covers post-resolution rows (positions_raw forward-
+  -- fills non-zero balances past resolved_on_timestamp for unredeemed holders,
+  -- and those still need outcome propagation).
   select
     p.day,
     p.address,
@@ -53,7 +54,8 @@ positions_to_emit as (
   from {{ ref('polymarket_polygon_positions_raw') }} as p
   inner join changed_markets as cm
     on p.token_id = cm.token_id
-    and p.day >= cast(try_cast(cm.market_start_time as timestamp) as date)
+    and p.day between cast(try_cast(cm.market_start_time as timestamp) as date)
+                  and current_date
   where not ({{ incremental_predicate('p.day') }})
 )
 

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions.sql
@@ -5,7 +5,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    partition_by = ['day'],
+    partition_by = ['block_month'],
     unique_key = ['day', 'address', 'token_id'],
     merge_skip_unchanged = true,
     post_hook = '{{ private_data_explorer(blockchains = \'["polygon"]\',
@@ -14,173 +14,107 @@
   )
 }}
 
-with positions as (
-  select
-    p.day,
-    p.address,
-    mm.unique_key,
-    p.token_id,
-    mm.token_outcome,
-    mm.token_outcome_name,
-    p.balance,
-    mm.question_id,
-    mm.question AS market_question,
-    mm.market_description,
-    mm.event_market_name,
-    mm.event_market_description,
-    mm.active,
-    mm.closed,
-    mm.accepting_orders,
-    mm.polymarket_link,
-    mm.market_start_time,
-    mm.market_end_time,
-    mm.outcome as market_outcome,
-    mm.resolved_on_timestamp
-  from {{ ref('polymarket_polygon_positions_raw') }} as p
-  inner join {{ ref('polymarket_polygon_market_details') }} as mm on p.token_id = mm.token_id
-)
-
 {% if is_incremental() -%}
 
-, changed_markets AS (
+-- Triggers only on outcome / resolved_on_timestamp changes; other market flags are snapshot-at-write.
+with changed_markets as (
   select distinct
-    mm_check.token_id
+    mm_check.token_id,
+    cast(mm_check.market_start_time as timestamp) as market_start_time,
+    cast(mm_check.resolved_on_timestamp as timestamp) as resolved_on_timestamp
   from {{ ref('polymarket_polygon_market_details') }} as mm_check
   inner join {{ this }} as existing
     on mm_check.token_id = existing.token_id
     and existing.day >= cast(try_cast(mm_check.market_start_time as timestamp) as date)
-  where existing.active is distinct from mm_check.active
-    or existing.closed is distinct from mm_check.closed
-    or existing.accepting_orders is distinct from mm_check.accepting_orders
-    or existing.market_outcome is distinct from mm_check.outcome
+  where existing.market_outcome is distinct from mm_check.outcome
     or existing.resolved_on_timestamp is distinct from mm_check.resolved_on_timestamp
 ),
 
-recent_positions AS (
-  select
-    jp.day,
-    jp.address,
-    jp.unique_key,
-    jp.token_id,
-    jp.token_outcome,
-    jp.token_outcome_name,
-    jp.balance,
-    jp.question_id,
-    jp.market_question,
-    jp.market_description,
-    jp.event_market_name,
-    jp.event_market_description,
-    jp.active,
-    jp.closed,
-    jp.accepting_orders,
-    jp.polymarket_link,
-    jp.market_start_time,
-    jp.market_end_time,
-    jp.market_outcome,
-    jp.resolved_on_timestamp
-  from positions as jp
-  where {{ incremental_predicate('jp.day') }}
+-- Scalar bound pushed as a partition predicate; per-row day-range can't be.
+changed_markets_day_bounds as (
+  select min(cast(market_start_time as date)) as min_day
+  from changed_markets
 ),
 
-historical_changed_positions as (
+positions_to_emit as (
   select
-    jp.day,
-    jp.address,
-    jp.unique_key,
-    jp.token_id,
-    jp.token_outcome,
-    jp.token_outcome_name,
-    jp.balance,
-    jp.question_id,
-    jp.market_question,
-    jp.market_description,
-    jp.event_market_name,
-    jp.event_market_description,
-    jp.active,
-    jp.closed,
-    jp.accepting_orders,
-    jp.polymarket_link,
-    jp.market_start_time,
-    jp.market_end_time,
-    jp.market_outcome,
-    jp.resolved_on_timestamp
-  from positions as jp
-  inner join changed_markets as cm on jp.token_id = cm.token_id
-  where not ({{ incremental_predicate('jp.day') }})
+    p.day,
+    p.address,
+    p.token_id,
+    p.balance
+  from {{ ref('polymarket_polygon_positions_raw') }} as p
+  where {{ incremental_predicate('p.day') }}
+
+  union all
+
+  select
+    p.day,
+    p.address,
+    p.token_id,
+    p.balance
+  from {{ ref('polymarket_polygon_positions_raw') }} as p
+  inner join changed_markets as cm
+    on p.token_id = cm.token_id
+    and p.day between cast(cm.market_start_time as date)
+                  and cast(cm.resolved_on_timestamp as date)
+  where not ({{ incremental_predicate('p.day') }})
+    and p.day >= (select min_day from changed_markets_day_bounds)
 )
 
 select
-  day,
-  address,
-  unique_key,
-  token_id,
-  token_outcome,
-  token_outcome_name,
-  balance,
-  question_id,
-  market_question,
-  market_description,
-  event_market_name,
-  event_market_description,
-  active,
-  closed,
-  accepting_orders,
-  polymarket_link,
-  market_start_time,
-  market_end_time,
-  market_outcome,
-  resolved_on_timestamp,
+  date_trunc('month', p.day) as block_month,
+  p.day,
+  p.address,
+  mm.unique_key,
+  p.token_id,
+  mm.token_outcome,
+  mm.token_outcome_name,
+  p.balance,
+  mm.question_id,
+  mm.question as market_question,
+  mm.market_description,
+  mm.event_market_name,
+  mm.event_market_description,
+  mm.active,
+  mm.closed,
+  mm.accepting_orders,
+  mm.polymarket_link,
+  mm.market_start_time,
+  mm.market_end_time,
+  mm.outcome as market_outcome,
+  mm.resolved_on_timestamp,
   now() as _updated_at
-from recent_positions
-union all
-select
-  day,
-  address,
-  unique_key,
-  token_id,
-  token_outcome,
-  token_outcome_name,
-  balance,
-  question_id,
-  market_question,
-  market_description,
-  event_market_name,
-  event_market_description,
-  active,
-  closed,
-  accepting_orders,
-  polymarket_link,
-  market_start_time,
-  market_end_time,
-  market_outcome,
-  resolved_on_timestamp,
-  now() as _updated_at
-from historical_changed_positions
+from positions_to_emit as p
+inner join {{ ref('polymarket_polygon_market_details') }} as mm
+  on p.token_id = mm.token_id
 
-{% else -%}
+{%- else -%}
 
 select
-  day,
-  address,
-  unique_key,
-  token_id,
-  token_outcome,
-  token_outcome_name,
-  balance,
-  question_id,
-  market_question,
-  market_description,
-  event_market_name,
-  event_market_description,
-  active,
-  closed,
-  accepting_orders,
-  polymarket_link,
-  market_start_time,
-  market_end_time,
-  market_outcome,
-  resolved_on_timestamp,
+  date_trunc('month', p.day) as block_month,
+  p.day,
+  p.address,
+  mm.unique_key,
+  p.token_id,
+  mm.token_outcome,
+  mm.token_outcome_name,
+  p.balance,
+  mm.question_id,
+  mm.question as market_question,
+  mm.market_description,
+  mm.event_market_name,
+  mm.event_market_description,
+  mm.active,
+  mm.closed,
+  mm.accepting_orders,
+  mm.polymarket_link,
+  mm.market_start_time,
+  mm.market_end_time,
+  mm.outcome as market_outcome,
+  mm.resolved_on_timestamp,
   now() as _updated_at
-from positions
+from {{ ref('polymarket_polygon_positions_raw') }} as p
+inner join {{ ref('polymarket_polygon_market_details') }} as mm
+  on p.token_id = mm.token_id
 
-{% endif -%}
+{%- endif %}

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions.sql
@@ -17,15 +17,16 @@
 {% if is_incremental() -%}
 
 -- Triggers only on outcome / resolved_on_timestamp changes; other market flags are snapshot-at-write.
+-- Full scan of {{ this }} preserves drift recovery for any token with history, matching prod.
 with changed_markets as (
   select distinct
     mm_check.token_id,
-    cast(mm_check.market_start_time as timestamp) as market_start_time,
-    cast(mm_check.resolved_on_timestamp as timestamp) as resolved_on_timestamp
+    mm_check.market_start_time,
+    mm_check.resolved_on_timestamp
   from {{ ref('polymarket_polygon_market_details') }} as mm_check
   inner join {{ this }} as existing
     on mm_check.token_id = existing.token_id
-    and existing.day >= cast(try_cast(mm_check.market_start_time as timestamp) as date)
+    and existing.day >= cast(mm_check.market_start_time as date)
   where existing.market_outcome is distinct from mm_check.outcome
     or existing.resolved_on_timestamp is distinct from mm_check.resolved_on_timestamp
 ),


### PR DESCRIPTION
Part of [CUR2-2699 — daily model quick wins](https://linear.app/dune/issue/CUR2-2699/daily-model-quick-wins).

## Summary

Two focused changes on top of [#9696](https://github.com/duneanalytics/spellbook/pull/9696) (which already restructured `positions_raw` upstream via `positions_balances_repro`):

1. **`polymarket_polygon_positions.sql`** — narrowed `changed_markets` trigger, single-pass join, `block_month` partition (+ added to `unique_key`), historical rewrite scoped via two-sided `BETWEEN market_start_time AND current_date`, full `{{ this }}` scan preserved for drift recovery.
2. **`_schema.yml`** — `block_month` added to `polymarket_polygon_positions` columns and to its uniqueness test.

Diff vs main: 3 files, +~ /−~ lines (small).

> Note: an earlier revision of this PR also parsed `market_details.market_start_time` / `market_end_time` from ISO‑8601 strings into `timestamp(3) with time zone`. That change has been **reverted** here — downstream models (`ohlcv_hourly`, `market_prices_hourly`, `market_prices_daily`) call `from_iso8601_timestamp(...)` / `substring(...)` on `market_end_time` and would break under a type change. Timestamp normalization will be a follow‑up PR scoped to those callers.

## Scope of perf impact

The target was prod's daily incremental on `polymarket_polygon_positions`, reported at ~115 min on 2026-06-09 (`query_id 20260609_075452_19190_xee2n`, ~14 CPU-hrs / 5.2 TB spill).

**What this PR optimizes**:
- The `changed_markets` trigger now fires only on `outcome` / `resolved_on_timestamp` changes (Group A→B freeze for `active` / `closed` / `accepting_orders`). API flag flutter no longer triggers a daily historical rewrite — that's the big win on downstream cost when `changed_markets` is non-trivial.
- Single-pass join (`positions_to_emit ⋈ market_details` runs once, not twice).
- Historical rewrite is partition-scoped to each token's `[market_start_time, current_date]` range.
- `block_month` partition + `unique_key` per repo convention.

**What this PR does NOT optimize** (left for [CUR2-2713](https://linear.app/dune/issue/CUR2-2713/perfpolymarket-polygon-positions-reduce-changed-markets-full-history), André's parallel work):
- The `changed_markets` CTE itself still hash-joins `market_details` (~2.6 M rows) against a full scan of `{{ this }}` (~10 B rows / ~1.9 TB), which is where the **5.2 TB spill** comes from. CUR2-2713's lever is to pre-aggregate `{{ this }}` to one row per `(token_id, market_outcome, resolved_on_timestamp)` before the join, collapsing the probe side to a few million rows. That work is being developed in parallel and should land after this PR.

| Path | Before | After |
|---|---|---|
| `changed_markets` trigger | fires on `active` / `closed` / `accepting_orders` / `outcome` / `resolved_on_timestamp` | fires on `outcome` / `resolved_on_timestamp` only |
| `positions_to_emit` join | original `positions` CTE referenced twice → join recomputed | single inner join after `recent_positions ∪ historical_changed_positions` |
| `positions` partition | `['day']` (1 978 partitions → hits Trino's 100‑open‑writer cap on full refresh) | `['block_month']` (~66 partitions; `day` stays queryable via Delta column stats) |
| `unique_key` | `['day', 'address', 'token_id']` | `['block_month', 'day', 'address', 'token_id']` — merge partition‑prunes |
| `changed_markets` build-side scan/spill | 10 B-row probe, 5.2 TB spill | **unchanged here — see CUR2-2713** |

## Behaviour change

`active` / `closed` / `accepting_orders` are now **snapshot at write time**. Old prod behaviour rewrote these on historical rows to today's API value whenever any of them flapped — inconsistent with the other 9 metadata columns from `market_details` (`question`, `market_description`, `event_market_name`, `polymarket_link`, `market_start_time`, `market_end_time`, etc.) which were already snapshot‑at‑write.

After this PR, all 12 descriptive columns behave the same way. Settlement columns (`market_outcome`, `resolved_on_timestamp`) still propagate across history when a market resolves.

Querying `positions where day = '2024-01-15'` now returns a consistent as‑of‑day view instead of a row with Jan‑15 question text but today's `active` flag.

Product team review of these semantic changes: signed off.

## Validation against prod (CI run 27171747419 on commit b9ad0edfa)

Headline counts on the CI‑built `positions` vs current prod:

| Metric | New | Prod | Δ |
|---|---:|---:|---|
| rows | 9 980 787 654 | 10 049 278 344 | new is −68.5 M (CI ran one day before prod's last incremental) |
| addrs | 2 753 551 | 2 761 378 | within day‑drift expectation |
| tokens | 2 476 654 | 2 491 726 | within day‑drift expectation |
| min_day | 2021-04-09 | 2021-04-09 | identical |
| max_day | 2026-06-07 | 2026-06-08 | CI is one day behind prod |
| `null_outcome` | 0 | 0 | identical (invariant holds) |
| `null_resolved_on_timestamp` | 308 M | 332 M | **new has 24 M fewer nulls** (drift recovery improvement) |

Row‑level diff on 1/1000 address‑hash sample:

| Field | Diff count | Source of diffs |
|---|---:|---|
| `balance` | 58 397 | exactly matches `missing_in_new` (one‑day delta), so **zero real value drift** |
| `outcome` | 73 849 | ~15 K above missing → drift‑recovery rows (new has settled values where prod is still stale) |
| `resolved_on_timestamp` | 69 779 | ~11 K above missing → same pattern |
| `active` / `closed` / `accepting_orders` | 58 K – 74 K | intentional Group A→B snapshot freeze on historical rows |
| `missing_in_prod` | **0** | every row in new exists in prod ✅ |
| `missing_in_new` | 58 397 | rows for prod's most‑recent day that CI didn't include |

Every divergence is in the "new is correct, prod was stale" direction. Zero rows are missing from prod's perspective.

## Review feedback addressed

1. **Timestamp type break** (commit `0289c1e5f`) — reverted. `market_start_time` / `market_end_time` stay varchar to preserve downstream callers.
2. **Stale post‑resolution rows** (commits `0289c1e5f` + `756508b54`) — historical rewrite originally had `p.day between cm.market_start_time and cm.resolved_on_timestamp`, which excluded forward‑filled rows for unredeemed holders past the resolution date. Replaced with `between cm.market_start_time and current_date` — preserves the lower-bound partition prune AND a two-sided range filter for Trino, while covering all post-resolution forward-fill rows.
3. **`block_month` added to `unique_key`** (commit `0289c1e5f`) — matches repo convention; merge now partition‑prunes.

## Test plan

- [x] dbt compile + tests pass locally
- [x] CI build succeeds (full history) on b9ad0edfa
- [x] CI tests pass (uniqueness, not‑null on full tables)
- [x] Headline‑count diff: new is identical to prod modulo Group A→B freeze + one‑day CI lag
- [x] Sample row‑level diff: zero `balance` drift, zero `missing_in_prod`
- [x] EXPLAIN ANALYZE confirms no double‑scan of `{{ this }}` in `changed_markets`
- [ ] Re‑run CI on `756508b54` to confirm the explicit upper bound restores ~4 min incremental wall time

🤖 Generated with [Claude Code](https://claude.com/claude-code)