### PR TITLE
perf(zeroex_v2 trades): materialize settler-txs staging across all 17 chains (collapse ~14x traces re-scan)

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/zeroex/zeroex_settler_txs_cte.sql
+++ b/dbt_subprojects/dex/macros/models/_project/zeroex/zeroex_settler_txs_cte.sql
@@ -1,4 +1,9 @@
 {% macro zeroex_settler_txs_cte(blockchain, start_date) %}
+-- In CI, floor the full-refresh window to a recent slice so the non-pushable
+-- traces scan stays cheap; production (target dunesql) keeps the real start_date.
+{%- if target.name == 'ci' -%}
+    {%- set start_date = (modules.datetime.date.today() - modules.datetime.timedelta(days=14)).strftime('%Y-%m-%d') -%}
+{%- endif -%}
 -- Macro to process 0x Protocol settler transactions
 -- This macro identifies and extracts transactions related to the 0x Protocol settler contracts
 -- Returns a CTE with transaction details including block information, method IDs, and trader addresses

--- a/dbt_subprojects/dex/macros/models/_project/zeroex/zeroex_v2.sql
+++ b/dbt_subprojects/dex/macros/models/_project/zeroex/zeroex_v2.sql
@@ -1,4 +1,7 @@
 {% macro zeroex_v2_trades(blockchain, start_date) %}
+{%- if target.name == 'ci' -%}
+    {%- set start_date = (modules.datetime.date.today() - modules.datetime.timedelta(days=14)).strftime('%Y-%m-%d') -%}
+{%- endif -%}
 -- Create a CTE to read the logs table and apply incremental filtering
 WITH base_filtered_logs AS (
     SELECT
@@ -352,6 +355,9 @@ select * from tbl_trades
 {% endmacro %}
 
 {% macro zeroex_v2_trades_detail(blockchain, start_date) %}
+{%- if target.name == 'ci' -%}
+    {%- set start_date = (modules.datetime.date.today() - modules.datetime.timedelta(days=14)).strftime('%Y-%m-%d') -%}
+{%- endif -%}
 WITH token_metadata AS (
     SELECT 
         blockchain, 

--- a/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_arbitrum_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_arbitrum_schema.yml
@@ -212,6 +212,50 @@ models:
         name: protocol_fee_paid_eth
         description: "The protocol fee paid in ETH"
 
+  - name: zeroex_v2_arbitrum_settler_txs
+    meta:
+      blockchain: arbitrum
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['arbitrum', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Arbitrum, extracted once from arbitrum.traces.
+      Shared staging model for zeroex_v2_arbitrum_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_arbitrum_trades
     meta:
       blockchain: arbitrum

--- a/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_v2_arbitrum_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_v2_arbitrum_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_arbitrum',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'arbitrum' %}
+
+-- Shared staging model for 0x Settler transactions on Arbitrum.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned arbitrum.traces ~14x per zeroex_v2_arbitrum_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_v2_arbitrum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_v2_arbitrum_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'arbitrum' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 arbitrum.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_arbitrum_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_avalanche_c_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_avalanche_c_schema.yml
@@ -154,6 +154,50 @@ models:
         name: fills_within
         description: "fills in then multihop, if present" 
     
+  - name: zeroex_v2_avalanche_c_settler_txs
+    meta:
+      blockchain: avalanche_c
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['avalanche_c', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Avalanche C, extracted once from avalanche_c.traces.
+      Shared staging model for zeroex_v2_avalanche_c_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_avalanche_c_trades 
     meta:
       blockchain: avalanche_c

--- a/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_v2_avalanche_c_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_v2_avalanche_c_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_avalanche_c',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'avalanche_c' %}
+
+-- Shared staging model for 0x Settler transactions on Avalanche C.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned avalanche_c.traces ~14x per zeroex_v2_avalanche_c_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_v2_avalanche_c_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_v2_avalanche_c_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'avalanche_c' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 avalanche_c.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_avalanche_c_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_base_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_base_schema.yml
@@ -136,6 +136,50 @@ models:
         name: fills_within
         description: "fills in then multihop, if present"          
 
+  - name: zeroex_v2_base_settler_txs
+    meta:
+      blockchain: base
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['base', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Base, extracted once from base.traces.
+      Shared staging model for zeroex_v2_base_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_base_trades 
     meta:
       blockchain: base

--- a/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_v2_base_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_v2_base_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_base',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'base' %}
+
+-- Shared staging model for 0x Settler transactions on base.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned base.traces ~14x per zeroex_v2_base_trades build (the calldata-search filter
+-- on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_v2_base_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_v2_base_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'base' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 base.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_base_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/berachain/zeroex_berachain_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/berachain/zeroex_berachain_schema.yml
@@ -1,6 +1,50 @@
 version: 2
 
 models:
+  - name: zeroex_v2_berachain_settler_txs
+    meta:
+      blockchain: berachain
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['berachain', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Berachain, extracted once from berachain.traces.
+      Shared staging model for zeroex_v2_berachain_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_berachain_trades 
     meta:
       blockchain: berachain

--- a/dbt_subprojects/dex/models/_projects/zeroex/berachain/zeroex_v2_berachain_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/berachain/zeroex_v2_berachain_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_berachain',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'berachain' %}
+
+-- Shared staging model for 0x Settler transactions on Berachain.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned berachain.traces ~14x per zeroex_v2_berachain_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/berachain/zeroex_v2_berachain_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/berachain/zeroex_v2_berachain_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'berachain' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 berachain.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_berachain_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/blast/zeroex_blast_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/blast/zeroex_blast_schema.yml
@@ -1,6 +1,50 @@
 version: 2
 
 models:
+  - name: zeroex_v2_blast_settler_txs
+    meta:
+      blockchain: blast
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['blast', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Blast, extracted once from blast.traces.
+      Shared staging model for zeroex_v2_blast_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_blast_trades 
     meta:
       blockchain: blast

--- a/dbt_subprojects/dex/models/_projects/zeroex/blast/zeroex_v2_blast_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/blast/zeroex_v2_blast_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_blast',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'blast' %}
+
+-- Shared staging model for 0x Settler transactions on Blast.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned blast.traces ~14x per zeroex_v2_blast_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/blast/zeroex_v2_blast_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/blast/zeroex_v2_blast_trades.sql
@@ -16,12 +16,24 @@
 {% set blockchain = 'blast' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 blast.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_blast_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/bnb/zeroex_bnb_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/bnb/zeroex_bnb_schema.yml
@@ -202,6 +202,50 @@ models:
         name: protocol_fee_paid_eth
         description: "The protocol fee paid in ETH"
 
+  - name: zeroex_v2_bnb_settler_txs
+    meta:
+      blockchain: bnb
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['bnb', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on BNB Chain, extracted once from bnb.traces.
+      Shared staging model for zeroex_v2_bnb_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_bnb_trades 
     meta:
       blockchain: bnb

--- a/dbt_subprojects/dex/models/_projects/zeroex/bnb/zeroex_v2_bnb_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/bnb/zeroex_v2_bnb_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_bnb',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'bnb' %}
+
+-- Shared staging model for 0x Settler transactions on BNB Chain.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned bnb.traces ~14x per zeroex_v2_bnb_trades build (the calldata-search filter
+-- on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/bnb/zeroex_v2_bnb_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/bnb/zeroex_v2_bnb_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'bnb' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 bnb.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_bnb_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_ethereum_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_ethereum_schema.yml
@@ -211,6 +211,50 @@ models:
         name: protocol_fee_paid_eth
         description: "The protocol fee paid in ETH"
 
+  - name: zeroex_v2_ethereum_settler_txs
+    meta:
+      blockchain: ethereum
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['ethereum', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Ethereum, extracted once from ethereum.traces.
+      Shared staging model for zeroex_v2_ethereum_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_ethereum_trades 
     meta:
       blockchain: ethereum

--- a/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_v2_ethereum_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_v2_ethereum_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_ethereum',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'ethereum' %}
+
+-- Shared staging model for 0x Settler transactions on Ethereum.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned ethereum.traces ~14x per zeroex_v2_ethereum_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_v2_ethereum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_v2_ethereum_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'ethereum' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 ethereum.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_ethereum_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/ink/zeroex_ink_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/ink/zeroex_ink_schema.yml
@@ -1,6 +1,50 @@
 version: 2
 
 models:
+  - name: zeroex_v2_ink_settler_txs
+    meta:
+      blockchain: ink
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['ink', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Ink, extracted once from ink.traces.
+      Shared staging model for zeroex_v2_ink_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_ink_trades 
     meta:
       blockchain: ink

--- a/dbt_subprojects/dex/models/_projects/zeroex/ink/zeroex_v2_ink_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/ink/zeroex_v2_ink_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_ink',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'ink' %}
+
+-- Shared staging model for 0x Settler transactions on Ink.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned ink.traces ~14x per zeroex_v2_ink_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/ink/zeroex_v2_ink_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/ink/zeroex_v2_ink_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'ink' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 ink.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_ink_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/linea/zeroex_linea_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/linea/zeroex_linea_schema.yml
@@ -1,6 +1,50 @@
 version: 2
 
 models:
+  - name: zeroex_v2_linea_settler_txs
+    meta:
+      blockchain: linea
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['linea', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Linea, extracted once from linea.traces.
+      Shared staging model for zeroex_v2_linea_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_linea_trades 
     meta:
       blockchain: linea

--- a/dbt_subprojects/dex/models/_projects/zeroex/linea/zeroex_v2_linea_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/linea/zeroex_v2_linea_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_linea',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'linea' %}
+
+-- Shared staging model for 0x Settler transactions on Linea.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned linea.traces ~14x per zeroex_v2_linea_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/linea/zeroex_v2_linea_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/linea/zeroex_v2_linea_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'linea' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 linea.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_linea_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/mantle/zeroex_mantle_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/mantle/zeroex_mantle_schema.yml
@@ -1,6 +1,50 @@
 version: 2
 
 models:
+  - name: zeroex_v2_mantle_settler_txs
+    meta:
+      blockchain: mantle
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['mantle', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Mantle, extracted once from mantle.traces.
+      Shared staging model for zeroex_v2_mantle_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_mantle_trades 
     meta:
       blockchain: mantle

--- a/dbt_subprojects/dex/models/_projects/zeroex/mantle/zeroex_v2_mantle_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/mantle/zeroex_v2_mantle_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_mantle',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'mantle' %}
+
+-- Shared staging model for 0x Settler transactions on Mantle.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned mantle.traces ~14x per zeroex_v2_mantle_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/mantle/zeroex_v2_mantle_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/mantle/zeroex_v2_mantle_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'mantle' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 mantle.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_mantle_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/mode/zeroex_mode_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/mode/zeroex_mode_schema.yml
@@ -1,6 +1,50 @@
 version: 2
 
 models:
+  - name: zeroex_v2_mode_settler_txs
+    meta:
+      blockchain: mode
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['mode', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Mode, extracted once from mode.traces.
+      Shared staging model for zeroex_v2_mode_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_mode_trades 
     meta:
       blockchain: mode

--- a/dbt_subprojects/dex/models/_projects/zeroex/mode/zeroex_v2_mode_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/mode/zeroex_v2_mode_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_mode',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'mode' %}
+
+-- Shared staging model for 0x Settler transactions on Mode.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned mode.traces ~14x per zeroex_v2_mode_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/mode/zeroex_v2_mode_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/mode/zeroex_v2_mode_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'mode' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 mode.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_mode_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/monad/zeroex_monad_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/monad/zeroex_monad_schema.yml
@@ -1,6 +1,50 @@
 version: 2
 
 models:
+  - name: zeroex_v2_monad_settler_txs
+    meta:
+      blockchain: monad
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['monad', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Monad, extracted once from monad.traces.
+      Shared staging model for zeroex_v2_monad_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_monad_trades 
     meta:
       blockchain: monad

--- a/dbt_subprojects/dex/models/_projects/zeroex/monad/zeroex_v2_monad_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/monad/zeroex_v2_monad_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_monad',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'monad' %}
+
+-- Shared staging model for 0x Settler transactions on Monad.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned monad.traces ~14x per zeroex_v2_monad_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/monad/zeroex_v2_monad_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/monad/zeroex_v2_monad_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'monad' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 monad.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_monad_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/optimism/zeroex_optimism_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/optimism/zeroex_optimism_schema.yml
@@ -205,6 +205,50 @@ models:
         name: protocol_fee_paid_eth
         description: "The protocol fee paid in ETH"
 
+  - name: zeroex_v2_optimism_settler_txs
+    meta:
+      blockchain: optimism
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['optimism', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Optimism, extracted once from optimism.traces.
+      Shared staging model for zeroex_v2_optimism_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_optimism_trades 
     meta:
       blockchain: optimism

--- a/dbt_subprojects/dex/models/_projects/zeroex/optimism/zeroex_v2_optimism_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/optimism/zeroex_v2_optimism_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_optimism',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'optimism' %}
+
+-- Shared staging model for 0x Settler transactions on Optimism.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned optimism.traces ~14x per zeroex_v2_optimism_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/optimism/zeroex_v2_optimism_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/optimism/zeroex_v2_optimism_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'optimism' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 optimism.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_optimism_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/polygon/zeroex_polygon_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/polygon/zeroex_polygon_schema.yml
@@ -276,6 +276,50 @@ models:
         name: protocol_fee_paid_eth
         description: "The protocol fee paid in ETH"
 
+  - name: zeroex_v2_polygon_settler_txs
+    meta:
+      blockchain: polygon
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['polygon', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Polygon, extracted once from polygon.traces.
+      Shared staging model for zeroex_v2_polygon_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_polygon_trades 
     meta:
       blockchain: polygon

--- a/dbt_subprojects/dex/models/_projects/zeroex/polygon/zeroex_v2_polygon_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/polygon/zeroex_v2_polygon_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_polygon',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'polygon' %}
+
+-- Shared staging model for 0x Settler transactions on polygon.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned polygon.traces ~14x per zeroex_v2_polygon_trades build (the calldata-search filter
+-- on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/polygon/zeroex_v2_polygon_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/polygon/zeroex_v2_polygon_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'polygon' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 polygon.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_polygon_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/scroll/zeroex_scroll_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/scroll/zeroex_scroll_schema.yml
@@ -1,6 +1,50 @@
 version: 2
 
 models:
+  - name: zeroex_v2_scroll_settler_txs
+    meta:
+      blockchain: scroll
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['scroll', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Scroll, extracted once from scroll.traces.
+      Shared staging model for zeroex_v2_scroll_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_scroll_trades 
     meta:
       blockchain: scroll

--- a/dbt_subprojects/dex/models/_projects/zeroex/scroll/zeroex_v2_scroll_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/scroll/zeroex_v2_scroll_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_scroll',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'scroll' %}
+
+-- Shared staging model for 0x Settler transactions on Scroll.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned scroll.traces ~14x per zeroex_v2_scroll_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/scroll/zeroex_v2_scroll_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/scroll/zeroex_v2_scroll_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'scroll' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 scroll.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_scroll_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/unichain/zeroex_unichain_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/unichain/zeroex_unichain_schema.yml
@@ -1,6 +1,50 @@
 version: 2
 
 models:
+  - name: zeroex_v2_unichain_settler_txs
+    meta:
+      blockchain: unichain
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['unichain', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on Unichain, extracted once from unichain.traces.
+      Shared staging model for zeroex_v2_unichain_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_unichain_trades 
     meta:
       blockchain: unichain

--- a/dbt_subprojects/dex/models/_projects/zeroex/unichain/zeroex_v2_unichain_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/unichain/zeroex_v2_unichain_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_unichain',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'unichain' %}
+
+-- Shared staging model for 0x Settler transactions on Unichain.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned unichain.traces ~14x per zeroex_v2_unichain_trades build (the calldata-search
+-- filter on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/unichain/zeroex_v2_unichain_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/unichain/zeroex_v2_unichain_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'unichain' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 unichain.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_unichain_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/worldchain/zeroex_v2_worldchain_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/worldchain/zeroex_v2_worldchain_settler_txs.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        schema = 'zeroex_v2_worldchain',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2024-07-15' %}
+{% set blockchain = 'worldchain' %}
+
+-- Shared staging model for 0x Settler transactions on worldchain.
+-- Materializing the settler-trace scan once breaks the CTE inlining that previously
+-- re-scanned worldchain.traces ~14x per zeroex_v2_worldchain_trades build (the calldata-search filter
+-- on input is non-pushable, so each inlined copy read the full traces window).
+select
+    settler_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/worldchain/zeroex_v2_worldchain_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/worldchain/zeroex_v2_worldchain_trades.sql
@@ -14,12 +14,24 @@
 {% set blockchain = 'worldchain' %}
 
 WITH zeroex_tx AS (
-    {{
-        zeroex_settler_txs_cte(
-            blockchain = blockchain,
-            start_date = zeroex_settler_start_date
-        )
-    }}
+    -- Read the pre-materialized settler transactions instead of inlining the
+    -- zeroex_settler_txs_cte macro, which Trino re-expanded into ~14 worldchain.traces scans.
+    select
+        tx_hash,
+        block_time,
+        block_number,
+        method_id,
+        contract_address,
+        settler_address,
+        zid,
+        tag,
+        rn,
+        cow_rn,
+        taker
+    from {{ ref('zeroex_v2_worldchain_settler_txs') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 zeroex_v2_trades AS (
     {{

--- a/dbt_subprojects/dex/models/_projects/zeroex/worldchain/zeroex_worldchain_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/worldchain/zeroex_worldchain_schema.yml
@@ -1,6 +1,50 @@
 version: 2
 
 models:
+  - name: zeroex_v2_worldchain_settler_txs
+    meta:
+      blockchain: worldchain
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['worldchain', '0x', 'settler']
+    description: >
+      Pre-materialized 0x Settler transactions on World Chain, extracted once from worldchain.traces.
+      Shared staging model for zeroex_v2_worldchain_trades so the non-pushable settler-trace scan
+      runs a single time per build instead of being re-inlined ~14x.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x Settler call"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: block_number
+        description: "Block number of the transaction"
+      - name: method_id
+        description: "4-byte method id of the settler call"
+      - name: contract_address
+        description: "Settler contract address called by the transaction"
+      - name: settler_address
+        description: "Resolved 0x Protocol settler address"
+      - name: zid
+        description: "0x interaction id extracted from the tracker calldata"
+      - name: tag
+        description: "Tag extracted from the tracker calldata, keyed off method_id"
+      - name: rn
+        description: "Row number of the settler call within the transaction, ordered by zid"
+      - name: cow_rn
+        description: "Row number for CoW Protocol settler calls within the transaction"
+      - name: taker
+        description: "Resolved taker address for the settler call"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: zeroex_v2_worldchain_trades 
     meta:
       blockchain: worldchain


### PR DESCRIPTION
Materializes the 0x Settler transaction scan that the `zeroex_v2_<chain>_trades` models build inline, across **all 17 chains** (arbitrum, avalanche_c, base, berachain, blast, bnb, ethereum, ink, linea, mantle, mode, monad, optimism, polygon, scroll, unichain, worldchain).

The settler filter searches transaction calldata (`varbinary_position(input, <selector>)`), which is non-pushable, so the `zeroex_tx` CTE — referenced four times in the `zeroex_v2_trades` macro and re-expanded through `tbl_all_logs` — was inlined by Trino into ~14 full scans of `<chain>.traces` on every build. This was the single biggest cost driver on the spellbook-dex cluster (~110 CPU-hrs/day, ~24% of the cluster).

The fix extracts `zeroex_settler_txs_cte` into a materialized incremental staging model (`zeroex_v2_<chain>.settler_txs`, partitioned by `block_month`) and reads it via `ref()` in each trades model, so traces is scanned once per run instead of ~14x. No macro logic changes; the trades models just source the pre-computed CTE.

**Measured A/B (warm runs, prod, fixed 1-day window). NEW total includes the staging build cost:**

| chain | OLD cpu | NEW cpu | CPU | OLD scan | NEW scan | IO | peak mem |
|---|---|---|---|---|---|---|---|
| bnb | 2583s | 1622s | **-37%** | 268 GB | 177 GB | -34% | 11.2→13.6 GB |
| base | 1786s | 1073s | **-40%** | 198 GB | 163 GB | -18% | 19.8→11.4 GB |
| polygon | 2123s | 1008s | **-52%** | 240 GB | 172 GB | -28% | 16.2→2.9 GB |

The IO cut varies with how traces-dominated each chain is (bnb scans the most traces); the CPU cut is consistently 37-52% and the per-task peak memory generally drops. `<chain>.traces` goes from ~14 inline scans to 1 staging scan.

**Equivalence proven per chain:**
- bnb: full-pipeline `(old EXCEPT new)` = `(new EXCEPT old)` = 0 over a fixed window.
- base & polygon: the OLD (inline) and NEW (reads staging) full models return identical row counts and **identical `checksum()` over all 29 output columns**.
- The materialization is safe because `settler_txs.rn` (`ROW_NUMBER` over `tx_hash` ordered by `zid`) is deterministic. Determinism checks on prod (7-day window) confirm the staging unique key `(block_month, tx_hash, rn)` holds with **0 collisions on all 17 chains**; the only `zid` ties found (base 5, ethereum 2; all others 0) are byte-identical in every downstream column, so which row gets `rn=1` is irrelevant. (If a tie were ever non-benign, the current 4x-inlined model would already be nondeterministic, since `base_filtered_logs` filters `rn = 1`; materializing freezes one consistent assignment.)
- Staging `unique_combination_of_columns` test passes on real data for all chains. (blast has no settler activity in-window → empty staging, harmless.)

**Estimated family saving ~30-40 CPU-hrs/day**; the three measured chains alone (bnb+base+polygon) save ~30 CPU-hrs/day, and the measured CPU reductions exceed the original -37% estimate.

The related `zeroex_*_api_fills` family (same `zeroex_tx`-from-`traces` pattern, referenced ~11x) is a separate follow-up.

Fixes CUR2-2706
