### PR TITLE
perf(flokibot bot_trades): replace OR-join nested loop with equi-join branches

### DIFF
--- a/dbt_subprojects/dex/models/bot_trades/_schema.yml
+++ b/dbt_subprojects/dex/models/bot_trades/_schema.yml
@@ -197,6 +197,16 @@ models:
       - check_bot_trades_seed:
           arguments:
             seed_file: ref('flokibot_ethereum_trades_seed')
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
 
   - name: flokibot_base_bot_trades
     meta:
@@ -218,6 +228,16 @@ models:
       - check_bot_trades_seed:
           arguments:
             seed_file: ref('flokibot_base_trades_seed')
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
 
   - name: flokibot_bnb_bot_trades
     meta:

--- a/dbt_subprojects/dex/models/bot_trades/flokibot/base/flokibot_base_bot_trades.sql
+++ b/dbt_subprojects/dex/models/bot_trades/flokibot/base/flokibot_base_bot_trades.sql
@@ -71,29 +71,91 @@ with
         select evt_block_time as block_time, evt_tx_hash as tx_hash
         from {{ source('openocean_v2_base', 'OpenOceanExchange_evt_Swapped') }}
         where
-            referrer = {{ aggregator_fee_wallet_1 }}
-            or referrer = {{ treasury_fee_wallet_1 }}
-            or referrer = {{ treasury_fee_wallet_2 }}
-            or referrer = {{ buyback_fee_wallet_1 }}
+            (
+                referrer = {{ aggregator_fee_wallet_1 }}
+                or referrer = {{ treasury_fee_wallet_1 }}
+                or referrer = {{ treasury_fee_wallet_2 }}
+                or referrer = {{ buyback_fee_wallet_1 }}
+            )
             {% if is_incremental() %}
                 and {{ incremental_predicate('evt_block_time') }}
             {% else %} and evt_block_time >= timestamp '{{project_start_date}}'
             {% endif %}
     ),
-    trade_transactions as (
-        select block_time, address, null as tx_hash
-        from bot_contracts
-        union all
-        select block_time, null as address, tx_hash
+    aggregator_trades as (
+        select block_time, tx_hash
         from oneinch_aggregator_trades
         union all
-        select block_time, null as address, tx_hash
+        select block_time, tx_hash
         from openocean_aggregator_trades
     ),
-    bot_trades as (
+    -- Two equi-join branches instead of one OR-join: the OR forces a nested-loop
+    -- join (trades x every trade transaction), exploding 10M rows into billions.
+    -- trade_transactions rows have address XOR tx_hash non-null, so splitting per
+    -- side preserves the exact match multiplicity.
+    matched_trades as (
         select
             trades.block_time,
             trades.block_number,
+            trades.amount_usd,
+            trades.token_bought_amount,
+            trades.token_bought_symbol,
+            trades.token_bought_address,
+            trades.token_sold_amount,
+            trades.token_sold_symbol,
+            trades.token_sold_address,
+            trades.project,
+            trades.version,
+            trades.token_pair,
+            trades.project_contract_address,
+            trades.tx_from,
+            trades.tx_to,
+            trades.tx_hash,
+            trades.evt_index
+        from {{ source('dex', 'trades') }} as trades
+        join bot_contracts
+            on trades.tx_to = bot_contracts.address
+            and trades.block_time >= bot_contracts.block_time
+        where
+            trades.blockchain = '{{blockchain}}'
+            {% if is_incremental() %}
+                and {{ incremental_predicate('trades.block_time') }}
+            {% else %} and trades.block_time >= timestamp '{{project_start_date}}'
+            {% endif %}
+        union all
+        select
+            trades.block_time,
+            trades.block_number,
+            trades.amount_usd,
+            trades.token_bought_amount,
+            trades.token_bought_symbol,
+            trades.token_bought_address,
+            trades.token_sold_amount,
+            trades.token_sold_symbol,
+            trades.token_sold_address,
+            trades.project,
+            trades.version,
+            trades.token_pair,
+            trades.project_contract_address,
+            trades.tx_from,
+            trades.tx_to,
+            trades.tx_hash,
+            trades.evt_index
+        from {{ source('dex', 'trades') }} as trades
+        join aggregator_trades
+            on trades.tx_hash = aggregator_trades.tx_hash
+            and trades.block_time >= aggregator_trades.block_time
+        where
+            trades.blockchain = '{{blockchain}}'
+            {% if is_incremental() %}
+                and {{ incremental_predicate('trades.block_time') }}
+            {% else %} and trades.block_time >= timestamp '{{project_start_date}}'
+            {% endif %}
+    ),
+    bot_trades as (
+        select
+            matched_trades.block_time,
+            matched_trades.block_number,
             amount_usd,
             if(token_sold_address = {{ weth }}, 'Buy', 'Sell') as type,
             token_bought_amount,
@@ -111,28 +173,10 @@ with
             project_contract_address,
             tx_from as user,
             tx_to as bot,
-            trades.tx_hash,
+            matched_trades.tx_hash,
             evt_index
-        from {{ source('dex', 'trades') }} as trades
-        join trade_transactions ON (
-          (
-            trades.tx_to = trade_transactions.address
-            OR trades.tx_hash = trade_transactions.tx_hash
-          )
-          AND trades.block_time >= trade_transactions.block_time
-        )
-        left join fees on fees.tx_hash = trades.tx_hash
-        where
-            trades.blockchain = '{{blockchain}}'
-            {% if is_incremental() %}
-                and {{ incremental_predicate('trades.block_time') }}
-            {% else %} and trades.block_time >= timestamp '{{project_start_date}}'
-            {% endif %}
-    ),
-    highest_event_index_for_each_trade as (
-        select tx_hash, max(evt_index) as highest_event_index
-        from bot_trades
-        group by tx_hash
+        from matched_trades
+        left join fees on fees.tx_hash = matched_trades.tx_hash
     )
 select
     block_time,
@@ -168,11 +212,10 @@ select
     user as user,
     bot_trades.tx_hash,
     evt_index,
-    if(evt_index = highest_event_index, true, false) as is_last_trade_in_transaction
+    -- Window instead of a self-join on a grouped copy of bot_trades: referencing
+    -- the CTE twice inlines the whole upstream scan tree twice.
+    if(evt_index = max(evt_index) over (partition by bot_trades.tx_hash), true, false) as is_last_trade_in_transaction
 from bot_trades
-join
-    highest_event_index_for_each_trade
-    on bot_trades.tx_hash = highest_event_index_for_each_trade.tx_hash
 left join
     {{ source('prices', 'usd') }}
     on (

--- a/dbt_subprojects/dex/models/bot_trades/flokibot/ethereum/flokibot_ethereum_bot_trades.sql
+++ b/dbt_subprojects/dex/models/bot_trades/flokibot/ethereum/flokibot_ethereum_bot_trades.sql
@@ -71,29 +71,91 @@ with
         select evt_block_time as block_time, evt_tx_hash as tx_hash
         from {{ source('openocean_v2_ethereum', 'OpenOceanExchangeProxy_evt_Swapped') }}
         where
-            referrer = {{ treasury_fee_wallet_1 }}
-            or referrer = {{ treasury_fee_wallet_2 }}
-            or referrer = {{ aggregator_fee_wallet_1 }}
-            or referrer = {{ buyback_fee_wallet_1 }}
+            (
+                referrer = {{ treasury_fee_wallet_1 }}
+                or referrer = {{ treasury_fee_wallet_2 }}
+                or referrer = {{ aggregator_fee_wallet_1 }}
+                or referrer = {{ buyback_fee_wallet_1 }}
+            )
             {% if is_incremental() %}
                 and {{ incremental_predicate('evt_block_time') }}
             {% else %} and evt_block_time >= timestamp '{{project_start_date}}'
             {% endif %}
     ),
-    trade_transactions as (
-        select block_time, address, null as tx_hash
-        from bot_contracts
-        union all
-        select block_time, null as address, tx_hash
+    aggregator_trades as (
+        select block_time, tx_hash
         from oneinch_aggregator_trades
         union all
-        select block_time, null as address, tx_hash
+        select block_time, tx_hash
         from openocean_aggregator_trades
     ),
-    bot_trades as (
+    -- Two equi-join branches instead of one OR-join: the OR forces a nested-loop
+    -- join (trades x every trade transaction), exploding 10M rows into billions.
+    -- trade_transactions rows have address XOR tx_hash non-null, so splitting per
+    -- side preserves the exact match multiplicity.
+    matched_trades as (
         select
             trades.block_time,
             trades.block_number,
+            trades.amount_usd,
+            trades.token_bought_amount,
+            trades.token_bought_symbol,
+            trades.token_bought_address,
+            trades.token_sold_amount,
+            trades.token_sold_symbol,
+            trades.token_sold_address,
+            trades.project,
+            trades.version,
+            trades.token_pair,
+            trades.project_contract_address,
+            trades.tx_from,
+            trades.tx_to,
+            trades.tx_hash,
+            trades.evt_index
+        from {{ source('dex', 'trades') }} as trades
+        join bot_contracts
+            on trades.tx_to = bot_contracts.address
+            and trades.block_time >= bot_contracts.block_time
+        where
+            trades.blockchain = '{{blockchain}}'
+            {% if is_incremental() %}
+                and {{ incremental_predicate('trades.block_time') }}
+            {% else %} and trades.block_time >= timestamp '{{project_start_date}}'
+            {% endif %}
+        union all
+        select
+            trades.block_time,
+            trades.block_number,
+            trades.amount_usd,
+            trades.token_bought_amount,
+            trades.token_bought_symbol,
+            trades.token_bought_address,
+            trades.token_sold_amount,
+            trades.token_sold_symbol,
+            trades.token_sold_address,
+            trades.project,
+            trades.version,
+            trades.token_pair,
+            trades.project_contract_address,
+            trades.tx_from,
+            trades.tx_to,
+            trades.tx_hash,
+            trades.evt_index
+        from {{ source('dex', 'trades') }} as trades
+        join aggregator_trades
+            on trades.tx_hash = aggregator_trades.tx_hash
+            and trades.block_time >= aggregator_trades.block_time
+        where
+            trades.blockchain = '{{blockchain}}'
+            {% if is_incremental() %}
+                and {{ incremental_predicate('trades.block_time') }}
+            {% else %} and trades.block_time >= timestamp '{{project_start_date}}'
+            {% endif %}
+    ),
+    bot_trades as (
+        select
+            matched_trades.block_time,
+            matched_trades.block_number,
             amount_usd,
             if(token_sold_address = {{ weth }}, 'Buy', 'Sell') as type,
             token_bought_amount,
@@ -111,28 +173,10 @@ with
             project_contract_address,
             tx_from as user,
             tx_to as bot,
-            trades.tx_hash,
+            matched_trades.tx_hash,
             evt_index
-        from {{ source('dex', 'trades') }} as trades
-        join trade_transactions ON (
-          (
-            trades.tx_to = trade_transactions.address
-            OR trades.tx_hash = trade_transactions.tx_hash
-          )
-          AND trades.block_time >= trade_transactions.block_time
-        )
-        left join fees on fees.tx_hash = trades.tx_hash
-        where
-            trades.blockchain = '{{blockchain}}'
-            {% if is_incremental() %}
-                and {{ incremental_predicate('trades.block_time') }}
-            {% else %} and trades.block_time >= timestamp '{{project_start_date}}'
-            {% endif %}
-    ),
-    highest_event_index_for_each_trade as (
-        select tx_hash, max(evt_index) as highest_event_index
-        from bot_trades
-        group by tx_hash
+        from matched_trades
+        left join fees on fees.tx_hash = matched_trades.tx_hash
     )
 select
     block_time,
@@ -168,11 +212,10 @@ select
     user as user,
     bot_trades.tx_hash,
     evt_index,
-    if(evt_index = highest_event_index, true, false) as is_last_trade_in_transaction
+    -- Window instead of a self-join on a grouped copy of bot_trades: referencing
+    -- the CTE twice inlines the whole upstream scan tree twice.
+    if(evt_index = max(evt_index) over (partition by bot_trades.tx_hash), true, false) as is_last_trade_in_transaction
 from bot_trades
-join
-    highest_event_index_for_each_trade
-    on bot_trades.tx_hash = highest_event_index_for_each_trade.tx_hash
 left join
     {{ source('prices', 'usd') }}
     on (


### PR DESCRIPTION
The flokibot `bot_trades` models join `dex.trades` to bot transactions with an OR condition (`tx_to = address OR tx_hash = tx_hash`), which Trino can only execute as a nested-loop join: every base trade is compared against every bot transaction. On the base model this explodes 10.6M rows into 19.0B intermediate rows (1798x) per run — 2,769 CPU-seconds every run, ~200 times a day, for a bot that last traded in Sept 2025. The model also references the `bot_trades` CTE twice (main select + a max-evt_index group-by), which inlines the entire upstream scan tree twice.

The rewrite splits the OR-join into a UNION ALL of two hash equi-joins (contract-side on `tx_to`, aggregator-side on `tx_hash`). Multiplicity is preserved exactly because `trade_transactions` rows carry `address` XOR `tx_hash` (never both). The second CTE reference is replaced with `max(evt_index) over (partition by tx_hash)`, so the upstream tree is scanned once. Also parenthesizes the openocean `referrer` ORs so the incremental time filter applies to all four wallets instead of only the last branch (output-neutral, verified). Same change applied to the structurally identical ethereum sibling; the bnb sibling is `prod_exclude` and left untouched.

## Proofs (base model, spellbook-dex)

Equivalence:
- Incremental window (`block_time >= 2026-06-09`): `EXCEPT` = 0 rows both ways.
- Active windows (multiset equality over all 27 output columns, catches duplicate-multiplicity diffs): 2024-06-01→2024-09-01 (both join branches exercised: 203 contract-side + 230 aggregator-side rows) → 433 = 433 rows, 0 mismatches; 2025-09-01→2025-09-17 → 5 = 5, 0 mismatches.

A/B, 3 interleaved warm runs, medians, `checksum()` over all 27 output columns (checksums identical):

| metric | current | rewrite | delta |
|---|---|---|---|
| CPU | 2,769 s | 60.7 s | **-97.8% (45.6x)** |
| wall | 197.9 s | 4.2 s | -97.9% |
| IO (physical input) | 18.7 GB | 9.9 GB | -47% |
| peak memory | 2.13 GB | 0.03 GB | -99% |
| spill | 0 | 0 | — |

Projected on the base model alone (198 runs/day): ~14.9 → ~0.3 CPU-hrs/day on spellbook-dex (~4.4% of the cluster), ~3.2 TB/day less IO. Ethereum sibling adds ~1.4 CPU-hrs/day on the same pattern.

No schema or output change; incremental config untouched, no backfill needed.

Towards CUR2-2702
