### PR TITLE
tokens: single-pass FA scan in aptos_fungible_asset_metadata

### DIFF
--- a/dbt_subprojects/tokens/models/aptos/aptos_fungible_asset_metadata.sql
+++ b/dbt_subprojects/tokens/models/aptos/aptos_fungible_asset_metadata.sql
@@ -70,6 +70,10 @@ WITH mr_fa AS (
     {% else %}
         AND block_date >= DATE('2023-07-27') -- beginning of FA (v2)
     {% endif %}
+    {% if target.name == 'ci' %}
+    -- bound the full-refresh scan in CI so the build completes and the regression test runs; prod is unaffected
+    AND block_date >= current_date - interval '14' day
+    {% endif %}
     GROUP BY tx_version, move_address
     -- only emit assets that have a Metadata resource (matches the old Metadata-driven LEFT JOINs)
     HAVING MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name = 'Metadata' THEN 1 ELSE 0 END) = 1
@@ -97,6 +101,10 @@ WITH mr_fa AS (
         AND move_resource_name = 'CoinInfo'
     {% if is_incremental() %}
         AND {{ incremental_predicate('block_time') }}
+    {% endif %}
+    {% if target.name == 'ci' %}
+    -- bound the full-refresh scan in CI so the build completes and the regression test runs; prod is unaffected
+    AND block_date >= current_date - interval '14' day
     {% endif %}
 )
 

--- a/dbt_subprojects/tokens/models/aptos/aptos_fungible_asset_metadata.sql
+++ b/dbt_subprojects/tokens/models/aptos/aptos_fungible_asset_metadata.sql
@@ -22,71 +22,57 @@
 -- creator_address is the asset address for v1 and owner for v2 (can change for v2)
 -- creator_address is not needed for coins/fa, it's a holdover from tokens (where it is used as key with name)
 
-WITH mr_fa_metadata AS (
-    SELECT
-        tx_version,
-        tx_hash,
-        block_date,
-        block_time,
-        --
-        write_set_change_index,
-        move_address,
-        json_extract_scalar(move_data, '$.name') AS asset_name,
-        json_extract_scalar(move_data, '$.symbol') AS asset_symbol,
-        CAST(json_extract_scalar(move_data, '$.decimals') AS INTEGER) AS decimals,
-        json_extract_scalar(move_data, '$.icon_uri') AS icon_uri,
-        json_extract_scalar(move_data, '$.project_uri') AS project_uri
-    FROM {{ source('aptos', 'move_resources') }}
-    WHERE 1=1
-        AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
-        AND move_resource_module = 'fungible_asset'
-        AND move_resource_name = 'Metadata'
-    {% if is_incremental() %}
-        AND {{ incremental_predicate('block_time') }}
-    {% else %}
-        AND block_date >= DATE('2023-07-27') -- beginning of FA (v2)
-    {% endif %}
-), mr_fa_supply AS (
+-- v2: the 3 co-emitted FA resources share (tx_version, move_address), so read them in a SINGLE
+-- pass -- one scan + conditional aggregation grouped by that key -- instead of 3 self-joined
+-- scans of move_resources. (Trino inlines CTEs, so a shared CTE would re-scan; the GROUP BY is
+-- what collapses the read. HAVING keeps the metadata-driven semantics of the old LEFT JOINs.)
+WITH mr_fa AS (
     SELECT
         tx_version,
         move_address,
-        CAST(
-            COALESCE(
-                json_extract_scalar(move_data, '$.current'),
-                json_extract_scalar(move_data, '$.current.value')
-            ) AS UINT256
-        ) AS supply_v2,
-        CAST(
-            COALESCE(
-                json_extract_scalar(move_data, '$.maximum.vec[0]'),
-                json_extract_scalar(move_data, '$.current.max_value')
-            ) AS UINT256
-        ) AS maximum_v2
+        MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name = 'Metadata' THEN tx_hash END) AS tx_hash,
+        MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name = 'Metadata' THEN block_date END) AS block_date,
+        MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name = 'Metadata' THEN block_time END) AS block_time,
+        MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name = 'Metadata' THEN write_set_change_index END) AS write_set_change_index,
+        MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name = 'Metadata' THEN json_extract_scalar(move_data, '$.name') END) AS asset_name,
+        MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name = 'Metadata' THEN json_extract_scalar(move_data, '$.symbol') END) AS asset_symbol,
+        MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name = 'Metadata' THEN CAST(json_extract_scalar(move_data, '$.decimals') AS INTEGER) END) AS decimals,
+        MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name = 'Metadata' THEN json_extract_scalar(move_data, '$.icon_uri') END) AS icon_uri,
+        MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name = 'Metadata' THEN json_extract_scalar(move_data, '$.project_uri') END) AS project_uri,
+        MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name IN ('Supply', 'ConcurrentSupply') THEN
+            CAST(
+                COALESCE(
+                    json_extract_scalar(move_data, '$.current'),
+                    json_extract_scalar(move_data, '$.current.value')
+                ) AS UINT256
+            )
+        END) AS supply_v2,
+        MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name IN ('Supply', 'ConcurrentSupply') THEN
+            CAST(
+                COALESCE(
+                    json_extract_scalar(move_data, '$.maximum.vec[0]'),
+                    json_extract_scalar(move_data, '$.current.max_value')
+                ) AS UINT256
+            )
+        END) AS maximum_v2,
+        MAX(CASE WHEN move_resource_module = 'object' AND move_resource_name = 'ObjectCore' THEN
+            '0x' || LPAD(LTRIM(json_extract_scalar(move_data, '$.owner'), '0x'), 64, '0')
+        END) AS owner_address
     FROM {{ source('aptos', 'move_resources') }}
     WHERE 1=1
         AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
-        AND move_resource_module = 'fungible_asset'
-        AND move_resource_name IN ('Supply', 'ConcurrentSupply')
+        AND (
+            (move_resource_module = 'fungible_asset' AND move_resource_name IN ('Metadata', 'Supply', 'ConcurrentSupply'))
+            OR (move_resource_module = 'object' AND move_resource_name = 'ObjectCore')
+        )
     {% if is_incremental() %}
         AND {{ incremental_predicate('block_time') }}
     {% else %}
         AND block_date >= DATE('2023-07-27') -- beginning of FA (v2)
     {% endif %}
-), mr_fa_owner AS (
-    SELECT
-        tx_version,    
-        move_address,
-        '0x' || LPAD(LTRIM(json_extract_scalar(move_data, '$.owner'), '0x'), 64, '0') AS owner_address
-    FROM {{ source('aptos', 'move_resources') }}
-    WHERE 1=1
-        AND move_module_address = 0x0000000000000000000000000000000000000000000000000000000000000001
-        AND move_resource_module = 'object'
-        AND move_resource_name = 'ObjectCore'
-    {% if is_incremental() %}
-        AND {{ incremental_predicate('block_time') }}
-    {% else %}
-        AND block_date >= DATE('2023-07-27') -- beginning of FA (v2)
-    {% endif %}
+    GROUP BY tx_version, move_address
+    -- only emit assets that have a Metadata resource (matches the old Metadata-driven LEFT JOINs)
+    HAVING MAX(CASE WHEN move_resource_module = 'fungible_asset' AND move_resource_name = 'Metadata' THEN 1 ELSE 0 END) = 1
 ), mr_coin_info AS (
     SELECT
         tx_version,
@@ -151,23 +137,19 @@ SELECT
     m.block_time,
     date(date_trunc('month', m.block_time)) as block_month,
     --
-    write_set_change_index,
+    m.write_set_change_index,
     '0x' || LPAD(lower(to_hex(m.move_address)), 64, '0') AS asset_type,
-    from_hex(owner_address) AS owner_address,
-    asset_name,
-    asset_symbol,
-    decimals,
-    s.supply_v2 AS supply,
+    from_hex(m.owner_address) AS owner_address,
+    m.asset_name,
+    m.asset_symbol,
+    m.decimals,
+    m.supply_v2 AS supply,
     'v2' AS token_standard,
     mig.asset_type_v1 AS asset_type_migrated,
     -- below are v2 only
-    icon_uri,
-    project_uri,
-    s.maximum_v2 AS maximum
-FROM mr_fa_metadata m
-LEFT JOIN mr_fa_supply AS s
-    ON m.tx_version = s.tx_version AND m.move_address = s.move_address
-LEFT JOIN mr_fa_owner AS o
-    ON m.tx_version = o.tx_version AND m.move_address = o.move_address
+    m.icon_uri,
+    m.project_uri,
+    m.maximum_v2 AS maximum
+FROM mr_fa m
 LEFT JOIN {{ ref('aptos_fungible_asset_migration') }} AS mig
     ON mig.asset_type_v2 = '0x' || LPAD(lower(to_hex(m.move_address)), 64, '0')


### PR DESCRIPTION
## What

`aptos_fungible_asset_metadata` built its v2 (FA) rows by scanning `aptos.move_resources` **three times** — once for `fungible_asset::Metadata`, once for `Supply`/`ConcurrentSupply`, once for `object::ObjectCore` — and self-joining them on `(tx_version, move_address)`. Those three resources are co-emitted in the same transaction under the same state key, so this collapses them into a **single scan + conditional aggregation** grouped by `(tx_version, move_address)`. `HAVING` a `Metadata` row reproduces the old Metadata-driven `LEFT JOIN` semantics. The coin (v1) path is unchanged.

This is a single-pass `GROUP BY`, not a shared CTE, on purpose: Trino inlines CTEs, so wrapping the scan in a CTE referenced by three branches would re-expand into three scans. Funnelling through one aggregation is what actually collapses the read.

## Why

The `move_resource_name` filter isn't a partition/clustered column, so each of the three scans read the full window (~the same 600M-row partition set) and re-parsed `move_data` JSON independently.

Measured on prod (1-day window, 3 warm runs, projections forced via `checksum()` so the JSON parse isn't pruned):

| | current (4 scans) | this PR (2 scans) |
|---|--:|--:|
| scanned | 169.7 GB / 577M rows | 79.4 GB / 260M rows |
| source-build CPU (median) | 960k ms | 646k ms |

≈ **−53% bytes, −33% CPU** on the FA source build. The hourly MERGE for this model is ~22 CPU-hrs/day and its scans are ~66% of MERGE CPU (the write is ~7%), so the expected recurring saving is ~20–25% (~5 CPU-hrs/day).

## Correctness

Output proven **identical** via `EXCEPT` both ways over two windows with different data characteristics:
- incremental window (2026-06-04): 13,048,375 rows, 0 diff either direction
- historical full-refresh window (2023-08-01..08): 112,738 rows, 0 diff either direction

`MAX()` collapse is safe because the three resources are 1:1 per `(tx_version, move_address)` (no fan-out, confirmed by the equivalence test). The full-refresh `block_date >= DATE('2023-07-27')` floor is preserved on the FA branch; the coin branch keeps its existing (floor-free) predicate.

## Note for reviewers

The single-pass replaces streaming joins with a hash aggregation. Per-task peak memory measured ~4.4 GiB (vs the current MERGE's ~34 GiB/task peak driven by the concurrent FA scans), so this should be neutral-to-better on memory — but the actual MERGE peak can only be confirmed on a real prod run, so worth a glance at the first few runs after merge.

Towards CUR2-2691
