### PR TITLE
feat(polymarket): add maker_side and taker_side to market_trades

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/_schema.yml
@@ -201,6 +201,20 @@ models:
         description: "Trader who is filling the order (often a contract from Polymarket)"
       - name: is_taker_side
         description: "TRUE on the taker leg of a CLOB match (one of the two OrderFilled events the exchange emits per match). Filter `WHERE is_taker_side` to get one-sided volume that matches Polymarket's published methodology and avoids 2x double-counting. Predicate: `taker IN (V1 CTF 0x4bfb…82e, V1 NegRisk 0xc5d5…80a, V2 CTF 0xe111…996b, V2 NegRisk 0xe222…0f59)`."
+      - name: maker_side
+        description: "Side of the maker's order w.r.t. asset_id: 'BUY' if the maker is acquiring outcome tokens (paying USDC on V1 / pUSD on V2), 'SELL' if releasing them. Always the inverse of taker_side. Derived from makerAssetId on V1 (0 = USDC, so maker is buying tokens) and from the explicit side enum on V2 (0 = BUY, 1 = SELL)."
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['BUY', 'SELL']
+      - name: taker_side
+        description: "Side of the taker's leg w.r.t. asset_id: 'BUY' if the taker is acquiring outcome tokens, 'SELL' if releasing them. Always the inverse of maker_side. Lets consumers read the right side directly from whichever address (maker or taker) matches their wallet, without an inversion CASE."
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['BUY', 'SELL']
       - name: unique_key
         description: "Unique key of the event or market"
       - name: token_outcome_name

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades.sql
@@ -65,6 +65,8 @@ source_trades as (
     maker,
     taker,
     is_taker_side,
+    maker_side,
+    taker_side,
     contract_version,
     builder,
     metadata
@@ -108,6 +110,8 @@ source_trades as (
     maker,
     taker,
     is_taker_side,
+    maker_side,
+    taker_side,
     contract_version,
     builder,
     metadata
@@ -138,6 +142,8 @@ select
   t.maker,
   t.taker,
   t.is_taker_side,
+  t.maker_side,
+  t.taker_side,
   t.contract_version,
   t.builder,
   t.metadata,

--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades_raw.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades_raw.sql
@@ -106,6 +106,8 @@ select
     0xe111180000d2663c0091e4f400237545b87b996b,
     0xe2222d279d744050d28e00520010520000310f59
   ) as is_taker_side,
+  case when t.makerAssetId = 0 then 'BUY' else 'SELL' end as maker_side,
+  case when t.makerAssetId = 0 then 'SELL' else 'BUY' end as taker_side,
   t.makerAmountFilled as maker_amount_raw,
   t.takerAmountFilled as taker_amount_raw,
   t.contract_address,
@@ -146,6 +148,8 @@ select
     0xe111180000d2663c0091e4f400237545b87b996b,
     0xe2222d279d744050d28e00520010520000310f59
   ) as is_taker_side,
+  case when t.makerAssetId = 0 then 'BUY' else 'SELL' end as maker_side,
+  case when t.makerAssetId = 0 then 'SELL' else 'BUY' end as taker_side,
   t.makerAmountFilled as maker_amount_raw,
   t.takerAmountFilled as taker_amount_raw,
   t.contract_address,
@@ -191,6 +195,8 @@ select
     0xe111180000d2663c0091e4f400237545b87b996b,
     0xe2222d279d744050d28e00520010520000310f59
   ) as is_taker_side,
+  case when t.side = 0 then 'BUY' else 'SELL' end as maker_side,
+  case when t.side = 0 then 'SELL' else 'BUY' end as taker_side,
   t.makerAmountFilled as maker_amount_raw,
   t.takerAmountFilled as taker_amount_raw,
   t.contract_address,


### PR DESCRIPTION
## Summary

Adds `maker_side` and `taker_side` (`'BUY'` / `'SELL'`, always opposite) to `polymarket_polygon.market_trades`. Requested by BAM ([CUR2-2551](https://linear.app/dune/issue/CUR2-2551)) to reconstruct wallet positions over time. The Polymarket `/trades` API exposes a per-wallet `side`; this surfaces the same semantic at the spell layer so consumers don't have to scrape or maintain their own derivation.

## Derivation

- **V1** (`CTFExchange_evt_OrderFilled` + `NegRiskCtfExchange_evt_OrderFilled`): `makerAssetId = 0` means the maker paid USDC for outcome tokens, so `maker_side = 'BUY'` (otherwise `'SELL'`).
- **V2** (`polymarket_v2_polygon.CTFExchange_evt_OrderFilled`): the event carries an explicit `side` enum, `0 = BUY`, `1 = SELL`.
- `taker_side` is the inverse of `maker_side` by construction.

## Usage

```sql
select asset_id, shares,
  case when maker = :wallet then maker_side
       when taker = :wallet then taker_side end as side_for_wallet
from polymarket_polygon.market_trades
where (maker = :wallet or taker = :wallet);
```

`BUY` => +shares, `SELL` => -shares. No inversion CASE required.

## Verification

- **Tier 1**: `uv run dbt --warn-error compile --select polymarket_polygon_market_trades polymarket_polygon_market_trades_raw` clean.
- **Tier 2 invariants** on 194M production rows (last 30 days):

  | Contract Version | Rows | NULL maker | NULL taker | Invalid value | Non-opposite |
  |---|---:|---:|---:|---:|---:|
  | V1 | 2,818,476 | 0 | 0 | 0 | 0 |
  | V2 | 191,326,847 | 0 | 0 | 0 | 0 |

- **Both branches fire on every source** (24h window):

  | Source | maker BUY | maker SELL |
  |---|---:|---:|
  | V1 CTFExchange | 5,898,513 | 929,211 |
  | V1 NegRiskCtfExchange | 1,010,306 | 512,634 |
  | V2 CTFExchange | 5,410,796 | 940,707 |

- **Cross-platform check against the Polymarket `/trades` API**: 8 distinct tx_hashes / 10 OrderFilled events for a sample wallet, **10/10 match** between our derived `(maker_side, taker_side)` and the API's `side`. Two trades emit both legs and the derivation produces the correct side for the wallet on each leg.

Note on observed distribution: maker_side skews ~85% BUY on production data. This is genuine Polymarket microstructure (LP rewards favor bid posting; position opens often go via `PositionSplit` minting rather than the orderbook; sells tend to sweep multiple resting bids). Not a derivation artifact; verified by independently filtering each `is_taker_side` leg.

## Tests

`not_null` + `accepted_values(['BUY','SELL'])` on both columns. Existing `is_taker_side` unchanged.

## Test plan

- [x] dbt compile
- [x] Dune MCP invariant + distribution check
- [x] Row-for-row validation against Polymarket /trades API
- [ ] CI: dbt slim ci
- [ ] After merge: full refresh of `market_trades_raw` + `market_trades`, then notify BAM in the existing email thread to validate against their Snowflake share

## Linear

[CUR2-2551](https://linear.app/dune/issue/CUR2-2551)