### PR TITLE
optimize(stablecoins_solana): read latest snapshot for prior_balances instead of full-history self-scan

### DIFF
--- a/dbt_subprojects/solana/macros/stablecoins/stablecoins_svm_balances.sql
+++ b/dbt_subprojects/solana/macros/stablecoins/stablecoins_svm_balances.sql
@@ -85,17 +85,23 @@ daily_aggregated as (
 ),
 
 {% if is_incremental() %}
--- get last known balance for each address/token from before the incremental window
+-- get last known balance for each address/token from before the incremental window.
+-- core/extended_balances is a daily forward-filled snapshot (one row per active
+-- address/token/day), so every still-active (non-zero) balance is present on the
+-- most recent pre-window day. Reading that single partition is equivalent to
+-- max_by(...) over all history but avoids a full self-scan of {{ this }}.
 prior_balances as (
   select
     address,
     token_mint_address,
-    max(day) as last_day,
-    max_by(last_updated, day) as last_updated,
-    max_by(balance_raw, day) as prior_balance
+    day as last_day,
+    last_updated,
+    balance_raw as prior_balance
   from {{ this }}
-  where not {{ incremental_predicate('day') }}
-  group by 1, 2
+  where day = (
+    select max(day) from {{ this }}
+    where not {{ incremental_predicate('day') }}
+  )
 ),
 {% endif %}
 


### PR DESCRIPTION
Mirrors #9727 for the Solana SVM stablecoin balances. The `stablecoins_svm_balances` macro recovered each address/token's last-known balance in the `prior_balances` CTE with `max_by(...)` over all history from `{{ this }}` filtered to `not incremental_predicate('day')`. The CTE is referenced twice (the new-transfer seed join and the forward-fill union), so Trino inlines it into two full-history self-scans of `core_balances` — a ~6.5B-row / ~268 GB scan feeding a `HashAggregation` that dominates the daily MERGE (stage 3 = 60% CPU, 9.7x skew, ~100 GB/task, 210 GB peak).

`core_balances`/`extended_balances` are daily forward-filled snapshots (one row per active address/token/day), so the most recent pre-window day already holds every still-active balance. Reading that single partition is equivalent to the `max_by` over all history but avoids the self-scan.

Measured on the isolated `prior_balances` component (spellbook-hourly, `checksum()` over all output columns, warm medians): scan **268.27 GB -> 0.42 GB** (~639x), CPU **9,297s -> ~18s** (~516x), peak mem **43.3 GB -> 0.07 GB**. The component is referenced twice in the body, so the daily MERGE sheds its dominant self-scan and aggregation.

Equivalence proven exhaustively over all pre-window history: of 83,238,176 prior keys, 73,239,667 are dropped by the single-partition read and **0** of them carry a non-zero balance (every dropped key is zero, absorbed by the existing `coalesce(prior_balance, 0)` default). A forward-fill soundness check over the last 10 daily transitions also found 0 violations across 95.4M non-zero rows. Covers both `stablecoins_solana_core_balances` and `stablecoins_solana_extended_balances`.

Fixes CUR2-2686
