### PR TITLE
Add Dependabot cooldown and standardize update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,9 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     groups:
       security-updates:
@@ -16,7 +18,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     groups:
       security-updates:


### PR DESCRIPTION
## Summary
- Added a 7-day cooldown before Dependabot opens dependency update PRs
- Standardized update groups across ecosystems
- Set the update schedule to monthly