### PR TITLE
Fix Omen Gnosis trades merge duplicates

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/omen/gnosis/omen_gnosis_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/omen/gnosis/omen_gnosis_trades.sql
@@ -65,6 +65,10 @@ trades_slot AS (
         ,t1.feeamount
         ,TRANSFORM(SEQUENCE(0, COALESCE(CARDINALITY(t2.partition),CARDINALITY(t3.partition)) - 1 ), x -> IF(x = t1.outcomeindex, t1.outcometokens, 0)) AS outcometokens_amount
         ,t1.action
+        ,ROW_NUMBER() OVER (
+            PARTITION BY t1.block_day, t1.tx_hash, t1.evt_index
+            ORDER BY COALESCE(t2.evt_index, t3.evt_index) DESC
+        ) AS match_rank
     FROM
         trades  t1
     LEFT JOIN 
@@ -97,6 +101,8 @@ final AS (
         ) AS reserves_delta
     FROM    
         trades_slot
+    WHERE
+        match_rank = 1
 )
 
 SELECT  


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description:

Apply a minimal deduplication step in `omen_gnosis_trades` so each trade event keeps only one matching ConditionalTokens split/merge event before the incremental merge source is produced. This prevents multiple source rows from matching the same merge target key during prod retries.

Validation:
- `uv run dbt deps` from `dbt_subprojects/daily_spellbook`
- `uv run dbt compile -s omen_gnosis_trades` from `dbt_subprojects/daily_spellbook`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duneanalytics.slack.com/archives/C04E0CV1SG3/p1781081783328339?thread_ts=1781081783.328339&cid=C04E0CV1SG3)

<div><a href="https://cursor.com/agents/bc-d745af53-14c1-517a-8d16-5ac8e50e1ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d745af53-14c1-517a-8d16-5ac8e50e1ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

