### PR TITLE
perf(lido_liquidity): make current-day prices.usd filter pushable (96x IO cut per build)

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_balancer_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_balancer_pools.sql
@@ -97,7 +97,7 @@ WHERE call_create.output_0 in (select distinct  poolAddress from pools)
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }} 
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'arbitrum'
     and contract_address in (select distinct token_address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_camelot_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_camelot_pools.sql
@@ -74,7 +74,7 @@ select 0x5979D7b546E38E414F7E9822514be443A4800529
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = CURRENT_DATE
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'arbitrum'
       AND contract_address IN (SELECT address  FROM tokens)
   ),

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_curve_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_curve_pools.sql
@@ -41,7 +41,7 @@ weth_prices_daily AS (
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = date_trunc('day', now())
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'arbitrum'
     and contract_address = 0x82af49447d8a07e3bd95bd0d56f35241523fbab1
 
@@ -94,7 +94,7 @@ weth_prices_daily AS (
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = date_trunc('day', now())
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'arbitrum'
     and contract_address = 0x5979d7b546e38e414f7e9822514be443a4800529
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_pools.sql
@@ -71,7 +71,7 @@ select 0x5979D7b546E38E414F7E9822514be443A4800529
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'arbitrum'
       AND contract_address IN (SELECT address  FROM tokens)
   )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_v2_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_kyberswap_v2_pools.sql
@@ -72,7 +72,7 @@ select 0x5979D7b546E38E414F7E9822514be443A4800529
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'arbitrum'
       AND contract_address IN (SELECT address  FROM tokens where address NOT IN  (0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48, 0x9cfb13e6c11054ac9fcb92ba89644f30775436e4 ))
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_pancakeswap_v3_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_pancakeswap_v3_pools.sql
@@ -61,7 +61,7 @@ select 0x5979D7b546E38E414F7E9822514be443A4800529
         symbol,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'arbitrum'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_ramses_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_ramses_pools.sql
@@ -84,7 +84,7 @@ with
     FROM
       {{source('prices','usd')}} p
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'arbitrum'
       AND contract_address IN (SELECT address  FROM tokens      )
   ),

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_uniswap_v3_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_uniswap_v3_pools.sql
@@ -84,7 +84,7 @@ with
     FROM
       {{source('prices','usd')}} p
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'arbitrum'
       AND contract_address IN (SELECT address  FROM tokens      )
   ),

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_wombat_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/arbitrum/lido_liquidity_arbitrum_wombat_pools.sql
@@ -43,7 +43,7 @@ tokens_prices_daily AS (
       LAST_VALUE(price) OVER (PARTITION BY  DATE_TRUNC('day', minute), contract_address  ORDER BY minute NULLS FIRST range BETWEEN UNBOUNDED preceding AND UNBOUNDED following) AS price
     FROM {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = DATE_TRUNC('day', now())
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'arbitrum'
       AND contract_address = 0x5979d7b546e38e414f7e9822514be443a4800529
   )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_aerodrome_cl_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_aerodrome_cl_pools.sql
@@ -75,7 +75,7 @@ select distinct
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       and blockchain = 'base'
   and contract_address IN (select token from tokens) 
  )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_aerodrome_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_aerodrome_pools.sql
@@ -75,7 +75,7 @@ select distinct
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       and blockchain = 'base'
   and contract_address IN (select token from tokens) 
  )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_balancer_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_balancer_pools.sql
@@ -68,7 +68,7 @@ WHERE call_create.output_0 in (select distinct  poolAddress from pools)
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'base'
     and contract_address in (select distinct token_address from tokens)
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_kyberswap_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_kyberswap_pools.sql
@@ -66,7 +66,7 @@ from (
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute NULLS FIRST range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}} p
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'base'
     and contract_address in (select address from tokens)
       

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_maverick_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_maverick_pools.sql
@@ -62,7 +62,7 @@ select 0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'base'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_pancakeswap_v3_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_pancakeswap_v3_pools.sql
@@ -61,7 +61,7 @@ select 0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452
         symbol,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'base'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_uniswap_v3_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/base/lido_liquidity_base_uniswap_v3_pools.sql
@@ -84,7 +84,7 @@ with
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'base'
       AND contract_address IN (SELECT address  FROM tokens)
   ),

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/bnb/lido_liquidity_bnb_pancakeswap_v3_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/bnb/lido_liquidity_bnb_pancakeswap_v3_pools.sql
@@ -61,7 +61,7 @@ select 0x26c5e01524d2E6280A48F2c50fF6De7e52E9611C
         symbol,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'bnb'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/bnb/lido_liquidity_bnb_thena_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/bnb/lido_liquidity_bnb_thena_pools.sql
@@ -61,7 +61,7 @@ select 0x26c5e01524d2E6280A48F2c50fF6De7e52E9611C
         symbol,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'bnb'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_balancer_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_balancer_pools.sql
@@ -63,7 +63,7 @@ group by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84
 
@@ -180,7 +180,7 @@ from (
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address in (select distinct token_address from tokens)
     union all
@@ -209,7 +209,7 @@ union all
         18,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
 union all

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_conc_pool.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_conc_pool.sql
@@ -178,7 +178,7 @@ order by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and symbol = 'WETH'
 
@@ -224,7 +224,7 @@ order by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_frxeth_pool.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_frxeth_pool.sql
@@ -191,7 +191,7 @@ from {{source('curvefi_ethereum','frxeth_eth_pool_call_price_oracle')}}
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and symbol = 'WETH'
 
@@ -238,7 +238,7 @@ from {{source('curvefi_ethereum','frxeth_eth_pool_call_price_oracle')}}
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_ng_pool.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_ng_pool.sql
@@ -172,7 +172,7 @@ group by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and symbol = 'WETH'
 
@@ -218,7 +218,7 @@ group by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_pool.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_steth_pool.sql
@@ -171,7 +171,7 @@ group by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and symbol = 'WETH'
 
@@ -216,7 +216,7 @@ group by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_wsteth_pufeth_pool.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_wsteth_pufeth_pool.sql
@@ -129,7 +129,7 @@ order by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0xD9A442856C234a39a81a089C06451EBAa4306a72
 
@@ -174,7 +174,7 @@ order by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_wsteth_reth_pool.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_curve_wsteth_reth_pool.sql
@@ -129,7 +129,7 @@ order by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0xae78736Cd615f374D3085123A210448E74Fc6393
 
@@ -174,7 +174,7 @@ order by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_kyberswap_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_kyberswap_pools.sql
@@ -61,7 +61,7 @@ select 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0
         symbol,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_kyberswap_v2_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_kyberswap_v2_pools.sql
@@ -61,7 +61,7 @@ select 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0
         symbol,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_maverick_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_maverick_pools.sql
@@ -62,7 +62,7 @@ select 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_pancakeswap_v3_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_pancakeswap_v3_pools.sql
@@ -61,7 +61,7 @@ select 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0
         symbol,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_solidly_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_solidly_pools.sql
@@ -62,7 +62,7 @@ group by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84
 
@@ -137,7 +137,7 @@ group by 1
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'ethereum'
       AND contract_address IN (SELECT address  FROM tokens      )
   ),

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_uniswap_v2_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_uniswap_v2_pools.sql
@@ -87,7 +87,7 @@ cross join unnest(day) as days(day)
       ) AS price
     FROM {{source('prices','usd')}} p
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'ethereum'
       AND contract_address IN (SELECT address  FROM tokens      )
   )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_uniswap_v3_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/ethereum/lido_liquidity_ethereum_uniswap_v3_pools.sql
@@ -62,7 +62,7 @@ group by 1
         DATE_TRUNC('day', minute),
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84
 
@@ -151,7 +151,7 @@ group by 1
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'ethereum'
       AND contract_address IN (SELECT address  FROM tokens      )
   ),

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/linea/lido_liquidity_linea_lynex_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/linea/lido_liquidity_linea_lynex_pools.sql
@@ -63,7 +63,7 @@ select distinct
       LAST_VALUE(price) OVER (PARTITION BY DATE_TRUNC('day', minute),contract_address  ORDER BY minute NULLS FIRST range BETWEEN UNBOUNDED preceding AND UNBOUNDED following) AS price
     FROM {{source('prices','usd')}} p
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       and blockchain = 'linea'
   and contract_address IN (select token from tokens) 
  )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/linea/lido_liquidity_linea_pancakeswap_v3_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/linea/lido_liquidity_linea_pancakeswap_v3_pools.sql
@@ -61,7 +61,7 @@ select 0xB5beDd42000b71FddE22D3eE8a79Bd49A568fC8F
         symbol,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'linea'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/linea/lido_liquidity_linea_syncswap_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/linea/lido_liquidity_linea_syncswap_pools.sql
@@ -63,7 +63,7 @@ select distinct
       LAST_VALUE(price) OVER (PARTITION BY DATE_TRUNC('day', minute),contract_address  ORDER BY minute NULLS FIRST range BETWEEN UNBOUNDED preceding AND UNBOUNDED following) AS price
     FROM {{source('prices','usd')}} p
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       and blockchain = 'linea'
   and contract_address IN (select token from tokens) 
  )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_balancer_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_balancer_pools.sql
@@ -84,7 +84,7 @@ WHERE call_create.output_0 in (select distinct  poolAddress from pools)
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'optimism'
     and contract_address in (select distinct token_address from tokens)
     union all
@@ -113,7 +113,7 @@ union all
         18,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices','usd')}} p
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'optimism'
     and contract_address = 0x7F5c764cBc14f9669B88837ca1490cCa17c31607
 union all
@@ -142,7 +142,7 @@ union all
         18,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'optimism'
     and contract_address = 0x68f180fcCe6836688e9084f035309E29Bf0A2095
 union all
@@ -171,7 +171,7 @@ union all
         18,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'optimism'
     and contract_address = 0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_curve_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_curve_pools.sql
@@ -43,7 +43,7 @@ with
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'optimism'
     and contract_address = 0x4200000000000000000000000000000000000006
 
@@ -98,7 +98,7 @@ with
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = date_trunc('day', now())
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'ethereum'
     and contract_address = 0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_kyberswap_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_kyberswap_pools.sql
@@ -60,7 +60,7 @@ select 0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }} p
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'optimism'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_kyberswap_v2_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_kyberswap_v2_pools.sql
@@ -62,7 +62,7 @@ select 0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }} p
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'optimism'
     and contract_address in (select address from tokens where address not in (0x9cfb13e6c11054ac9fcb92ba89644f30775436e4))
 
@@ -92,7 +92,7 @@ select 0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }} p
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'optimism'
     and contract_address in (0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb)
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_solidly_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_solidly_pools.sql
@@ -81,7 +81,7 @@ with pools AS (
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'optimism'
       AND contract_address IN (SELECT address  FROM tokens      )
   ),

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_uniswap_v3_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_uniswap_v3_pools.sql
@@ -85,7 +85,7 @@ with
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'optimism'
       AND contract_address IN (SELECT address  FROM tokens)
   ),

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_velodrome_cl_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_velodrome_cl_pools.sql
@@ -75,7 +75,7 @@ select distinct
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       and blockchain = 'optimism'
   and contract_address IN (select token from tokens) 
  )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_velodrome_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_velodrome_pools.sql
@@ -72,7 +72,7 @@ select distinct
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       and blockchain = 'optimism'
   and contract_address IN (select token from tokens) 
  )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_velodrome_v2_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/optimism/lido_liquidity_optimism_velodrome_v2_pools.sql
@@ -73,7 +73,7 @@ select distinct
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       and blockchain = 'optimism'
   and contract_address IN (select token from tokens) 
  )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/polygon/lido_liquidity_polygon_balancer_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/polygon/lido_liquidity_polygon_balancer_pools.sql
@@ -89,7 +89,7 @@ WHERE call_create.output_0 in (select distinct  poolAddress from pools)
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source ('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'polygon'
     and contract_address in (select distinct token_address from tokens)
     union all
@@ -117,7 +117,7 @@ union all
         18,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source ('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'polygon'
     and contract_address = 0x7ceb23fd6bc0add59e62ac25578270cff1b9f619
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/polygon/lido_liquidity_polygon_kyberswap_v2_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/polygon/lido_liquidity_polygon_kyberswap_v2_pools.sql
@@ -62,7 +62,7 @@ select 0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }} p
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'polygon'
     and contract_address in (select address from tokens where address not in (0xd7bb095a60d7666d4a6f236423b47ddd6ae6cfa7))
 
@@ -92,7 +92,7 @@ select 0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }} p
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'polygon'
     and contract_address in (0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD)
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/polygon/lido_liquidity_polygon_uniswap_v3_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/polygon/lido_liquidity_polygon_uniswap_v3_pools.sql
@@ -83,7 +83,7 @@ with
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       AND blockchain = 'polygon'
       AND contract_address IN (SELECT address  FROM tokens)
   ),

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/scroll/lido_liquidity_scroll_maverick_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/scroll/lido_liquidity_scroll_maverick_pools.sql
@@ -62,7 +62,7 @@ select 0xf610A9dfB7C89644979b4A0f27063E9e7d7Cda32
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'scroll'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/scroll/lido_liquidity_scroll_nuri_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/scroll/lido_liquidity_scroll_nuri_pools.sql
@@ -65,7 +65,7 @@ select distinct
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       and blockchain = 'scroll'
   and contract_address IN (select token from tokens) 
  )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/scroll/lido_liquidity_scroll_syncswap_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/scroll/lido_liquidity_scroll_syncswap_pools.sql
@@ -65,7 +65,7 @@ select distinct
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       and blockchain = 'scroll'
   and contract_address IN (select token from tokens) 
  )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/scroll/lido_liquidity_scroll_zebra_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/scroll/lido_liquidity_scroll_zebra_pools.sql
@@ -66,7 +66,7 @@ select distinct
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       and blockchain = 'scroll'
   and contract_address IN (select token from tokens) 
  )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/zksync/lido_liquidity_zksync_maverick_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/zksync/lido_liquidity_zksync_maverick_pools.sql
@@ -63,7 +63,7 @@ select 0x703b52F2b28fEbcB60E1372858AF5b18849FE867
         decimals,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{source('prices','usd')}}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'zksync'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/zksync/lido_liquidity_zksync_pancakeswap_v3_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/zksync/lido_liquidity_zksync_pancakeswap_v3_pools.sql
@@ -61,7 +61,7 @@ select 0x703b52F2b28fEbcB60E1372858AF5b18849FE867
         symbol,
         last_value(price) over (partition by DATE_TRUNC('day', minute), contract_address ORDER BY  minute range between unbounded preceding AND unbounded following) AS price
     FROM {{ source('prices', 'usd') }}
-    WHERE date_trunc('day', minute) = current_date
+    WHERE minute >= current_date and minute < current_date + interval '1' day
     and blockchain = 'zksync'
     and contract_address in (select address from tokens)
 )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/zksync/lido_liquidity_zksync_syncswap_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/zksync/lido_liquidity_zksync_syncswap_pools.sql
@@ -65,7 +65,7 @@ select distinct
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       and blockchain = 'zksync'
   and contract_address IN (select token from tokens) 
  )

--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/zksync/lido_liquidity_zksync_syncswap_v2_pools.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/liquidity/zksync/lido_liquidity_zksync_syncswap_v2_pools.sql
@@ -65,7 +65,7 @@ select distinct
     FROM
       {{source('prices','usd')}}
     WHERE
-      DATE_TRUNC('day', minute) = current_date
+      minute >= current_date and minute < current_date + interval '1' day
       and blockchain = 'zksync'
   and contract_address IN (select token from tokens) 
  )


### PR DESCRIPTION
The lido_liquidity_*_pools models fetch the current day's price with `date_trunc('day', minute) = current_date`. `prices.usd` is a view joining the minute-grain fact to the tokens dimension on `token_id`, so `minute` is the only column that can prune the fact scan — and wrapping it in `date_trunc` defeats Delta file skipping entirely. Each such branch reads the full 4.4B-row / ~29 GB `prices.usd` fact, and CTE inlining multiplies it: on `lido_liquidity_optimism_curve_pools` one hourly MERGE runs 17 scans of `prices.usd`, 8 of them full-table, ~229 GB and ~70% of query CPU (query `20260611_025535_39364_2g4m5`).

This PR rewrites the predicate to the equivalent pushable range `minute >= current_date and minute < current_date + interval '1' day` — 73 occurrences across the 55 models in the family. No other logic touched.

Measured A/B on `lido_liquidity_optimism_curve_pools` (incremental window frozen to 2026-06-08, medians of 3 warm runs, checksum over all output columns):

| axis | before | after | delta |
|---|---|---|---|
| physical input | 228.5 GB | 2.38 GB | -99.0% (96x) |
| CPU | 648 s | 31 s | -95.2% (20.6x) |
| wall | 94 s | 31 s | -67% (3.0x) |
| peak memory | 1.06 GB | 0.83 GB | -22% |

The family runs hourly (~35-40 CPU-hrs/day, ~100+ TB/day scanned); projected post-merge family impact is roughly 30+ CPU-hrs/day and ~100 TB/day of S3 reads removed. Realized prod numbers will be posted after merge.

Equivalence proof: the old and new predicates select the exact same `prices.usd` row set (EXCEPT = 0 both ways per token, on a frozen past day and on the live current day); full-model EXCEPT both ways is 0 modulo the model's own floating-point noise floor (an A-vs-A control of the unchanged SQL shows the same 1-row checksum drift in `avg`/`sum` over doubles). All non-double output columns checksum-identical across 6 runs (3 per variant).

Fixes CUR2-2763