### PR TITLE
test(tokens): add prod_exclude tag and a run-time failing dev model

### DIFF
--- a/dbt_subprojects/tokens/models/_dev/tokens_dev_fail.sql
+++ b/dbt_subprojects/tokens/models/_dev/tokens_dev_fail.sql
@@ -4,5 +4,5 @@
     tags = ['prod_exclude']
 ) }}
 
---stamp 2
-select 2 as stamp
+select *
+from nonexistent_catalog.nonexistent_schema.nonexistent_table_for_failure_test

--- a/dbt_subprojects/tokens/models/_dev/tokens_dev_table.sql
+++ b/dbt_subprojects/tokens/models/_dev/tokens_dev_table.sql
@@ -1,7 +1,8 @@
 {{ config(
     schema = 'dev',
     materialized = 'table',
-    file_format = 'delta'
+    file_format = 'delta',
+    tags = ['prod_exclude']
 ) }}
 
 --stamp 2


### PR DESCRIPTION
## Summary
- Add `tags = ['prod_exclude']` to existing tokens `_dev/` stamp models (`tokens_dev_table`, `tokens_dev_view`) so they are excluded from production orchestration.
- Add `tokens_dev_fail` (view, `prod_exclude`) that selects from a non-existent catalog. Parses and compiles cleanly, then fails at execution — exercising CI's run-time failure path rather than a pre-compile error.

## Test plan
- [x] `dbt parse` / `dbt compile` succeed for the new model
- [x] Compiled SQL fails on DuneSQL at execution with `Catalog 'nonexistent_catalog' not found` — verified at https://dune.com/queries/7554529
- [ ] CI `dbt run` on this PR fails the `tokens_dev_fail` model and reports the catalog-not-found error
- [ ] Confirm `prod_exclude`-tagged models are skipped by production orchestration

🤖 Generated with [Claude Code](https://claude.com/claude-code)