### PR TITLE
feat(stablecoins): add BUIDL + OUSD to ethereum _extended list

### DIFF
--- a/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/tokens_ethereum_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/tokens_ethereum_erc20_stablecoins_extended.sql
@@ -29,12 +29,13 @@ from (values
      (0x3231cb76718cdef2155fc47b5286d82e6eda273f, 'EUR'), -- EURe
      (0x09fd37d9aa613789c517e76df1c53aece2b60df4, 'USD'), -- ebUSD
      (0x16f93ebc5320c89efc8701577efe49d14a276a06, 'CAD'), -- CADD
-     (0xf3527ef8de265eaa3716fb312c12847bfba66cef, 'USD')  -- USDX
+     (0xf3527ef8de265eaa3716fb312c12847bfba66cef, 'USD'), -- USDX
+     (0x7712c34205737192402172409a8f7ccef8aa2aec, 'USD'), -- BUIDL (BlackRock USD Institutional Digital Liquidity Fund — peg held at $1, daily yield paid as USDC dividends, not via rebase)
+     (0x2a8e1e676ec238d8a992307b495b45b3feaa5e86, 'USD')  -- OUSD (Origin Dollar)
 
      /* yield-bearing / rebasing tokens
      (0x96f6ef951840721adbf46ac996b59e0235cb985c, 'USD'), -- USDY
      (0xd46ba6d942050d489dbd938a2c909a5d5039a161, 'USD'), -- AMPL
-     (0x7712c34205737192402172409a8f7ccef8aa2aec, 'USD'), -- BUIDL
      (0xa774ffb4af6b0a91331c084e1aebae6ad535e6f3, 'USD'), -- FLEXUSD (list: flexUSD)
      (0x15700b564ca08d9439c58ca5053166e8317aa138, 'USD'), -- deUSD
      (0x79c58f70905f734641735bc61e45c19dd9ad60bc, 'USD'), -- usdc-dai-usdt (list: USDC-DAI-USDT)


### PR DESCRIPTION
## Summary

- **BUIDL** `0x7712c34205737192402172409a8f7ccef8aa2aec` — BlackRock's tokenized US Treasury fund. Moved from the yield-bearing comment block into the active values list. The CUR2-2113 yield-bearing exclusion was scoped to tokens whose **price drifts** (sUSDe, USDY, sUSDS, syrupUSDC, sDAI, …); BUIDL's peg holds at \$1.00 and yield is distributed as **USDC dividends**, so the token itself behaves as a clean \$1 stable. `balance_usd = balance × 1.0` via the existing peg-FX path — no `prices.usd` oracle dependency.
- **OUSD** `0x2a8e1e676ec238d8a992307b495b45b3feaa5e86` — Origin Dollar. Real USD-pegged stablecoin, ~\$17M 30d Ethereum transfer volume, 317 distinct recipients in the last 30d. Currently uncovered in any `_core` / `_extended` list.

Both tokens were validated via the `curated-stablecoins` add-token runbook (`docs/add-a-stablecoin.md`):
- Step 0 explorer + on-chain checks ran clean (\<1,000-recipient warning expected — BUIDL is institutional/permissioned; OUSD validated as a real DeFi stable).
- Dup-check against `tokens_ethereum.erc20_stablecoins_core` and `_extended` returned 0 rows for both addresses.

## Test plan

- [ ] CI on this PR builds \`tokens_ethereum_erc20_stablecoins_extended\` and its union view \`tokens_ethereum_erc20_stablecoins\` without uniqueness violations.
- [ ] After merge, fire \`prefect deployment run "main-flow/dbtjo - spellbook_tokens"\` to backfill \`stablecoins_ethereum.extended_transfers\` + \`extended_balances\` for both tokens. Track in the runbook's run-log (CUR2-2416).
- [ ] Then trigger \`spellbook_daily\` (\`stablecoins_ethereum_extended_balances+ --full-refresh\`) and the \`curated-stablecoins\` \`dbt_deploy.yml\` workflow per the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)