### PR TITLE
perf(dex_solana.trades test): bound accepted_range scan to a recent window

### DIFF
--- a/dbt_subprojects/solana/models/_sector/dex/_schema.yml
+++ b/dbt_subprojects/solana/models/_sector/dex/_schema.yml
@@ -76,6 +76,11 @@ models:
           - dbt_utils.accepted_range:
               arguments:
                 max_value: 1000000000 # $1b is an arbitrary number, intended to flag outlier amounts early
+              config:
+                # Bound the scan to recent trades: the test flags outlier amount_usd as data lands,
+                # so re-scanning all history (17.2B rows / 236 GB) every run adds no value over a
+                # recent window. Cuts the test's IO ~17x and CPU ~16x.
+                where: "block_time >= now() - interval '7' day"
       - &fee_tier
         name: fee_tier
         description: "Whirlpool fee tier (fee %)"


### PR DESCRIPTION
The `dbt_utils.accepted_range` test on `dex_solana.trades.amount_usd` ran with no `where` config, so every run full-scanned the entire table — 17.2B rows / 236.8 GB, ~1.34M cpu_ms, ~62s wall — just to flag trades above $1b. It runs 4 heavy times/day = ~0.95 TB IO and ~1.49 CPU-hrs/day, purely re-validating immutable history.

The test exists to catch outlier `amount_usd` as data lands, so bounding it to a recent window matches its intent. This adds a `config.where` of `block_time >= now() - interval '7' day`. `block_time` is a regular column with Delta min/max stats and `block_month` is the partition key, so the bound prunes to recent files (pushdown confirmed live).

Measured on prod data (spellbook-hourly, faithful full-column scan, 3 warm runs, medians):

| axis | full history (prod) | 7-day bound | factor |
|---|---|---|---|
| IO | 236.8 GB | 13.7 GB | 17.2x |
| rows scanned | 17.20B | 100.3M | ~171x |
| cpu_ms | 1,338,645 | 85,556 | 15.6x |
| wall | 62.3s | 4.8s | ~13x |

Per day (4 heavy runs): ~947 → ~55 GB IO and ~1.49 → ~0.10 CPU-hrs.

No equivalence proof here on purpose: this changes the test's coverage from all-history to the recent window. An outlier landing more than 7 days ago (e.g. a late backfill) would no longer be flagged — wanting reviewer sign-off on the window length (happy to bump to 30d for a wider safety net; ~30d still scans far less than full history).

Compiled test confirms the bound wraps the relation:

```sql
from (select * from dex_solana.trades where block_time >= now() - interval '7' day) dbt_subquery
```

Fixes CUR2-2800
