### PR TITLE
perf(dex_sui_pool_map): prune the 30B-row sui.objects scan in incremental runs

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/sui/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/sui/_schema.yml
@@ -36,3 +36,26 @@ models:
     config:
       tags: ['sui','walrus']
     description: "Walrus decentralized storage blob registrations and certifications on Sui, including blob hash, size, epoch range, and sender."
+
+  - name: dex_sui_pool_map
+    meta:
+      blockchain: sui
+      project: dex
+      short_description: "Mapping of Sui DEX pool ids to their two coin types, resolved from the on-chain object type of each traded pool."
+    config:
+      tags: ['sui','dex']
+    description: "Mapping of Sui DEX pool ids to their two coin types, resolved from the on-chain object type of each traded pool."
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - pool_id
+    columns:
+      - name: pool_id
+        description: "Normalized ('0x' + 64 hex) Sui object id of the DEX pool; merge key of this incremental model."
+        data_tests:
+          - not_null
+      - name: coin_type_a
+        description: "Fully-qualified Sui coin type of the pool's first asset."
+      - name: coin_type_b
+        description: "Fully-qualified Sui coin type of the pool's second asset."

--- a/dbt_subprojects/daily_spellbook/models/sui/dex_sui_pool_map.sql
+++ b/dbt_subprojects/daily_spellbook/models/sui/dex_sui_pool_map.sql
@@ -21,19 +21,33 @@ with used_pools as (
 )
 
 -- 2) Latest object row per pool_id
+-- Join on the raw varbinary object_id (not a per-row hex-string expression) so the
+-- planner can build a dynamic filter from the small used_pools side and push it
+-- into the objects scan. try() keeps the old behavior for malformed pool_ids:
+-- they simply never match.
 , latest as (
   select
       ('0x' || lower(to_hex(o.object_id))) as object_id_hex
       , cast(o.type_ as varchar)             as type_str
       , o.checkpoint
       , row_number() over (
-        partition by ('0x' || lower(to_hex(o.object_id)))
+        partition by o.object_id
         order by o.checkpoint desc
       ) as rn
   from {{ source('sui','objects') }} o
   join used_pools u
-    on ('0x' || lower(to_hex(o.object_id))) = u.pool_id
+    on o.object_id = try(from_hex(substr(u.pool_id, 3)))
   where strpos(cast(o.type_ as varchar), '<') > 0
+  {% if is_incremental() %}
+    -- Pools traded inside the incremental window were mutated at those trade
+    -- checkpoints, so each has at least one object version in the window
+    -- (objects.date is the checkpoint date, same midnight floor as block_time).
+    -- Sui object types are immutable, so any version parses to the same coin
+    -- types as the all-time latest. This prunes the 30B-row objects scan to the
+    -- last few date partitions. Full refresh keeps the unbounded scan because
+    -- historic pools' latest versions can be arbitrarily old.
+    and o.date >= date(date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}))
+  {% endif %}
 )
 
 -- 3) Extract generic type parameters


### PR DESCRIPTION
The incremental MERGE for `dex_sui.pool_map` resolves ~1.4K recently-traded pools against `sui.objects`, but it joined on a per-row hex-string expression (`'0x' || lower(to_hex(o.object_id))`), which blocked dynamic filtering and forced a full, unfiltered scan of the 30B-row / 561 GB objects table every run. The 30B-row probe side then spilled 1.47 TB in the lookup join.

Two changes, incremental runs only (full refresh keeps the unbounded scan since historic pools' latest versions can be arbitrarily old):

1. Join on the raw varbinary `o.object_id = try(from_hex(substr(u.pool_id, 3)))` so the planner builds a dynamic filter from the small `used_pools` side and pushes it into the objects scan (`try()` preserves the old never-match behavior for malformed ids). The `row_number` partition key moves to `o.object_id`, which is bijective with the hex string.
2. Bound the objects scan to the incremental window: `o.date >= date(date_trunc('day', now() - interval '3' day))` (same vars/floor as `incremental_predicate('block_time')` on the trades side). `objects.date` is the checkpoint date, so any pool traded in-window has at least one in-window object version, and Sui object types are immutable, so any version row parses to the same coin types as the all-time latest.

## Proof

Equivalence over a fixed window (`block_time >= 2026-06-08`, single-query FULL OUTER JOIN so both pipelines see one snapshot): **1,173 pool keys, 0 only-in-old, 0 only-in-new, 0 value mismatches** (= EXCEPT 0 both ways; query `20260611_213543_24366_tnt5z`). Coverage probe: all 1,417 in-window pools have a typed object version inside the window, each with exactly 1 distinct type.

A/B, baseline = prod MERGE `20260609_063425_17088_xee2n` (spellbook-daily) vs rewrite source build (median of 3 warm runs, checksum over all output columns, spellbook-sqlmesh):

| dimension | before | after | Δ |
|---|---|---|---|
| CPU | 35,676 s | 27.5 s | ~1,297x |
| IO (physical input) | 561.5 GB | 1.14 GB | ~494x |
| wall | 1,940 s | 0.88 s | — |
| peak memory | 7.31 GB | 0.22 GB | ~33x |
| spill | 1.47 TB | 0 | eliminated |

Post-change scan facts confirm both levers fired: partition pruning `date >= 2026-06-08` (109.7M rows in) and dynamic filter on `object_id` completed (16.2M rows out).

Per-day projection on spellbook-daily: ~9.9 -> ~0.01 CPU-hrs/day, ~562 GB -> ~1.1 GB scanned/day, 1.48 TB/day spill eliminated.

No backfill needed: the merge target is untouched and the incremental window behavior is identical.

Fixes CUR2-2728
