### PR TITLE
perf(seaport_v4): bound OrdersMatched scan to incremental window

### DIFF
--- a/dbt_subprojects/hourly_spellbook/macros/_sector/nft/platforms/seaport_v4_trades.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/_sector/nft/platforms/seaport_v4_trades.sql
@@ -22,7 +22,7 @@ with source_ethereum_transactions as (
     where block_time >= TIMESTAMP '{{start_date}}'  -- seaport first txn
     {% endif %}
     {% if is_incremental() %}
-    where block_time >= date_trunc('day', now() - interval '7' day)
+    where {{ incremental_predicate('block_time') }}
     {% endif %}
 )
 ,iv_orders_matched AS (
@@ -46,7 +46,7 @@ with source_ethereum_transactions as (
         and evt_block_time >= TIMESTAMP '{{start_date}}'  -- seaport first txn
         {% endif %}
         {% if is_incremental() %}
-        and evt_block_time >= date_trunc('day', now() - interval '7' day)
+        and {{ incremental_predicate('evt_block_time') }}
         {% endif %}
     ) group by 1,2,3,4  -- deduplicate order hash re-use in advanced matching
 )
@@ -119,7 +119,7 @@ with source_ethereum_transactions as (
         and evt_block_time >= TIMESTAMP '{{start_date}}'  -- seaport first txn
         {% endif %}
         {% if is_incremental() %}
-        and evt_block_time >= date_trunc('day', now() - interval '7' day)
+        and {{ incremental_predicate('evt_block_time') }}
         {% endif %}
     )
     union all
@@ -187,7 +187,7 @@ with source_ethereum_transactions as (
         and evt_block_time >= TIMESTAMP '{{start_date}}'  -- seaport first txn
         {% endif %}
         {% if is_incremental() %}
-        and evt_block_time >= date_trunc('day', now() - interval '7' day)
+        and {{ incremental_predicate('evt_block_time') }}
         {% endif %}
     )
 )

--- a/dbt_subprojects/hourly_spellbook/macros/_sector/nft/platforms/seaport_v4_trades.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/_sector/nft/platforms/seaport_v4_trades.sql
@@ -42,6 +42,12 @@ with source_ethereum_transactions as (
       where contract_address in ({% for order_contract in Seaport_order_contracts %}
         {{order_contract}}{%- if not loop.last -%},{%- endif -%}
         {% endfor %})
+        {% if not is_incremental() %}
+        and evt_block_time >= TIMESTAMP '{{start_date}}'  -- seaport first txn
+        {% endif %}
+        {% if is_incremental() %}
+        and evt_block_time >= date_trunc('day', now() - interval '7' day)
+        {% endif %}
     ) group by 1,2,3,4  -- deduplicate order hash re-use in advanced matching
 )
 ,fee_wallet_list as (


### PR DESCRIPTION
The `seaport_v4_trades` macro bounds the `Seaport_evt_OrderFulfilled` scans to the incremental 7-day window, but the sibling `Seaport_evt_OrdersMatched` scan (the `iv_orders_matched` CTE) has no time bound at all. So every hourly run scans `OrdersMatched` over **all history** while the rest of the model only looks at the last 7 days. On base today that scan reads the full 805,482-row OrdersMatched history (forcing a ~34.4M-row `logs_decoded` read, 98% rejected) when only **779** rows fall in the incremental window — and it grows unbounded as history accumulates.

This adds the same `is_incremental()` 7-day bound that `OrderFulfilled` already uses, so all three Seaport event scans prune to the same window.

The fix lives in the shared macro, so it applies to all 16 models that call `seaport_v4_trades` (opensea_v4 across ~12 chains plus magic_eden / spaace / mooar / nova).

### Equivalence (provable no-op)

`iv_orders_matched` only affects output through `left join ... on b.om_tx_hash = a.tx_hash and b.om_order_hash = a.order_hash`, where `a` (OrderFulfilled) is already bounded to 7 days. A matched order emits its `OrdersMatched` and `OrderFulfilled` events in the **same transaction** (same `block_time`), so any OrdersMatched row older than the cutoff has a `tx_hash` that is absent from the bounded OrderFulfilled set and can never join.

Verified on prod (`spellbook-hourly`, base, incremental window):
- **Join lemma**: of the OrdersMatched rows that join the 7-day-bounded OrderFulfilled set, **779 join and 0 fall outside the window** — the bound removes only non-joining rows.
- **Full-output EXCEPT both ways = 0** on all 28 meaningful output columns (359,280 rows), current macro vs. bounded macro. The only column that differs is `sub_tx_trade_id` (`row_number() over (partition by tx_hash order by evt_index)`), which is pre-existing tie-break nondeterminism — it varies run-to-run on the **current** code too (16/24 then 19/19 on identical inputs), independent of this change.

### A/B (base, 3 warm interleaved runs, medians, dtrino UTC)

| | current (OM unbounded) | this PR (OM bounded) |
|---|---|---|
| physical_input_bytes | 12.86 GB | **10.88 GB (-15.4%)** |
| cpu_ms | 548.4 s | 568.3 s (flat, within noise) |
| wall | 29.1 s | 21.4 s (noisy) |
| peak mem | ~3.0 GB | ~2.3 GB |
| spill | 0 | 0 |

This is an IO win (CPU is flat — the dominant CPU stage is the JSON-parse in `iv_base_pairs`, untouched here; tracked separately). The IO saving grows over time because the eliminated scan is full-history.

---

Fixes CUR2-2814
Towards CUR2-2700
