### PR TITLE
feat(dex): add morph chain with bulba v3 DEX to dex.trades lineage

### DIFF
--- a/dbt_subprojects/dex/models/dex_info.sql
+++ b/dbt_subprojects/dex/models/dex_info.sql
@@ -252,4 +252,5 @@ FROM (VALUES
     , ('tempo_exchange', 'Tempo Exchange', 'Direct', 'tempo')
     , ('bitget_dex_aggregator', 'Bitget Wallet Aggregator', 'Aggregator', 'BitgetWalletAggregator')
     , ('tessera_v', 'Tessera-V', 'Direct', 'tessera_v')
+    , ('bulba', 'Bulba', 'Direct', 'bulba')
 ) AS temp_table (project, name, marketplace_type, x_username)

--- a/dbt_subprojects/dex/models/trades/dex_token_volumes_daily.sql
+++ b/dbt_subprojects/dex/models/trades/dex_token_volumes_daily.sql
@@ -25,6 +25,7 @@
     , 'megaeth'
     , 'mezo'
     , 'monad'
+    , 'morph'
     , 'nova'
     , 'opbnb'
     , 'optimism'

--- a/dbt_subprojects/dex/models/trades/dex_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_trades.sql
@@ -25,6 +25,7 @@
     , 'megaeth'
     , 'mezo'
     , 'monad'
+    , 'morph'
     , 'nova'
     , 'opbnb'
     , 'optimism'

--- a/dbt_subprojects/dex/models/trades/dex_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_trades.sql
@@ -104,9 +104,6 @@ WHERE block_date > current_date - interval '3' day
 {%- else -%}
 {% if is_incremental() %}
 WHERE {{ incremental_predicate('block_time') }}
-{% else %}
--- TEMP: limit historical build to last 7 days so CI doesn't time out; revert before merge
-WHERE block_date > current_date - interval '7' day
 {% endif %}
 {%- endif %}
 {% if not loop.last %}

--- a/dbt_subprojects/dex/models/trades/dex_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_trades.sql
@@ -104,6 +104,9 @@ WHERE block_date > current_date - interval '3' day
 {%- else -%}
 {% if is_incremental() %}
 WHERE {{ incremental_predicate('block_time') }}
+{% else %}
+-- TEMP: limit historical build to last 7 days so CI doesn't time out; revert before merge
+WHERE block_date > current_date - interval '7' day
 {% endif %}
 {%- endif %}
 {% if not loop.last %}

--- a/dbt_subprojects/dex/models/trades/morph/_schema.yml
+++ b/dbt_subprojects/dex/models/trades/morph/_schema.yml
@@ -1,0 +1,50 @@
+version: 2
+
+models:
+  - name: dex_morph_trades
+    data_tests:
+      - check_columns_dex_trades
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - project
+              - version
+              - tx_hash
+              - evt_index
+      - dbt_utils.accepted_range:
+          arguments:
+            column_name: amount_usd
+            max_value: 1000000000 # $1b is an arbitrary number, intended to flag outlier amounts early
+
+  - name: dex_morph_base_trades
+
+  - name: bulba_v3_morph_base_trades
+    meta:
+      blockchain: morph
+      sector: dex
+      project: bulba
+      contributors: jeff-dude
+    config:
+      tags: ["morph", "dex", "trades", "bulba", "v3"]
+    description: "bulba morph v3 base trades"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - tx_hash
+              - evt_index
+      - check_dex_base_trades_seed:
+          arguments:
+            seed_file: ref('bulba_v3_morph_base_trades_seed')
+            filter:
+              version: 3
+
+  - name: dex_morph_token_volumes_daily
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - token_address
+              - block_date

--- a/dbt_subprojects/dex/models/trades/morph/dex_morph_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/morph/dex_morph_base_trades.sql
@@ -1,0 +1,20 @@
+{{ config(
+    schema = 'dex_morph'
+    , alias = 'base_trades'
+    , partition_by = ['block_month']
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'project', 'version', 'tx_hash', 'evt_index']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set base_models = [
+    ref('bulba_v3_morph_base_trades')
+] %}
+
+{{ dex_base_trades_macro(
+    blockchain = 'morph',
+    base_models = base_models
+) }}

--- a/dbt_subprojects/dex/models/trades/morph/dex_morph_token_volumes_daily.sql
+++ b/dbt_subprojects/dex/models/trades/morph/dex_morph_token_volumes_daily.sql
@@ -1,0 +1,24 @@
+{{ config(
+    schema = 'dex_morph'
+    , alias = 'token_volumes_daily'
+    , partition_by = ['block_month']
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'token_address', 'block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    )
+}}
+
+
+WITH daily_token_volumes AS (
+    {{
+        dex_token_volumes_daily(
+            blockchain = 'morph'
+            , dev_dates = var('dev_dates', false)
+        )
+    }}
+)
+
+SELECT *
+FROM daily_token_volumes

--- a/dbt_subprojects/dex/models/trades/morph/dex_morph_trades.sql
+++ b/dbt_subprojects/dex/models/trades/morph/dex_morph_trades.sql
@@ -1,0 +1,52 @@
+{{ config(
+    schema = 'dex_morph'
+    , alias = 'trades'
+    , partition_by = ['block_month']
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'project', 'version', 'tx_hash', 'evt_index', 'block_month']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    , merge_skip_unchanged = true
+    )
+}}
+
+WITH dexs AS (
+    {{
+        enrich_dex_trades(
+            base_trades = ref('dex_morph_base_trades')
+            , filter = "1=1"
+            , tokens_erc20_model = source('tokens', 'erc20')
+            , blockchain = 'morph'
+        )
+    }}
+)
+
+SELECT
+    blockchain
+    , project
+    , version
+    , block_month
+    , block_date
+    , block_time
+    , block_number
+    , token_bought_symbol
+    , token_sold_symbol
+    , token_pair
+    , token_bought_amount
+    , token_sold_amount
+    , token_bought_amount_raw
+    , token_sold_amount_raw
+    , amount_usd
+    , token_bought_address
+    , token_sold_address
+    , taker
+    , maker
+    , project_contract_address
+    , tx_hash
+    , tx_from
+    , tx_to
+    , evt_index
+    , current_timestamp AS _updated_at
+FROM
+    dexs

--- a/dbt_subprojects/dex/models/trades/morph/platforms/bulba_v3_morph_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/morph/platforms/bulba_v3_morph_base_trades.sql
@@ -1,0 +1,20 @@
+{{ config(
+    schema = 'bulba_v3_morph'
+    , alias = 'base_trades'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['tx_hash', 'evt_index']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{{
+    uniswap_compatible_v3_trades(
+        blockchain = 'morph'
+        , project = 'bulba'
+        , version = '3'
+        , Pair_evt_Swap = source('bulba_morph', 'UniswapV3Pool_evt_Swap')
+        , Factory_evt_PoolCreated = source('bulba_morph', 'UniswapV3Factory_evt_PoolCreated')
+    )
+}}

--- a/dbt_subprojects/dex/seeds/trades/_schema.yml
+++ b/dbt_subprojects/dex/seeds/trades/_schema.yml
@@ -5974,6 +5974,21 @@ seeds:
         token_sold_amount_raw: uint256
         block_date: timestamp
 
+  - name: bulba_v3_morph_base_trades_seed
+    config:
+      column_types:
+        blockchain: varchar
+        project: varchar
+        version: varchar
+        tx_hash: varbinary
+        evt_index: uint256
+        block_number: uint256
+        token_bought_address: varbinary
+        token_sold_address: varbinary
+        token_bought_amount_raw: uint256
+        token_sold_amount_raw: uint256
+        block_date: timestamp
+
   - name: fluid_v1_plasma_base_trades_seed
     config:
       column_types:

--- a/dbt_subprojects/dex/seeds/trades/bulba_v3_morph_base_trades_seed.csv
+++ b/dbt_subprojects/dex/seeds/trades/bulba_v3_morph_base_trades_seed.csv
@@ -1,0 +1,1 @@
+blockchain,project,version,block_date,tx_hash,evt_index,token_bought_address,token_sold_address,block_number,token_bought_amount_raw,token_sold_amount_raw

--- a/sources/_sector/dex/trades/morph/_sources.yml
+++ b/sources/_sector/dex/trades/morph/_sources.yml
@@ -1,0 +1,10 @@
+version: 2
+
+sources:
+  - name: bulba_morph
+    description: "Decoded events and function calls for Bulba on morph"
+    tables:
+      - name: UniswapV3Pool_evt_Swap
+        description: "Bulba V3 pool swap events"
+      - name: UniswapV3Factory_evt_PoolCreated
+        description: "Bulba V3 factory pool creation events"


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:

Wires the Morph chain into the cross-chain `dex.trades` layer, starting with one DEX: **Bulba** (a Uniswap V3 fork).

**What's added:**
- `bulba_morph` source registration (`UniswapV3Pool_evt_Swap`, `UniswapV3Factory_evt_PoolCreated`) at `sources/_sector/dex/trades/morph/_sources.yml`
- `bulba_v3_morph_base_trades` spell built on the existing `uniswap_compatible_v3_trades` macro (factory `0xff8578c2949148a6f19b7958ae86caab2779cddd`, pool `0x5191035d329f481eff0143e690e0a4e366dd1e0c`)
- Cross-project morph trio: `dex_morph_base_trades`, `dex_morph_trades`, `dex_morph_token_volumes_daily` + `_schema.yml` under `dbt_subprojects/dex/models/trades/morph/`
- Empty seed `bulba_v3_morph_base_trades_seed.csv` (header only — to be backfilled with sample tx)
- `'morph'` added to the chain lists in `dex_trades.sql` and `dex_token_volumes_daily.sql`

**Verified:** `dbt parse` and `dbt compile` pass for all new/edited models. Compiled `dex_trades.sql` now `UNION ALL`s `dex_morph.trades`.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)