### PR TITLE
Add uv no-build (binary-only)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,7 @@ dependencies = [
 
 [tool.uv]
 exclude-newer = "3 days"
+no-build = true
+# daff 1.3.46 publishes no wheel (sdist-only on all platforms); allow its build
+no-build-package = { daff = false }
 package = false

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = "==3.13.*"
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P3D"
-
 [[package]]
 name = "agate"
 version = "1.9.1"


### PR DESCRIPTION
Add uv `no-build = true` (binary-only). `daff` exempted via `no-build-package` (publishes no wheel; sdist-only).