### PR TITLE
fix(eigenlayer): switch slashing scaledShares cast to INT256

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_slashing_withdrawal_completed_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_slashing_withdrawal_completed_enriched.sql
@@ -1,4 +1,5 @@
-{{ 
+-- ci stamp: 1
+{{
     config(
         schema = 'eigenlayer_ethereum',
         alias = 'slashing_withdrawal_completed_enriched',

--- a/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_slashing_withdrawal_queued_flattened.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_slashing_withdrawal_queued_flattened.sql
@@ -25,7 +25,7 @@ SELECT
     t.evt_block_number,
     t.withdrawalRoot,
     from_hex(substr(u.strategy, 3)) AS strategy,
-    CAST(v.shares AS UINT256) AS shares
+    CAST(v.shares AS INT256) AS shares
 FROM
     parsed_data AS t
     CROSS JOIN UNNEST (

--- a/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_strategy_shares_netflow_by_day.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_strategy_shares_netflow_by_day.sql
@@ -1,4 +1,5 @@
-{{ 
+-- ci stamp: 1
+{{
     config(
         schema = 'eigenlayer_ethereum',
         alias = 'strategy_shares_netflow_by_day'

--- a/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_strategy_shares_outflow_by_day.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_strategy_shares_outflow_by_day.sql
@@ -1,4 +1,5 @@
-{{ 
+-- ci stamp: 1
+{{
     config(
         schema = 'eigenlayer_ethereum',
         alias = 'strategy_shares_outflow_by_day'


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Description:

Follow-up to [#9675](https://github.com/duneanalytics/spellbook/pull/9675).

**Bug:** Yesterday's UINT256 fix unblocked the upstream model but broke a downstream one. Production:

\`\`\`
Database Error in model eigenlayer_ethereum_strategy_shares_outflow_by_day
TrinoUserError(type=USER_ERROR, name=INVALID_CAST_ARGUMENT,
  message=\"Negative cast to UINT256: -180737659000000000\")
\`\`\`

**Why it happens:** [\`eigenlayer_ethereum_strategy_shares_outflow_by_day\`](https://github.com/duneanalytics/spellbook/blob/main/dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_strategy_shares_outflow_by_day.sql) UNION ALLs four branches — three are \`DECIMAL(38,0)\` (one of which, \`pod_shares_updated_enriched\`, contains negative \`sharesDelta\`) and the slashing branch was now \`UINT256\`. Trino picks UINT256 as the union supertype, then chokes when coercing the negative DECIMAL value.

**Fix:** Cast \`scaledShares\` to \`INT256\` instead of \`UINT256\` in [\`eigenlayer_ethereum_slashing_withdrawal_queued_flattened\`](dbt_subprojects/daily_spellbook/models/_projects/eigenlayer/ethereum/eigenlayer_ethereum_slashing_withdrawal_queued_flattened.sql). \`INT256\` holds the 39-digit scaled values (max ~5.79e76) AND is signed, so Trino's UNION promotion preserves negatives correctly.

### Verification

Ran 3 ad-hoc queries against real prod data via Dune to confirm the fix without needing a second incident:

1. **Single-value cast** — INT256 holds the original failing 39-digit value \`116468516031183163565269914560259104622\` ✓
2. **outflow_by_day UNION** — combined slashing (INT256) + 3 DECIMAL(38,0) branches incl. negative pod_shares; result coerces cleanly to INT256, negatives preserved ✓
3. **netflow_by_day UNION** — combined inflow (DECIMAL(38,0)) + outflow (INT256); result coerces to INT256, large >10^38 values preserved ✓

### Notes for reviewers

- The cast is still required because \`scaledShares\` is inside the \`withdrawal\` JSON struct, so \`JSON_EXTRACT\` returns VARCHAR.
- Downstream models pass through type changes via UNION promotion — no other files need to change.
- The shared \`&shares\` schema anchor declares no type, so the schema YAML is unaffected.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)