### PR TITLE
perf(near_v1_signer_users): convert daily full rebuild to incremental append

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_blockchains/near/v1_signer/near_v1_signer_users.sql
+++ b/dbt_subprojects/daily_spellbook/models/_blockchains/near/v1_signer/near_v1_signer_users.sql
@@ -2,33 +2,61 @@
   config(
     schema = 'near_v1_signer',
     alias = 'users',
-    materialized = 'table'
+    materialized = 'incremental',
+    incremental_strategy = 'append'
     , post_hook='{{ hide_spells() }}'
   )
 }}
 
 -- PoC Query: https://dune.com/queries/4642523
+WITH sign_requests AS (
+  SELECT
+    receipt_predecessor_account_id as account_id,
+    json_extract_scalar(action_function_call_args_parsed, '$.request.path') AS derivation_path,
+    CAST(json_extract_scalar(action_function_call_args_parsed, '$.request.key_version') AS INTEGER) AS key_version
+  FROM {{ source('near', 'actions') }} action
+  JOIN {{ source('near', 'logs') }} log
+  ON action.block_height = log.block_height
+  AND action.block_date = log.block_date
+  AND action.receipt_id = log.receipt_id
+  WHERE
+    receipt_receiver_account_id = 'v1.signer'
+    -- Deployment block of v1.signer: https://nearblocks.io/txns/79BBi3H3XgzktscGqKDZHAiNGRseuAJuYCmHkxKFLNif
+    AND action.block_height >= 124788114
+    AND log.block_height >= 124788114
+    -- block_date of the deployment block: bounds full refreshes to
+    -- post-deployment partitions (block_height alone cannot prune)
+    AND action.block_date >= DATE '2024-08-01'
+    AND log.block_date >= DATE '2024-08-01'
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('action.block_date') }}
+    AND {{ incremental_predicate('log.block_date') }}
+    {% endif %}
+    AND action_kind = 'FUNCTION_CALL'
+    AND action_function_call_call_method_name = 'sign'
+    -- $ echo "eyJyZXF1ZXN0Ijp" | base64 --decode ==> {"request":{
+    AND SUBSTRING(
+      action_function_call_call_args_base64,
+      1,
+      LENGTH('eyJyZXF1ZXN0Ijp')
+    ) = 'eyJyZXF1ZXN0Ijp'
+    AND index_in_execution_outcome_logs = 1
+    GROUP BY 1,2,3
+)
+
 SELECT
-  receipt_predecessor_account_id as account_id,
-  json_extract_scalar(action_function_call_args_parsed, '$.request.path') AS derivation_path,
-  CAST(json_extract_scalar(action_function_call_args_parsed, '$.request.key_version') AS INTEGER) AS key_version
-FROM {{ source('near', 'actions') }} action
-JOIN {{ source('near', 'logs') }} log
-ON action.block_height = log.block_height
-AND action.block_date = log.block_date
-AND action.receipt_id = log.receipt_id
-WHERE
-  receipt_receiver_account_id = 'v1.signer'
-  -- Deployment block of v1.signer: https://nearblocks.io/txns/79BBi3H3XgzktscGqKDZHAiNGRseuAJuYCmHkxKFLNif
-  AND action.block_height >= 124788114
-  AND log.block_height >= 124788114
-  AND action_kind = 'FUNCTION_CALL'
-  AND action_function_call_call_method_name = 'sign'
-  -- $ echo "eyJyZXF1ZXN0Ijp" | base64 --decode ==> {"request":{
-  AND SUBSTRING(
-    action_function_call_call_args_base64,
-    1,
-    LENGTH('eyJyZXF1ZXN0Ijp')
-  ) = 'eyJyZXF1ZXN0Ijp'
-  AND index_in_execution_outcome_logs = 1
-  GROUP BY 1,2,3
+  account_id,
+  derivation_path,
+  key_version
+FROM sign_requests
+{% if is_incremental() %}
+-- key_version can be NULL (655 of 6136 rows), so a merge unique_key would not
+-- dedupe those rows; append only the triples not already in the table
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM {{ this }} existing
+  WHERE existing.account_id = sign_requests.account_id
+    AND existing.derivation_path IS NOT DISTINCT FROM sign_requests.derivation_path
+    AND existing.key_version IS NOT DISTINCT FROM sign_requests.key_version
+)
+{% endif %}


### PR DESCRIPTION
`near_v1_signer.users` was a daily full rebuild that scanned all of `near.actions` (12B rows, 1.38 TB) plus `near.logs` (11.8B rows, 386 GB) every run -- 1.77 TB of IO and ~3.9 CPU-hrs per day -- to produce a ~6,100-row dimension of distinct `(account_id, derivation_path, key_version)` triples. The output is a monotonic set: triples only ever get added, never restated, so rebuilding history daily is pure waste.

This converts the model to `incremental` with `strategy='append'` plus a `NOT EXISTS` anti-join against `{{ this }}`. Merge with a `unique_key` was deliberately avoided: `key_version` is NULL for 655 of 6,136 rows (and `derivation_path` is nullable), and a merge `ON` clause never matches NULL keys, which would silently duplicate those rows. The anti-join uses `IS NOT DISTINCT FROM` to handle NULLs correctly (same pattern as #9754).

Incremental runs read only the last 3 days of `block_date` partitions on both sides of the join (`incremental_predicate` on `action.block_date` and `log.block_date`; both tables are `block_date`-partitioned). A constant `block_date >= DATE '2024-08-01'` floor (the v1.signer deployment block 124788114's date) also bounds full refreshes; proven a semantic no-op (0 rows exist with `block_height >= 124788114` and an earlier `block_date`).

## Proofs (read-only, prod data, spellbook-cd-large, UTC)

- Floor safety: `count(*)` of rows with `block_height >= 124788114 AND block_date < DATE '2024-08-01'` = 0 on both `near.actions` and `near.logs`.
- Floored full SELECT vs current full SELECT: identical row count (6,136) and identical `checksum()` on all three output columns.
- Incremental simulation (current table UNION ALL 3-day window with the anti-join) vs full rebuild: FULL OUTER JOIN diff = **0 rows both ways**.

## A/B (medians of warm runs, same cluster)

| | full rebuild (current) | incremental run | ratio |
|---|---|---|---|
| IO scanned | 1,766 GB | 4.37 GB | **404x** |
| CPU | ~12,100 s | ~24 s | **~500x** |
| wall | 53-106 s (540 s on prod cluster) | ~1.7 s | |
| peak memory | 37-67 GB | 0.4 GB | |

Projected per-day on spellbook-daily (1 build/day): 3.9 CPU-hrs -> ~0.01; 1.77 TB IO -> ~4.4 GB.

No backfill needed: the existing table is already the correct full-history set; the first incremental run simply appends from it. A `--full-refresh` reproduces the table exactly (proven by checksum above).
