### PR TITLE
Fix Uniswap V4 swap direction logic and Angstrom evt_index mismatch

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/angstrom/angstrom_all_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/angstrom/angstrom_all_trades.sql
@@ -26,6 +26,8 @@ WITH
     swap_events AS (
         SELECT
             evt_tx_hash,
+            evt_block_number,
+            evt_block_date,
             evt_index AS real_evt_index,
             id AS pool_id,
             row_number() over(partition by evt_tx_hash, id order by evt_index) AS pool_rn
@@ -37,6 +39,7 @@ WITH
     ),
     bundle_ranked AS (
         SELECT *,
+            CAST(date_trunc('day', block_time) AS date) AS block_date,
             row_number() over(partition by tx_hash, maker order by evt_index) AS pool_rn
         FROM bundle_orders
     ),
@@ -61,6 +64,8 @@ WITH
         FROM bundle_ranked b
         LEFT JOIN swap_events se
             ON b.tx_hash = se.evt_tx_hash
+            AND b.block_number = se.evt_block_number
+            AND b.block_date = se.evt_block_date
             AND b.maker = se.pool_id
             AND b.pool_rn = se.pool_rn
     ),

--- a/dbt_subprojects/dex/macros/models/_project/angstrom/angstrom_all_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/angstrom/angstrom_all_trades.sql
@@ -16,12 +16,53 @@
 
 WITH
     bundle_orders AS (
-        SELECT * 
+        SELECT *
         FROM ({{ angstrom_bundle_orders(angstrom_contract_addr, controller_v1_contract_addr, earliest_block, blockchain, controller_pool_configured_log_topic0) }})
     ),
     composable_orders AS (
         SELECT *
         FROM ({{ angstrom_composable_trades(angstrom_contract_addr, controller_v1_contract_addr, earliest_block, blockchain, controller_pool_configured_log_topic0, PoolManager_call_Swap, PoolManager_evt_Swap, taker_column_name) }})
+    ),
+    swap_events AS (
+        SELECT
+            evt_tx_hash,
+            evt_index AS real_evt_index,
+            id AS pool_id,
+            row_number() over(partition by evt_tx_hash, id order by evt_index) AS pool_rn
+        FROM {{ PoolManager_evt_Swap }}
+        WHERE evt_block_number >= {{ earliest_block }}
+        {%- if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+        {%- endif %}
+    ),
+    bundle_ranked AS (
+        SELECT *,
+            row_number() over(partition by tx_hash, maker order by evt_index) AS pool_rn
+        FROM bundle_orders
+    ),
+    bundle_with_real_evt_index AS (
+        SELECT
+            b.block_time,
+            b.block_number,
+            b.token_bought_amount_raw,
+            b.token_sold_amount_raw,
+            b.token_bought_address,
+            b.token_sold_address,
+            b.token_sold_lp_fees_paid_raw,
+            b.token_bought_lp_fees_paid_raw,
+            b.token_sold_protocol_fees_paid_raw,
+            b.token_bought_protocol_fees_paid_raw,
+            b.taker,
+            b.maker,
+            b.project_contract_address,
+            b.tx_hash,
+            coalesce(se.real_evt_index, b.evt_index) AS evt_index,
+            b.trade_type
+        FROM bundle_ranked b
+        LEFT JOIN swap_events se
+            ON b.tx_hash = se.evt_tx_hash
+            AND b.maker = se.pool_id
+            AND b.pool_rn = se.pool_rn
     )
 SELECT
     '{{ blockchain }}' AS blockchain,
@@ -32,16 +73,16 @@ SELECT
     *
 FROM composable_orders
 
-UNION ALL 
+UNION ALL
 
-SELECT 
+SELECT
     '{{ blockchain }}' AS blockchain,
     '{{ project }}' AS project,
     '{{ version }}' AS version,
     CAST(date_trunc('month', block_time) AS date) AS block_month,
     CAST(date_trunc('day', block_time) AS date) AS block_date,
     *
-FROM bundle_orders
+FROM bundle_with_real_evt_index
 
 
 {% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/angstrom/angstrom_all_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/angstrom/angstrom_all_trades.sql
@@ -64,29 +64,43 @@ WITH
             AND b.maker = se.pool_id
             AND b.pool_rn = se.pool_rn
     )
+    all_trades AS (
+        SELECT * FROM composable_orders
+        UNION ALL
+        SELECT * FROM bundle_with_real_evt_index
+    ),
+    deduped AS (
+        SELECT *,
+            row_number() over(
+                partition by tx_hash, evt_index
+                order by CASE WHEN trade_type = 'Composable Swap' THEN 1 ELSE 0 END
+            ) AS _rn
+        FROM all_trades
+    )
 SELECT
     '{{ blockchain }}' AS blockchain,
     '{{ project }}' AS project,
     '{{ version }}' AS version,
     CAST(date_trunc('month', block_time) AS date) AS block_month,
     CAST(date_trunc('day', block_time) AS date) AS block_date,
-    *
-FROM composable_orders co
-WHERE NOT EXISTS (
-    SELECT 1 FROM bundle_with_real_evt_index bw
-    WHERE co.tx_hash = bw.tx_hash AND co.evt_index = bw.evt_index
-)
-
-UNION ALL
-
-SELECT
-    '{{ blockchain }}' AS blockchain,
-    '{{ project }}' AS project,
-    '{{ version }}' AS version,
-    CAST(date_trunc('month', block_time) AS date) AS block_month,
-    CAST(date_trunc('day', block_time) AS date) AS block_date,
-    *
-FROM bundle_with_real_evt_index
+    block_time,
+    block_number,
+    token_bought_amount_raw,
+    token_sold_amount_raw,
+    token_bought_address,
+    token_sold_address,
+    token_sold_lp_fees_paid_raw,
+    token_bought_lp_fees_paid_raw,
+    token_sold_protocol_fees_paid_raw,
+    token_bought_protocol_fees_paid_raw,
+    taker,
+    maker,
+    project_contract_address,
+    tx_hash,
+    evt_index,
+    trade_type
+FROM deduped
+WHERE _rn = 1
 
 
 {% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/angstrom/angstrom_all_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/angstrom/angstrom_all_trades.sql
@@ -71,7 +71,11 @@ SELECT
     CAST(date_trunc('month', block_time) AS date) AS block_month,
     CAST(date_trunc('day', block_time) AS date) AS block_date,
     *
-FROM composable_orders
+FROM composable_orders co
+WHERE NOT EXISTS (
+    SELECT 1 FROM bundle_with_real_evt_index bw
+    WHERE co.tx_hash = bw.tx_hash AND co.evt_index = bw.evt_index
+)
 
 UNION ALL
 

--- a/dbt_subprojects/dex/macros/models/_project/angstrom/angstrom_all_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/angstrom/angstrom_all_trades.sql
@@ -63,7 +63,7 @@ WITH
             ON b.tx_hash = se.evt_tx_hash
             AND b.maker = se.pool_id
             AND b.pool_rn = se.pool_rn
-    )
+    ),
     all_trades AS (
         SELECT * FROM composable_orders
         UNION ALL

--- a/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_trades.sql
@@ -245,8 +245,8 @@ WITH dexs AS
     , e.evt_block_time AS block_time
     , {% if taker_column_name -%} t.{{ taker_column_name }} {% else -%} cast(null as varbinary) {% endif -%} as taker
     , e.id as maker -- In v4, the maker (i.e. what sold the token) is the pool's virtual address. We also pass the pool ID, making it easier to join with Initialize() and retrieve hooked pool metrics.
-    , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN ABS(e.amount1) ELSE ABS(e.amount0) END AS token_bought_amount_raw
-    , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN ABS(e.amount0) ELSE ABS(e.amount1) END AS token_sold_amount_raw
+    , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN ABS(c.amount1) ELSE ABS(c.amount0) END AS token_bought_amount_raw
+    , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN ABS(c.amount0) ELSE ABS(c.amount1) END AS token_sold_amount_raw
     , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN c.currency1 ELSE c.currency0 END AS token_bought_address
     , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN c.currency0 ELSE c.currency1 END AS token_sold_address
     , e.contract_address AS project_contract_address

--- a/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_trades.sql
@@ -245,10 +245,10 @@ WITH dexs AS
     , e.evt_block_time AS block_time
     , {% if taker_column_name -%} t.{{ taker_column_name }} {% else -%} cast(null as varbinary) {% endif -%} as taker
     , e.id as maker -- In v4, the maker (i.e. what sold the token) is the pool's virtual address. We also pass the pool ID, making it easier to join with Initialize() and retrieve hooked pool metrics.
-    , CASE WHEN c.amount0 < INT256 '0' THEN ABS(c.amount1) ELSE ABS(c.amount0) END AS token_bought_amount_raw 
-    , CASE WHEN c.amount0 < INT256 '0' THEN ABS(c.amount0) ELSE ABS(c.amount1) END AS token_sold_amount_raw
-    , CASE WHEN c.amount0 < INT256 '0' THEN c.currency1 ELSE currency0 END AS token_bought_address
-    , CASE WHEN c.amount0 < INT256 '0' THEN c.currency0 ELSE currency1 END AS token_sold_address
+    , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN ABS(e.amount1) ELSE ABS(e.amount0) END AS token_bought_amount_raw
+    , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN ABS(e.amount0) ELSE ABS(e.amount1) END AS token_sold_amount_raw
+    , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN c.currency1 ELSE c.currency0 END AS token_bought_address
+    , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN c.currency0 ELSE c.currency1 END AS token_sold_address
     , e.contract_address AS project_contract_address
     , e.evt_tx_hash AS tx_hash
     , e.evt_index


### PR DESCRIPTION
## Summary

Two fixes for Uniswap V4 dex.trades accuracy:

### 1. Defensive fix to V4 swap direction logic (`uniswap_compatible_trades.sql`)

Use Swap **event** amounts (`e.amount0`) instead of call output (`c.amount0`) for buy/sell direction, and add `OR e.amount1 > INT256 '0'` condition.

In V4, afterSwap hooks can modify the BalanceDelta after the Swap event is emitted but before the call returns. Using event amounts is more reliable because they reflect the core swap before hook adjustments. The extra `OR` condition handles edge cases where `amount0 == 0` (hooks absorbing the full counterparty amount).

### 2. Fix Angstrom bundle orders evt_index (`angstrom_all_trades.sql`)

The `angstrom_bundle_orders` macro generated synthetic `evt_index` values via `ROW_NUMBER()` (1, 2, 3...) instead of the actual Swap event log index. This caused Angstrom swaps in `dex.trades` to be unmatchable by `evt_index` with other systems that reference the real event index.

**Root cause investigation:** A comparison query joining the dex trade stream with `dex.trades` on `(block_number, tx_hash, evt_index)` showed all Angstrom V4 swaps as "missing" — the synthetic evt_index never matched the real one.

Verified with transactions:
- `0xbc49c090...`: real evt_index=2, dex.trades had evt_index=1
- `0x5ab46bde...`: real evt_index=3,4, dex.trades had evt_index=1,2

**Fix:** Join bundle_orders with `PoolManager_evt_Swap` on `(tx_hash, pool_id)` to resolve the real `evt_index`, falling back to the synthetic value for orders without a corresponding Swap event (e.g. off-chain matched user orders).

### Affected models

- `uniswap_compatible_v4_trades` macro — used by all 15 chain-specific V4 base_trades models
- `angstrom_all_trades` macro — used by `angstrom_ethereum_base_trades`

## Test plan

- [ ] Verify Angstrom swaps in `dex.trades` now have correct `evt_index` matching Swap event logs
- [ ] Re-run comparison query (dune.com/queries/7527524) — Angstrom rows should no longer appear as "missing"
- [ ] Spot-check non-Angstrom V4 trades for regression
- [ ] CI dbt slim build passes


Closes SIM-5858