### PR TITLE
CI: do not log in to AWS to get manifests

### DIFF
--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -49,7 +49,7 @@ jobs:
           echo "PROJECT_DIR=$PROJECT_DIR" >> $GITHUB_ENV
 
       - name: Get latest manifest
-        run: "aws s3 cp $S3_LOCATION/manifest.json $PROJECT_DIR/manifest.json --no-sign-request"
+        run: "aws s3 cp $S3_LOCATION/manifest.json $PROJECT_DIR/manifest.json --no-sign-request --region=eu-west-1"
 
       - name: dbt dependencies
         working-directory: ${{env.PROJECT_DIR}}

--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -48,14 +48,8 @@ jobs:
           PROJECT_DIR=dbt_subprojects/${{ inputs.project }}
           echo "PROJECT_DIR=$PROJECT_DIR" >> $GITHUB_ENV
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.SPELLBOOK_CI_IAM_ROLE }}
-          aws-region: eu-west-1
-
       - name: Get latest manifest
-        run: "aws s3 cp $S3_LOCATION/manifest.json $PROJECT_DIR/manifest.json"
+        run: "aws s3 cp $S3_LOCATION/manifest.json $PROJECT_DIR/manifest.json --no-sign-request"
 
       - name: dbt dependencies
         working-directory: ${{env.PROJECT_DIR}}


### PR DESCRIPTION
### Description:

Do not log into AWS during CI/CD – it doesn't work with OIDC, and we do not need it. Just retrieve the manifest directly.