### PR TITLE
Add uv no-build (binary-only) with daff source-build allow-list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,6 @@ dependencies = [
 [tool.uv]
 exclude-newer = "3 days"
 package = false
+no-build = true
+# binary-only, except allow daff (sdist-only, no wheels) to build from source
+no-binary-package = ["daff"]


### PR DESCRIPTION
Enforce wheels-only installs via `no-build = true`, with an auditable allow-list
exception for `daff` (sdist-only, no wheels) via `no-binary-package = ["daff"]`.
Keeps the `exclude-newer` cooldown and `package = false`.

Supersedes #9761.