### PR TITLE
fix(balancer): resolve ERC4626 wrappers to underlying in v3 trades

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/balancer/erc4626_tokens/monad/balancer_v3_monad_erc4626_token_mapping.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/balancer/erc4626_tokens/monad/balancer_v3_monad_erc4626_token_mapping.sql
@@ -1,7 +1,7 @@
 {{
     config(
         schema = 'balancer_v3_monad',
-        alias = 'erc4626_token_mapping', 
+        alias = 'erc4626_token_mapping',
         materialized = 'table',
         file_format = 'delta'
     )
@@ -29,14 +29,15 @@
       AND t.contract_address != vm.vault_address -- Exclude transfers of the vault token itself
       AND t.value = vm.amountUnderlying -- Match the amount transferred
       AND t.to = 0xba1333333333a1ba1108e8412f11850a5c319ba9  -- Only transfers to the balancer vault
-  )
+  ),
 
+  buffer_derived AS (
     SELECT DISTINCT
-      'monad' AS blockchain, 
-      ut.vault_address as erc4626_token,
+      'monad' AS blockchain,
+      ut.vault_address AS erc4626_token,
       COALESCE(vault_tokens.name, 'Unknown Vault') AS erc4626_token_name,
       COALESCE(vault_tokens.symbol, 'Unknown') AS erc4626_token_symbol,
-      ut.underlying_address as underlying_token,
+      ut.underlying_address AS underlying_token,
       COALESCE(underlying_tokens.symbol, 'Unknown') AS underlying_token_symbol,
       vault_tokens.decimals AS decimals
     FROM underlying_tokens ut
@@ -44,3 +45,31 @@
       AND vault_tokens.blockchain = 'monad'
     LEFT JOIN {{ source('tokens','erc20') }} underlying_tokens ON underlying_tokens.contract_address = ut.underlying_address
       AND underlying_tokens.blockchain = 'monad'
+  ),
+
+  -- Hardcoded fallbacks for wrappers that ops never seeded via LiquidityAddedToBuffer (e.g. wnWMON)
+  hardcoded AS (
+    SELECT
+      'monad' AS blockchain,
+      erc4626_token,
+      erc4626_token_name,
+      erc4626_token_symbol,
+      underlying_token,
+      underlying_token_symbol,
+      decimals
+    FROM (VALUES
+      (
+        0xdb39a9d4a1f1b4e93a5684d602207628ad60613c,
+        'Wrapped Neverland WMON',
+        'wnWMON',
+        0x3bd359c1119da7da1d913d1c4d2b7c461115433a,
+        'WMON',
+        18
+      )
+    ) AS t (erc4626_token, erc4626_token_name, erc4626_token_symbol, underlying_token, underlying_token_symbol, decimals)
+  )
+
+SELECT * FROM buffer_derived
+UNION ALL
+SELECT * FROM hardcoded
+WHERE erc4626_token NOT IN (SELECT erc4626_token FROM buffer_derived)

--- a/dbt_subprojects/dex/macros/models/_project/balancer_compatible_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/balancer_compatible_trades.sql
@@ -286,6 +286,16 @@ unwrap_for_swap AS (
         AND rn_event = 1
 ),
 
+{# When a swap pairs with a matched Wrap/Unwrap, the amount is already substituted to the underlying;
+   resolve the address to the underlying too so downstream pricing applies to the underlying token. #}
+erc4626_token_mapping AS (
+    SELECT
+        erc4626_token,
+        underlying_token
+    FROM {{ source('balancer_v3', 'erc4626_token_mapping') }}
+    WHERE blockchain = '{{ blockchain }}'
+),
+
 dexs AS (
     SELECT
         swap.evt_block_number AS block_number,
@@ -294,8 +304,16 @@ dexs AS (
         CAST(NULL AS VARBINARY) AS maker,
         COALESCE(unwrap_for_swap.withdrawnUnderlying, swap.amountOut) AS token_bought_amount_raw,
         COALESCE(wrap_for_swap.depositedUnderlying, swap.amountIn) AS token_sold_amount_raw,
-        swap.tokenOut AS token_bought_address,
-        swap.tokenIn AS token_sold_address,
+        CASE
+            WHEN unwrap_for_swap.swap_evt_index IS NOT NULL AND m_out.underlying_token IS NOT NULL
+                THEN m_out.underlying_token
+            ELSE swap.tokenOut
+        END AS token_bought_address,
+        CASE
+            WHEN wrap_for_swap.swap_evt_index IS NOT NULL AND m_in.underlying_token IS NOT NULL
+                THEN m_in.underlying_token
+            ELSE swap.tokenIn
+        END AS token_sold_address,
         swap.pool AS project_contract_address,
         swap.pool AS pool_id,
         l.pool_symbol,
@@ -310,7 +328,11 @@ dexs AS (
     LEFT JOIN unwrap_for_swap
         ON unwrap_for_swap.evt_tx_hash = swap.evt_tx_hash
         AND unwrap_for_swap.swap_evt_index = swap.evt_index
-    LEFT JOIN pool_labels l 
+    LEFT JOIN erc4626_token_mapping m_in
+        ON m_in.erc4626_token = swap.tokenIn
+    LEFT JOIN erc4626_token_mapping m_out
+        ON m_out.erc4626_token = swap.tokenOut
+    LEFT JOIN pool_labels l
         ON l.blockchain = '{{ blockchain }}'
         AND l.pool_address = swap.pool
 )


### PR DESCRIPTION
The v3 macro already substituted underlying amounts from matched Wrap/Unwrap events but kept the wrapped (wn*) token addresses, leaving rows internally inconsistent (underlying amount, wrapped address) and unpriceable downstream in dex.trades.

Substitute the address too when wrap/unwrap matched and the ERC4626 mapping has the underlying. Also seed wnWMON -> WMON on Monad, which never appears in Vault_evt_LiquidityAddedToBuffer and so was missing from the auto-derived mapping. Recovers ~\$2.4M/day of previously NULL-priced volume in monad balancer dex.trades.

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
