### PR TITLE
feat(uniswap): BaseAggregatorHook registry + hook-aware v4 trades macro (CUR2-2711, 1/2)

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_trades.sql
@@ -129,10 +129,21 @@ FROM
     , taker_column_name = null
     , maker_column_name = null
     , filter_angstrom_addr = null
-    , pool_manager_addr = '0x' 
+    , pool_manager_addr = '0x'
     , start_date = '2024-12-01'
+    , aggregator_hooks = null
     )
 %}
+{#- aggregator_hooks: ref to the BaseAggregatorHook registry; when set, rows get an
+    is_aggregator_hook_swap flag and hook swaps derive direction from the call swapDelta -#}
+{%- if aggregator_hooks %}
+{#- aggregator-hook swaps emit an empty Swap event (amount0=0, amount1=0), so the event-based
+    direction always falls through to the ELSE branch; for those rows the direction must come
+    from the call swapDelta (same swapper-perspective sign convention) -#}
+{%- set buy_is_currency1 = "CASE WHEN ah.address IS NOT NULL THEN (c.amount0 < INT256 '0' OR c.amount1 > INT256 '0') ELSE (e.amount0 < INT256 '0' OR e.amount1 > INT256 '0') END" %}
+{%- else %}
+{%- set buy_is_currency1 = "e.amount0 < INT256 '0' OR e.amount1 > INT256 '0'" %}
+{%- endif %}
 WITH dexs AS
 (
     WITH clean_swaps AS (
@@ -239,16 +250,23 @@ WITH dexs AS
         {%- endif %}
 
 )
+    {% if aggregator_hooks %}
+    , agg_hooks as (
+        select address
+        from {{ aggregator_hooks }}
+        where blockchain = '{{ blockchain }}'
+    )
+    {% endif %}
 
-    SELECT 
+    SELECT
         e.evt_block_number AS block_number
     , e.evt_block_time AS block_time
     , {% if taker_column_name -%} t.{{ taker_column_name }} {% else -%} cast(null as varbinary) {% endif -%} as taker
     , e.id as maker -- In v4, the maker (i.e. what sold the token) is the pool's virtual address. We also pass the pool ID, making it easier to join with Initialize() and retrieve hooked pool metrics.
-    , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN ABS(c.amount1) ELSE ABS(c.amount0) END AS token_bought_amount_raw
-    , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN ABS(c.amount0) ELSE ABS(c.amount1) END AS token_sold_amount_raw
-    , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN c.currency1 ELSE c.currency0 END AS token_bought_address
-    , CASE WHEN e.amount0 < INT256 '0' OR e.amount1 > INT256 '0' THEN c.currency0 ELSE c.currency1 END AS token_sold_address
+    , CASE WHEN {{ buy_is_currency1 }} THEN ABS(c.amount1) ELSE ABS(c.amount0) END AS token_bought_amount_raw
+    , CASE WHEN {{ buy_is_currency1 }} THEN ABS(c.amount0) ELSE ABS(c.amount1) END AS token_sold_amount_raw
+    , CASE WHEN {{ buy_is_currency1 }} THEN c.currency1 ELSE c.currency0 END AS token_bought_address
+    , CASE WHEN {{ buy_is_currency1 }} THEN c.currency0 ELSE c.currency1 END AS token_sold_address
     , e.contract_address AS project_contract_address
     , e.evt_tx_hash AS tx_hash
     , e.evt_index
@@ -260,11 +278,17 @@ WITH dexs AS
     , e.sqrtPriceX96
     , e.tick
     , c.call_trace_address
+    {%- if aggregator_hooks %}
+    , (ah.address is not null) as is_aggregator_hook_swap
+    {%- endif %}
 
-    FROM clean_swaps c 
-    JOIN swap_evt e on c.call_block_number = e.evt_block_number 
+    FROM clean_swaps c
+    JOIN swap_evt e on c.call_block_number = e.evt_block_number
         and c.call_tx_hash = e.evt_tx_hash
-        and c.call_rn = e.evt_rn 
+        and c.call_rn = e.evt_rn
+    {% if aggregator_hooks %}
+    LEFT JOIN agg_hooks ah on ah.address = c.hooks
+    {% endif %}
     {% if filter_angstrom_addr %}
     WHERE NOT c.hooks = {{ filter_angstrom_addr }}
     {% endif %}
@@ -350,6 +374,9 @@ SELECT
     , dexs.sqrtPriceX96
     , dexs.tick
     , dexs.call_trace_address
+    {%- if aggregator_hooks %}
+    , dexs.is_aggregator_hook_swap
+    {%- endif %}
 FROM
-    get_taker dexs 
+    get_taker dexs
 {% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_trades.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_trades.sql
@@ -140,7 +140,7 @@ FROM
 {#- aggregator-hook swaps emit an empty Swap event (amount0=0, amount1=0), so the event-based
     direction always falls through to the ELSE branch; for those rows the direction must come
     from the call swapDelta (same swapper-perspective sign convention) -#}
-{%- set buy_is_currency1 = "CASE WHEN ah.address IS NOT NULL THEN (c.amount0 < INT256 '0' OR c.amount1 > INT256 '0') ELSE (e.amount0 < INT256 '0' OR e.amount1 > INT256 '0') END" %}
+{%- set buy_is_currency1 = "(ah.address IS NOT NULL AND (c.amount0 < INT256 '0' OR c.amount1 > INT256 '0')) OR (ah.address IS NULL AND (e.amount0 < INT256 '0' OR e.amount1 > INT256 '0'))" %}
 {%- else %}
 {%- set buy_is_currency1 = "e.amount0 < INT256 '0' OR e.amount1 > INT256 '0'" %}
 {%- endif %}

--- a/dbt_subprojects/dex/macros/models/_project/uniswap_v4_chains.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_v4_chains.sql
@@ -1,0 +1,7 @@
+{% macro uniswap_v4_chains() %}
+{#- single owner of the Uniswap V4 chain list. Used by the aggregator-hook
+    registry (uniswap_v4_aggregator_hooks) and the cross-chain aggregator
+    union (uniswap_v4_aggregator_base_trades) — when onboarding a new V4
+    chain, adding it here covers both, alongside the per-chain models. -#}
+{{ return(['arbitrum','avalanche_c','base','blast','bnb','celo','ethereum','ink','monad','optimism','polygon','tempo','unichain','worldchain','zora']) }}
+{% endmacro %}

--- a/dbt_subprojects/dex/models/_projects/uniswap/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/_schema.yml
@@ -273,3 +273,32 @@ models:
               - block_month
               - tx_hash
               - evt_index
+
+  - name: uniswap_v4_aggregator_hooks
+    meta:
+      blockchain: ethereum,arbitrum,base,optimism,polygon,zora,blast,bnb,avalanche_c,worldchain,ink,unichain,celo,monad,tempo
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts across all V4 chains, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+

--- a/dbt_subprojects/dex/models/_projects/uniswap/uniswap_v4_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/uniswap_v4_aggregator_hooks.sql
@@ -1,0 +1,45 @@
+{{ config(
+    schema = 'uniswap_v4'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Registry of Uniswap V4 BaseAggregatorHook contracts.
+-- These hooks hold no V4 liquidity: in beforeSwap they route the entire swap to an
+-- external DEX (Curve / Aerodrome / PancakeSwap / etc.) and return the full delta,
+-- so their swaps must be classified as aggregator trades, not venue trades.
+-- A contract is a BaseAggregatorHook iff its deployed bytecode dispatches BOTH
+-- pollTokenJar() (0x3f7d1179) AND pseudoTotalValueLocked(bytes32) (0x2d910fb4);
+-- matching the PUSH4-prefixed selectors keeps the check deterministic and
+-- self-maintaining (no static address list).
+
+{% set chains = ['arbitrum','avalanche_c','base','blast','bnb','celo','ethereum','ink','monad','optimism','polygon','tempo','unichain','worldchain','zora'] %}
+
+{% for chain in chains %}
+select
+    '{{ chain }}' as blockchain
+    , address
+    , min(block_time) as created_at
+from {{ source(chain, 'creation_traces') }}
+where bytearray_position(code, 0x633f7d1179) > 0   -- PUSH4 + pollTokenJar()
+  and bytearray_position(code, 0x632d910fb4) > 0   -- PUSH4 + pseudoTotalValueLocked(bytes32)
+  and address is not null
+  -- BaseAggregatorHook takes the PoolManager in its constructor; the earliest V4
+  -- PoolManager deploy is unichain, late Dec 2024 — no aggregator hook can predate this
+  and block_time >= timestamp '2024-11-01'
+{%- if is_incremental() %}
+  -- deliberately wider than incremental_predicate (3d): a creation_traces ingestion
+  -- lag beyond the lookback would permanently miss a hook; this scan is tiny
+  and block_time >= now() - interval '30' day
+{%- endif %}
+-- metamorphic CREATE2 redeploys can emit two creation rows for one address;
+-- duplicate source keys would fail the Trino MERGE
+group by 1, 2
+{% if not loop.last %}
+union all
+{% endif %}
+{% endfor %}

--- a/dbt_subprojects/dex/models/_projects/uniswap/uniswap_v4_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/uniswap_v4_aggregator_hooks.sql
@@ -17,7 +17,7 @@
 -- matching the PUSH4-prefixed selectors keeps the check deterministic and
 -- self-maintaining (no static address list).
 
-{% set chains = ['arbitrum','avalanche_c','base','blast','bnb','celo','ethereum','ink','monad','optimism','polygon','tempo','unichain','worldchain','zora'] %}
+{% set chains = uniswap_v4_chains() %}
 
 {% for chain in chains %}
 select


### PR DESCRIPTION
## Context — CUR2-2711 (part 1 of 2, inert)

Uniswap V4 **aggregator hooks** (the `BaseAggregatorHook` family) hold no V4 liquidity: in `beforeSwap` they route the entire swap to an **external** DEX (Curve / Aerodrome / PancakeSwap / Uniswap V2-V3 / Tempo) and return the full delta. The `PoolManager` `Swap` event comes out empty (`amount0=0, amount1=0, liquidity=0`), but the V4 trades macro reads amounts from the swap call's `swapDelta`, so `dex.trades` emits a `uniswap`/`4` row anyway — **the same swap is counted twice** (once as uniswap v4, once as the real backing venue): **~54,434 trades / ~$196.8M over 30d** across ethereum, base, tempo.

A blanket "drop empty Swap events" would be wrong — legit V4 venues (own-inventory PMMs like BuffetAMM ~$91.9M/30d, 1:1 wrappers, bonding-curve launchpads) also emit empty events and must stay.

Linear: [CUR2-2711](https://linear.app/dune/issue/CUR2-2711) · [Slack thread](https://duneanalytics.slack.com/archives/C0A9FGJE2S1/p1781035729324109)

## What this PR does (zero behavior change)

1. **`uniswap_v4.aggregator_hooks`** — new incremental cross-chain registry of BaseAggregatorHook contracts, detected **deterministically from deployed bytecode**: a contract qualifies iff its `creation_traces.code` contains BOTH PUSH4-prefixed selectors `0x633f7d1179` (`pollTokenJar()`) and `0x632d910fb4` (`pseudoTotalValueLocked(bytes32)`). Self-maintaining — auto-covers new hook deployments, no address list to keep.
   - Initial scan bounded by `block_time >= 2024-11-01` (the hook takes PoolManager in its constructor; the earliest V4 PoolManager deploy is unichain, late Dec 2024).
   - Incremental source lookback is deliberately 30d (vs the standard 3d predicate): an ingestion lag beyond the lookback would *permanently* miss a hook. The scan is tiny.
   - `group by` dedupes metamorphic CREATE2 redeploys (duplicate source keys would fail the Trino MERGE).
2. **`uniswap_compatible_v4_trades`** — new optional `aggregator_hooks` param. When set: rows carry an `is_aggregator_hook_swap` flag, and hook swaps derive buy/sell direction from the **call** `swapDelta` (their event amounts are zero, so the existing event-based direction is wrong ~half the time for them). All changes are jinja-guarded.

**Inertness proof:** with `aggregator_hooks` unset, the macro render is byte-identical to the previous version — verified by compiling the same model against old and new macro and diffing the compiled SQL (whitespace-normalized: identical). The macro edit makes slim CI rebuild all 15 V4 venue models; their CI tables should diff clean vs prod.

**Detector validation against live data** (selector scan ∩ actual v4 pool hooks): exactly the known hook families — ethereum 536, base 5, tempo 3 (all `…888`-suffix deployments). Negative controls confirmed selector-negative: BuffetAMM `0x880bfa…0088` (base, real PMM venue) and Jurassic `0x038e19…0888` (bnb, routes to an un-indexed venue — must stay).

## Part 2

The follow-up PR (stacked on this one) does the actual reclassification: venue-side exclusion from `dex.trades` + emission into `dex_aggregator.trades`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
