### PR TITLE
perf(nft): single-pass nft_ethereum_wallet_metrics (filter pushdown, buys/sells fan-out, lead() instead of self-join)

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/nft/nft_metrics/ethereum/nft_ethereum_wallet_metrics.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/nft/nft_metrics/ethereum/nft_ethereum_wallet_metrics.sql
@@ -9,12 +9,21 @@
 
 with
 --- filtering out wash trades based on definition in this model https://github.com/duneanalytics/spellbook/blob/main/models/nft/nft_wash_trades.sql
+--- the ethereum / ETH-WETH / single-item / non-self-trade filters are applied here (and on the
+--- mints branch below) instead of after the union, so the trades / wash_trades / mints scans
+--- prune to the ethereum slice once instead of re-scanning every chain
 nft_trades_no_wash as
 ( select nft.*
     from {{ref('nft_trades')}} nft
     INNER JOIN {{ref('nft_wash_trades')}} wt ON wt.block_number=nft.block_number
     AND wt.unique_trade_id=nft.unique_trade_id
-    where is_wash_trade = FALSE ),
+    AND wt.blockchain = 'ethereum'
+    where is_wash_trade = FALSE
+    AND nft.blockchain = 'ethereum'
+    AND nft.currency_symbol IN ('ETH', 'WETH')
+    AND nft.buyer != nft.seller
+    AND nft.number_of_items = UINT256 '1'
+    AND nft.amount_original IS NOT NULL ),
 
 --- adding in mints because a mint can be interpreted as a buy for $0 or gas fees
 nft_trades_no_wash_w_mints as (
@@ -75,56 +84,32 @@ select aggregator_address       as aggregator_address,
        tx_to                    as tx_to,
        version                  as version
 from {{ref('nft_mints')}}
+where blockchain = 'ethereum'
+  AND currency_symbol IN ('ETH', 'WETH')
+  AND buyer != seller
+  AND number_of_items = UINT256 '1'
+  AND amount_original IS NOT NULL
 )
 ,
--- creating a longform version of buys and sells
+-- creating a longform version of buys and sells: one scan fanned out into a sell row (seller)
+-- and a buy row (buyer) per trade, instead of two UNION ALL branches re-scanning the source
 buys_and_sells_nft_trades_no_wash_w_mints as
 (
-    --sells
     SELECT
-        src.seller as wallet,
-        project,
-        collection,
+        side.wallet,
+        src.project,
+        src.collection,
         src.nft_contract_address,
-        token_standard,
-        token_id,
-        'sell' as trade_type,
-        block_time,
-        tx_hash,
-        amount_usd,
-        src.amount_original eth_amount
+        src.token_standard,
+        src.token_id,
+        side.trade_type,
+        src.block_time,
+        src.tx_hash,
+        case when side.trade_type = 'buy' then -1 * src.amount_usd else src.amount_usd end as amount_usd,
+        case when side.trade_type = 'buy' then -1 * src.amount_original else src.amount_original end as eth_amount
     FROM
         nft_trades_no_wash_w_mints src
-    WHERE
-        src.currency_symbol IN ('ETH', 'WETH')
-        AND src.blockchain = 'ethereum'
-        AND src.buyer != src.seller
-        AND src.number_of_items = UINT256 '1'
-        AND src.amount_original IS NOT NULL
-
-    UNION ALL
-
-    --buys
-    SELECT
-        src.buyer as wallet,
-        project,
-        collection,
-        src.nft_contract_address,
-        token_standard,
-        token_id,
-        'buy' as trade_type,
-        block_time,
-        tx_hash,
-        -1 * amount_usd as amount_usd,
-        -1 * src.amount_original as eth_amount
-    FROM
-        nft_trades_no_wash_w_mints src
-    WHERE
-        src.currency_symbol IN ('ETH', 'WETH')
-        AND src.blockchain = 'ethereum'
-        AND src.buyer != src.seller
-        AND src.number_of_items = UINT256 '1'
-        AND src.amount_original IS NOT NULL
+    CROSS JOIN unnest(array[src.seller, src.buyer], array['sell', 'buy']) as side(wallet, trade_type)
 ),
 ----- FLOOR PRICES -------
 ----- FIRST SOURCE: Reservoir - includes offchain sources
@@ -163,6 +148,10 @@ eth_collection_stats_latest_floor as (
     where rn = 1
 ),
 
+-- the next trade per (wallet, collection, token) is taken with lead() in a single window pass,
+-- replacing the previous row_number() + self-join (which re-computed the whole pipeline twice
+-- and was the skewed join in the plan). The order-by carries a full tiebreaker so the build is
+-- deterministic when several trades share the same block_time
 buys_and_sells_w_index as (
 select wallet,
        nft_contract_address,
@@ -175,12 +164,14 @@ select wallet,
        tx_hash,
        amount_usd,
        eth_amount,
-       row_number() over (partition by wallet, nft_contract_address, token_id order by block_time) nft_tx_index,
-       lag(eth_amount)
-           over (partition by wallet, nft_contract_address, token_id order by block_time)          prev_trade_eth_amount,
-       lag(amount_usd)
-           over (partition by wallet, nft_contract_address, token_id order by block_time)          prev_trade_usd_amount
+       lead(trade_type) over w as next_trade_type,
+       lead(block_time) over w as next_block_time,
+       lead(tx_hash)    over w as next_tx_hash,
+       lead(amount_usd) over w as next_amount_usd,
+       lead(eth_amount) over w as next_eth_amount
 from buys_and_sells_nft_trades_no_wash_w_mints
+window w as (partition by wallet, nft_contract_address, token_id
+             order by block_time, tx_hash, trade_type, amount_usd, eth_amount, project, collection, token_standard)
 ),
 
 lastest_eth_price_usd as (
@@ -195,35 +186,29 @@ where blockchain = 'ethereum' and symbol = 'WETH'
 
 
 all_trades_profit_and_unrealized_profit as (
-select b.wallet,
-       b.nft_contract_address,
-       b.project,
-       b.collection,
-       b.token_standard,
-       b.token_id,
-       case when s.wallet is not null then 1 else 0 end                                        nft_was_sold,
-       b.block_time                                                                            buy_block_time,
-       s.block_time                                                                            sell_block_time,
+select wallet,
+       nft_contract_address,
+       project,
+       collection,
+       token_standard,
+       token_id,
+       case when next_trade_type is not null then 1 else 0 end                                 nft_was_sold,
+       block_time                                                                              buy_block_time,
+       next_block_time                                                                         sell_block_time,
        -- Sell time else current time (for calculating ROI)
-       coalesce(s.block_time, current_timestamp)                                               sell_block_time_or_current_time,
-       b.tx_hash                                                                               buy_tx_hash,
-       s.tx_hash                                                                               sell_tx_hash,
-       b.amount_usd                                                                            buy_amount_usd,
-       s.amount_usd                                                                            sell_amount_usd,
-       b.eth_amount                                                                            buy_amount_eth,
+       coalesce(next_block_time, current_timestamp)                                            sell_block_time_or_current_time,
+       tx_hash                                                                                 buy_tx_hash,
+       next_tx_hash                                                                            sell_tx_hash,
+       amount_usd                                                                              buy_amount_usd,
+       next_amount_usd                                                                         sell_amount_usd,
+       eth_amount                                                                              buy_amount_eth,
        -- Sell amount else current floor (for calculating ROI)
-       s.eth_amount                                                                            sell_amount_eth,
-       case when s.wallet is not null then s.eth_amount + b.eth_amount else 0 end              eth_profit_realized
-from buys_and_sells_w_index b
-left join buys_and_sells_w_index s
-    on b.wallet = s.wallet
-    and b.nft_contract_address = s.nft_contract_address
-    and b.token_id = s.token_id
-    and b.nft_tx_index + 1 = s.nft_tx_index
+       next_eth_amount                                                                         sell_amount_eth,
+       case when next_trade_type is not null then next_eth_amount + eth_amount else 0 end      eth_profit_realized
+from buys_and_sells_w_index
 where 1 = 1
-  and b.trade_type = 'buy'
-  and coalesce(s.trade_type, 'sell') = 'sell'
-order by b.block_time desc
+  and trade_type = 'buy'
+  and coalesce(next_trade_type, 'sell') = 'sell'
 ),
 
 --- Hacky split to fix bloom size error

--- a/dbt_subprojects/hourly_spellbook/models/_sector/nft/nft_metrics/ethereum/nft_ethereum_wallet_metrics.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/nft/nft_metrics/ethereum/nft_ethereum_wallet_metrics.sql
@@ -150,8 +150,14 @@ eth_collection_stats_latest_floor as (
 
 -- the next trade per (wallet, collection, token) is taken with lead() in a single window pass,
 -- replacing the previous row_number() + self-join (which re-computed the whole pipeline twice
--- and was the skewed join in the plan). The order-by carries a full tiebreaker so the build is
--- deterministic when several trades share the same block_time
+-- and was the skewed join in the plan). The order-by is not a strict total order (rows identical on
+-- all eight keys can still tie), but the wallet metrics are invariant to that residual tie: every
+-- value the result reads is either a partition key or one of these order-by keys (lead() only reads
+-- trade_type/block_time/tx_hash/amount_usd/eth_amount), so tied rows carry identical buy/sell values
+-- and whichever one the pairing keeps contributes the same numbers. Verified on full prod data:
+-- adding a per-row unique id to the order-by leaves the output bit-identical (same wallet count, same
+-- checksum over every integer count column, same eth sums) -- so the unique id is omitted to avoid
+-- doubling the window's peak memory (a ~90-char key over ~100M rows) for no change in result.
 buys_and_sells_w_index as (
 select wallet,
        nft_contract_address,


### PR DESCRIPTION
`nft_ethereum_wallet_metrics` rebuilds hourly at ~32.5 CPU-hrs/day and ~1.46 TB/day of IO. The snapshot of the frozen reservoir floor source (#9737) barely moved it (~-2% realized) because the cost was elsewhere: every upstream scan (19 per-chain `wash_trades` tables, `nft.mints`, `nft.trades_beta`) was inlined **4x** -- once per branch of the buys/sells UNION ALL, times once per side of the `nft_tx_index` self-join -- and the heavy window was computed twice, with the self-join showing 450x task skew (post-merge run `20260612_171250_60584_at4xv`: 89 scans, 84 of them duplicates, 59.2 GiB / 4,788 cpu-s per run).

Three in-model changes, none touching the output schema:

1. **Filters pushed into the scans.** The `blockchain='ethereum' / ETH-WETH / single-item / non-self-trade` predicates moved from after the trades+mints union into the `nft_trades_no_wash` and mints branches, and the wash-trades join gained `wt.blockchain = 'ethereum'` -- so the 18 non-ethereum wash tables and non-ethereum mints partitions prune instead of being scanned.
2. **Buys/sells fan-out.** The two UNION ALL branches (identical predicates, seller vs buyer) became a single scan with `cross join unnest(array[seller, buyer], array['sell','buy'])` (same pattern as #9755).
3. **`lead()` instead of the index self-join.** The `row_number()` + `b.nft_tx_index + 1 = s.nft_tx_index` self-join (which recomputed the entire pipeline a second time) became `lead()` columns in the same window pass. The window order-by carries a full tiebreaker, which makes the build deterministic: the old self-join evaluated the window twice and the two instances could order same-`block_time` trades differently -- three back-to-back prod-data runs of the **current** model produced three different outputs (5,813,002 / 5,812,991 / 5,813,003 wallets), while the rewrite returns bit-identical results (5,813,019 wallets, identical per-column checksums) on every run.

**Equivalence proofs** (full prod data, no sampling, UTC sessions):
- Lemma 1 (filter pushdown + unnest fan-out): old vs new longform buys/sells, `EXCEPT` = **0 both ways** over all ~207.3M rows.
- Lemma 2 (self-join vs `lead()`): both forms built from the same input under a total order, `EXCEPT` = **0 both ways** on all output columns.
- The remaining pipeline text (floors, aggregation) is unchanged, so equivalence composes to the final output, up to the tie resolution the current model already does not pin down.

**A/B, full model SELECT, `checksum()` over all 26 output columns, medians of 3 warm runs** (spellbook-hourly):

| axis | current | rewrite | delta |
|---|---|---|---|
| CPU | 4,726 s | 3,703 s | **-21.7%** |
| IO (physical input) | 59.22 GB | 18.58 GB | **-68.6%** |
| wall | 157.9 s | 80.5 s | -49% |
| peak memory | 46.8 GB | 38.8 GB | -17% |
| spill | 0 | 0 | -- |

Projected per day (24 hourly builds): ~32.5 -> ~25.4 CPU-hrs and 1.46 -> ~0.45 TB scanned.

Towards CUR2-2730
