### PR TITLE
CUR2-2600: prepare Sui token transfer cutover

### DIFF
--- a/dbt_subprojects/tokens/models/transfers_and_balances/sui/sui_coin_info.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sui/sui_coin_info.sql
@@ -2,6 +2,7 @@
   config(
     schema = 'sui',
     alias = 'coin_info',
+    tags = ['prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_base_transfers.sql
@@ -2,6 +2,7 @@
   config(
     schema = 'tokens_sui',
     alias = 'base_transfers',
+    tags = ['prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     partition_by = ['block_date'],

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_coin_object_anchor_state.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_coin_object_anchor_state.sql
@@ -2,6 +2,7 @@
   config(
     schema = 'tokens_sui',
     alias = 'coin_object_anchor_state',
+    tags = ['prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     partition_by = ['block_month'],

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_coin_object_history.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_coin_object_history.sql
@@ -2,6 +2,7 @@
   config(
     schema = 'tokens_sui',
     alias = 'coin_object_history',
+    tags = ['prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     partition_by = ['block_date'],

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_direct_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_direct_transfers.sql
@@ -2,6 +2,7 @@
   config(
     schema = 'tokens_sui',
     alias = 'direct_transfers',
+    tags = ['prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     partition_by = ['block_date'],

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_object_event_deltas.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_object_event_deltas.sql
@@ -4,6 +4,7 @@
   config(
     schema = 'tokens_sui',
     alias = 'object_event_deltas',
+    tags = ['prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     partition_by = ['block_date'],

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_owner_net_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_owner_net_transfers.sql
@@ -2,6 +2,7 @@
   config(
     schema = 'tokens_sui',
     alias = 'owner_net_transfers',
+    tags = ['prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     partition_by = ['block_date'],

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_supply_events.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_supply_events.sql
@@ -2,6 +2,7 @@
   config(
     schema = 'tokens_sui',
     alias = 'supply_events',
+    tags = ['prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     partition_by = ['block_date'],

--- a/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/sui/tokens_sui_transfers.sql
@@ -2,6 +2,7 @@
   config(
     schema = 'tokens_sui',
     alias = 'transfers',
+    tags = ['prod_exclude'],
     materialized = 'incremental',
     file_format = 'delta',
     partition_by = ['block_date'],

--- a/dbt_subprojects/tokens/models/transfers_and_balances/tokens_multichain_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/tokens_multichain_transfers.sql
@@ -66,6 +66,7 @@
   config(
     schema = 'tokens_multichain',
     alias = 'transfers',
+    tags = ['prod_exclude'],
     materialized = 'view',
     post_hook = '{{ private_data_explorer(blockchains = \'["' + chains | join('","') + '"]\',
                     spell_type = "sector",
@@ -181,7 +182,7 @@ select
   amount_usd,
   transfer_type,
   _updated_at
-from {{ ref('tokens_sui_transfers') }}
+from {{ source('tokens_sui', 'transfers') }}
 
 union all
 

--- a/sources/_subprojects_outputs/tokens/transfers.yml
+++ b/sources/_subprojects_outputs/tokens/transfers.yml
@@ -308,6 +308,10 @@ sources:
       - name: net_transfers_daily_asset
       - name: spl_stablecoins
 
+  - name: tokens_sui
+    tables:
+      - name: transfers
+
   - name: tokens_stellar
     tables:
       - name: transfers


### PR DESCRIPTION
## Summary
- Adds `prod_exclude` to the existing spellbook Sui token transfer writer lineage and `tokens_multichain_transfers`.
- Switches the Sui branch of `tokens_multichain.transfers` to read canonical `tokens_sui.transfers` via `source()`.
- Registers `tokens_sui.transfers` in token subproject output sources for the cutover.

## Test plan
- `uv run dbt deps`
- `uv run dbt parse`
- `uv run dbt compile -s tokens_multichain_transfers`


Made with [Cursor](https://cursor.com)