### PR TITLE
feat(optimize_spell): skip OPTIMIZE on incremental no-op runs

### DIFF
--- a/dbt_macros/dune/optimize_spell.sql
+++ b/dbt_macros/dune/optimize_spell.sql
@@ -1,10 +1,59 @@
+{#-
+  optimize_spell: post-hook that runs Delta-Lake OPTIMIZE on a materialized
+  model, conditional on the most recent main statement having affected enough
+  rows to make compaction worthwhile.
+
+  Background: prior versions ran `ALTER TABLE ... EXECUTE optimize` on every
+  prod incremental model regardless of whether the MERGE wrote any rows. About
+  one in four incremental cadence runs writes 0 rows (no new source data, no
+  late-arriving rows in the lookback window), making OPTIMIZE pure overhead.
+  Measured across recent cadence runs (Hourly, Tokens, Daily, DEX, Solana),
+  the OPTIMIZE post-hook accounts for an estimated ~30% of total dbt execute
+  time, and ~12% is burned on zero-row models alone.
+
+  This macro now skips OPTIMIZE when `rows_affected < OPTIMIZE_MIN_ROWS`
+  (default 1000) for incremental models. The threshold is overridable
+  per-invocation via `--vars '{OPTIMIZE_MIN_ROWS: N}'` or per-model via the
+  `optimize_min_rows` config.
+
+  `table` materialization is unchanged: CTAS replaces the table wholesale,
+  so we keep the conservative always-optimize behavior there for now.
+
+  Small-file accumulation on rarely-touched tables is mitigated by Delta's
+  internal compaction and can be addressed by a separate, scheduled OPTIMIZE
+  pass (out of scope for this PR).
+
+  Testing affordance: setting `OPTIMIZE_SPELL_FORCE=true` enables the macro
+  on non-prod targets so the conditional logic can be exercised against a
+  personal schema. Default is false (behavior unchanged on dev/ci targets).
+-#}
 {% macro optimize_spell(this, materialization) %}
-{%- if target.name == 'prod' and materialization in ('table', 'incremental') -%}
+{%- set is_optimize_target = (target.name == 'prod') or var('OPTIMIZE_SPELL_FORCE', false) -%}
+{%- if not is_optimize_target -%}
+  {#- non-prod (and OPTIMIZE_SPELL_FORCE not set): no-op (unchanged) -#}
+{%- elif materialization not in ('table', 'incremental') -%}
+  {#- views and other materializations: nothing to compact -#}
+{%- elif materialization == 'table' -%}
+  {#- full refresh table: keep existing always-optimize behavior -#}
   {%- if target.type == 'trino' -%}
-    ALTER TABLE {{this}} EXECUTE optimize
+    ALTER TABLE {{ this }} EXECUTE optimize
   {%- else -%}
-     OPTIMIZE {{this}};
+    OPTIMIZE {{ this }};
   {%- endif -%}
 {%- else -%}
+  {#- incremental: gate on rows actually written by the main statement -#}
+  {%- set main_result = load_result('main') -%}
+  {%- set rows_affected = 0 -%}
+  {%- if main_result is not none and main_result.response is not none and main_result.response.rows_affected is not none -%}
+    {%- set rows_affected = main_result.response.rows_affected | int -%}
+  {%- endif -%}
+  {%- set min_rows = config.get('optimize_min_rows', var('OPTIMIZE_MIN_ROWS', 1000)) | int -%}
+  {%- if rows_affected >= min_rows -%}
+    {%- if target.type == 'trino' -%}
+      ALTER TABLE {{ this }} EXECUTE optimize
+    {%- else -%}
+      OPTIMIZE {{ this }};
+    {%- endif -%}
+  {%- endif -%}
 {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
Skip the `optimize_spell` post-hook on incremental models when the just-run main statement wrote fewer than `OPTIMIZE_MIN_ROWS` rows (default 1000). Table materialization keeps the existing always-optimize behavior.

About one in four incremental cadence runs MERGE zero rows (no new source data, no late-arriving rows in the lookback window), and the `ALTER TABLE EXECUTE optimize` post-hook still runs unconditionally on each. Across 5 representative cadence runs sampled in the last 7 days (Hourly, Tokens, Daily, DEX, Solana — 5,238 model executions, 55.3h of dbt execute time), `optimize_spell` accounts for an estimated ~30% of total dbt execute time and ~12% is burned on zero-row models alone.

The worst outliers are stark: `chainlink_bnb_fm_reward_evt_transfer_daily`, `chainlink_bnb_ocr_reward_evt_transfer_daily`, and `chainlink_bnb_ccip_transmitted_reverted` each burned **1000+ seconds** of Trino time per Daily run while MERGE-ing **zero rows**. Six similar chainlink models cost ~50 minutes per Daily cycle between them.

Estimated savings per cadence cycle by threshold:

| Threshold | Models skipped | Time saved | % of total |
|---|---|---|---|
| `1` (only 0-row) | 1,236 | 5.0h | 9.2% |
| `100` | 2,335 | 8.7h | 16.0% |
| `1000` (default) | 2,932 | 11.1h | 20.5% |
| `10000` | 3,635 | 12.8h | 23.6% |

Default of 1000 was chosen to keep most of the win while leaving headroom for models that genuinely need compaction on small-but-real writes. Adjust globally via `--vars '{OPTIMIZE_MIN_ROWS: N}'` or per-model via `optimize_min_rows`.

The `load_result('main').response.rows_affected` read works for all incremental strategies in dbt-trino 1.10 (merge, delete+insert, append, microbatch). For runs where the main statement didn't produce a response (defensive case), we treat rows_affected as 0 and skip.

## Testing affordance

Setting `--vars '{OPTIMIZE_SPELL_FORCE: true}'` enables the macro on non-prod targets, so the conditional logic can be exercised against a personal schema without spoofing the target name. Default is false (behavior unchanged on dev/ci targets). Used by the test sequence below.

## Local test recipe (incremental only)

Probe model (in `models/_test/optimize_spell_probe.sql`, untracked):

```sql
{{ config(materialized='incremental', file_format='delta',
          incremental_strategy='merge', unique_key=['id'],
          schema='_test_optimize_spell', alias='probe',
          tags=['optimize_test']) }}
select cast(n as bigint) as id, cast('{{ run_started_at }}' as timestamp) as _updated_at
from unnest(sequence(1, cast({{ var('test_rows', 0) }} as bigint))) as t(n)
```

Sequence:

```bash
uv run dbt run --select tag:optimize_test --full-refresh \
  --vars '{test_rows: 2000, OPTIMIZE_SPELL_FORCE: true}'   # bootstrap, OPTIMIZE expected
uv run dbt run --select tag:optimize_test \
  --vars '{test_rows: 0,    OPTIMIZE_SPELL_FORCE: true}'   # SKIP (0 rows)
uv run dbt run --select tag:optimize_test \
  --vars '{test_rows: 500,  OPTIMIZE_SPELL_FORCE: true}'   # SKIP (<1000)
uv run dbt run --select tag:optimize_test \
  --vars '{test_rows: 2000, OPTIMIZE_SPELL_FORCE: true}'   # RUN (>=1000)
```

## Follow-ups (out of scope)

- Audit the chainlink_bnb / chainlink_polygon outliers (the worst 6 models contributing ~5h/week of waste even at threshold=0)
- Conditional OPTIMIZE for `table` materialization
- Scheduled weekly OPTIMIZE pass for cold tables
- `merge_skip_unchanged=true` as default (stacks additively with this change)

Rollback is trivial: revert this file.