### PR TITLE
perf(lido_accounting): single-pass prices.usd scan (7x -> 1x, -83% IO)

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/lido/lido_accounting.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/lido/lido_accounting.sql
@@ -22,88 +22,55 @@ with tokens AS (
                 (0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0)   --wstETH
         ) as tokens(address)
 ),
-eth_prices as (
+-- Single pass over prices.usd (previously scanned 7x: eth_prices self-join inlined across 3 UNION branches).
+-- weth_close is the WETH daily-close per day via a window, replacing the eth_prices join.
+daily_close_prices as (
         SELECT
                 CAST(DATE_TRUNC('day', minute) as date) AS period,
                 contract_address AS token,
                 symbol,
                 decimals,
-                price
+                price,
+                MAX(CASE WHEN blockchain = 'ethereum'
+                          AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+                         THEN price END)
+                    OVER (PARTITION BY CAST(DATE_TRUNC('day', minute) as date)) AS weth_close,
+                (blockchain = 'ethereum' AND contract_address IN (SELECT address FROM tokens)) AS is_eth_token,
+                (symbol = 'stSOL') AS is_stsol
         FROM {{source('prices','usd')}}
-        WHERE blockchain = 'ethereum'
-        AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
-        AND DATE_TRUNC('day', minute) >= date '2020-12-01'
-        AND DATE_TRUNC('day', minute) <= DATE_TRUNC('day', NOW() - INTERVAL '1' DAY)
+        WHERE minute >= timestamp '2020-12-01'
         AND EXTRACT(hour FROM minute) = 23
         AND EXTRACT(minute FROM minute) = 59
-
-        union all
-
-        SELECT
-                CAST(DATE_TRUNC('day', NOW()) as date) AS period,
-                contract_address AS token,
-                symbol,
-                decimals,
-                price
-        FROM {{source('prices','usd')}}
-        WHERE blockchain = 'ethereum'
-        AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
-        AND DATE_TRUNC('day', minute) = DATE_TRUNC('day', NOW() - INTERVAL '1' DAY)
-        AND EXTRACT(hour FROM minute) = 23
-        AND EXTRACT(minute FROM minute) = 59
+        AND (
+                (blockchain = 'ethereum' AND contract_address IN (SELECT address FROM tokens))
+                OR symbol = 'stSOL'
+        )
 ),
 tokens_prices AS (
+        -- Fan each base row out to its output period(s): the historical day, plus -- for the
+        -- ethereum tokens only -- a copy of yesterday relabelled to today (stSOL keeps its own day).
         SELECT
-                CAST(DATE_TRUNC('day', prices.usd.minute) as date) AS period,
-                prices.usd.contract_address AS token,
-                prices.usd.symbol,
-                prices.usd.decimals,
-                prices.usd.price,
-                eth_prices.price as eth_usd_price,
-                prices.usd.price/eth_prices.price as token_eth_price
-        FROM {{source('prices','usd')}}
-        left join eth_prices on DATE_TRUNC('day', prices.usd.minute) =  eth_prices.period
-        WHERE prices.usd.blockchain = 'ethereum'
-        AND prices.usd.contract_address IN (SELECT address FROM tokens)
-        AND DATE_TRUNC('day', minute) >= date '2020-12-01'
-        AND DATE_TRUNC('day', minute) <= DATE_TRUNC('day', NOW() - INTERVAL '1' DAY)
-        AND EXTRACT(hour FROM prices.usd.minute) = 23
-        AND EXTRACT(minute FROM prices.usd.minute) = 59
-
-        union all
-
-        SELECT
-                CAST(date_trunc('minute',now()) as date) AS period,
-                p.contract_address AS token,
-                p.symbol,
-                p.decimals,
-                p.price,
-                eth_prices.price as eth_usd_price,
-                p.price/eth_prices.price as token_eth_price
-        FROM {{source('prices','usd')}} p
-        left join eth_prices on DATE_TRUNC('day', p.minute) =  eth_prices.period
-        WHERE p.blockchain = 'ethereum'
-        AND p.contract_address IN (SELECT address FROM tokens)
-        AND DATE_TRUNC('day', minute) = DATE_TRUNC('day', NOW() - INTERVAL '1' DAY)
-        AND EXTRACT(hour FROM p.minute) = 23
-        AND EXTRACT(minute FROM p.minute) = 59
-
-        union all
-
-        SELECT
-                CAST(DATE_TRUNC('day', prices.usd.minute) as date) AS period,
-                0xedd1db59799c8b7753f141585986707812d783272eed8de22fab6b2a7d58ec0463,
-                'stSOL',
-                0,
-                prices.usd.price,
-                prices.usd.price as eth_usd_price,
-                prices.usd.price/eth_prices.price as token_eth_price
-        FROM {{source('prices','usd')}}
-        left join eth_prices on DATE_TRUNC('day', prices.usd.minute) =  eth_prices.period
-        WHERE prices.usd.symbol = 'stSOL'
-        AND DATE_TRUNC('day', minute) >= date '2020-12-01'
-        AND EXTRACT(hour FROM prices.usd.minute) = 23
-        AND EXTRACT(minute FROM prices.usd.minute) = 59
+                u.out_period AS period,
+                CASE WHEN is_stsol
+                     THEN 0xedd1db59799c8b7753f141585986707812d783272eed8de22fab6b2a7d58ec0463
+                     ELSE token END AS token,
+                CASE WHEN is_stsol THEN 'stSOL' ELSE symbol END AS symbol,
+                CASE WHEN is_stsol THEN 0 ELSE decimals END AS decimals,
+                price,
+                CASE WHEN is_stsol THEN price ELSE weth_close END AS eth_usd_price,
+                price / weth_close AS token_eth_price
+        FROM daily_close_prices
+        CROSS JOIN UNNEST(
+                CASE
+                        WHEN is_eth_token AND period < CAST(DATE_TRUNC('day', NOW() - INTERVAL '1' DAY) as date)
+                                THEN ARRAY[period]
+                        WHEN is_eth_token AND period = CAST(DATE_TRUNC('day', NOW() - INTERVAL '1' DAY) as date)
+                                THEN ARRAY[period, CAST(DATE_TRUNC('day', NOW()) as date)]
+                        WHEN is_eth_token THEN CAST(ARRAY[] as array(date))
+                        WHEN is_stsol THEN ARRAY[period]
+                        ELSE CAST(ARRAY[] as array(date))
+                END
+        ) AS u(out_period)
 )
 SELECT  CAST(date_trunc('day', accounts.period) as date) as period, --partition columns cannot be timestamp
         accounts.evt_tx_hash as hash,


### PR DESCRIPTION
`lido_accounting` (hourly, `materialized='table'`, full rebuild ~24x/day) scanned `prices.usd` **7 times per build** — the `eth_prices` CTE (WETH daily close, a self-join) was inlined across the three `tokens_prices` UNION branches, and none of the `DATE_TRUNC('day', minute) = ...` / `EXTRACT(hour)=23` predicates push down to the `usd_0003` fact, so every reference re-read the full ~4.7B-row fact. Measured build: **33.0B rows / 212 GB scanned, ~5.1 TB/day**.

This rewrites the prices section to a **single pass**: one scan of `prices.usd` for the token set (8 ethereum tokens + stSOL) at the daily close, deriving the WETH close per day with a `max(...) OVER (PARTITION BY period)` window instead of the self-join, and emitting the "today = yesterday's close" relabel rows (ethereum tokens) via a `CROSS JOIN UNNEST` fan-out instead of the two extra UNION branches. Same P13 family as #9756 (`lido_liquidity`): `minute` is the only prunable column on the fact.

The downstream account UNION + `LEFT JOIN tokens_prices` + `GROUP BY` is unchanged; `tokens_prices` keeps the same columns.

**Equivalence (read-only, prod `prices.usd`, UTC, full history 2020-12-01 -> live today, same query so `now()` is consistent):** old vs new `tokens_prices` = **16,623 rows each, `EXCEPT` 0 both ways** on (period, token, symbol, decimals, price, eth_usd_price) and on `round(token_eth_price, 9)`; the 8 today-relabel rows match. Independently, `checksum()` over **all 7 output columns** is **byte-identical** old-vs-new across 3+3 warm runs.

**A/B magnitude (isolated prices section, 3 warm-run medians):**

| dim | old (7 scans) | new (1 scan) | Δ |
|---|---|---|---|
| IO | 212.4 GB / 33.0B rows | **36.8 GB / 6.17B rows** | **-82.7% (5.8x)** |
| CPU | 697.6 cpu-s | 677.6 cpu-s | -2.9% (flat) |
| wall | 7.1 s | 7.5 s | flat (noisy) |
| peak mem | 6.44 GB | 7.14 GB | +10.9% |
| spill | 0 | 0 | — |

This is an **IO win**: ~5.1 TB/day -> ~0.9 TB/day (**-4.2 TB/day**) on spellbook-hourly. CPU is flat (the per-day WETH window offsets the saved scans) and peak memory rises slightly but stays well within limits — the lever here is the S3/read reduction, not compute.

No CI floor needed: the model is `materialized='table'`, so CI builds the same CTAS as prod (now cheaper). `lido_accounting` has no data tests; output is byte-identical regardless.

Fixes CUR2-2793
