### PR TITLE
optimize(polymarket_polygon_market_trades): fix changed_tokens detector to stop daily full-target rebuild

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/_projects/polymarket/polygon/polymarket_polygon_market_trades.sql
@@ -24,21 +24,32 @@ with market_details as (
     token_outcome,
     neg_risk,
     unique_key,
-    token_outcome_name,
-    market_start_time
+    token_outcome_name
   from {{ ref('polymarket_polygon_market_details') }}
 ),
 
 {% if is_incremental() -%}
 
+-- tokens whose latest already-merged row disagrees with market_details on any
+-- metadata column. Tokens with no rows in {{ this }} have nothing to update;
+-- their trades arrive through the recent-window branch below.
 changed_tokens as (
-  select distinct md.token_id
+  select md.token_id
   from market_details md
-  left join {{ this }} t
-    on md.token_id = t.asset_id
-    and t.block_time >= try_cast(md.market_start_time as timestamp)
-  where t.asset_id is null
-    or coalesce(cast(md.event_market_name as varchar), '') != coalesce(cast(t.event_market_name as varchar), '')
+  inner join (
+    select
+      asset_id,
+      max_by(event_market_name, block_time) as event_market_name,
+      max_by(question, block_time) as question,
+      max_by(polymarket_link, block_time) as polymarket_link,
+      max_by(token_outcome, block_time) as token_outcome,
+      max_by(neg_risk, block_time) as neg_risk,
+      max_by(unique_key, block_time) as unique_key,
+      max_by(token_outcome_name, block_time) as token_outcome_name
+    from {{ this }}
+    group by asset_id
+  ) t on md.token_id = t.asset_id
+  where coalesce(cast(md.event_market_name as varchar), '') != coalesce(cast(t.event_market_name as varchar), '')
     or coalesce(cast(md.question as varchar), '') != coalesce(cast(t.question as varchar), '')
     or coalesce(cast(md.polymarket_link as varchar), '') != coalesce(cast(t.polymarket_link as varchar), '')
     or coalesce(cast(md.token_outcome as varchar), '') != coalesce(cast(t.token_outcome as varchar), '')


### PR DESCRIPTION
`market_trades` is configured as an incremental merge, but it has been rebuilding its full 1.46B-row target every run. The `changed_tokens` CTE joins `{{ this }}` on `t.block_time >= try_cast(md.market_start_time as timestamp)` -- `market_start_time` is an ISO-8601 varchar (`2026-02-14T20:01:39Z`) that `try_cast` cannot parse, so the cast is NULL for all 2.66M market_details rows, the left join matches nothing, every token falls into the `t.asset_id is null` arm, and the changed-branch re-emits all 1.46B raw rows. Measured per run: 54,036 cpu-s, 258 GB read, 1.8 TB peak memory, 743 s wall -- ~15 CPU-hrs/day on spellbook-daily to merge ~1 row of actual change.

The rewrite compares market_details against the latest already-merged row per asset_id (`max_by(..., block_time)` over `{{ this }}`), flagging only tokens whose metadata actually drifted. Tokens with no rows in the target are dropped from the detector (inner join): they have nothing to update, and their trades arrive through the existing 3-day window branch. Using the latest row rather than an arbitrary one makes the detector convergent: once a token's metadata is re-merged, it stops being flagged.

Proof (read-only, prod data): the old pipeline's full re-emission is a pure no-op against the current target -- per-month count + checksum over all 28 content columns match for every month (0 mismatches, both directions via full outer join), and the true changed set today is 0 tokens. New-pipeline A/B (checksum over all output columns, 3 warm runs, medians): 2,917 cpu-s vs 54,036 (18.5x), 73 GB vs 258 GB read (3.5x), 41 GB vs 1,835 GB peak memory (45x), 82 s vs 743 s wall.

Fixes CUR2-2714
