### PR TITLE
perf(paraswap): bound price_missed prices.usd scans for file skipping

### DIFF
--- a/dbt_subprojects/dex/models/_projects/paraswap/avalanche_c/paraswap_v5_avalanche_c_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/paraswap/avalanche_c/paraswap_v5_avalanche_c_trades.sql
@@ -66,6 +66,7 @@ price_missed_previous AS (
         SELECT minute, contract_address, decimals, symbol, price
         FROM {{ source('prices', 'usd') }}
         WHERE contract_address = 0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664 -- USDC.e
+            AND minute <= TIMESTAMP '2020-01-01' -- first record is 2018-10-23; bound so the prices fact table file-skips
         ORDER BY minute
         LIMIT 1
     ),
@@ -74,6 +75,7 @@ price_missed_previous AS (
         SELECT minute, contract_address, decimals, symbol, price
         FROM {{ source('prices', 'usd') }}
         WHERE contract_address = 0xc7198437980c041c805a1edcba50c1ce5db95118 -- USDT.e
+            AND minute <= TIMESTAMP '2020-01-01' -- first record is 2015-03-11; bound so the prices fact table file-skips
         ORDER BY minute
         LIMIT 1
     )
@@ -93,6 +95,7 @@ price_missed_next AS (
         SELECT minute, contract_address, decimals, symbol, price
         FROM {{ source('prices', 'usd') }}
         WHERE contract_address = 0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664 -- USDC.e
+            AND minute >= now() - interval '7' day -- bound so the prices fact table file-skips
         ORDER BY minute DESC
         LIMIT 1
     ),
@@ -101,6 +104,7 @@ price_missed_next AS (
         SELECT minute, contract_address, decimals, symbol, price
         FROM {{ source('prices', 'usd') }}
         WHERE contract_address = 0xc7198437980c041c805a1edcba50c1ce5db95118 -- USDT.e
+            AND minute >= now() - interval '7' day -- bound so the prices fact table file-skips
         ORDER BY minute DESC
         LIMIT 1
     )

--- a/dbt_subprojects/dex/models/_projects/paraswap/avalanche_c/paraswap_v6_avalanche_c_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/paraswap/avalanche_c/paraswap_v6_avalanche_c_trades.sql
@@ -50,6 +50,7 @@ price_missed_previous AS (
         SELECT minute, contract_address, decimals, symbol, price
         FROM {{ source('prices', 'usd') }}
         WHERE contract_address = 0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664 -- USDC.e
+            AND minute <= TIMESTAMP '2020-01-01' -- first record is 2018-10-23; bound so the prices fact table file-skips
         ORDER BY minute
         LIMIT 1
     ),
@@ -58,6 +59,7 @@ price_missed_previous AS (
         SELECT minute, contract_address, decimals, symbol, price
         FROM {{ source('prices', 'usd') }}
         WHERE contract_address = 0xc7198437980c041c805a1edcba50c1ce5db95118 -- USDT.e
+            AND minute <= TIMESTAMP '2020-01-01' -- first record is 2015-03-11; bound so the prices fact table file-skips
         ORDER BY minute
         LIMIT 1
     )
@@ -75,6 +77,7 @@ price_missed_next AS (
         SELECT minute, contract_address, decimals, symbol, price
         FROM {{ source('prices', 'usd') }}
         WHERE contract_address = 0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664 -- USDC.e
+            AND minute >= now() - interval '7' day -- bound so the prices fact table file-skips
         ORDER BY minute DESC
         LIMIT 1
     ),
@@ -83,6 +86,7 @@ price_missed_next AS (
     SELECT minute, contract_address, decimals, symbol, price
     FROM {{ source('prices', 'usd') }}
     WHERE contract_address = 0xc7198437980c041c805a1edcba50c1ce5db95118 -- USDT.e
+        AND minute >= now() - interval '7' day -- bound so the prices fact table file-skips
     ORDER BY minute DESC
     LIMIT 1
 )

--- a/dbt_subprojects/dex/models/_projects/paraswap/polygon/paraswap_v4_polygon_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/paraswap/polygon/paraswap_v4_polygon_trades.sql
@@ -57,6 +57,7 @@ price_missed_previous AS (
     SELECT minute, contract_address, decimals, symbol, price
     FROM {{ source('prices', 'usd') }}
     WHERE contract_address = 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WMATIC
+        AND minute <= TIMESTAMP '2020-01-01' -- first record is 2019-05-13; bound so the prices fact table file-skips
     ORDER BY minute
     LIMIT 1
 ),
@@ -66,6 +67,7 @@ price_missed_next AS (
     SELECT minute, contract_address, decimals, symbol, price
     FROM {{ source('prices', 'usd') }}
     WHERE contract_address = 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WMATIC
+        AND minute >= now() - interval '7' day -- bound so the prices fact table file-skips
     ORDER BY minute desc
     LIMIT 1
 )

--- a/dbt_subprojects/dex/models/_projects/paraswap/polygon/paraswap_v5_polygon_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/paraswap/polygon/paraswap_v5_polygon_trades.sql
@@ -62,6 +62,7 @@ price_missed_previous AS (
     SELECT minute, contract_address, decimals, symbol, price
     FROM {{ source('prices', 'usd') }}
     WHERE contract_address = 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WMATIC
+        AND minute <= TIMESTAMP '2020-01-01' -- first record is 2019-05-13; bound so the prices fact table file-skips
     ORDER BY minute
     LIMIT 1
 ),
@@ -71,6 +72,7 @@ price_missed_next AS (
     SELECT minute, contract_address, decimals, symbol, price
     FROM {{ source('prices', 'usd') }}
     WHERE contract_address = 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WMATIC
+        AND minute >= now() - interval '7' day -- bound so the prices fact table file-skips
     ORDER BY minute desc
     LIMIT 1
 )

--- a/dbt_subprojects/dex/models/_projects/paraswap/polygon/paraswap_v6_polygon_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/paraswap/polygon/paraswap_v6_polygon_trades.sql
@@ -48,6 +48,7 @@ price_missed_previous AS (
     SELECT minute, contract_address, decimals, symbol, price
     FROM {{ source('prices', 'usd') }}
     WHERE contract_address = 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WMATIC
+        AND minute <= TIMESTAMP '2020-01-01' -- first record is 2019-05-13; bound so the prices fact table file-skips
     ORDER BY minute
     LIMIT 1
 ),
@@ -57,6 +58,7 @@ price_missed_next AS (
     SELECT minute, contract_address, decimals, symbol, price
     FROM {{ source('prices', 'usd') }}
     WHERE contract_address = 0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270 -- WMATIC
+        AND minute >= now() - interval '7' day -- bound so the prices fact table file-skips
     ORDER BY minute desc
     LIMIT 1
 )


### PR DESCRIPTION
The `price_missed_previous` / `price_missed_next` CTEs in the 5 paraswap polygon/avalanche trades models each pick one row from `prices.usd` filtered only by `contract_address`. `prices.usd` is a view joining the minute fact (`prices.usd_0003`, ~6.7B rows) to a tokens dim, so the contract filter prunes only the dim and the fact full-scans. Each CTE is referenced twice and inlines, giving 8 full scans of `usd_0003` per avalanche run (4 per polygon run). This family was the largest IO consumer on spellbook-dex: ~18 TB/day and ~12 CPU-hrs/day across the 5 models.

Fix: bound `minute` in each subquery so the fact table file-skips. The earliest-price branch gets `minute <= TIMESTAMP '2020-01-01'` (first price records: USDT.e 2015-03-11, USDC.e 2018-10-23, WMATIC 2019-05-13 — months of slack, prunes ~95% of the fact). The latest-price branch gets `minute >= now() - interval '7' day` (feeds are current to the minute; if a feed ever lapsed >7 days the CTE would return no row instead of a week-stale price, which is the safer failure mode).

Proof on `paraswap_v5_avalanche_c_trades` (compiled model SELECT, incremental window frozen on both sides):
- Equivalence: each bounded subquery `EXCEPT` unbounded = 0 rows both ways (all 12 contract x direction checks); full model output had identical row count and identical `checksum()` over all 24 output columns on 5 interleaved runs per side.
- A/B (medians of 4 warm runs): IO 237.46 GB -> 1.87 GB (-99.2%), CPU 559 s -> 9.5 s (-98.3%), wall ~82 s -> ~8 s, peak memory 3.8 GB -> 0.08 GB, spill 0 -> 0.

Projected family impact on spellbook-dex: ~18 TB/day -> ~0.15 TB/day IO, ~12 -> ~0.3 CPU-hrs/day.

Fixes CUR2-2795
