### PR TITLE
fix(polymarket_polygon): is_taker_side flag + apply filter in ohlcv to fix volume double-counting

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/_schema.yml
@@ -199,6 +199,8 @@ models:
         description: "Trader whose order is being filled"
       - name: taker
         description: "Trader who is filling the order (often a contract from Polymarket)"
+      - name: is_taker_side
+        description: "TRUE on the taker leg of a CLOB match (one of the two OrderFilled events the exchange emits per match). Filter `WHERE is_taker_side` to get one-sided volume that matches Polymarket's published methodology and avoids 2x double-counting. Predicate: `taker IN (V1 CTF 0x4bfb…82e, V1 NegRisk 0xc5d5…80a, V2 CTF 0xe111…996b, V2 NegRisk 0xe222…0f59)`."
       - name: unique_key
         description: "Unique key of the event or market"
       - name: token_outcome_name

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades.sql
@@ -64,6 +64,7 @@ source_trades as (
     fee,
     maker,
     taker,
+    is_taker_side,
     contract_version,
     builder,
     metadata
@@ -106,6 +107,7 @@ source_trades as (
     fee,
     maker,
     taker,
+    is_taker_side,
     contract_version,
     builder,
     metadata
@@ -135,6 +137,7 @@ select
   t.fee,
   t.maker,
   t.taker,
+  t.is_taker_side,
   t.contract_version,
   t.builder,
   t.metadata,

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades_raw.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades_raw.sql
@@ -100,10 +100,6 @@ select
   t.fee / 1e6 as fee,
   t.maker,
   t.taker,
-  -- Each CLOB match emits two OrderFilled events (maker leg + taker leg). The
-  -- row with taker IN (V1+V2 exchange contracts) is the canonical taker-side
-  -- accounting; sum amount/shares filtered to is_taker_side=true to match
-  -- Polymarket's published volume and avoid the 2x double-count.
   t.taker in (
     0x4bfb41d5b3570defd03c39a9a4d8de6bd8b8982e,
     0xc5d563a36ae78145c45a50134d48a1215220f80a,

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades_raw.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades_raw.sql
@@ -100,6 +100,16 @@ select
   t.fee / 1e6 as fee,
   t.maker,
   t.taker,
+  -- Each CLOB match emits two OrderFilled events (maker leg + taker leg). The
+  -- row with taker IN (V1+V2 exchange contracts) is the canonical taker-side
+  -- accounting; sum amount/shares filtered to is_taker_side=true to match
+  -- Polymarket's published volume and avoid the 2x double-count.
+  t.taker in (
+    0x4bfb41d5b3570defd03c39a9a4d8de6bd8b8982e,
+    0xc5d563a36ae78145c45a50134d48a1215220f80a,
+    0xe111180000d2663c0091e4f400237545b87b996b,
+    0xe2222d279d744050d28e00520010520000310f59
+  ) as is_taker_side,
   t.makerAmountFilled as maker_amount_raw,
   t.takerAmountFilled as taker_amount_raw,
   t.contract_address,
@@ -134,6 +144,12 @@ select
   t.fee / 1e6 as fee,
   t.maker,
   t.taker,
+  t.taker in (
+    0x4bfb41d5b3570defd03c39a9a4d8de6bd8b8982e,
+    0xc5d563a36ae78145c45a50134d48a1215220f80a,
+    0xe111180000d2663c0091e4f400237545b87b996b,
+    0xe2222d279d744050d28e00520010520000310f59
+  ) as is_taker_side,
   t.makerAmountFilled as maker_amount_raw,
   t.takerAmountFilled as taker_amount_raw,
   t.contract_address,
@@ -173,6 +189,12 @@ select
   t.fee / 1e6 as fee,
   t.maker,
   t.taker,
+  t.taker in (
+    0x4bfb41d5b3570defd03c39a9a4d8de6bd8b8982e,
+    0xc5d563a36ae78145c45a50134d48a1215220f80a,
+    0xe111180000d2663c0091e4f400237545b87b996b,
+    0xe2222d279d744050d28e00520010520000310f59
+  ) as is_taker_side,
   t.makerAmountFilled as maker_amount_raw,
   t.takerAmountFilled as taker_amount_raw,
   t.contract_address,

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades_raw.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades_raw.sql
@@ -118,6 +118,8 @@ from {{ source('polymarket_polygon', 'CTFExchange_evt_OrderFilled') }} t
   inner join {{ ref('polymarket_polygon_base_ctf_tokens') }} ctf on coalesce(nullif(t.makerAssetId, 0), nullif(t.takerAssetID, 0)) = ctf.token0
 {% if is_incremental() %}
 where {{ incremental_predicate('t.evt_block_time') }}
+{% else %}
+where t.evt_block_time >= date_trunc('day', now() - interval '7' day)
 {% endif %}
 
 
@@ -158,6 +160,8 @@ from {{ source('polymarket_polygon', 'NegRiskCtfExchange_evt_OrderFilled') }} t
   inner join {{ ref('polymarket_polygon_base_ctf_tokens') }} ctf on coalesce(nullif(t.makerAssetId, 0), nullif(t.takerAssetID, 0)) = ctf.token0
 {% if is_incremental() %}
 where {{ incremental_predicate('t.evt_block_time') }}
+{% else %}
+where t.evt_block_time >= date_trunc('day', now() - interval '7' day)
 {% endif %}
 
 
@@ -203,4 +207,6 @@ from {{ source('polymarket_v2_polygon', 'CTFExchange_evt_OrderFilled') }} t
   inner join {{ ref('polymarket_polygon_base_ctf_tokens') }} ctf on t.tokenId = ctf.token0
 {% if is_incremental() %}
 where {{ incremental_predicate('t.evt_block_time') }}
+{% else %}
+where t.evt_block_time >= date_trunc('day', now() - interval '7' day)
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades_raw.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades_raw.sql
@@ -118,8 +118,6 @@ from {{ source('polymarket_polygon', 'CTFExchange_evt_OrderFilled') }} t
   inner join {{ ref('polymarket_polygon_base_ctf_tokens') }} ctf on coalesce(nullif(t.makerAssetId, 0), nullif(t.takerAssetID, 0)) = ctf.token0
 {% if is_incremental() %}
 where {{ incremental_predicate('t.evt_block_time') }}
-{% else %}
-where t.evt_block_time >= date_trunc('day', now() - interval '7' day)
 {% endif %}
 
 
@@ -160,8 +158,6 @@ from {{ source('polymarket_polygon', 'NegRiskCtfExchange_evt_OrderFilled') }} t
   inner join {{ ref('polymarket_polygon_base_ctf_tokens') }} ctf on coalesce(nullif(t.makerAssetId, 0), nullif(t.takerAssetID, 0)) = ctf.token0
 {% if is_incremental() %}
 where {{ incremental_predicate('t.evt_block_time') }}
-{% else %}
-where t.evt_block_time >= date_trunc('day', now() - interval '7' day)
 {% endif %}
 
 
@@ -207,6 +203,4 @@ from {{ source('polymarket_v2_polygon', 'CTFExchange_evt_OrderFilled') }} t
   inner join {{ ref('polymarket_polygon_base_ctf_tokens') }} ctf on t.tokenId = ctf.token0
 {% if is_incremental() %}
 where {{ incremental_predicate('t.evt_block_time') }}
-{% else %}
-where t.evt_block_time >= date_trunc('day', now() - interval '7' day)
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
@@ -37,6 +37,7 @@ with base as (
     from {{ ref('polymarket_polygon_market_trades') }}
     where token_outcome is not null
       and price between 0 and 1  -- drop upstream bad-price trades (MINT/MERGE artefacts)
+      and is_taker_side          -- one-sided volume; each CLOB match emits two OrderFilled events and we want only the taker leg to match Polymarket's published volume methodology
     {% if is_incremental() -%}
       and {{ incremental_predicate('block_time') }}
     {%- endif %}

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
@@ -40,8 +40,6 @@ with base as (
       and is_taker_side
     {% if is_incremental() -%}
       and {{ incremental_predicate('block_time') }}
-    {%- else -%}
-      and block_time >= date_trunc('day', now() - interval '7' day)
     {%- endif %}
 ),
 
@@ -274,6 +272,4 @@ where not (
 )
 {% if is_incremental() -%}
   and {{ incremental_predicate('r.hour') }}
-{%- else -%}
-  and r.hour >= date_trunc('day', now() - interval '7' day)
 {%- endif %}

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
@@ -37,7 +37,7 @@ with base as (
     from {{ ref('polymarket_polygon_market_trades') }}
     where token_outcome is not null
       and price between 0 and 1  -- drop upstream bad-price trades (MINT/MERGE artefacts)
-      and is_taker_side          -- one-sided volume; each CLOB match emits two OrderFilled events and we want only the taker leg to match Polymarket's published volume methodology
+      and is_taker_side
     {% if is_incremental() -%}
       and {{ incremental_predicate('block_time') }}
     {%- endif %}

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_ohlcv_hourly.sql
@@ -40,6 +40,8 @@ with base as (
       and is_taker_side
     {% if is_incremental() -%}
       and {{ incremental_predicate('block_time') }}
+    {%- else -%}
+      and block_time >= date_trunc('day', now() - interval '7' day)
     {%- endif %}
 ),
 
@@ -272,4 +274,6 @@ where not (
 )
 {% if is_incremental() -%}
   and {{ incremental_predicate('r.hour') }}
+{%- else -%}
+  and r.hour >= date_trunc('day', now() - interval '7' day)
 {%- endif %}


### PR DESCRIPTION
## Summary

Polymarket's CLOB contracts emit two `OrderFilled` events per match (one for the maker leg, one for the taker leg), each carrying the full fill amount. Naive `SUM(amount)` over `polymarket_polygon.market_trades` therefore over-reports volume by ~2x. This is the [double-counting documented by Paradigm in Dec 2025](https://www.paradigm.xyz/2025/12/polymarket-volume-is-being-double-counted).

This PR:

- **`market_trades_raw` + `market_trades`**: adds a new column `is_taker_side BOOLEAN`. TRUE on the taker leg of each match. All rows preserved (no row-count change), so users who want the raw OrderFilled stream still have it.
- **`ohlcv_hourly`**: filters to `is_taker_side = true` at the base CTE. `volume_usd`, `volume_contracts`, `trade_count`, `vwap` halve to Polymarket-canonical values. `open` / `high` / `low` / `close` unchanged (price is per-trade, symmetric across both legs).

Predicate: `taker IN (V1 CTF 0x4bfb...82e, V1 NegRisk 0xc5d5...80a, V2 CTF 0xe111...996b, V2 NegRisk 0xe222...0f59)`.

## Validation

Cell-by-cell match against the Polymarket-authored reference query [6899861](https://dune.com/queries/6899861) across 17 months (Jan 2025 to May 2026). Deltas are floating-point noise (1e-7 range). Sample:

| Month | Reference query (Polymarket) | New `is_taker_side` filter | Delta |
|---|---:|---:|---:|
| 2025-01 | $711,931,402.49 | $711,931,402.49 | 0 |
| 2025-12 | $2,377,961,354.40 | $2,377,961,354.40 | 4.77e-7 |
| 2026-03 | $4,984,078,339.64 | $4,984,078,339.64 | -9.54e-7 |
| 2026-04 | $4,212,805,014.74 | $4,212,805,014.74 | -1.43e-6 |
| 2026-04 notional (shares) | 9.0086B | 9.0086B | 0 |

The 9.0086B April 2026 notional matches the publicly-cited "[Polymarket posted $9 billion in notional terms](https://news.bitcoin.com/prediction-market-traders-push-april-2026-volume-to-8-6b-kalshi-takes-the-lead/)" figure exactly.

Verification query: [7538562](https://dune.com/queries/7538562).

## Downstream impact

| Spell / consumer | Effect |
|---|---|
| `polymarket_polygon.market_trades` | New column. Existing columns unchanged. Row count unchanged. |
| `polymarket_polygon.ohlcv_hourly` | `volume_usd`, `volume_contracts`, `trade_count` halve. Prices unchanged. |
| `prediction_markets.ohlcv_hourly` (curated-data) | Auto-corrects on rebuild. Same shape change. |
| `prediction_markets.trades` (curated-data) | Will be updated in a follow-up PR to surface `is_taker_side`. All Kalshi rows will carry `is_taker_side = TRUE` (Kalshi has no double-counting) so the filter can be applied uniformly across venues. |
| External dashboards reading `market_trades.amount` without filter | Continue to show 2x. Methodology change worth a comms note (Paradigm + Allium + DefiLlama already moved to this convention). |

## Test plan

- [x] `dbt parse --warn-error-options error:all` clean locally (matches CI's exact flag set).
- [x] `dbt compile` clean for `market_trades_raw`, `market_trades`, `ohlcv_hourly`.
- [x] Side-by-side match against Polymarket's reference methodology query 6899861 (17 months, see table above).
- [x] Notional shares cross-check against publicly-stated April 2026 number.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)