### PR TITLE
feat: add pathUSD to Tempo token prices

### DIFF
--- a/dbt_subprojects/tokens/models/prices/tempo/prices_tempo_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/tempo/prices_tempo_tokens.sql
@@ -23,6 +23,6 @@ FROM
     , ('usdt0-usdt0', 'USDT0', 0x20c00000000000000000000014f22ca97301eb73, 6)
     , ('frxusd-frax-usd', 'frxUSD', 0x20c0000000000000000000003554d28269e0f3c2, 6)
     , ('cusd-cap-usd', 'cUSD', 0x20c0000000000000000000000520792dcccccccc, 6)
+    , ('pathusd-pathusd', 'pathUSD', 0x20c0000000000000000000000000000000000000, 6)
     -- , ('stcusd-staked-cap-usd', 'stcUSD', 0x20c0000000000000000000008ee4fcff88888888, 6) --inactive on Coinpaprika
-    -- , ('', 'pathUSD', 0x20c0000000000000000000000000000000000000, 6) --not available on Coinpaprika
 ) as temp (token_id, symbol, contract_address, decimals)


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Description:

Add **pathUSD** to `prices_tempo_tokens` now that it is listed on [Coinpaprika](https://coinpaprika.com/coin/pathusd-pathusd/).

- `token_id` = `pathusd-pathusd`
- Contract `0x20c0000000000000000000000000000000000000`
- **6 decimals** — verified against `tokens.erc20` on Tempo (symbol `pathUSD`, decimals `6`)

This model feeds `prices_tokens`, so pathUSD now flows into `prices.minute` / `prices.hour` / `prices.day` — same approach used for the other Tempo stablecoins (USDC.e, USDT0, frxUSD, cUSD).

### Test plan:
- [ ] CI builds `prices_tempo_tokens` and downstream prices models
- [ ] `test_prices_tokens_against_erc20` passes (decimals/symbol match on-chain ERC20)
- [ ] `unique` test on `contract_address` passes

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)