### PR TITLE
perf(readyswap_solana_bot_trades): replace last-trade self-join with window function

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/readyswap_solana_bot_trades.sql
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/platforms/readyswap_solana_bot_trades.sql
@@ -109,17 +109,6 @@ WITH
       {% else %}
       AND trades.block_time >= TIMESTAMP '{{project_start_date}}'
       {% endif %}
-  ),
-  highestInnerInstructionIndexForEachTrade AS (
-    SELECT
-      tx_id,
-      outer_instruction_index,
-      MAX(inner_instruction_index) AS highestInnerInstructionIndex
-    FROM
-      botTrades
-    GROUP BY
-      tx_id,
-      outer_instruction_index
   )
 SELECT
   block_time,
@@ -149,16 +138,12 @@ SELECT
   botTrades.outer_instruction_index,
   COALESCE(inner_instruction_index, 0) AS inner_instruction_index,
   IF(
-    inner_instruction_index = highestInnerInstructionIndex,
+    inner_instruction_index = MAX(inner_instruction_index) OVER (PARTITION BY tx_id, outer_instruction_index),
     true,
     false
   ) AS is_last_trade_in_transaction
 FROM
   botTrades
-  JOIN highestInnerInstructionIndexForEachTrade ON (
-    botTrades.tx_id = highestInnerInstructionIndexForEachTrade.tx_id
-    AND botTrades.outer_instruction_index = highestInnerInstructionIndexForEachTrade.outer_instruction_index
-  )
 ORDER BY
   block_time DESC,
   tx_index DESC,


### PR DESCRIPTION
CI-fit probe (do not merge). Single-model slice of the bot_trades window-function rewrite (#9774) to measure whether one heavy solana bot_trades model full-refreshes within the CI 1h query cap. readyswap is the worst case: no address_prefix partition pruning, scans solana.account_activity (8.67B rows) from project_start_date. Outcome decides whether #9774 can ship as batches (if this fits) or needs address_prefix pruning added to the 3 unpruned models first.

Window rewrite proven equivalent on trojan (EXCEPT=0 both ways, n=51,726, 27-col checksums identical); readyswap A/B IO 83.11->41.66 GB (-50%), CPU 692->404 s (-42%).