### PR TITLE
fix(oneinch): resolve AR v6 trace-decoded token details via calldata fallback

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_executions_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_executions_macro.sql
@@ -6,6 +6,12 @@
 -%}
 
 {%- set date_from = [blockchain.start, stream.start] | max -%}
+{%- set wrapper = blockchain.wrapped_native_token_address -%}
+{%- set nsymbol = blockchain.native_token_symbol -%}
+{%- set native = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' -%}
+{%- set nullss = '0x0000000000000000000000000000000000000000' -%}
+{%- set src_calldata_token = 'if(src_token_address in (' ~ nullss ~ ', ' ~ native ~ '), ' ~ wrapper ~ ', src_token_address)' -%}
+{%- set dst_calldata_token = 'if(dst_token_address in (' ~ nullss ~ ', ' ~ native ~ '), ' ~ wrapper ~ ', dst_token_address)' -%}
 
 
 
@@ -28,6 +34,15 @@ calls as (
         and protocol = 'AR'
         and block_date >= timestamp '{{ date_from }}'
         {% if is_incremental() -%} and {{ incremental_predicate('block_time') }} {%- endif %}
+)
+
+, tokens as ( -- token metadata fallback by the calldata token addresses for calls without matched transfers (e.g. internal calls of the router from wallet proxies)
+    select
+        contract_address
+        , symbol as token_symbol
+        , decimals as token_decimals
+    from {{ source('tokens', 'erc20') }}
+    where blockchain = '{{ blockchain.name }}'
 )
 
 {%- set src_data = 'cast(row(transfer_contract_address, transfer_symbol, transfer_amount, transfer_decimals, transfer_from) as row(address varbinary, symbol varchar, amount uint256, decimals bigint, sender varbinary))' -%}
@@ -108,17 +123,17 @@ select
     , dst_receiver as receiver
     , src_token_address
     , src_token_amount
-    , coalesce(src_user_data.address, src_data.address) as src_executed_address
-    , coalesce(src_user_data.symbol, src_data.symbol) as src_executed_symbol
-    , coalesce(src_user_data.amount, src_amount) as src_executed_amount -- first from the user, then only with the correct amount
+    , coalesce(src_user_data.address, src_data.address, {{ src_calldata_token }}) as src_executed_address
+    , coalesce(src_user_data.symbol, src_data.symbol, if(src_token_address in ({{ nullss }}, {{ native }}), {{ nsymbol }}, src_token.token_symbol)) as src_executed_symbol
+    , coalesce(src_user_data.amount, src_amount, src_token_amount) as src_executed_amount -- first from the user, then only with the correct amount, then from the decoded call params
     , src_amount_usd as src_executed_amount_usd
 
     , cast(null as varchar) as dst_blockchain
     , dst_token_address
     , dst_token_amount
-    , coalesce(dst_user_data.address, dst_data.address) as dst_executed_address
-    , coalesce(dst_user_data.symbol, dst_data.symbol) as dst_executed_symbol
-    , coalesce(dst_user_data.amount, dst_amount) as dst_executed_amount -- first to the user, then only with the correct amount
+    , coalesce(dst_user_data.address, dst_data.address, {{ dst_calldata_token }}) as dst_executed_address
+    , coalesce(dst_user_data.symbol, dst_data.symbol, if(dst_token_address in ({{ nullss }}, {{ native }}), {{ nsymbol }}, dst_token.token_symbol)) as dst_executed_symbol
+    , coalesce(dst_user_data.amount, dst_amount, dst_token_amount) as dst_executed_amount -- first to the user, then only with the correct amount, then from the decoded call output
     , dst_amount_usd as dst_executed_amount_usd
     
     , cast(null as varbinary) as order_hash
@@ -133,8 +148,8 @@ select
         , ('sources_amount_usd', format('$%,.0f', sources_amount_usd))
         , ('trusted_amount_usd', format('$%,.0f', trusted_amount_usd))
         , ('amount_usd', format('$%,.0f', amount_usd))
-        , ('src_decimals', cast(coalesce(src_user_data.decimals, src_data.decimals) as varchar))
-        , ('dst_decimals', cast(coalesce(dst_user_data.decimals, dst_data.decimals) as varchar))
+        , ('src_decimals', cast(coalesce(src_user_data.decimals, src_data.decimals, src_token.token_decimals) as varchar))
+        , ('dst_decimals', cast(coalesce(dst_user_data.decimals, dst_data.decimals, dst_token.token_decimals) as varchar))
     ]) as complement
 
     , remains
@@ -146,5 +161,7 @@ select
     , native_decimals
 from calls
 join executions using(block_date, block_number, tx_hash, call_trace_address)
+left join tokens as src_token on src_token.contract_address = {{ src_calldata_token }}
+left join tokens as dst_token on dst_token.contract_address = {{ dst_calldata_token }}
 
 {%- endmacro -%}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_executions_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_executions_macro.sql
@@ -12,6 +12,7 @@
 {%- set nullss = '0x0000000000000000000000000000000000000000' -%}
 {%- set src_calldata_token = 'if(src_token_address in (' ~ nullss ~ ', ' ~ native ~ '), ' ~ wrapper ~ ', src_token_address)' -%}
 {%- set dst_calldata_token = 'if(dst_token_address in (' ~ nullss ~ ', ' ~ native ~ '), ' ~ wrapper ~ ', dst_token_address)' -%}
+{%- set settlement_vaults = oneinch_ar_settlement_vaults_cfg_macro().get(blockchain.name, []) -%}
 
 
 
@@ -19,6 +20,10 @@ with
 
 calls as (
     select *
+        -- v6 swaps built by external routing proxies (e.g. the Binance wallet) carry a synthetic marker in the decoded desc
+        -- (srcToken = dstToken = srcReceiver = dstReceiver = marker address, amounts = 1) with the real route packed only in
+        -- the opaque executor data, so the token legs of these calls are recovered from the nested transfers instead
+        , coalesce(protocol_version = 6 and src_token_address = dst_token_address, false) as degenerate_params
     from {{ ref('oneinch_' + blockchain.name + '_ar') }}
     where true
         and block_date >= timestamp '{{ date_from }}'
@@ -45,10 +50,52 @@ calls as (
     where blockchain = '{{ blockchain.name }}'
 )
 
+, venues as ( -- venue-side parties for the degenerate netting: registered pools + flash-accounting singletons that hold the pool funds
+    select pool from {{ ref('dex_raw_pools') }} where blockchain = '{{ blockchain.name }}'
+    {%- for vault in settlement_vaults %}
+    union all select {{ vault }}
+    {%- endfor %}
+)
+
+, degenerate_netting as ( -- per-token net flow into the venue side of the nested transfers of degenerate calls
+    select
+        block_date
+        , block_number
+        , tx_hash
+        , call_trace_address
+        , if(cardinality(same) > 1, {{ wrapper }}, transfer_contract_address) as token_address -- the native leg as the wrapped native token
+        , max(transfer_symbol) as token_symbol
+        , max(transfer_decimals) as token_decimals
+        , sum(if(transfer_to in (select pool from venues), cast(transfer_amount as int256), int256 '0'))
+        - sum(if(transfer_from in (select pool from venues), cast(transfer_amount as int256), int256 '0')) as venue_net
+        , max(transfer_amount_usd) as token_amount_usd
+    from calls
+    join transfers using(blockchain, block_month, block_date, block_number, block_time, tx_hash, call_trace_address, call_selector, call_method, call_to, protocol, contract_name)
+    where degenerate_params
+        and transfer_contract_address <> src_token_address -- skip the marker token dust
+    group by 1, 2, 3, 4, 5
+)
+
+{%- set net_row_type = 'row(address varbinary, symbol varchar, amount uint256, decimals bigint)' -%}
+
+, degenerate_executions as ( -- src = the token flowing into the venues, dst = the token flowing out of them; the biggest by USD when several
+    select
+        block_date
+        , block_number
+        , tx_hash
+        , call_trace_address
+        , max_by(cast(row(token_address, token_symbol, cast(if(venue_net > int256 '0', venue_net) as uint256), token_decimals) as {{ net_row_type }}), coalesce(token_amount_usd, 0)) filter(where venue_net > int256 '0') as net_src_data
+        , max_by(cast(row(token_address, token_symbol, cast(if(venue_net < int256 '0', -venue_net) as uint256), token_decimals) as {{ net_row_type }}), coalesce(token_amount_usd, 0)) filter(where venue_net < int256 '0') as net_dst_data
+        , max(token_amount_usd) filter(where venue_net > int256 '0') as net_src_amount_usd
+        , max(token_amount_usd) filter(where venue_net < int256 '0') as net_dst_amount_usd
+    from degenerate_netting
+    group by 1, 2, 3, 4
+)
+
 {%- set src_data = 'cast(row(transfer_contract_address, transfer_symbol, transfer_amount, transfer_decimals, transfer_from) as row(address varbinary, symbol varchar, amount uint256, decimals bigint, sender varbinary))' -%}
 {%- set dst_data = 'cast(row(transfer_contract_address, transfer_symbol, transfer_amount, transfer_decimals, transfer_to) as row(address varbinary, symbol varchar, amount uint256, decimals bigint, receiver varbinary))' -%}
-{%- set src_condition = 'array_position(same, src_token_address) > 0 and transfer_amount <= src_token_amount' -%}
-{%- set dst_condition = 'array_position(same, dst_token_address) > 0 and transfer_amount <= dst_token_amount' -%}
+{%- set src_condition = 'not degenerate_params and array_position(same, src_token_address) > 0 and transfer_amount <= src_token_amount' -%}
+{%- set dst_condition = 'not degenerate_params and array_position(same, dst_token_address) > 0 and transfer_amount <= dst_token_amount' -%}
 {%- set user_condition = 'cardinality(array_intersect(array[transfer_from, transfer_to], array[tx_from, call_from, dst_receiver])) > 0' %}
 
 , executions as (
@@ -121,20 +168,20 @@ select
 
     , tx_from as user
     , dst_receiver as receiver
-    , src_token_address
+    , if(degenerate_params, net_src_data.address, src_token_address) as src_token_address -- the marker address of degenerate calls is replaced with the netted one
     , src_token_amount
-    , coalesce(src_user_data.address, src_data.address, {{ src_calldata_token }}) as src_executed_address
-    , coalesce(src_user_data.symbol, src_data.symbol, if(src_token_address in ({{ nullss }}, {{ native }}), {{ nsymbol }}, src_token.token_symbol)) as src_executed_symbol
-    , coalesce(src_user_data.amount, src_amount, src_token_amount) as src_executed_amount -- first from the user, then only with the correct amount, then from the decoded call params
-    , src_amount_usd as src_executed_amount_usd
+    , coalesce(src_user_data.address, src_data.address, net_src_data.address, if(protocol_version = 6 and not degenerate_params, {{ src_calldata_token }})) as src_executed_address
+    , coalesce(src_user_data.symbol, src_data.symbol, net_src_data.symbol, if(protocol_version = 6 and not degenerate_params, if(src_token_address in ({{ nullss }}, {{ native }}), {{ nsymbol }}, src_token.token_symbol))) as src_executed_symbol
+    , coalesce(src_user_data.amount, src_amount, net_src_data.amount, if(protocol_version = 6 and not degenerate_params, src_token_amount)) as src_executed_amount -- first from the user, then only with the correct amount, then netted from the nested transfers, then from the decoded call params
+    , coalesce(src_amount_usd, net_src_amount_usd) as src_executed_amount_usd
 
     , cast(null as varchar) as dst_blockchain
-    , dst_token_address
+    , if(degenerate_params, net_dst_data.address, dst_token_address) as dst_token_address -- the marker address of degenerate calls is replaced with the netted one
     , dst_token_amount
-    , coalesce(dst_user_data.address, dst_data.address, {{ dst_calldata_token }}) as dst_executed_address
-    , coalesce(dst_user_data.symbol, dst_data.symbol, if(dst_token_address in ({{ nullss }}, {{ native }}), {{ nsymbol }}, dst_token.token_symbol)) as dst_executed_symbol
-    , coalesce(dst_user_data.amount, dst_amount, dst_token_amount) as dst_executed_amount -- first to the user, then only with the correct amount, then from the decoded call output
-    , dst_amount_usd as dst_executed_amount_usd
+    , coalesce(dst_user_data.address, dst_data.address, net_dst_data.address, if(protocol_version = 6 and not degenerate_params, {{ dst_calldata_token }})) as dst_executed_address
+    , coalesce(dst_user_data.symbol, dst_data.symbol, net_dst_data.symbol, if(protocol_version = 6 and not degenerate_params, if(dst_token_address in ({{ nullss }}, {{ native }}), {{ nsymbol }}, dst_token.token_symbol))) as dst_executed_symbol
+    , coalesce(dst_user_data.amount, dst_amount, net_dst_data.amount, if(protocol_version = 6 and not degenerate_params, dst_token_amount)) as dst_executed_amount -- first to the user, then only with the correct amount, then netted from the nested transfers, then from the decoded call output
+    , coalesce(dst_amount_usd, net_dst_amount_usd) as dst_executed_amount_usd
     
     , cast(null as varbinary) as order_hash
     , cast(null as varbinary) as hashlock
@@ -148,8 +195,8 @@ select
         , ('sources_amount_usd', format('$%,.0f', sources_amount_usd))
         , ('trusted_amount_usd', format('$%,.0f', trusted_amount_usd))
         , ('amount_usd', format('$%,.0f', amount_usd))
-        , ('src_decimals', cast(coalesce(src_user_data.decimals, src_data.decimals, src_token.token_decimals) as varchar))
-        , ('dst_decimals', cast(coalesce(dst_user_data.decimals, dst_data.decimals, dst_token.token_decimals) as varchar))
+        , ('src_decimals', cast(coalesce(src_user_data.decimals, src_data.decimals, net_src_data.decimals, src_token.token_decimals) as varchar))
+        , ('dst_decimals', cast(coalesce(dst_user_data.decimals, dst_data.decimals, net_dst_data.decimals, dst_token.token_decimals) as varchar))
     ]) as complement
 
     , remains
@@ -161,7 +208,8 @@ select
     , native_decimals
 from calls
 join executions using(block_date, block_number, tx_hash, call_trace_address)
-left join tokens as src_token on src_token.contract_address = {{ src_calldata_token }}
-left join tokens as dst_token on dst_token.contract_address = {{ dst_calldata_token }}
+left join degenerate_executions using(block_date, block_number, tx_hash, call_trace_address)
+left join tokens as src_token on src_token.contract_address = {{ src_calldata_token }} and protocol_version = 6 and not degenerate_params
+left join tokens as dst_token on dst_token.contract_address = {{ dst_calldata_token }} and protocol_version = 6 and not degenerate_params
 
 {%- endmacro -%}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/_meta/oneinch_meta_cfg_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/_meta/oneinch_meta_cfg_macro.sql
@@ -26,6 +26,18 @@
     ]) }}
 {% endmacro %}
 
+-- v4-style flash-accounting singletons (vaults / pool managers) that hold the funds of all their pools,
+-- so they are the venue-side counterparties of executor transfer legs instead of the individual pools:
+-- bnb: pancakeswap infinity vault (0x238a...), uniswap v4 pool manager (0x28e2...)
+{% macro oneinch_ar_settlement_vaults_cfg_macro() %}
+    {{ return({
+        "bnb": [
+            '0x238a358808379702088667322f80ac48bad5e6c4',
+            '0x28e2ea090877bf75740558f6bfb36a5ffee9e9df',
+        ],
+    }) }}
+{% endmacro %}
+
 -- SUBSTREAMS CONFIGURATIONS --
 {% macro oneinch_ar_raw_calls_cfg_macro()   %} {{ return(dict(oneinch_ar_cfg_macro(), start="2019-06-01")) }} {% endmacro %}
 {% macro oneinch_ar_transfers_cfg_macro()   %} {{ return(dict(oneinch_ar_cfg_macro(), start="2019-06-01")) }} {% endmacro %}

--- a/dbt_subprojects/dex/models/_projects/oneinch/oneinch_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/oneinch_swaps.sql
@@ -18,9 +18,6 @@
 
 with
 
--- AR v6 calls with synthetic decoded params (srcToken = dstToken = marker address, e.g. swaps routed
--- by external proxies like the Binance wallet) arrive here with token addresses and executed details
--- already recovered from nested transfers by the executions macro
 executions as (
     {% for stream in oneinch_streams_cfg_macro() %}
         select *

--- a/dbt_subprojects/dex/models/_projects/oneinch/oneinch_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/oneinch_swaps.sql
@@ -18,6 +18,9 @@
 
 with
 
+-- AR v6 calls with synthetic decoded params (srcToken = dstToken = marker address, e.g. swaps routed
+-- by external proxies like the Binance wallet) arrive here with token addresses and executed details
+-- already recovered from nested transfers by the executions macro
 executions as (
     {% for stream in oneinch_streams_cfg_macro() %}
         select *

--- a/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_ar_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_ar_trades.sql
@@ -7,8 +7,9 @@
     )
 }}
 
-{% set src_symbol = "coalesce(src_executed_symbol, '')" %}
-{% set dst_symbol = "coalesce(dst_executed_symbol, '')" %}
+-- unresolved symbols stay NULL (instead of '') so gaps are detectable; token_pair then also stays NULL, like in enrich_dex_aggregator_trades
+{% set src_symbol = "src_executed_symbol" %}
+{% set dst_symbol = "dst_executed_symbol" %}
 {% set placeholder_tokens = oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') %}
 
 

--- a/dbt_subprojects/dex/tests/oneinch_ar_degenerate_calls_resolved.sql
+++ b/dbt_subprojects/dex/tests/oneinch_ar_degenerate_calls_resolved.sql
@@ -1,0 +1,21 @@
+-- E2E regression for 1inch AR v6 swaps with synthetic decoded params (srcToken = dstToken = marker
+-- address, amounts = 1; e.g. swaps routed by the Binance wallet proxy): the executions macro must
+-- recover the real token legs by netting the nested transfers against the venue side (SIM-6142).
+-- The anchor tx settles ~101.8 USDT -> ~13.2 Beat through the PancakeSwap Infinity vault, so no
+-- decoded field nor any directly matched transfer carries the user-level legs.
+-- The test goes vacuous once the upstream incremental windows age past this block date - that's
+-- expected; it guards the netting logic while the rebuilt window covers the anchor, not forever.
+select blockchain, tx_hash, token_sold_address, token_bought_address, token_sold_amount_raw, token_bought_amount_raw, token_sold_symbol, token_bought_symbol
+from {{ ref('oneinch_ar_trades') }}
+where blockchain = 'bnb'
+    and block_date = date '2026-06-12'
+    and tx_hash = 0x463b95a76eb82b6fda8e8a51f96291fef9714c550f9de17f14a37544a89ecfa9
+    and not coalesce(
+        token_sold_address = 0x55d398326f99059ff775485246999027b3197955 -- USDT
+        and token_bought_address = 0xcf3232b85b43bca90e51d38cc06cc8bb8c8a3e36 -- Beat
+        and token_sold_amount_raw = uint256 '101815292112449005466'
+        and token_bought_amount_raw = uint256 '13199978474816822881'
+        and token_sold_symbol = 'USDT'
+        and token_bought_symbol = 'Beat'
+        and token_pair = 'Beat-USDT'
+    , false)

--- a/dbt_subprojects/dex/tests/oneinch_ar_degenerate_calls_resolved.sql
+++ b/dbt_subprojects/dex/tests/oneinch_ar_degenerate_calls_resolved.sql
@@ -1,21 +1,26 @@
--- E2E regression for 1inch AR v6 swaps with synthetic decoded params (srcToken = dstToken = marker
+-- Regression for 1inch AR v6 swaps with synthetic decoded params (srcToken = dstToken = marker
 -- address, amounts = 1; e.g. swaps routed by the Binance wallet proxy): the executions macro must
 -- recover the real token legs by netting the nested transfers against the venue side (SIM-6142).
 -- The anchor tx settles ~101.8 USDT -> ~13.2 Beat through the PancakeSwap Infinity vault, so no
 -- decoded field nor any directly matched transfer carries the user-level legs.
--- The test goes vacuous once the upstream incremental windows age past this block date - that's
--- expected; it guards the netting logic while the rebuilt window covers the anchor, not forever.
-select blockchain, tx_hash, token_sold_address, token_bought_address, token_sold_amount_raw, token_bought_amount_raw, token_sold_symbol, token_bought_symbol
-from {{ ref('oneinch_ar_trades') }}
-where blockchain = 'bnb'
+-- The test anchors at the executions model because slim CI rebuilds it but cannot materialize the
+-- full-history oneinch_swaps that oneinch_ar_trades reads; the trades view is a thin projection of
+-- these fields. It goes vacuous once the rebuilt window ages past this block date - that's
+-- expected; it guards the netting logic whenever the anchor is visible, not forever.
+select blockchain, tx_hash, call_trace_address, src_token_address, dst_token_address, src_executed_amount, dst_executed_amount, src_executed_symbol, dst_executed_symbol
+from {{ ref('oneinch_bnb_ar_executions') }}
+where block_month = date '2026-06-01'
     and block_date = date '2026-06-12'
     and tx_hash = 0x463b95a76eb82b6fda8e8a51f96291fef9714c550f9de17f14a37544a89ecfa9
     and not coalesce(
-        token_sold_address = 0x55d398326f99059ff775485246999027b3197955 -- USDT
-        and token_bought_address = 0xcf3232b85b43bca90e51d38cc06cc8bb8c8a3e36 -- Beat
-        and token_sold_amount_raw = uint256 '101815292112449005466'
-        and token_bought_amount_raw = uint256 '13199978474816822881'
-        and token_sold_symbol = 'USDT'
-        and token_bought_symbol = 'Beat'
-        and token_pair = 'Beat-USDT'
+        src_token_address = 0x55d398326f99059ff775485246999027b3197955 -- USDT
+        and dst_token_address = 0xcf3232b85b43bca90e51d38cc06cc8bb8c8a3e36 -- Beat
+        and src_executed_address = 0x55d398326f99059ff775485246999027b3197955
+        and dst_executed_address = 0xcf3232b85b43bca90e51d38cc06cc8bb8c8a3e36
+        and src_executed_amount = uint256 '101815292112449005466'
+        and dst_executed_amount = uint256 '13199978474816822881'
+        and src_executed_symbol = 'USDT'
+        and dst_executed_symbol = 'Beat'
+        and element_at(complement, 'src_decimals') = '18'
+        and element_at(complement, 'dst_decimals') = '18'
     , false)


### PR DESCRIPTION
### Description:

**Fix: 1inch AR v6 trace-decoded trades ship with synthetic token details (~10%/day on bnb)**

**Problem.** `dex_aggregator.trades` rows for `project = '1inch', version = 'AR v6'` from the trace-decoding path (`evt_index = -2`) systematically ship without usable token detail: 25,152 of 71,323 successful bnb AR v6 swaps June 1–12 2026 (98% of the affected rows are on bnb, ~$4.6M/week of measured `amount_usd`).

- Daily blank rates: https://dune.com/queries/7709025
- Anchor tx (bnb) `0x463b95a76eb82b6fda8e8a51f96291fef9714c550f9de17f14a37544a89ecfa9` — the underlying fill is ~101.8 USDT → ~13.2 Beat via the PancakeSwap Infinity vault

**Root cause** (revised after review). These are v6 `swap` calls built by external routing proxies (98% the Binance wallet `LiFiProxyFacet`): the decoded `desc` carries a *synthetic marker* — `srcToken = dstToken = srcReceiver = dstReceiver = executor =` marker address, `amount = returnAmount = 1` — with the real route packed only in the opaque executor `data` blob. Two consequences in the executions macro:
1. the marker's own dust transfers (amount 1) satisfy the transfer-matching conditions, so `src_data`/`dst_data` fill with the marker address and amount 1;
2. any calldata-based fallback coalesces the same marker back in. The previous iteration of this PR (plain calldata fallback) therefore could not fix these rows.

The pattern is bnb + v6 only at scale: 2,126,708 calls since 2025-05-09, ongoing (all other chain/version combos total ~460 rows since 2025).

**Fix.**
1. `oneinch_ar_executions_macro.sql` — flag degenerate calls (`protocol_version = 6 and src_token_address = dst_token_address`), exclude them from transfer matching and from the calldata fallback, and recover their legs by netting the call's nested transfers against the venue side (`dex_raw_pools` + flash-accounting singletons that hold pool funds): **src = the token flowing into venues, dst = the token flowing out**, USD tiebreak when several. The netted addresses also replace the marker in `src/dst_token_address`. The calldata fallback (for real-calldata calls whose transfers were unparsed) is now restricted to v6, so v4/v5 rows are byte-identical to production.
2. `_meta/oneinch_meta_cfg_macro.sql` — new `oneinch_ar_settlement_vaults_cfg_macro` with the bnb flash-accounting singletons (PancakeSwap Infinity vault `0x238a…`, Uniswap v4 PoolManager `0x28e2…`).
3. `oneinch_ar_trades.sql` — unresolved symbols stay NULL (instead of `''`) so gaps are detectable; `token_pair` correspondingly stays NULL, matching `enrich_dex_aggregator_trades`.
4. `tests/oneinch_ar_degenerate_calls_resolved.sql` — regression on the anchor tx asserting the recovered legs (addresses, amounts, symbols, decimals) on `oneinch_bnb_ar_executions`, which slim CI rebuilds. Anchoring at `oneinch_ar_trades` isn't feasible in CI: the view reads `oneinch_swaps`, whose full-history all-chain rebuild exceeds the CI cluster (`EXCHANGE_MANAGER_NOT_CONFIGURED`); the trades view is a thin projection of the tested fields and was verified against production inputs on Dune.

**Validation** (bnb June 1–12 2026, patched macro run against production inputs on Dune):
- anchor tx resolves exactly: USDT `101815292112449005466` → Beat `13199978474816822881`, symbols/decimals/USD populated;
- all 25,152 degenerate successful calls get real legs (24,951 fully resolved, 201 with one side left as detectable NULL);
- netting direction agrees with `dex.trades` on **100%** of single-fill txs (24,429 checked; the only "mismatches" were native-vs-wrapped representation);
- **zero changes** to previously non-null values on the 69,907 non-degenerate calls (69,763 fully-resolved rows byte-identical; 88 previously-partial v6 rows improved by the calldata fallback).

**Backfill plan** (models are incremental; needs a coordinated run after merge):
1. `oneinch_bnb_ar_executions` — rebuild `2025-05-01 →` now (pattern starts 2025-05-09).
2. `oneinch_swaps` — re-merge the same window for `blockchain = 'bnb'` (unique key covers replacement).
3. Downstream incremental consumers of `oneinch_ar_trades` / `dex_aggregator.trades` — same window, bnb.
Other chains carry ~460 degenerate rows total since 2025; they can ride along with any future full refresh or be left as detectable NULLs.

Note: the singular test asserts the anchor tx's resolved values on the executions table, so it passes in this PR's CI (rebuilt tables) and will pass on production only after the backfill — a nudge to run the backfill promptly after merge.

**Behavior change note for reviewers:** previously-`''` symbols become NULL, and degenerate rows' `src/dst_token_address` change from the marker address to the real tokens. Anyone filtering `token_sold_symbol != ''` on 1inch AR rows sees a difference; this aligns 1inch with how other dex_aggregator projects represent unknown symbols.

**Post-merge check:** re-run https://dune.com/queries/7709025 — the AR v6 daily blank rate should drop from ~10% to ~0 after backfill, and the anchor tx's spell row should carry full token details.
