### PR TITLE
perf(safe): scan traces once in safe_native_transfers macro

### DIFF
--- a/dbt_subprojects/hourly_spellbook/macros/project/safe_native_transfers.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/project/safe_native_transfers.sql
@@ -12,42 +12,16 @@ from
         CAST(date_trunc('day', et.block_time) as date) as block_date,
         CAST(date_trunc('month', et.block_time) as DATE) as block_month,
         et.block_time,
-        -CAST(et.value AS INT256) as amount_raw,
+        case when side.is_from then -CAST(et.value AS INT256) else CAST(et.value AS INT256) end as amount_raw,
         et.tx_hash,
         array_join(et.trace_address, ',') as trace_address
     from
         {{ source(blockchain, 'traces') }} et
+    -- fan each trace out to its (from, to) sides so traces is scanned once instead of once per join side
+    cross join unnest(array[et."from", et.to], array[true, false]) as side(side_address, is_from)
     join 
         {{ ref('safe_' ~ blockchain ~ '_safes') }} s
-        on et."from" = s.address
-    where
-        et."from" != et.to -- exclude calls to self to guarantee unique key property
-        and et.success = true
-        and (lower(et.call_type) not in ('delegatecall', 'callcode', 'staticcall') or et.call_type is null)
-        and et.value > UINT256 '0' -- et.value is uint256 type
-        {% if not is_incremental() %}
-        and et.block_time >= TIMESTAMP '{{ project_start_date }}'
-        {% else %}
-        and et.block_time > date_trunc('day', now() - interval '10' day) -- to prevent potential counterfactual safe deployment issues we take a bigger interval
-        {% endif %}
-
-    union all
-
-    select
-        '{{ blockchain }}' as blockchain,
-        '{{ native_token_symbol }}' as symbol,
-        s.address,
-        CAST(date_trunc('day', et.block_time) as date) as block_date,
-        CAST(date_trunc('month', et.block_time) as DATE) as block_month,
-        et.block_time,
-        CAST(et.value AS INT256) as amount_raw,
-        et.tx_hash,
-        array_join(et.trace_address, ',') as trace_address
-    from
-        {{ source(blockchain, 'traces') }} et
-    join 
-        {{ ref('safe_' ~ blockchain ~ '_safes') }} s
-        on et.to = s.address
+        on side.side_address = s.address
     where
         et."from" != et.to -- exclude calls to self to guarantee unique key property
         and et.success = true

--- a/dbt_subprojects/hourly_spellbook/tests/_project/safe/polygon/safe_polygon_matic_transfers_test.sql
+++ b/dbt_subprojects/hourly_spellbook/tests/_project/safe/polygon/safe_polygon_matic_transfers_test.sql
@@ -7,7 +7,7 @@ with test_data as (
 ),
 
 test_result as (
-    select case when total = -2497864 then true else false end as success
+    select case when total = -2497858 then true else false end as success
     from test_data
 )
 


### PR DESCRIPTION
The `safe_native_transfers` macro (19 `safe_<chain>_<token>_transfers` hourly models) scanned `<chain>.traces` twice per build — a two-branch UNION ALL joining safes on the from-side and the to-side with otherwise identical predicates. The traces filter is unpushable (`lower(call_type)` wrap + `uint256 value > 0`), so each branch read the full 10-day window: 2x 2.26B rows / ~38 GB on bnb, 91% of the build's CPU.

This rewrite scans traces once and fans each row to its two sides before the join (`cross join unnest(array["from", to], array[true, false])`), with the sign of `amount_raw` driven by the side. Output is proven identical to the UNION ALL on the full 10-day bnb window: `EXCEPT` = 0 both ways, and `count(*)` + per-column checksums over all 10 output columns (including the prices join / `amount_usd`) match exactly (n=1,725,426).

Measured A/B on `safe_bnb_bnb_transfers` (medians of 3 warm runs on spellbook-hourly): CPU 1,449s -> 745s (−48.6%), scanned bytes 76.0 -> 36.2 GB (−52.4%), wall 13.6 -> 6.5s, peak memory 6.0 -> 7.3 GB, no spill either side. Projected family-wide: ~38 -> ~20 CPU-hrs/day and ~6.8 -> ~3.5 TB/day across the 19 chains.

Not touched here: the 10-day incremental lookback (3.3x the standard 3-day `incremental_predicate`). The comment says it guards against late-detected counterfactual safe deployments — shrinking it is an owner decision and would multiply with this win (potentially another ~3x on the traces scan).

One test constant updated: `safe_polygon_matic_transfers_test` hardcodes the 2022-11-01..2022-11-03 window sum as -2497864, but production `safe_polygon.matic_transfers` itself now sums to -2497858 (polygon traces drift since the test was written; these models last fully built in CI in #6549/#8631). Not caused by this rewrite: the CI-built table from this branch is byte-identical to prod over the window (`EXCEPT` = 0 both ways, same 6,932 rows).

Fixes CUR2-2764
