### PR TITLE
fix(oneinch): exclude ERC20True cross-chain placeholder fills from LOP/AR trade views (CUR2-2665)

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/oneinch/_meta/oneinch_meta_cfg_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/_meta/oneinch_meta_cfg_macro.sql
@@ -18,6 +18,14 @@
     ]) }}
 {% endmacro %}
 
+-- ERC20True placeholder used as the counter-leg of Fusion+ cross-chain orders: https://github.com/1inch/cross-chain-swap/blob/master/contracts/mocks/ERC20True.sol
+{% macro oneinch_cross_chain_placeholder_tokens_cfg_macro() %}
+    {{ return([
+        '0xda0000d4000015a526378bb6fafc650cea5966f8',
+        '0xd66097c27eb8dee404bac235737932260edc6f3b',
+    ]) }}
+{% endmacro %}
+
 -- SUBSTREAMS CONFIGURATIONS --
 {% macro oneinch_ar_raw_calls_cfg_macro()   %} {{ return(dict(oneinch_ar_cfg_macro(), start="2019-06-01")) }} {% endmacro %}
 {% macro oneinch_ar_transfers_cfg_macro()   %} {{ return(dict(oneinch_ar_cfg_macro(), start="2019-06-01")) }} {% endmacro %}

--- a/dbt_subprojects/dex/models/_projects/oneinch/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/oneinch/_schema.yml
@@ -322,6 +322,7 @@ models:
               - tx_hash
               - trace_address
               - evt_index
+      - oneinch_no_cross_chain_placeholder_tokens
     columns:
       - name: blockchain
         data_tests:
@@ -340,15 +341,7 @@ models:
       - name: token_sold_amount_raw
       - name: amount_usd
       - name: token_bought_address
-        data_tests:
-          - dbt_utils.expression_is_true:
-              arguments:
-                expression: "not in (0xda0000d4000015a526378bb6fafc650cea5966f8, 0xd66097c27eb8dee404bac235737932260edc6f3b)"
       - name: token_sold_address
-        data_tests:
-          - dbt_utils.expression_is_true:
-              arguments:
-                expression: "not in (0xda0000d4000015a526378bb6fafc650cea5966f8, 0xd66097c27eb8dee404bac235737932260edc6f3b)"
       - name: taker
       - name: maker
       - name: project_contract_address
@@ -378,6 +371,7 @@ models:
               - blockchain
               - tx_hash
               - evt_index
+      - oneinch_no_cross_chain_placeholder_tokens
     columns:
       - name: blockchain
         data_tests:
@@ -397,15 +391,7 @@ models:
       - name: token_sold_amount_raw
       - name: amount_usd
       - name: token_bought_address
-        data_tests:
-          - dbt_utils.expression_is_true:
-              arguments:
-                expression: "not in (0xda0000d4000015a526378bb6fafc650cea5966f8, 0xd66097c27eb8dee404bac235737932260edc6f3b)"
       - name: token_sold_address
-        data_tests:
-          - dbt_utils.expression_is_true:
-              arguments:
-                expression: "not in (0xda0000d4000015a526378bb6fafc650cea5966f8, 0xd66097c27eb8dee404bac235737932260edc6f3b)"
       - name: taker
       - name: maker
       - name: project_contract_address

--- a/dbt_subprojects/dex/models/_projects/oneinch/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/oneinch/_schema.yml
@@ -309,7 +309,7 @@ models:
     meta:
       blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
       sector: oneinch
-      contributors: ['max-morrow', 'grkhr']
+      contributors: ['max-morrow', 'grkhr', 'thevaizman']
     config:
       tags: ['oneinch', 'ar', 'trades']
     description: >
@@ -340,7 +340,15 @@ models:
       - name: token_sold_amount_raw
       - name: amount_usd
       - name: token_bought_address
+        data_tests:
+          - dbt_utils.expression_is_true:
+              arguments:
+                expression: "not in (0xda0000d4000015a526378bb6fafc650cea5966f8, 0xd66097c27eb8dee404bac235737932260edc6f3b)"
       - name: token_sold_address
+        data_tests:
+          - dbt_utils.expression_is_true:
+              arguments:
+                expression: "not in (0xda0000d4000015a526378bb6fafc650cea5966f8, 0xd66097c27eb8dee404bac235737932260edc6f3b)"
       - name: taker
       - name: maker
       - name: project_contract_address
@@ -358,7 +366,7 @@ models:
     meta:
       blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
       sector: oneinch
-      contributors: ['max-morrow', 'grkhr']
+      contributors: ['max-morrow', 'grkhr', 'thevaizman']
     config:
       tags: ['oneinch', 'lo', 'trades']
     description: >
@@ -389,7 +397,15 @@ models:
       - name: token_sold_amount_raw
       - name: amount_usd
       - name: token_bought_address
+        data_tests:
+          - dbt_utils.expression_is_true:
+              arguments:
+                expression: "not in (0xda0000d4000015a526378bb6fafc650cea5966f8, 0xd66097c27eb8dee404bac235737932260edc6f3b)"
       - name: token_sold_address
+        data_tests:
+          - dbt_utils.expression_is_true:
+              arguments:
+                expression: "not in (0xda0000d4000015a526378bb6fafc650cea5966f8, 0xd66097c27eb8dee404bac235737932260edc6f3b)"
       - name: taker
       - name: maker
       - name: project_contract_address

--- a/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_ar_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_ar_trades.sql
@@ -45,3 +45,6 @@ where true
     and mode in ('classic', 'fusion')
     and tx_success
     and call_success
+    -- exclude Fusion+ cross-chain fills: the ERC20True placeholder leg makes these degenerate single-chain rows
+    and (src_token_address is null or src_token_address not in ({{ oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') }}))
+    and (dst_token_address is null or dst_token_address not in ({{ oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') }}))

--- a/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_ar_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_ar_trades.sql
@@ -9,6 +9,7 @@
 
 {% set src_symbol = "coalesce(src_executed_symbol, '')" %}
 {% set dst_symbol = "coalesce(dst_executed_symbol, '')" %}
+{% set placeholder_tokens = oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') %}
 
 
 
@@ -46,5 +47,5 @@ where true
     and tx_success
     and call_success
     -- exclude Fusion+ cross-chain fills: the ERC20True placeholder leg makes these degenerate single-chain rows
-    and (src_token_address is null or src_token_address not in ({{ oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') }}))
-    and (dst_token_address is null or dst_token_address not in ({{ oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') }}))
+    and (src_token_address is null or src_token_address not in ({{ placeholder_tokens }}))
+    and (dst_token_address is null or dst_token_address not in ({{ placeholder_tokens }}))

--- a/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_lop_own_trades.sql
@@ -45,3 +45,6 @@ where true
     and mode = 'limits'
     and tx_success
     and call_success
+    -- exclude Fusion+ cross-chain fills: the ERC20True placeholder leg makes these degenerate single-chain rows
+    and (src_token_address is null or src_token_address not in ({{ oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') }}))
+    and (dst_token_address is null or dst_token_address not in ({{ oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') }}))

--- a/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_lop_own_trades.sql
@@ -9,6 +9,7 @@
 
 {% set src_symbol = "coalesce(src_executed_symbol, '')" %}
 {% set dst_symbol = "coalesce(dst_executed_symbol, '')" %}
+{% set placeholder_tokens = oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') %}
 
 
 
@@ -46,5 +47,5 @@ where true
     and tx_success
     and call_success
     -- exclude Fusion+ cross-chain fills: the ERC20True placeholder leg makes these degenerate single-chain rows
-    and (src_token_address is null or src_token_address not in ({{ oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') }}))
-    and (dst_token_address is null or dst_token_address not in ({{ oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') }}))
+    and (src_token_address is null or src_token_address not in ({{ placeholder_tokens }}))
+    and (dst_token_address is null or dst_token_address not in ({{ placeholder_tokens }}))

--- a/dbt_subprojects/dex/tests/generic/oneinch_no_cross_chain_placeholder_tokens.sql
+++ b/dbt_subprojects/dex/tests/generic/oneinch_no_cross_chain_placeholder_tokens.sql
@@ -1,0 +1,10 @@
+{% test oneinch_no_cross_chain_placeholder_tokens(model) %}
+
+{% set placeholder_tokens = oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') %}
+
+select tx_hash, token_bought_address, token_sold_address
+from {{ model }}
+where token_bought_address in ({{ placeholder_tokens }})
+   or token_sold_address in ({{ placeholder_tokens }})
+
+{% endtest %}


### PR DESCRIPTION
## Context

Fixes [CUR2-2665](https://linear.app/dune/issue/CUR2-2665/investigate-degenerate-1inch-fusion-rows-in-dextrades) ([Slack thread](https://duneanalytics.slack.com/archives/C0A9FGJE2S1/p1780616540955469)).

1inch Fusion+ (cross-chain) orders fill through LOP v4 with the `ERC20True` placeholder token as one leg (`0xda0000d4000015a526378bb6fafc650cea5966f8`; `0xd66097c27eb8dee404bac235737932260edc6f3b` on zksync). These produce degenerate `1inch-LOP` rows in `dex.trades`: no token metadata, no decimal-adjusted amounts, and the row doesn't represent the full cross-chain trade.

**Scope (live data):** 21,993 rows / ~$116.7M across 12 chains, first row 2025-07-31, ramping hard since 2026-03. Only `1inch-LOP` is affected.

## Root cause

`oneinch_lo_macro.sql` flags `cross_chain` by checking whether a configured `escrow_factory_addresses` entry appears in the LOP call args (`factory_in_args`). 1inch rotated to a new escrow factory (candidate observed on unichain: `0x03a25b3215a0e5c15cf23ac4d2e5cf86c0ff7efa`; the configured `0xa7bcb4eac8964306f9e3764f67db6a7af6ddf99a` appears nowhere in the example trace). New cross-chain fills therefore get `cross_chain=false`, slip past the `not flags['cross_chain']` exclusion in `oneinch_lo_executions_macro.sql`, and reach `dex.trades` as `mode='limits'`.

## Fix

Filter the placeholder token addresses (null-guarded, centralized in a new `oneinch_cross_chain_placeholder_tokens_cfg_macro`) in the two views feeding dex spells:
- `oneinch_lop_own_trades` → `dex_<chain>_trades` → `dex.trades` (the actual leak)
- `oneinch_ar_trades` → `dex_aggregator.trades` (clean today — verified 0 historical rows — filtered as future-proofing)

View-level filtering covers all of `oneinch.swaps` history without rebuilding the incremental 1inch lineage, at the cost of two varbinary comparisons per row. `expression_is_true` tests on both views' token address columns guard against regression. Tests are deliberately NOT placed on the downstream incremental tables — they would fail prod test runs until the full refresh below lands.

## Pre-merge verification (live queries against oneinch.swaps / dex.trades)

- **Exact complement:** per chain over 30d, `old_rows = new_rows + placeholder_rows` holds on all 12 chains; zero NULL token addresses affected.
- **Example tx** `0x5fab12bddc02d3554c85b25af2291e04afcbd0fd09d592964f37b65a8b856fe9` (unichain): 1 row under old logic → 0 under new logic.
- **Mixed txs (evt_index shift exposure):** 0 over 90d — no tx mixes placeholder and real fills, so no transient-duplicate risk from the `row_number()` evt_index.
- **Aggregator path:** 0 placeholder rows in `dex_aggregator.trades` since 2024-08; all 22,026 placeholder rows in `oneinch.swaps` carry `mode='limits'` exclusively.
- **Only `1inch-LOP`** carries placeholder rows in `dex.trades` (re-confirmed).

## Post-merge: full-refresh request (history cleanup)

The filter stops new degenerate rows; the existing 21,993 rows sit in incremental merge tables and need a `--full-refresh`:
1. `dex_{ethereum,base,bnb,arbitrum,polygon,avalanche_c,gnosis,optimism,linea,sonic,unichain,zksync}_trades` (fantom consumes the view but has zero placeholder rows)
2. `dex_trades` (holds the same rows)
3. `dex_<chain>_token_volumes_daily` for the same 12 chains (placeholder token volumes are materialized there)

Post-refresh check (expect 0 rows):
```sql
select count(*) from dex.trades
where token_bought_address in (0xda0000d4000015a526378bb6fafc650cea5966f8, 0xd66097c27eb8dee404bac235737932260edc6f3b)
   or token_sold_address in (0xda0000d4000015a526378bb6fafc650cea5966f8, 0xd66097c27eb8dee404bac235737932260edc6f3b)
```

## Known gap (out of scope here)

The cc stream (`oneinch_cc_contracts_cfg_macro.sql`) only tracks the old escrow factory, so 1inch Fusion+ cross-chain volume since ~2026-02 is missing from `oneinch.swaps` entirely (0 `mode='cross-chain'` rows for these fills). Restoring it requires decoding + onboarding the new escrow factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)