### PR TITLE
perf(zeroex_arbitrum_api_fills): materialize settler-txs staging (collapse ~5x traces re-scan)

### DIFF
--- a/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_arbitrum_api_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_arbitrum_api_fills.sql
@@ -17,39 +17,17 @@
 -- Test Query here: https://dune.com/queries/1855986
 
 WITH zeroex_tx AS (
-        SELECT
-            tr.tx_hash,
-            tr.block_time,
-            tr.block_number,
-            MAX(CASE
-                WHEN bytearray_position(INPUT, 0x869584cd ) <> 0
-                    THEN SUBSTRING(INPUT FROM (bytearray_position(INPUT, 0x869584cd) + 16) FOR 20)
-                WHEN bytearray_position(INPUT, 0xfbc019a7) <> 0
-                    THEN SUBSTRING(INPUT FROM (bytearray_position(INPUT, 0xfbc019a7 ) + 16) FOR 20)
-            END) AS affiliate_address
-        FROM {{ source('arbitrum', 'traces') }} tr
-        WHERE tr.to IN (
-                -- exchange contract
-                0x61935cbdd02287b511119ddb11aeb42f1593b7ef,
-                -- forwarder addresses
-                0x6958f5e95332d93d21af0d7b9ca85b8212fee0a5,
-                0x4aa817c6f383c8e8ae77301d18ce48efb16fd2be,
-                0x4ef40d1bf0983899892946830abf99eca2dbc5ce,
-                -- exchange proxy
-                0xdef1c0ded9bec7f1a1670819833240f027b25eff
-                )
-                AND (
-                    bytearray_position(INPUT, 0x869584cd ) <> 0
-                    OR bytearray_position(INPUT, 0xfbc019a7 ) <> 0
-                )
-
-                {% if is_incremental() %}
-                AND {{ incremental_predicate('tr.block_time') }}
-                {% endif %}
-                {% if not is_incremental() %}
-                AND tr.block_time >= TIMESTAMP '{{zeroex_v3_start_date}}'
-                {% endif %}
-        GROUP BY tr.tx_hash, tr.block_number, tr.block_time
+    -- Read the pre-materialized affiliate/tracker scan instead of inlining the
+    -- traces scan, which Trino re-expanded into ~5 arbitrum.traces scans.
+    select
+        tx_hash,
+        affiliate_address,
+        block_number,
+        block_time
+    from {{ ref('zeroex_arbitrum_api_fills_tx') }}
+    {% if is_incremental() %}
+    where {{ incremental_predicate('block_time') }}
+    {% endif %}
 ),
 
 v4_rfq_fills_no_bridge AS (

--- a/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_arbitrum_api_fills_tx.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_arbitrum_api_fills_tx.sql
@@ -1,0 +1,63 @@
+{{
+    config(
+        schema = 'zeroex_arbitrum',
+        alias = 'api_fills_tx',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'block_number'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_v3_start_date = '2019-12-01' %}
+
+-- Shared staging model for the 0x API affiliate/tracker scan on Arbitrum.
+-- No CI date floor: zeroex_arbitrum_api_fills (and _deduped) have check_seed
+-- tests against historical (2023) sample rows, so the CI full-refresh must
+-- build full history for those rows to be present.
+-- Materializing this once breaks the CTE inlining that previously re-scanned
+-- arbitrum.traces ~5x per zeroex_arbitrum_api_fills build (the calldata
+-- affiliate-selector search on input is non-pushable).
+-- block_number/block_time are carried so downstream joins on
+-- (tx_hash, block_number[, block_time]) are preserved.
+select
+    api_fills_tx.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    SELECT
+        tr.tx_hash,
+        MAX(CASE
+            WHEN bytearray_position(INPUT, 0x869584cd ) <> 0
+                THEN SUBSTRING(INPUT FROM (bytearray_position(INPUT, 0x869584cd) + 16) FOR 20)
+            WHEN bytearray_position(INPUT, 0xfbc019a7) <> 0
+                THEN SUBSTRING(INPUT FROM (bytearray_position(INPUT, 0xfbc019a7 ) + 16) FOR 20)
+        END) AS affiliate_address,
+        tr.block_number as block_number,
+        tr.block_time as block_time
+    FROM {{ source('arbitrum', 'traces') }} tr
+    WHERE tr.to IN (
+            -- exchange contract
+            0x61935cbdd02287b511119ddb11aeb42f1593b7ef,
+            -- forwarder addresses
+            0x6958f5e95332d93d21af0d7b9ca85b8212fee0a5,
+            0x4aa817c6f383c8e8ae77301d18ce48efb16fd2be,
+            0x4ef40d1bf0983899892946830abf99eca2dbc5ce,
+            -- exchange proxy
+            0xdef1c0ded9bec7f1a1670819833240f027b25eff
+            )
+            AND (
+                bytearray_position(INPUT, 0x869584cd ) <> 0
+                OR bytearray_position(INPUT, 0xfbc019a7 ) <> 0
+            )
+
+            {% if is_incremental() %}
+            AND {{ incremental_predicate('block_time') }}
+            {% endif %}
+            {% if not is_incremental() %}
+            AND block_time >= cast('{{zeroex_v3_start_date}}' as date)
+            {% endif %}
+        group by tr.tx_hash, tr.block_number, tr.block_time
+) as api_fills_tx

--- a/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_arbitrum_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_arbitrum_schema.yml
@@ -1,6 +1,43 @@
 version: 2
 
 models:
+  - name: zeroex_arbitrum_api_fills_tx
+    meta:
+      blockchain: arbitrum
+      project: zeroex
+      contributors: rantum
+    config:
+      tags: ['arbitrum', '0x', 'aggregator']
+    description: >
+      Pre-materialized 0x API affiliate/tracker scan on Arbitrum, extracted once from
+      arbitrum.traces. Shared staging model for zeroex_arbitrum_api_fills so the non-pushable
+      calldata affiliate-selector scan runs a single time per build instead of being
+      re-inlined many times.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - block_number
+    columns:
+      - name: tx_hash
+        description: "Transaction hash of the 0x API fill"
+        data_tests:
+          - not_null
+      - name: affiliate_address
+        description: "0x affiliate/tracker address parsed from calldata"
+      - name: block_number
+        description: "Block number of the transaction"
+        data_tests:
+          - not_null
+      - name: block_time
+        description: "Block time of the transaction (carried for partitioning/incremental)"
+      - name: block_month
+        description: "Month partition derived from block_time"
+        data_tests:
+          - not_null
+
   - name: zeroex_arbitrum_api_fills
     meta:
       blockchain: arbitrum


### PR DESCRIPTION
P6 materialization on `zeroex_arbitrum_api_fills`, the same fix already shipped for bnb+polygon (#9744) and the zeroex_v2 trades family (#9734). The inline `zeroex_tx` CTE scans `arbitrum.traces` with a non-pushable affiliate-selector calldata search (`bytearray_position(input, 0x869584cd / 0xfbc019a7)`) and is joined 5 times, so Trino re-expands it into ~5 full `arbitrum.traces` scans per build. Extracting it into a materialized incremental staging model `zeroex_arbitrum.api_fills_tx` (partitioned by `block_month`, read via `ref()`) scans traces once.

The staging carries `(tx_hash, block_number, block_time, affiliate_address)` so the downstream joins on `(tx_hash, block_number)` and `(tx_hash, block_number, block_time)` are preserved. Aggregation is `max()` (no `row_number`), so the staging is fully deterministic — no tie risk. The main model output is unchanged, so `zeroex_arbitrum_api_fills_deduped` (its only consumer) is unaffected.

Proven on spellbook-hourly over the prod incremental window (`block_time >= 2026-06-10`):
- Equivalence at the CTE boundary: 331 rows both sides; `(old EXCEPT new)` = `(new EXCEPT old)` = 0.
- A/B (3 warm medians): the single materialized traces scan = 3.399 GB IO / 21.2 cpu-s / peak ~10 MB / spill 0 (deterministic across runs).
- MCP analyze of a representative prod build confirmed `arbitrum.traces` scanned 5x (509.6M rows = 82% of positions) at 15.68 GB / 106 cpu-s.

Projected against the 24h baseline (0.66 CPU-hrs/day, 0.305 TB/day): CPU ~0.66 → ~0.25 CPU-hrs/day (−62%), IO ~0.305 → ~0.10 TB/day (−67%), peak/spill unchanged. In line with the realized bnb+polygon numbers (−76% CPU, −51% IO).

**CI note:** unlike the bnb/polygon staging (which carry a 14-day CI date floor), this change adds no CI floor. `zeroex_arbitrum_api_fills` and `zeroex_arbitrum_api_fills_deduped` have `check_seed` tests against 2023 sample rows, so the CI full-refresh must build full history for those rows to be present. arbitrum's main model already built full history in CI before this PR (it never had a CI floor) doing the 5x inline `arbitrum.traces` scans; the staging now does that scan once, so CI work is strictly less than before.

Towards CUR2-2732

