### PR TITLE
fix(prices): remove bad BOBO token mapping on ethereum

### DIFF
--- a/dbt_subprojects/tokens/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -1714,7 +1714,6 @@ FROM
     ('frxeth-frax-ether', 'ethereum', 'FRXETH',0x5e8422345238f34275888049021821e8e08caa1f,18),  
     --('cgpt-chaingpt', 'ethereum', 'CGPT',0x25931894a86d47441213199621f1f2994e1c39aa,18), 
     ('cswap-chainswap', 'ethereum', 'CSWAP',0xae41b275aaaf484b541a5881a2dded9515184cca,18),
-    ('bobo-bobo-coin', 'ethereum', 'BOBO',0xb90b2a35c65dbc466b04240097ca756ad2005295,18),
     ('bvm-bvm', 'ethereum', 'BVM',0x069d89974f4edabde69450f9cf5cf7d8cbd2568d,18),
     ('naka-nakachain', 'ethereum', 'NAKA',0xfae30394a76796dc3df37c2714f5fc12083dfdb0,18),
     ('pooh-pooh', 'ethereum', 'POOH',0xb69753c06bb5c366be51e73bfc0cc2e3dc07e371,18),


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Description:

Remove the `bobo-bobo-coin` mapping for contract `0xb90b2a35c65dbc466b04240097ca756ad2005295` from `prices_ethereum_tokens.sql`.

**Why:** The price feed for this contract in `prices.usd` was returning ~$0.012829 per token, which is roughly **40,000× higher** than the real Bobo Coin market price (~$3e-7). Sanity check: with ~69T supply, $0.0128 implies an ~$885B market cap — clearly wrong. The coingecko-id ↔ contract pairing appears to be misrouted (most likely the `bobo-bobo-coin` CG ID actually belongs to a different contract, or vice versa).

**Impact observed in prod:**
- `dex_aggregator.trades` had a row at `2026-05-18 16:59 UTC` (1inch AR v4, PEPE → BOBO) with `amount_usd = $1,187,696,269`, computed from `92.58B BOBO × $0.012829 ≈ $1.188B`.
- This broke the `dbt_utils.accepted_range` test on `dex.aggregator_trades.amount_usd` (max_value = $1B).
- The PEPE-side price was normal (~$3.6e-6); BOBO was the sole offender.

**Scope:** Removed only the ethereum mapping. No other chain files reference this token or contract address.

**Follow-up:** The upstream prices/tokens team should investigate why the `bobo-bobo-coin` CG feed maps to this contract at such an inflated price, and consider a broader sanity check for similar mismatches on other memecoin entries.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)