### PR TITLE
optimize(balances noncompliant): prefilter candidate tokens before running-balance window

### DIFF
--- a/dbt_subprojects/daily_spellbook/macros/sector/fungible/balances_fungible_noncompliant.sql
+++ b/dbt_subprojects/daily_spellbook/macros/sector/fungible/balances_fungible_noncompliant.sql
@@ -1,7 +1,25 @@
-{% macro balances_fungible_noncompliant(transfers_rolling_day) %}
-SELECT  
-    DISTINCT token_address
-FROM 
-{{ transfers_rolling_day }}
+{% macro balances_fungible_noncompliant(transfers_agg_day, day_column='block_day') %}
+WITH candidate_tokens AS (
+    -- a wallet's running balance can only fall below the noncompliance threshold
+    -- if the token's total negative flow does (every prefix sum >= the sum of all
+    -- negative amounts); -9e14 keeps slack vs the exact -0.0010005e18 rounding
+    -- boundary so float noise cannot drop a true candidate
+    SELECT token_address
+    FROM {{ transfers_agg_day }}
+    GROUP BY token_address
+    HAVING sum(if(amount < 0, amount, 0e0)) < -9e14
+),
+
+running_balances AS (
+    SELECT
+        t.token_address,
+        SUM(t.amount) OVER (PARTITION BY t.token_address, t.wallet_address ORDER BY t.{{ day_column }}) AS amount
+    FROM {{ transfers_agg_day }} t
+    INNER JOIN candidate_tokens c
+        ON c.token_address = t.token_address
+)
+
+SELECT DISTINCT token_address
+FROM running_balances
 WHERE round(amount/power(10, 18), 6) < -0.001
 {% endmacro %}

--- a/dbt_subprojects/daily_spellbook/models/balances/arbitrum/erc20/balances_arbitrum_erc20_noncompliant.sql
+++ b/dbt_subprojects/daily_spellbook/models/balances/arbitrum/erc20/balances_arbitrum_erc20_noncompliant.sql
@@ -6,8 +6,8 @@
         )
 }}
 
-SELECT  
-    DISTINCT token_address
-FROM 
-{{ ref('transfers_arbitrum_erc20_rolling_day') }}
-WHERE round(amount/power(10, 18), 6) < -0.001
+{{
+    balances_fungible_noncompliant(
+        transfers_agg_day = ref('transfers_arbitrum_erc20_agg_day')
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/balances/bnb/bep20/balances_bnb_bep20_noncompliant.sql
+++ b/dbt_subprojects/daily_spellbook/models/balances/bnb/bep20/balances_bnb_bep20_noncompliant.sql
@@ -6,8 +6,9 @@
         )
 }}
 
-SELECT  
-    DISTINCT token_address
-FROM 
-{{ ref('transfers_bnb_bep20_rolling_day') }}
-WHERE round(amount/power(10, 18), 6) < -0.001
+{{
+    balances_fungible_noncompliant(
+        transfers_agg_day = ref('transfers_bnb_bep20_agg_day'),
+        day_column = 'day'
+    )
+}}

--- a/dbt_subprojects/daily_spellbook/models/balances/polygon/erc20/balances_polygon_erc20_noncompliant.sql
+++ b/dbt_subprojects/daily_spellbook/models/balances/polygon/erc20/balances_polygon_erc20_noncompliant.sql
@@ -10,6 +10,6 @@
 
 {{
     balances_fungible_noncompliant(
-        transfers_rolling_day = ref('transfers_polygon_erc20_rolling_day')
+        transfers_agg_day = ref('transfers_polygon_erc20_agg_day')
     )
 }}


### PR DESCRIPTION
The `balances_{bnb,polygon,arbitrum}_*_noncompliant` models flag tokens whose cumulative wallet balance ever rounds below -0.001e18. They computed a running-sum window over the entire `*_agg_day` history through the `*_rolling_day` view — on bnb that is a 6.05B-row WindowOperator carrying 97% of the build's CPU (79.4M of 81M cpu-ms), peaking at 332 GB memory and spilling 37-67 GB, to keep 238k rows / 52,786 tokens.

This change inlines the running balance into the shared `balances_fungible_noncompliant` macro and prefilters candidate tokens first: a wallet's running balance can only fall below the threshold if the token's total negative flow does (every prefix sum >= the sum of all negative amounts, and `round` is monotonic; the -9e14 cutoff keeps ~10% slack vs the exact -1.0005e15 boundary so float noise cannot drop a true candidate). The cheap hash GROUP BY keeps 71,718 of 8.66M bnb tokens (0.83%), shrinking the window input 16.7x (6.05B -> 363M rows). The models now read `*_agg_day` directly instead of the `*_rolling_day` view; the views and all other consumers are untouched.

Equivalence proven on full prod data (single query = single Delta snapshot, FULL OUTER JOIN of old vs new output, i.e. EXCEPT=0 both ways):

| chain | old_only | new_only | tokens | proof query |
|---|---|---|---|---|
| bnb | 0 | 0 | 52,786 | `20260611_150812_00000_ixqqp` |
| polygon | 0 | 0 | 2,428 | `20260611_152643_00001_ixqqp` |
| arbitrum | 0 | 0 | 504 | `20260611_153259_00002_ixqqp` |

Measured A/B (OLD = prod daily builds on spellbook-daily, e.g. `20260611_054327_17639_zke99`; NEW = checksum-forced full SELECT, 3 warm runs on spellbook-solana, medians):

| chain | cpu (ms) | IO scanned | peak memory | spill |
|---|---|---|---|---|
| bnb | 81.0M -> 5.16M (**15.4x**) | 168.6 -> 202.3 GB (+20%) | 332.6 -> 25.6 GB | 37-67 GB -> 0 |
| polygon | 27.1M -> 2.61M (**10.4x**) | 68.9 -> 76.3 GB (+11%) | ~79 -> 21.1 GB | 41-66 GB -> 0 |
| arbitrum | 3.3M -> 0.13M (**24x**) | 13.0 -> 14.5 GB (+12%) | 37.8 -> 1.9 GB | 0 -> 0 |

Each model builds once per day, so this frees ~28.8 CPU-hrs/day (~8% of the spellbook-daily cluster) and eliminates ~80-130 GB/day of spill, for +46 GB/day extra S3 read (the candidate-token aggregation is a second scan of `agg_day`). bnb prod wall was ~36 min; the rewrite is CPU-bound-no-spill so the build should drop well under 10 min on the daily cluster.

Fixes CUR2-2716
