### PR TITLE
perf(chainlink_polygon_vrf_request_fulfilled_daily): push incremental time bounds below the aggregation

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_schema.yml
@@ -918,8 +918,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - blockchain
-              - block_number
               - tx_hash
               - index
     columns:
@@ -931,10 +929,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_polygon_vrf_v2_random_fulfilled_logs

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_request_fulfilled_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_request_fulfilled_daily.sql
@@ -31,13 +31,12 @@ WITH vrf_request_fulfilled AS (
     {{ ref('chainlink_polygon_vrf_v1_random_request_logs') }} v1_request
     INNER JOIN {{ ref('chainlink_polygon_vrf_v1_random_fulfilled_logs') }} v1_fulfilled ON bytearray_substring(v1_fulfilled.data, 1, 32) = bytearray_substring(v1_request.data, 129, 32)
   {% if is_incremental() %}
-  -- 7-day lookback >> the max request->fulfillment delay ever observed on
-  -- polygon (28.1h over all 6.31M historical pairs). All request logs of a
-  -- group share one tx (one block_time), so every group whose
-  -- MAX(fulfilled.block_time) falls in the incremental window keeps its full
-  -- row set and the aggregates stay exact.
-  WHERE v1_request.block_time >= {{ incremental_lower_bound }} - interval '7' day
-    AND v1_fulfilled.block_time >= {{ incremental_lower_bound }} - interval '7' day
+  -- The request side is a materialized ~6.3M-row table read in full, so no
+  -- request-side lookback (or delay assumption) is needed. The fulfilled-side
+  -- bound is exact: a group passes the post-agg evt_block_time predicate iff
+  -- its MAX(fulfilled.block_time) row is itself in the window, and dropping
+  -- older sibling fulfillments cannot change MAX() or the request-side values.
+  WHERE {{ incremental_predicate('v1_fulfilled.block_time') }}
   {% endif %}
   GROUP BY
     v1_request.tx_hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_request_fulfilled_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_request_fulfilled_daily.sql
@@ -11,6 +11,57 @@
   )
 }}
 
+{%- set incremental_lower_bound -%}
+date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }})
+{%- endset -%}
+
+-- The upstream view chainlink_polygon_vrf_request_fulfilled computes
+-- evt_block_time = MAX(block_time) above a GROUP BY, so filtering its output
+-- with incremental_predicate('evt_block_time') cannot reach the polygon.logs
+-- scans (3 full scans, ~2.4 TiB/run, to merge a handful of rows). The view
+-- body is inlined here so the time bounds apply BELOW the aggregations and
+-- prune the Delta scans via block_time file skipping.
+WITH vrf_request_fulfilled AS (
+  SELECT
+    'polygon' as blockchain,
+    MAX(bytearray_to_uint256(bytearray_substring(v1_request.data, 110, 19)) / 1e18) AS token_value,
+    MAX(v1_fulfilled.tx_from) as operator_address,
+    MAX(v1_fulfilled.block_time) as evt_block_time
+  FROM
+    {{ ref('chainlink_polygon_vrf_v1_random_request_logs') }} v1_request
+    INNER JOIN {{ ref('chainlink_polygon_vrf_v1_random_fulfilled_logs') }} v1_fulfilled ON bytearray_substring(v1_fulfilled.data, 1, 32) = bytearray_substring(v1_request.data, 129, 32)
+  {% if is_incremental() %}
+  -- 7-day lookback >> the max request->fulfillment delay ever observed on
+  -- polygon (28.1h over all 6.31M historical pairs). All request logs of a
+  -- group share one tx (one block_time), so every group whose
+  -- MAX(fulfilled.block_time) falls in the incremental window keeps its full
+  -- row set and the aggregates stay exact.
+  WHERE v1_request.block_time >= {{ incremental_lower_bound }} - interval '7' day
+    AND v1_fulfilled.block_time >= {{ incremental_lower_bound }} - interval '7' day
+  {% endif %}
+  GROUP BY
+    v1_request.tx_hash,
+    v1_fulfilled.tx_from
+
+  UNION
+
+  SELECT
+    'polygon' as blockchain,
+    MAX(bytearray_to_uint256(bytearray_substring(v2_fulfilled.data, 33, 32)) / 1e18) AS token_value,
+    MAX(v2_fulfilled.tx_from) as operator_address,
+    MAX(v2_fulfilled.block_time) as evt_block_time
+  FROM
+    {{ ref('chainlink_polygon_vrf_v2_random_fulfilled_logs') }} v2_fulfilled
+  {% if is_incremental() %}
+  -- exact: each group is a single log row (tx_hash + index), so the pre-agg
+  -- bound is equivalent to the post-agg evt_block_time predicate
+  WHERE {{ incremental_predicate('v2_fulfilled.block_time') }}
+  {% endif %}
+  GROUP BY
+    v2_fulfilled.tx_hash,
+    v2_fulfilled.tx_from,
+    v2_fulfilled.index
+)
 
 SELECT
   'polygon' as blockchain,
@@ -19,7 +70,7 @@ SELECT
   vrf_request_fulfilled.operator_address,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_polygon_vrf_request_fulfilled')}} vrf_request_fulfilled
+  vrf_request_fulfilled
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_v1_random_request_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_v1_random_request_logs.sql
@@ -1,10 +1,18 @@
 {{
   config(
-    
+
     alias='vrf_v1_random_request_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key=['tx_hash', 'index']
   )
 }}
+
+-- Materialized (was a view) so downstream consumers join the full ~6.3M-row
+-- request history without rescanning polygon.logs (50B+ rows); logs are
+-- append-only, so an incremental block_time window is exact.
 
 SELECT
   'polygon' as blockchain,
@@ -24,3 +32,6 @@ FROM
   {{ source('polygon', 'logs') }} logs
 WHERE
   topic0 = 0x56bd374744a66d531874338def36c906e3a6cf31176eb1e9afd9f1de69725d51 -- RandomnessRequest
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}


### PR DESCRIPTION
The daily incremental MERGE for `chainlink_polygon.vrf_request_fulfilled_daily` scans `polygon.logs` (50.9B rows) three times -- ~2.4 TiB and ~3.3 CPU-hrs per run -- to merge a handful of rows. The model filters `incremental_predicate('evt_block_time')` on the output of the `chainlink_polygon_vrf_request_fulfilled` view, where `evt_block_time = MAX(block_time)` sits above a GROUP BY, so the time predicate can never reach the log scans and only the `topic0` equality filters locally (selectivity ~0.0001).

This inlines the view body into the daily model and applies `is_incremental()` time bounds below the aggregations, where they push into the Delta scans and file-prune. Both bounds are exact -- no heuristic lookback:

- the v2 branch takes the incremental bound directly (each group is a single log row, so pre-agg == post-agg filtering);
- the v1 branch (request JOIN fulfilled on a `data`-substring requestId) joins recent fulfillments against the **full** request history: `chainlink_polygon_vrf_v1_random_request_logs` is converted from a view to an incremental table (~6.3M rows all-time; logs are append-only so its 3-day `block_time` merge window is exact). The fulfilled-side bound is exact too: a group passes the retained post-agg `evt_block_time >= B` predicate iff its `MAX(fulfilled.block_time)` row is itself `>= B`, and dropping older sibling fulfillments cannot change `MAX()` aggregates or request-side values -- so an arbitrarily-delayed fulfillment is still captured in the window where it lands.

The original post-aggregation predicate is retained as the authoritative window filter. Full-refresh paths are unchanged. As a side effect the cross-chain `chainlink_vrf_request_fulfilled` rollup view now reads the materialized request table instead of rescanning `polygon.logs`.

**Equivalence proof** (read-only, prod data, UTC, spellbook-sqlmesh):
- Single-evaluation FULL OUTER JOIN compare of OLD vs NEW (final shape: full request side, exact fulfilled bound) at historical bound `2026-05-15`: 82 output keys, **0 old-only, 0 new-only, 0 `date_month` mismatches** (queries `20260612_171832_19372_iypyc`, `20260612_172157_19785_iypyc`). 8-10 bit-level diffs on the double `token_amount`, max abs ~1e-15 -- matching the A-vs-A control noise floor (identical SQL both sides: 10 diffs, max 7.8e-16, query `20260612_100127_17708_pjfxe`), i.e. parallel-aggregation FP reassociation, not the rewrite.
- At the real prod bound (`date_trunc('day', now() - interval '3' day)`): `count(*)` and `checksum()` of every non-double output column **bit-identical** across all 3 OLD and 3 NEW runs.
- v1 delay-distribution context (full history, 6,307,139 request->fulfillment pairs): min 8s, max 28.1h, p99.9 2.5h (query `20260612_095300_17706_pjfxe`) -- informational only; the final design does not depend on any delay bound.

**A/B, medians of 3 warm runs** (checksum over all output columns, spellbook-sqlmesh, UTC):

| axis | OLD | NEW | delta |
|---|---|---|---|
| IO scanned | 2,583.8 GB | 6.08 GB | **-99.8% (425x)** |
| CPU | 17,233 s | 37.5 s | **-99.8% (460x)** |
| wall | 40.5 s | 1.5 s | 27x |
| peak memory | 18.7 GB | 0.02 GB | ~900x |
| spill | 0 | 0 | -- |

OLD runs: `20260612_100233_17895_pjfxe` `20260612_100326_18047_pjfxe` `20260612_100410_18157_pjfxe`; NEW runs: `20260612_100208_17780_pjfxe` `20260612_100212_17807_pjfxe` `20260612_100215_17833_pjfxe`. (Measured with the 7-day-lookback variant; the final shape additionally reads the ~few-hundred-MB materialized request dimension per run, which does not change the order of magnitude.)

Production baseline (spellbook-daily, 1 MERGE/day, stable across 06-10..06-12): ~3.3 CPU-hrs/day, ~2.58 TB IO/day, ~790-910 s wall/run, peak task mem 1.8 GiB (e.g. `20260612_035736_06848_9cu3v`). Expected realized: < 0.05 CPU-hrs/day and < 15 GB IO/day, plus the one-time initial build of the request table.

No backfill needed: history in the target table is untouched; only the incremental window source changes. Per-chain siblings share the pattern and are tracked separately.

Fixes CUR2-2786
