### PR TITLE
optimize(polymarket_polygon_positions_balances_repro): read latest snapshot for prior_balances instead of full-history self-scan

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions_balances_repro.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_positions_balances_repro.sql
@@ -96,14 +96,22 @@ daily_deltas as (
 -- `last_updated` is the underlying change day; using `max(day)` would rewrite
 -- `last_updated` for every inactive pair on every incremental run.
 prior_balances as (
+  -- {{ this }} is a daily forward-filled snapshot, so the latest pre-window `day`
+  -- partition already carries the current balance per (address, token_id) with
+  -- `last_updated` = its last real-change day. Reading just that partition is
+  -- equivalent to max_by(balance_raw, last_updated) over all history: pairs absent
+  -- from it are closed positions (balance_raw = 0) whose forward-fill stops before
+  -- the window, so they emit no output rows. Collapses a full-history self-scan
+  -- (~835 GB, referenced twice) to a single-partition read (~7 GB).
   select
     address,
     token_id,
-    max(last_updated) as day,
-    max_by(balance_raw, last_updated) as balance_raw
+    last_updated as day,
+    balance_raw
   from {{ this }}
-  where not {{ incremental_predicate('day') }}
-  group by 1, 2
+  where day = (
+    select max(day) from {{ this }} where not {{ incremental_predicate('day') }}
+  )
 ),
 
 window_deltas as (


### PR DESCRIPTION
`polymarket_polygon_positions_balances_repro` rebuilt its `prior_balances` seed by scanning the **entire history** of `{{ this }}` and taking `max_by(balance_raw, last_updated)` per `(address, token_id)`. Because the CTE is referenced twice it inlines to **two full-history self-scans** — on the 2026-06-09 prod run that was ~20.1B rows / **835 GB**, ~99% of the model's IO, feeding a hash aggregation that dominated CPU and pushed peak memory to ~57 GiB.

The table is a daily forward-filled snapshot: every open position is re-emitted on every day, with `last_updated` carrying the last real-change day. So the latest pre-window `day` partition already holds the current balance for every active pair — reading just that partition is equivalent to the full-history `max_by`. Pairs absent from it are closed positions whose forward-fill stopped at their closure day (balance_raw = 0); they contribute no output rows (their anchor day is before the window, so the fill range is empty). This is the same pattern (P7) already shipped for the EVM and Solana stablecoin balances.

Equivalence proven on prod (read-only, full pre-window history, window start 2026-06-06, latest partition 2026-06-05):

| check | result |
|---|---|
| OLD pairs (`max_by` over all history) | 280,992,718 |
| NEW pairs (latest partition) | 72,588,559 |
| OLD-keeps / NEW-drops | 208,404,159 |
| dropped pairs with balance_raw ≠ 0 | **0** |
| kept pairs where OLD/NEW disagree on (day, balance) | **0** |

So NEW ⊆ OLD with identical values for every kept pair, and every dropped pair is a zero-balance closed position that emits nothing downstream.

A/B on the `prior_balances` read (single reference; the model has two):

| | scan | cpu | wall | peak mem | query_id |
|---|---|---|---|---|---|
| OLD full-history `max_by` | 417.4 GB | 14,545 cpu-s | 55.7 s | 90.1 GB | `20260609_155650_58630_se88x` |
| NEW latest partition | 3.67 GB | 71 cpu-s | 3.7 s | 0.2 GB | `20260609_155638_58629_se88x` |

~114x less IO, ~204x less CPU, ~450x less peak memory per reference; ~2x that at model scope. Output is unchanged.

Towards CUR2-2699
