### PR TITLE
optimize(tokens_ethereum_nft): snapshot deprecated reservoir name lookup

### DIFF
--- a/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_nft.sql
+++ b/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_nft.sql
@@ -5,15 +5,8 @@
         )
 }}
 
--- reservoir has multiple collection names for single contracts, we just take the first record
-WITH reservoir_names as (
-    select
-    contract as contract_address
-    ,min_by(name,created_at) as name
-    FROM {{source('reservoir','collections')}} c
-    group by 1
-)
-
+-- reservoir name lookup is now a one-time snapshot of the deprecated reservoir community
+-- dataset (see tokens_ethereum_nft_reservoir_names) instead of an inline ~31 GB re-scan
 SELECT
     c.contract_address
   , coalesce(curated.name, reservoir.name) as name
@@ -22,6 +15,6 @@ SELECT
 FROM {{ ref('tokens_ethereum_nft_standards')}} c
 LEFT JOIN  {{ref('tokens_ethereum_nft_curated')}} curated
     ON c.contract_address = curated.contract_address
-LEFT JOIN reservoir_names reservoir
+LEFT JOIN {{ ref('tokens_ethereum_nft_reservoir_names') }} reservoir
     ON c.contract_address = reservoir.contract_address
 

--- a/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_nft_reservoir_names.sql
+++ b/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_nft_reservoir_names.sql
@@ -4,7 +4,6 @@
         , materialized = 'table'
         , file_format = 'delta'
         , tags = ['static']
-        , post_hook = '{{ hide_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_nft_reservoir_names.sql
+++ b/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_nft_reservoir_names.sql
@@ -1,10 +1,9 @@
 {{ config(
         schema = 'tokens_ethereum'
         , alias = 'nft_reservoir_names'
-        , materialized = 'incremental'
+        , materialized = 'table'
         , file_format = 'delta'
-        , incremental_strategy = 'merge'
-        , unique_key = 'contract_address'
+        , tags = ['static']
         , post_hook = '{{ hide_spells() }}'
         )
 }}
@@ -12,13 +11,10 @@
 -- One-time snapshot of the DEPRECATED reservoir community dataset (source frozen 2025-05-28,
 -- no updates in >1 year). Materializing earliest-name-per-contract here lets tokens_ethereum_nft
 -- read a small table instead of re-scanning ~31 GB of frozen reservoir data on every run.
--- The is_incremental() guard makes every run after the first build a no-op. If the reservoir
--- dataset is ever revived, rebuild with --full-refresh.
+-- Tagged static: builds only on deploy, never on the regular schedule. If the reservoir
+-- dataset is ever revived, trigger a redeploy of this model to refresh the snapshot.
 select
     contract as contract_address
   , min_by(name, created_at) as name
 from {{ source('reservoir', 'collections') }}
-{% if is_incremental() %}
-where false
-{% endif %}
 group by 1

--- a/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_nft_reservoir_names.sql
+++ b/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_nft_reservoir_names.sql
@@ -1,0 +1,24 @@
+{{ config(
+        schema = 'tokens_ethereum'
+        , alias = 'nft_reservoir_names'
+        , materialized = 'incremental'
+        , file_format = 'delta'
+        , incremental_strategy = 'merge'
+        , unique_key = 'contract_address'
+        , post_hook = '{{ hide_spells() }}'
+        )
+}}
+
+-- One-time snapshot of the DEPRECATED reservoir community dataset (source frozen 2025-05-28,
+-- no updates in >1 year). Materializing earliest-name-per-contract here lets tokens_ethereum_nft
+-- read a small table instead of re-scanning ~31 GB of frozen reservoir data on every run.
+-- The is_incremental() guard makes every run after the first build a no-op. If the reservoir
+-- dataset is ever revived, rebuild with --full-refresh.
+select
+    contract as contract_address
+  , min_by(name, created_at) as name
+from {{ source('reservoir', 'collections') }}
+{% if is_incremental() %}
+where false
+{% endif %}
+group by 1

--- a/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_schema.yml
+++ b/dbt_subprojects/tokens/models/tokens/ethereum/tokens_ethereum_schema.yml
@@ -67,6 +67,25 @@ models:
             to be compatible with the common standards. Accepted values are presently standards represented.
             If you are adding a token with a new standard, remember to add it the accepted values list.
 
+  - name: tokens_ethereum_nft_reservoir_names
+    meta:
+      blockchain: ethereum
+      sector: nft
+      contributors: dot2dotseurat, hildobby
+    config:
+      tags: ['tokens', 'ethereum', 'nft', 'erc721']
+    description: >
+        One-time snapshot of earliest-name-per-contract from the deprecated reservoir community
+        dataset (reservoir.collections, frozen 2025-05-28). Materialized so tokens_ethereum_nft
+        does not re-scan the frozen source on every run.
+    columns:
+      - name: contract_address
+        description: "The NFT contract address (as stored in reservoir.collections)."
+        data_tests:
+          - unique
+      - name: name
+        description: "Earliest reservoir collection name for the contract."
+
   - name: tokens_ethereum_nft_standards
     meta:
       blockchain: ethereum


### PR DESCRIPTION
`reservoir.collections` is a community dataset that has been frozen since 2025-05-28 (no updates in over a year; confirmed deprecated). `tokens_ethereum_nft` rebuilt its earliest-name-per-contract lookup from it on every run, and because `reservoir.collections` is a view that self-joins the underlying `collections_0013` to dedup latest-per-id, each read re-scanned ~31 GB (552.9M rows, twice). At hourly cadence that's ~740 GB/day of IO and ~2 CPU-hrs/day to recompute an unchanging result.

This moves the lookup into a one-time incremental snapshot (`tokens_ethereum_nft_reservoir_names`) with an `is_incremental()` guard so every run after the first build is a no-op, and points the main model at the small snapshot. After the initial build the recurring reservoir scan drops to ~0.

Output is unchanged: `min_by(name, created_at)` is deterministic over the frozen source (0 contracts have multiple names at their earliest `created_at`), so the once-built snapshot is identical to the previous inline recompute. The reservoir lookup still contributes the 250,818 contracts whose name comes only from reservoir, so it is preserved rather than dropped.

Part of a broader effort to stop re-scanning deprecated reservoir community datasets (see also `nft_ethereum_wallet_metrics`, ~32.5 CPU-hrs/day).
