### PR TITLE
Add USDGO, MOVEUSD, USDtb, USDPT to Solana stablecoin extended list

### DIFF
--- a/dbt_subprojects/solana/models/stablecoins/_list/tokens_solana_spl_stablecoins_extended.sql
+++ b/dbt_subprojects/solana/models/stablecoins/_list/tokens_solana_spl_stablecoins_extended.sql
@@ -38,7 +38,11 @@ from (values
     ('2VhjJ9WxaGC3EZFwJG9BDUs9KxKCAjQY4vgd1qxgYWVg', 'EUR'),  -- EUROe
     ('CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH', 'USD'),  -- CASH
     ('AUSD1jCcCyPLybk1YnvPWsHQSrZ46dxwoMniN4N2UEB9', 'USD'),  -- AUSD
-    ('AUDDttiEpCydTm7joUMbYddm72jAWXZnCpPZtDoxqBSw', 'AUD')   -- AUDD
+    ('AUDDttiEpCydTm7joUMbYddm72jAWXZnCpPZtDoxqBSw', 'AUD'),  -- AUDD
+    ('72puLt71H93Z9CzHuBRTwFpL4TG3WZUhnoCC7p8gxigu', 'USD'),  -- USDGO
+    ('3AdhVEX6k85yNivHVXDEiY3WyP2WgFQTUZCahGaeC2qm', 'USD'),  -- MOVEUSD
+    ('8yXrtJ54jZtE84xEBzTESKuegjcAkAuDrdAhRd8i8n3T', 'USD'),  -- USDtb
+    ('HVWf8JmLoHs99Lw8Psf3fyqAtA4crWxCPkrmSdNjhNH3', 'USD')   -- USDPT
 
     /* yield-bearing / rebasing tokens
     ('AvZZF1YaZDziPY2RCK4oJrRVrbN3mTD9NL24hPeaZeUj', 'USD'),  -- syrupUSD


### PR DESCRIPTION
## Summary

Add 4 SPL stablecoins to the Solana `_extended` list, surfaced via a DeFiLlama top-Solana-stablecoins review cross-referenced against the current `_core` + `_extended`:

| Symbol | Mint | Peg | Sol TVL | 30d transfers / recipients |
|---|---|---|---|---|
| **USDGO** | `72puLt71H93Z9CzHuBRTwFpL4TG3WZUhnoCC7p8gxigu` | USD | $333M | 7,290 / 1,076 |
| **MOVEUSD** | `3AdhVEX6k85yNivHVXDEiY3WyP2WgFQTUZCahGaeC2qm` | USD | $116M | 18,647 / 279 |
| **USDtb** (Ethena) | `8yXrtJ54jZtE84xEBzTESKuegjcAkAuDrdAhRd8i8n3T` | USD | $43M  | 36 / 9 |
| **USDPT** (Western Union) | `HVWf8JmLoHs99Lw8Psf3fyqAtA4crWxCPkrmSdNjhNH3` | USD | $1.5M | 33 / 15 |

USDtb / USDPT have low 30d recipient counts but were explicitly approved as payments-relevant. The other two clear the standard volume threshold.

### Skipped from the same review

- **syrupUSD** — yield-bearing, deferred per [CUR2-2113](https://linear.app/dune/issue/CUR2-2113).
- **SoFiUSD** — suspected fake address (0 on-chain activity over 30d on the supplied mint).

## Test plan

- [ ] CI: `tokens_solana_spl_stablecoins_extended` + downstream `stablecoins_solana_extended_transfers` build green on the PR schema.
- [ ] Post-merge: drive the curated backfill via [`docs/add-a-stablecoin.md`](https://github.com/duneanalytics/curated-stablecoins/blob/main/docs/add-a-stablecoin.md) (CUR2-2416) — `scripts/add_stablecoin.py` handles steps 2–6 with prefect polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)