### PR TITLE
perf(bridges): propagate block_time into layerzero deposits transfers scan

### DIFF
--- a/dbt_subprojects/hourly_spellbook/macros/sector/bridges/layerzero_v1_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/bridges/layerzero_v1_deposits.sql
@@ -17,15 +17,17 @@ WITH send_calls AS (
     )
 
 , distinct_calls AS (
-    SELECT block_number
+    SELECT block_time
+    , block_number
     , tx_hash
     , MAX(call_send_index) AS max_call_send_index
     FROM send_calls
-    GROUP BY 1, 2
+    GROUP BY 1, 2, 3
     )
 
 , transfers AS (
-    SELECT block_number
+    SELECT block_time
+    , block_number
     , tx_hash
     , sender
     , recipient
@@ -36,7 +38,8 @@ WITH send_calls AS (
     , unique_key
     , rn
     FROM (
-        SELECT t.block_number
+        SELECT t.block_time
+        , t.block_number
         , t.tx_hash
         , t."from" AS sender
         , t.to AS recipient
@@ -45,11 +48,15 @@ WITH send_calls AS (
         , t.contract_address AS deposit_token_address
         , t.evt_index
         , t.unique_key
-        , ROW_NUMBER() OVER (PARTITION BY t.tx_hash ORDER BY COALESCE(t.trace_address, ARRAY[t.evt_index])) AS rn
+        -- block_time in the window partition keys is redundant for correctness (tx_hash
+        -- determines the block) but lets the planner propagate the incremental
+        -- block_time predicate below the window instead of scanning all history
+        , ROW_NUMBER() OVER (PARTITION BY t.block_time, t.block_number, t.tx_hash ORDER BY COALESCE(t.trace_address, ARRAY[t.evt_index])) AS rn
         , sc.max_call_send_index
         FROM {{ source('tokens_' + blockchain, 'transfers') }} t
         INNER JOIN {{ ref('bridges_layerzero_chain_indexes') }} i ON i.blockchain='{{blockchain}}'
-        INNER JOIN distinct_calls sc ON t.block_number=sc.block_number
+        INNER JOIN distinct_calls sc ON t.block_time=sc.block_time
+                AND t.block_number=sc.block_number
                 AND t.tx_hash=sc.tx_hash
                 AND t.to=i.endpoint_address
         )
@@ -75,7 +82,8 @@ SELECT distinct '{{blockchain}}' AS deposit_chain
 , sc.contract_address
 , {{ dbt_utils.generate_surrogate_key(['sc.tx_hash', 't.evt_index', 'sc.call_send_index']) }} as bridge_transfer_id
 FROM send_calls sc
-LEFT JOIN transfers t ON t.block_number=sc.block_number
+LEFT JOIN transfers t ON t.block_time=sc.block_time
+        AND t.block_number=sc.block_number
         AND t.tx_hash=sc.tx_hash
         AND t.rn=sc.call_send_index
 LEFT JOIN {{ ref('bridges_layerzero_chain_indexes') }} ci ON sc.withdrawal_chain_id=ci.id


### PR DESCRIPTION
The `bridges_*_deposits` hourly MERGEs are the spellbook-hourly cluster's largest IO family (~50 TB/day, ~48 CPU-hrs/day across 8 chains). Almost all of it comes from one scan: the layerzero branch reads `tokens_<chain>.transfers` over **all history** every hour — on base that's 13.0B rows / 574 GiB per run emitting just 5.1M rows (94% of the build's CPU, query `20260611_054107_76366_2g4m5`).

Root cause: the `transfers` CTE in `layerzero_v1_deposits` never selects `block_time`, so the model's 3-day incremental predicate (applied on `send_calls.block_time`) cannot reach the transfers scan, and Delta file-skipping never kicks in. The orbiter branch in the same build scans the same table with `block_time` propagated and reads only 78M rows — proving the table prunes fine when the predicate gets there.

Fix: carry `block_time` through `distinct_calls` and the `transfers` CTE, add it to the join keys and to the window partition keys. Semantically a no-op (`tx_hash` already determines the block, so `block_time` is functionally dependent on the existing keys), but it gives the planner an equality chain to push the incremental predicate all the way into the transfers scan.

Equivalence proven on base: `current EXCEPT rewrite` = 0 and `rewrite EXCEPT current` = 0 over the 3-day incremental window, plus identical row count (9,042) and identical per-column checksums over all 18 output columns for a historical week (2024-09-01..08).

A/B on the standalone layerzero view (3 warm runs each, medians, `count(*)` + checksum over every output column):

| | current | rewrite | factor |
|---|---|---|---|
| IO scanned | 612.24 GB | 3.51 GB | **174x** |
| CPU | 1,534 s | 36 s | **43x** |
| wall | 273 s | 2.1 s | **130x** |
| peak memory | 7.0 GB | 0.4 GB | 18x |
| spill | 0 | 0 | — |

The macro is used by 8 chains (arbitrum, avalanche_c, base, celo, ethereum, fantom, optimism, polygon), each merging ~hourly. Projected family impact: ~48 → ~3-4 CPU-hrs/day and ~51 → ~2-4 TB/day scanned (saves ~7% of cluster CPU and ~47 TB/day of S3 reads). A full-refresh/backfill run is unaffected — without an incremental predicate the plan is the same as today.

Fixes CUR2-2767
