### PR TITLE
fix(prices): exclude bad optimism BRIGHT bridge deposit causing duplicate token mapping

### DIFF
--- a/dbt_subprojects/tokens/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping.sql
+++ b/dbt_subprojects/tokens/models/tokens/optimism/tokens_optimism_erc20_bridged_mapping.sql
@@ -23,7 +23,10 @@ FROM (
 
         SELECT l1Token AS l1_token, l2Token AS l2_token, NULL AS symbol, NULL AS decimals
             FROM {{source( 'optimism_ethereum', 'L1StandardBridge_evt_ERC20DepositInitiated' ) }}
-        WHERE evt_tx_hash != 0x460965f169a99b3d372cd749621a3652ad232d1b1580fd77424eacc2e973b672 --bad event emitted
+        WHERE evt_tx_hash NOT IN (
+            0x460965f169a99b3d372cd749621a3652ad232d1b1580fd77424eacc2e973b672 --bad event emitted
+            ,0x180bce7dc523b1631cb8d7e8f0ca75cf26db46c73c32c06d9563cc465b6f0af5 --bright-union (0xbeab71..) self-bridged onto bright-token's optimism L2 (0x65334ce5..); creates a duplicate (blockchain, contract_address) with a wrong price downstream
+        )
         {% if is_incremental() %}
         AND evt_block_time >= date_trunc('day', now() - interval '7' day)
         {% endif %}


### PR DESCRIPTION
## Problem

A prod audit on `prices_v2_hybrid.metadata` (and `prices.usd`) in spellbook-sqlmesh failed on duplicate `(blockchain, contract_address)` for optimism `0x65334ce5aae9fb390c056574c7aa4de33cf1d40e` (BRIGHT).

Root cause traces to **this** model. On **2026-06-03** a self-transfer ([tx `0x180bce7d…`](https://optimistic.etherscan.io/tx/0x180bce7dc523b1631cb8d7e8f0ca75cf26db46c73c32c06d9563cc465b6f0af5)) bridged **Bright Union** L1 (`0xbeab712832112bd7664226db7cd025b153d3af55`) onto **Bright Token**'s optimism L2 (`0x65334ce5…`) — which has been the canonical bridged BRIGHT since 2024 (6 deposits from L1 `0x5dd57d…`).

That single deposit added a second `(l1_token → l2_token)` row to `erc20_bridged_mapping`, so `prices_optimism_tokens_bridged` (which `INNER JOIN`s `prices_ethereum_tokens` on `l1_token`) emitted **two** optimism rows for the same contract — one per ethereum `token_id` (`bright-bright-token`, `bright-bright-union`). The dup flows into `prices.tokens` → `tokens_patched`/`tokens_old` → breaks unique audits downstream.

### Impact measured (sqlmesh `prices.usd`)
- 28,890 duplicated minutes, **100% with divergent prices** (~5× spread: Bright Union ≠ Bright Token).
- Because `prices.tokens_old` is a current-snapshot join to all-history `coinpaprika_raw`, the new mapping **retroactively** poisons history (overlap window 2026-05-06 → 05-26).

## Fix

Exclude the anomalous tx, following the existing `--bad event emitted` precedent already in this model. This keeps the legitimate Bright Token mapping (correct price) and does **not** touch the two distinct ethereum BRIGHT token_ids, which are valid and used elsewhere.

## ⚠️ Deploy note

`erc20_bridged_mapping` is `incremental` (merge on `unique_key (l1_token, l2_token)`). This filter prevents future re-adds but will **not** evict the already-merged row — a **full-refresh** of `erc20_bridged_mapping` is required, after which the downstream `prices.tokens` rebuild propagates the correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)