### PR TITLE
perf(solana bot_trades): replace last-trade self-join with window function

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/base_app/base_app_swapper_solana_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/base_app/base_app_swapper_solana_trades.sql
@@ -79,26 +79,15 @@ with filtered_transactions as (
             {% else %}
                 and trades.block_time >= timestamp '{{query_start_date}}'
             {% endif %}
-    ),
-    highest_inner_instruction_index_for_each_trade as (
-        select
-            tx_id,
-            block_date,
-            outer_instruction_index,
-            max(inner_instruction_index) as highest_inner_instruction_index
-        from trades
-        group by tx_id, block_date, outer_instruction_index
     )
 select
     trades.*,
     if(
-        inner_instruction_index = highest_inner_instruction_index, true, false
+        inner_instruction_index
+        = max(inner_instruction_index) over (
+            partition by tx_id, block_date, outer_instruction_index
+        ),
+        true,
+        false
     ) as is_last_trade_in_transaction
 from trades
-join
-    highest_inner_instruction_index_for_each_trade
-    on (
-        trades.block_date = highest_inner_instruction_index_for_each_trade.block_date
-        and trades.tx_id = highest_inner_instruction_index_for_each_trade.tx_id
-        and trades.outer_instruction_index = highest_inner_instruction_index_for_each_trade.outer_instruction_index
-    )

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/alpha_dex_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/alpha_dex_solana_bot_trades.sql
@@ -70,14 +70,6 @@ with
         where
             trades.trader_id != '{{fee_receiver}}'  -- Exclude trades signed by FeeWallet
             and transactions.signer != '{{fee_receiver}}'  -- Exclude trades signed by FeeWallet
-    ),
-    highest_inner_instruction_index_for_each_trade as (
-        select
-            tx_id,
-            outer_instruction_index,
-            max(inner_instruction_index) as highest_inner_instruction_index
-        from bot_trades
-        group by tx_id, outer_instruction_index
     )
 select
     block_time,
@@ -107,16 +99,9 @@ select
     bot_trades.outer_instruction_index,
     coalesce(inner_instruction_index, 0) as inner_instruction_index,
     if(
-        inner_instruction_index = highest_inner_instruction_index, true, false
+        inner_instruction_index = max(inner_instruction_index) over (partition by tx_id, outer_instruction_index), true, false
     ) as is_last_trade_in_transaction
 from bot_trades
-join
-    highest_inner_instruction_index_for_each_trade
-    on (
-        bot_trades.tx_id = highest_inner_instruction_index_for_each_trade.tx_id
-        and bot_trades.outer_instruction_index
-        = highest_inner_instruction_index_for_each_trade.outer_instruction_index
-    )
 order by
     block_time desc,
     tx_index desc,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/autosnipe_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/autosnipe_solana_bot_trades.sql
@@ -94,17 +94,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -134,16 +123,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/banana_gun_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/banana_gun_solana_bot_trades.sql
@@ -125,17 +125,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -165,16 +154,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/bitfoot_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/bitfoot_solana_bot_trades.sql
@@ -94,17 +94,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -134,16 +123,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/bloom_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/bloom_solana_bot_trades.sql
@@ -94,17 +94,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -134,16 +123,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/bonkbot/bonkbot_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/bonkbot/bonkbot_solana_bot_trades.sql
@@ -63,28 +63,13 @@ with
                 and trades.block_time >= timestamp '{{project_start_date}}'
                 and fee_payments.block_time >= timestamp '{{project_start_date}}'
             {% endif %}
-    ),
-    highest_inner_instruction_index_for_each_trade as (
-        select
-            tx_id,
-            outer_instruction_index,
-            max(inner_instruction_index) as highest_inner_instruction_index
-        from trades
-        group by tx_id, outer_instruction_index
     )
 select
     trades.*,
     if(
-        inner_instruction_index = highest_inner_instruction_index, true, false
+        inner_instruction_index = max(inner_instruction_index) over (partition by tx_id, outer_instruction_index), true, false
     ) as is_last_trade_in_transaction
 from trades
-join
-    highest_inner_instruction_index_for_each_trade
-    on (
-        trades.tx_id = highest_inner_instruction_index_for_each_trade.tx_id
-        and trades.outer_instruction_index
-        = highest_inner_instruction_index_for_each_trade.outer_instruction_index
-    )
 order by
     block_time desc,
     tx_index desc,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/cswap_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/cswap_solana_bot_trades.sql
@@ -94,17 +94,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -134,16 +123,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/falcon_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/falcon_solana_bot_trades.sql
@@ -94,17 +94,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -134,16 +123,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/jupbot_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/jupbot_solana_bot_trades.sql
@@ -94,17 +94,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -134,16 +123,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/looter_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/looter_solana_bot_trades.sql
@@ -94,14 +94,6 @@ with
                 and {{ incremental_predicate('trades.block_time') }}
             {% else %} and trades.block_time >= timestamp '{{project_start_date}}'
             {% endif %}
-    ),
-    highest_inner_instruction_index_for_each_trade as (
-        select
-            tx_id,
-            outer_instruction_index,
-            max(inner_instruction_index) as highest_inner_instruction_index
-        from bot_trades
-        group by tx_id, outer_instruction_index
     )
 select
     block_time,
@@ -131,16 +123,9 @@ select
     bot_trades.outer_instruction_index,
     coalesce(inner_instruction_index, 0) as inner_instruction_index,
     if(
-        inner_instruction_index = highest_inner_instruction_index, true, false
+        inner_instruction_index = max(inner_instruction_index) over (partition by tx_id, outer_instruction_index), true, false
     ) as is_last_trade_in_transaction
 from bot_trades
-join
-    highest_inner_instruction_index_for_each_trade
-    on (
-        bot_trades.tx_id = highest_inner_instruction_index_for_each_trade.tx_id
-        and bot_trades.outer_instruction_index
-        = highest_inner_instruction_index_for_each_trade.outer_instruction_index
-    )
 order by
     block_time desc,
     tx_index desc,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/maestro_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/maestro_solana_bot_trades.sql
@@ -137,17 +137,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -177,16 +166,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/magnum_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/magnum_solana_bot_trades.sql
@@ -100,17 +100,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -140,16 +129,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/mev_x_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/mev_x_solana_bot_trades.sql
@@ -104,17 +104,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -144,16 +133,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/nova_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/nova_solana_bot_trades.sql
@@ -94,17 +94,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -134,16 +123,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pepe_boost_solana_bot_trades.sql
@@ -102,17 +102,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -142,16 +131,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pinkpunk_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/pinkpunk_solana_bot_trades.sql
@@ -100,17 +100,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highest_inner_instruction_index_for_each_trade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      bot_trades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -140,16 +129,12 @@ SELECT
   bot_trades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   bot_trades
-  JOIN highest_inner_instruction_index_for_each_trade ON (
-    bot_trades.tx_id = highest_inner_instruction_index_for_each_trade.tx_id
-    AND bot_trades.outer_instruction_index = highest_inner_instruction_index_for_each_trade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/prophetbots_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/prophetbots_solana_bot_trades.sql
@@ -98,17 +98,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -138,16 +127,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/readyswap_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/readyswap_solana_bot_trades.sql
@@ -109,17 +109,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -149,16 +138,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/sanji_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/sanji_solana_bot_trades.sql
@@ -94,17 +94,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -134,16 +123,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/shuriken_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/shuriken_solana_bot_trades.sql
@@ -94,17 +94,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -134,16 +123,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/sol_gun_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/sol_gun_solana_bot_trades.sql
@@ -94,17 +94,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -134,16 +123,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/sol_trading_bot_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/sol_trading_bot_solana_bot_trades.sql
@@ -108,17 +108,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -148,16 +137,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/soul_sniper_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/soul_sniper_solana_bot_trades.sql
@@ -70,14 +70,6 @@ with
         where
             trades.trader_id != '{{fee_receiver}}'  -- Exclude trades signed by FeeWallet
             and transactions.signer != '{{fee_receiver}}'  -- Exclude trades signed by FeeWallet
-    ),
-    highest_inner_instruction_index_for_each_trade as (
-        select
-            tx_id,
-            outer_instruction_index,
-            max(inner_instruction_index) as highest_inner_instruction_index
-        from bot_trades
-        group by tx_id, outer_instruction_index
     )
 select
     block_time,
@@ -107,16 +99,9 @@ select
     bot_trades.outer_instruction_index,
     coalesce(inner_instruction_index, 0) as inner_instruction_index,
     if(
-        inner_instruction_index = highest_inner_instruction_index, true, false
+        inner_instruction_index = max(inner_instruction_index) over (partition by tx_id, outer_instruction_index), true, false
     ) as is_last_trade_in_transaction
 from bot_trades
-join
-    highest_inner_instruction_index_for_each_trade
-    on (
-        bot_trades.tx_id = highest_inner_instruction_index_for_each_trade.tx_id
-        and bot_trades.outer_instruction_index
-        = highest_inner_instruction_index_for_each_trade.outer_instruction_index
-    )
 order by
     block_time desc,
     tx_index desc,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/tirador_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/tirador_solana_bot_trades.sql
@@ -94,17 +94,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -134,16 +123,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/tradewiz_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/tradewiz_solana_bot_trades.sql
@@ -94,17 +94,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -134,16 +123,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/trojan_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/trojan_solana_bot_trades.sql
@@ -100,17 +100,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -140,16 +129,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/unibot_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/unibot_solana_bot_trades.sql
@@ -101,17 +101,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -140,16 +129,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/wifbot_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/wifbot_solana_bot_trades.sql
@@ -95,14 +95,6 @@ with
                 and {{ incremental_predicate('trades.block_time') }}
             {% else %} and trades.block_time >= timestamp '{{project_start_date}}'
             {% endif %}
-    ),
-    highest_inner_instruction_index_for_each_trade as (
-        select
-            tx_id,
-            outer_instruction_index,
-            max(inner_instruction_index) as highest_inner_instruction_index
-        from bot_trades
-        group by tx_id, outer_instruction_index
     )
 select
     block_time,
@@ -132,16 +124,9 @@ select
     bot_trades.outer_instruction_index,
     coalesce(inner_instruction_index, 0) as inner_instruction_index,
     if(
-        inner_instruction_index = highest_inner_instruction_index, true, false
+        inner_instruction_index = max(inner_instruction_index) over (partition by tx_id, outer_instruction_index), true, false
     ) as is_last_trade_in_transaction
 from bot_trades
-join
-    highest_inner_instruction_index_for_each_trade
-    on (
-        bot_trades.tx_id = highest_inner_instruction_index_for_each_trade.tx_id
-        and bot_trades.outer_instruction_index
-        = highest_inner_instruction_index_for_each_trade.outer_instruction_index
-    )
 order by
     block_time desc,
     tx_index desc,

--- a/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/phantom_swapper/phantom_swapper_solana_trades.sql
@@ -76,28 +76,13 @@ with filtered_transactions as (
                 and trades.block_time >= timestamp '{{query_start_date}}'
                 and fee_payments.block_time >= timestamp '{{query_start_date}}'
             {% endif %}
-    ),
-    highest_inner_instruction_index_for_each_trade as (
-        select
-            tx_id,
-            outer_instruction_index,
-            max(inner_instruction_index) as highest_inner_instruction_index
-        from trades
-        group by tx_id, outer_instruction_index
     )
 select
     trades.*,
     if(
-        inner_instruction_index = highest_inner_instruction_index, true, false
+        inner_instruction_index = max(inner_instruction_index) over (partition by tx_id, outer_instruction_index), true, false
     ) as is_last_trade_in_transaction
 from trades
-join
-    highest_inner_instruction_index_for_each_trade
-    on (
-        trades.tx_id = highest_inner_instruction_index_for_each_trade.tx_id
-        and trades.outer_instruction_index
-        = highest_inner_instruction_index_for_each_trade.outer_instruction_index
-    )
 order by
     block_time desc,
     tx_index desc,


### PR DESCRIPTION
Every Solana bot_trades model (plus the base_app and phantom swapper trades models) computed `is_last_trade_in_transaction` by GROUP-BY-ing the main `botTrades` CTE into a `highestInnerInstructionIndexForEachTrade` CTE and joining it back on the grouping keys. Trino inlines multi-referenced CTEs, so the entire upstream subtree -- including the `solana.account_activity` fee scan (8.67B rows on a representative readyswap run), `solana.transactions`, `dex_solana.trades`, and `prices.usd` -- was physically scanned twice per run.

This replaces the self-join with `MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index)` (plus `block_date` in the partition key for base_app, matching its original grouping keys), which is computed on the single pass. Semantics are identical: the original INNER JOIN back on the grouping keys preserves every row, and the window max equals the joined max per group.

## Proof (read-only A/B on spellbook-tokens, 24h frozen window 2026-06-11)

Equivalence on trojan (the busiest variant with rows in window): `OLD EXCEPT NEW = 0` and `NEW EXCEPT OLD = 0` over 51,726 rows, plus 3 warm runs per side with `checksum()` over all 27 output columns -- byte-identical across all 6 runs.

A/B medians (3 warm runs each, checksum-forced materialization):

| model | | IO | CPU | peak mem |
|---|---|---|---|---|
| readyswap | old | 83.11 GB | 692 s | 0.48 GB |
| | new | **41.66 GB (-50%)** | **404 s (-42%)** | 0.23 GB |
| trojan | old | 24.34 GB | 300 s | 0.36 GB |
| | new | **12.52 GB (-49%)** | **154 s (-49%)** | 0.91 GB |

Spill 0 everywhere. Wall time tracked the IO drop on quiet-cluster runs but is noisy under load.

The 30 models together currently cost ~11.3 CPU-hrs/day and ~3.6 TB IO/day on spellbook-solana; the structural halving of the scan subtree projects to roughly -1.8 TB IO/day and -4.5-5.5 CPU-hrs/day.

## CI note (known pre-existing timeout -- not a regression)

`dbt-run / dbt-test` times out at the 90-min workflow cap on this PR. This is a **pre-existing structural limit of slim CI for bulk bot_trades changes**, not a regression from this rewrite:

- Slim CI full-history-rebuilds every modified incremental from its 2024 `project_start_date`. Each rebuild scans multiple TB (measured 2-5 TB still unfinished at the kill), and CI runs all 30 concurrently, so the build cannot fit the 90-min workflow cap.
- This is independent of the change here: the rewrite only removes a self-join (proven -50% IO / -42% CPU, `EXCEPT`=0 above). A solo full-refresh of the heaviest model (readyswap) was measured at 92.8 min / 10.76 TB on its own.
- `address_prefix` partition pruning does **not** help (even pruned models scanned 2-5 TB unfinished); a CI scan floor does **not** help either (it empties the 2024 `check_bot_trades_seed` fixtures and fails those tests).
- Precedent: **#9670** (the 28-file `address_prefix` bulk change to these same models) merged on 2026-05-14 with this identical check failing at 1h30m16s.

Given the proven equivalence + the mechanical, identical nature of the change across all 30 files, this needs a human merge-through decision (same as #9670), not a CI fix.

Towards CUR2-2703
