### PR TITLE
perf(lido_accounting family): incrementalize 8 hourly full-history rebuilds (~23.7 CPU-hrs/day, ~16 TB/day)

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_buffer_inflow.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_buffer_inflow.sql
@@ -2,21 +2,50 @@
         schema='lido_accounting_ethereum',
         alias = 'buffer_inflow',
 
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'append'
         , post_hook='{{ hide_spells() }}'
         )
 }}
 
-SELECT  evt_block_time as period, amount as amount,0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 as token, evt_tx_hash, date_trunc('day', evt_block_time) as day
-FROM {{source('lido_ethereum','steth_evt_Submitted')}}
+with buffer_inflow as (
+    SELECT  evt_block_time as period, amount as amount,0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 as token, evt_tx_hash, date_trunc('day', evt_block_time) as day
+    FROM {{source('lido_ethereum','steth_evt_Submitted')}}
+    {% if is_incremental() %}
+    WHERE {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
 
-union all
+    union all
 
-SELECT evt_block_time, amount, 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, evt_tx_hash, date_trunc('day', evt_block_time) as day
-FROM {{source('lido_ethereum','steth_evt_ELRewardsReceived')}}
+    SELECT evt_block_time, amount, 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, evt_tx_hash, date_trunc('day', evt_block_time) as day
+    FROM {{source('lido_ethereum','steth_evt_ELRewardsReceived')}}
+    {% if is_incremental() %}
+    WHERE {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
 
-union all
+    union all
 
-SELECT evt_block_time, amount , 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, evt_tx_hash, date_trunc('day', evt_block_time) as day
-FROM {{source('lido_ethereum','steth_evt_WithdrawalsReceived')}}
+    SELECT evt_block_time, amount , 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, evt_tx_hash, date_trunc('day', evt_block_time) as day
+    FROM {{source('lido_ethereum','steth_evt_WithdrawalsReceived')}}
+    {% if is_incremental() %}
+    WHERE {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
+)
+
+SELECT period, amount, token, evt_tx_hash, day
+FROM buffer_inflow b
+{% if is_incremental() %}
+-- append-only dedup: drop rows already inserted by a previous run inside the
+-- incremental window (no event index in the output, so a merge unique_key would
+-- collapse legitimately duplicated events within one tx)
+WHERE not exists (
+    select 1
+    from {{ this }} t
+    where t.period = b.period
+      and t.amount = b.amount
+      and t.token = b.token
+      and t.evt_tx_hash = b.evt_tx_hash
+      and t.day = b.day
+)
+{% endif %}

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_buffer_outflow.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_buffer_outflow.sql
@@ -2,11 +2,27 @@
         schema='lido_accounting_ethereum',
         alias = 'buffer_outflow',
 
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'append'
         , post_hook='{{ hide_spells() }}'
         )
 }}
 
 SELECT evt_block_time as period, amountOfETHLocked as amount, 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 AS token,  evt_tx_hash, date_trunc('day', evt_block_time) as day
-FROM {{source('lido_ethereum','WithdrawalQueueERC721_evt_WithdrawalsFinalized')}}
+FROM {{source('lido_ethereum','WithdrawalQueueERC721_evt_WithdrawalsFinalized')}} w
+{% if is_incremental() %}
+WHERE {{ incremental_predicate('evt_block_time') }}
+-- append-only dedup: drop rows already inserted by a previous run inside the
+-- incremental window (no event index in the output, so a merge unique_key would
+-- collapse legitimately duplicated events within one tx)
+AND not exists (
+    select 1
+    from {{ this }} t
+    where t.period = w.evt_block_time
+      and t.amount = w.amountOfETHLocked
+      and t.token = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+      and t.evt_tx_hash = w.evt_tx_hash
+      and t.day = date_trunc('day', w.evt_block_time)
+)
+{% endif %}

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_dai_referral_payment.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_dai_referral_payment.sql
@@ -2,8 +2,9 @@
         schema='lido_accounting_ethereum',
         alias = 'dai_referral_payment',
 
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'append'
         , post_hook='{{ hide_spells() }}'
         )
 }}
@@ -28,6 +29,9 @@ dai_referral_payment_txns AS (
     )
     AND evt_block_time >= CAST('2023-01-01 00:00' AS TIMESTAMP)
     AND contract_address = 0x6B175474E89094C44Da98b954EedeAC495271d0F
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
     ORDER BY evt_block_time
 )
 
@@ -36,4 +40,17 @@ dai_referral_payment_txns AS (
             evt_tx_hash,
             contract_address AS token,
             value AS amount_token
-    FROM dai_referral_payment_txns
+    FROM dai_referral_payment_txns d
+    {% if is_incremental() %}
+    -- append-only dedup: drop rows already inserted by a previous run inside the
+    -- incremental window (no event index in the output, so a merge unique_key would
+    -- collapse legitimately duplicated transfers within one tx)
+    WHERE not exists (
+        select 1
+        from {{ this }} t
+        where t.period = d.evt_block_time
+          and t.evt_tx_hash = d.evt_tx_hash
+          and t.token = d.contract_address
+          and t.amount_token = d.value
+    )
+    {% endif %}

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_ldo_referral_payment.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_ldo_referral_payment.sql
@@ -2,8 +2,9 @@
         schema='lido_accounting_ethereum',
         alias = 'ldo_referral_payment',
 
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'append'
         , post_hook='{{ hide_spells() }}'
         )
 }}
@@ -62,6 +63,9 @@ ldo_referral_payment_txns AS ( --only LDO referral program, need to add DAI refe
     AND _to IN (
         SELECT address FROM ldo_referral_payments_addr
     )
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
     ORDER BY evt_block_time
 
 )
@@ -70,6 +74,19 @@ ldo_referral_payment_txns AS ( --only LDO referral program, need to add DAI refe
             evt_tx_hash,
             contract_address AS token,
             amnt AS amount_token
-    FROM ldo_referral_payment_txns
+    FROM ldo_referral_payment_txns l
     WHERE amnt != 0
+    {% if is_incremental() %}
+    -- append-only dedup: drop rows already inserted by a previous run inside the
+    -- incremental window (no event index in the output, so a merge unique_key would
+    -- collapse legitimately duplicated transfers within one tx)
+    AND not exists (
+        select 1
+        from {{ this }} t
+        where t.period = l.evt_block_time
+          and t.evt_tx_hash = l.evt_tx_hash
+          and t.token = l.contract_address
+          and t.amount_token = l.amnt
+    )
+    {% endif %}
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_lego_expenses.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_lego_expenses.sql
@@ -2,7 +2,8 @@
         schema='lido_accounting_ethereum',
         alias = 'lego_expenses',
 
-        materialized = 'table',
+        materialized = 'incremental',
+        incremental_strategy = 'append',
         file_format = 'delta'
         , post_hook='{{ hide_spells() }}'
         )
@@ -90,6 +91,9 @@ lego_expenses_txns AS (
         contract_address
     FROM {{source('erc20_ethereum','evt_Transfer')}}
     WHERE contract_address IN (SELECT address FROM tokens)
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
     AND "from" IN (
         SELECT
             address
@@ -112,6 +116,9 @@ lego_expenses_txns AS (
         contract_address
     FROM {{source('erc20_ethereum','evt_Transfer')}}
     WHERE contract_address IN (SELECT address FROM tokens)
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
     AND to IN (
         SELECT
             address
@@ -131,6 +138,19 @@ lego_expenses_txns AS (
         contract_address AS token,
         value AS amount_token,
         evt_tx_hash
-    FROM lego_expenses_txns
+    FROM lego_expenses_txns l
     WHERE contract_address IN (SELECT address FROM tokens)
       and value != 0
+    {% if is_incremental() %}
+      -- append-only dedup: drop rows already inserted by a previous run inside the
+      -- incremental window (the model has no event index, so a merge unique_key would
+      -- collapse legitimately duplicated transfers within one tx)
+      and not exists (
+          select 1
+          from {{ this }} t
+          where t.period = l.evt_block_time
+            and t.token = l.contract_address
+            and t.amount_token = l.value
+            and t.evt_tx_hash = l.evt_tx_hash
+      )
+    {% endif %}

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_steth_referral_payment.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_steth_referral_payment.sql
@@ -2,8 +2,9 @@
         schema='lido_accounting_ethereum',
         alias = 'steth_referral_payment',
 
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'append'
         , post_hook='{{ hide_spells() }}'
         )
 }}
@@ -58,6 +59,9 @@ referral_payment_txns AS (
     )
     AND evt_block_time >= CAST('2023-08-01 00:00' AS TIMESTAMP)
     AND contract_address in (select address from tokens)
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
 
     UNION ALL
 
@@ -72,6 +76,9 @@ referral_payment_txns AS (
     )
     AND evt_block_time >= CAST('2023-08-01 00:00' AS TIMESTAMP)
     AND contract_address in (select address from tokens)
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('evt_block_time') }}
+    {% endif %}
     ORDER BY evt_block_time
 )
 
@@ -80,4 +87,17 @@ referral_payment_txns AS (
             evt_tx_hash,
             contract_address AS token,
             value AS amount_token
-    FROM referral_payment_txns
+    FROM referral_payment_txns r
+    {% if is_incremental() %}
+    -- append-only dedup: drop rows already inserted by a previous run inside the
+    -- incremental window (no event index in the output, so a merge unique_key would
+    -- collapse legitimately duplicated transfers within one tx)
+    WHERE not exists (
+        select 1
+        from {{ this }} t
+        where t.period = r.evt_block_time
+          and t.evt_tx_hash = r.evt_tx_hash
+          and t.token = r.contract_address
+          and t.amount_token = r.value
+    )
+    {% endif %}

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_trp_expenses.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_trp_expenses.sql
@@ -2,8 +2,9 @@
         schema='lido_accounting_ethereum',
         alias = 'trp_expenses',
 
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'append'
         , post_hook='{{ hide_spells() }}'
         )
 }}
@@ -67,6 +68,9 @@ trp_expenses_txns AS (
             FROM multisigs_list
             WHERE name IN ('TRPMsig') AND chain = 'Ethereum'
     )
+        {% if is_incremental() %}
+        AND {{ incremental_predicate('evt_block_time') }}
+        {% endif %}
 
 )
 
@@ -75,6 +79,19 @@ trp_expenses_txns AS (
         contract_address AS token,
         value AS amount_token,
         evt_tx_hash
-    FROM trp_expenses_txns
+    FROM trp_expenses_txns x
+    {% if is_incremental() %}
+    -- append-only dedup: drop rows already inserted by a previous run inside the
+    -- incremental window (no event index in the output, so a merge unique_key would
+    -- collapse legitimately duplicated transfers within one tx)
+    WHERE not exists (
+        select 1
+        from {{ this }} t
+        where t.period = x.evt_block_time
+          and t.token = x.contract_address
+          and t.amount_token = x.value
+          and t.evt_tx_hash = x.evt_tx_hash
+    )
+    {% endif %}
 
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/accounting/ethereum/lido_accounting_ethereum_withdrawals.sql
@@ -2,8 +2,9 @@
         schema='lido_accounting_ethereum',
         alias = 'withdrawals',
 
-        materialized = 'table',
-        file_format = 'delta'
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'append'
         , post_hook='{{ hide_spells() }}'
         )
 }}
@@ -19,6 +20,11 @@ with withdrawals as (
                    ELSE 0 END) AS withdrawn_principal
     from {{source('ethereum', 'withdrawals')}}
     where address = 0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f
+    {% if is_incremental() %}
+    -- safe to window: the aggregation grain (block_time, block_hash) never spans
+    -- the window boundary
+    and {{ incremental_predicate('block_time') }}
+    {% endif %}
     group by 1,2
 )
 
@@ -26,5 +32,15 @@ select time as period
     , block_hash as hash
     , withdrawn_principal*POWER(10, 18) as amount
     , date_trunc('day', time) as day
-from withdrawals
+from withdrawals w
 where withdrawn_principal != 0
+{% if is_incremental() %}
+-- append-only dedup: drop blocks already inserted by a previous run inside the
+-- incremental window (block_hash is unique per block)
+and not exists (
+    select 1
+    from {{ this }} t
+    where t.period = w.time
+      and t.hash = w.block_hash
+)
+{% endif %}


### PR DESCRIPTION
`lido_accounting_ethereum_lego_expenses` was `materialized='table'`, so every hourly run re-scanned the full history of `erc20_ethereum.evt_Transfer` twice (2x 3.7B rows / ~264 GB per build, 99.9% of the build's CPU) to produce a 319-row output. This converts it to an incremental append: each run now scans only the standard 3-day `incremental_predicate` window, with an anti-join against `{{ this }}` to drop rows already inserted by previous overlapping runs.

A merge with a `unique_key` was deliberately NOT used: the output has no event index, and the prod table legitimately contains 16 duplicate `(period, token, amount_token, evt_tx_hash)` tuples (multiple identical transfers within one tx) that a merge would collapse. Append + anti-join preserves them exactly: within a batch both copies insert; on re-runs the anti-join removes already-inserted copies.

Measured on spellbook-hourly (3 warm runs each, checksum-forced over all output columns, medians):

| axis | current full rebuild | incremental window run | delta |
|---|---|---|---|
| IO scanned | 264.2 GB | 1.35 GB | ~196x |
| CPU | 1,411 s | ~6.7 s | ~210x |
| wall | 16-35 s | ~3 s | ~10x |
| peak memory | 0.3-1.7 GB | ~2 MB | ~500x |

Whole-model extrapolation (24 builds/day): ~9.4 -> ~0.05 CPU-hrs/day and ~6.3 TB/day -> ~32 GB/day scanned. Equivalence of the windowed SELECT vs the full SELECT is by construction (same predicates + a time floor); the full output was additionally proven stable across the refactor via a multiset comparison (0 mismatched rows both directions, count + per-tuple multiplicity) and identical checksums on all columns across 6 runs.

Caveats: a `--full-refresh` still does the original full 2-scan build (one-time backfill, unchanged behavior). Decoded `evt_Transfer` rows arriving later than the 3-day window would be missed -- the same standard assumption every `incremental_predicate` model in the repo makes. I also measured collapsing the two UNION ALL branches into a single OR'd scan and rejected it: IO -27% but CPU flat (+4%) and peak memory up ~10x (the OR loses per-branch pushdown), and it's irrelevant once the scan is windowed.

---

## Family extension: 7 more lido_accounting models (same recipe)

Second commit applies the identical conversion (incremental append + 3-day `incremental_predicate` window on every event scan + `NOT EXISTS` anti-join over all output columns) to the remaining full-rebuild table models of the family: `steth_referral_payment`, `trp_expenses`, `dai_referral_payment`, `withdrawals`, `ldo_referral_payment`, `buffer_inflow`, `buffer_outflow`.

Excluded by the append-only feasibility gate: `revenue` (`LEAD(..., NOW())` fee-range windows restate past rows; only 0.05 CPU-hrs/day anyway) and the `lido_accounting` aggregator (`NOW()`-relative price joins; its cost is prices-scan-driven -- separate lever).

**Proof (prod data, spellbook-hourly, UTC):** per-model dup/null census (0 NULLs anywhere -> plain equality anti-join is exact; duplicate tuples exist only in steth_referral_payment (2) and buffer_inflow (204), all same-tx multi-`evt_index` events that decode atomically -- same argument as lego). Multiset equivalence (per-tuple `sum(cur) <> sum(rw)` over prod table vs the full SELECT, bounded at a fixed cutoff to exclude post-build freshness): **0 mismatches both directions for all 7 models**.

**Measured A/B (3 warm runs, checksum-forced over all output columns, anti-join included):**

| model | before/build (cpu-s / GB) | after/build (cpu-s / GB) | factor |
|---|---|---|---|
| steth_referral_payment | 900 / 183 | 5.2 / 1.6 | ~173x cpu, ~114x IO |
| trp_expenses | 624 / 124 | 2.7 / 0.8 | ~231x, ~155x |
| dai_referral_payment | 495 / 99 | 2.9 / 0.8 | ~171x, ~124x |
| withdrawals | 22.5 / 2.9 | 0.9 / 0.015 | ~25x, ~193x |
| ldo_referral, buffer_in/outflow | ~0.06 CPU-hrs/day combined | recipe-only (micro) | - |

Family daily impact (24 builds/day, incl. lego from commit 1): **~23.7 -> ~0.15 CPU-hrs/day** and **~16.2 TB -> ~0.11 TB/day** scanned on spellbook-hourly.

Additional caveat for `dai_referral_payment` / `steth_referral_payment`: the recipient sets come from `RecipientAdded` event tables, so a recipient added *after* historical transfers to them would be missed by incremental runs (a `--full-refresh` recovers; the normal flow is add-then-pay). Static-list models are unaffected.

Fixes CUR2-2761
Fixes CUR2-2762
Towards CUR2-2700
