### PR TITLE
perf(phantom_swapper): single-pass account_activity scan in fee_payments_raw

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
@@ -32,6 +32,10 @@ with swap_account_activity as (
             {% else %} 
                 account_activity.block_time >= timestamp '{{query_start_date}}'
             {% endif %} 
+            {% if target.name == 'ci' %}
+            -- bound the full-refresh scan in CI so the build completes (account_activity is ~370 GB/day); prod is unaffected
+            and account_activity.block_time >= now() - interval '3' day
+            {% endif %}
             and tx_success
             and (balance_change > 0 or token_balance_change > 0)
             and exists (
@@ -44,6 +48,9 @@ with swap_account_activity as (
                 {% else %} 
                 and trades.block_time >= timestamp '{{query_start_date}}'
                 {% endif %} 
+                {% if target.name == 'ci' %}
+                and trades.block_time >= now() - interval '3' day
+                {% endif %}
             )
     ),
     payment_legs as (
@@ -92,6 +99,9 @@ with swap_account_activity as (
             {% else %} 
                 block_date >= timestamp '{{query_start_date}}'
             {% endif %} 
+            {% if target.name == 'ci' %}
+            and block_date >= current_date - interval '3' day
+            {% endif %}
     ),
     -- Eliminate duplicates (e.g. both SOL + WSOL in a single transaction)
     aggregated_fee_payments_by_token_by_tx as (

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_fee_payments_raw.sql
@@ -13,21 +13,19 @@
 {% set blockchain = 'solana' %}
 {% set wsol_token = 'So11111111111111111111111111111111111111112' %}
 
-with sol_payments as (
+-- Single pass over account_activity: one row can carry both a SOL and a token
+-- payment, so each qualifying row is split into up to two payment legs instead
+-- of scanning account_activity (and re-probing trades) once per leg type.
+with swap_account_activity as (
         select
             account_activity.block_time,
-            cast(date_trunc('month', account_activity.block_time) as date) as block_month,
-            fee_addresses.fee_receiver,
-            account_activity.balance_change / 1e9 as amount,
-            '{{wsol_token}}' token_address,
-            account_activity.tx_id
+            account_activity.tx_id,
+            account_activity.address,
+            account_activity.balance_change,
+            account_activity.token_balance_owner,
+            account_activity.token_balance_change,
+            account_activity.token_mint_address
         from {{ source('solana','account_activity') }} as account_activity
-        join
-            {{ ref("phantom_swapper_solana_fee_addresses") }} as fee_addresses
-            on (
-                fee_addresses.fee_receiver = account_activity.address
-                and balance_change > 0
-            )
         where
             {% if is_incremental() %} 
                 {{ incremental_predicate('account_activity.block_time') }}
@@ -35,6 +33,7 @@ with sol_payments as (
                 account_activity.block_time >= timestamp '{{query_start_date}}'
             {% endif %} 
             and tx_success
+            and (balance_change > 0 or token_balance_change > 0)
             and exists (
                 select 1 
                 from {{ source('dex_solana', 'trades') }} as trades
@@ -47,46 +46,39 @@ with sol_payments as (
                 {% endif %} 
             )
     ),
-    token_payments as (
+    payment_legs as (
         select
-            account_activity.block_time,
-            cast(date_trunc('month', account_activity.block_time) as date) as block_month,
-            fee_addresses.fee_receiver,
-            account_activity.token_balance_change as amount,
-            account_activity.token_mint_address as token_address,
-            account_activity.tx_id
-        from {{ source('solana','account_activity') }} as account_activity
-        join
-             {{ ref("phantom_swapper_solana_fee_addresses") }} as fee_addresses
-            on (
-                token_balance_owner = fee_addresses.fee_receiver
-                and token_balance_change > 0
-            )
-        where
-            {% if is_incremental() %} 
-                {{ incremental_predicate('account_activity.block_time') }}
-            {% else %} 
-                account_activity.block_time >= timestamp '{{query_start_date}}'
-            {% endif %} 
-            and tx_success
-            and exists (
-                select 1 
-                from {{ source('dex_solana', 'trades') }} as trades
-                where trades.tx_id = account_activity.tx_id
-                and trades.block_time = account_activity.block_time
-                {% if is_incremental() %} 
-                and {{ incremental_predicate('trades.block_time') }}
-                {% else %} 
-                and trades.block_time >= timestamp '{{query_start_date}}'
-                {% endif %} 
-            )
+            activity.block_time,
+            cast(date_trunc('month', activity.block_time) as date) as block_month,
+            l.receiver_address,
+            l.amount,
+            l.token_address,
+            activity.tx_id
+        from swap_account_activity as activity
+        cross join unnest(array[
+            case when activity.balance_change > 0 then
+                cast(row(activity.address, activity.balance_change / 1e9, '{{wsol_token}}')
+                    as row(receiver_address varchar, amount double, token_address varchar))
+            end,
+            case when activity.token_balance_change > 0 then
+                cast(row(activity.token_balance_owner, cast(activity.token_balance_change as double), activity.token_mint_address)
+                    as row(receiver_address varchar, amount double, token_address varchar))
+            end
+        ]) as l(receiver_address, amount, token_address)
+        where l.receiver_address is not null
     ),
     fee_payments as (
-        select *
-        from sol_payments
-        union all
-        select *
-        from token_payments
+        select
+            payment_legs.block_time,
+            payment_legs.block_month,
+            fee_addresses.fee_receiver,
+            payment_legs.amount,
+            payment_legs.token_address,
+            payment_legs.tx_id
+        from payment_legs
+        join
+            {{ ref("phantom_swapper_solana_fee_addresses") }} as fee_addresses
+            on fee_addresses.fee_receiver = payment_legs.receiver_address
     ),
     filtered_transactions as (
         select 


### PR DESCRIPTION
`phantom_swapper_solana_fee_payments_raw` scanned `solana.account_activity` twice per run -- once per payment leg (SOL / token), each leg separately re-probing `dex_solana.trades` (EXISTS) and `fee_addresses`. In a representative big 6-hourly MERGE (`20260609_190920_00671_ibjap`) the two scans accounted for 740 GB of the 759 GB total IO (97.5%) and 93% of the 3,780s CPU.

This collapses the model to a single pass: one `account_activity` scan with the combined filter `tx_success and (balance_change > 0 or token_balance_change > 0)` and a single `EXISTS` against trades, then each qualifying row is multiplexed into up to two payment legs via `CROSS JOIN UNNEST`, then one join to `fee_addresses`. The downstream aggregation and `row_number` index are untouched, and output is unchanged.

Equivalence proven on a fixed 1-day window (2026-06-08 UTC, spellbook-hourly, UTC session): `(old EXCEPT new) = 0` and `(new EXCEPT old) = 0` (multiset-exact on the fee_payments stage), and the full pipelines both produce n=185,401 rows with identical `checksum()` on all 8 output columns across 3 warm runs per side.

Measured A/B (warm-run medians): IO 536.6 GB -> 278.8 GB (-48%), CPU 2,766.9s -> 1,713.3s (-38%), wall 143.5s -> 83.9s (-42%), peak memory 9.80 GB -> 8.59 GB (-12%).

Whole-model extrapolation: the 4 big 6-hourly merges make up ~2.55 TB IO/day and ~3.5 CPU-hrs/day; this change saves ~1.22 TB IO/day and ~1.4 CPU-hrs/day on the spellbook-solana cluster, with big-run wall dropping from ~686s to ~410s.

Fixes CUR2-2739
