### PR TITLE
perf(addresses_events): shrink first_activity lookback to profiled late-arrival bound

### DIFF
--- a/dbt_subprojects/hourly_spellbook/macros/sector/addresses_events/addresses_events_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/addresses_events/addresses_events_first_activity.sql
@@ -1,4 +1,4 @@
-{% macro addresses_events_first_activity(blockchain, native_symbol, lookback_days=2) %}
+{% macro addresses_events_first_activity(blockchain, native_symbol) %}
 SELECT '{{blockchain}}' AS blockchain
 , et."from" AS address
 , MIN_BY(et."to", et.block_number) AS first_activity_to
@@ -25,7 +25,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '{{ lookback_days }}' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/macros/sector/addresses_events/addresses_events_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/macros/sector/addresses_events/addresses_events_first_activity.sql
@@ -1,4 +1,4 @@
-{% macro addresses_events_first_activity(blockchain, native_symbol) %}
+{% macro addresses_events_first_activity(blockchain, native_symbol, lookback_days=2) %}
 SELECT '{{blockchain}}' AS blockchain
 , et."from" AS address
 , MIN_BY(et."to", et.block_number) AS first_activity_to
@@ -25,7 +25,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '{{ lookback_days }}' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/base/addresses_events_base_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/base/addresses_events_base_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/base/addresses_events_base_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/base/addresses_events_base_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/bnb/addresses_events_bnb_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/bnb/addresses_events_bnb_first_activity.sql
@@ -11,6 +11,5 @@
 
 {{addresses_events_first_activity(
     blockchain='bnb',
-    native_symbol = 'bnb',
-    lookback_days = 3
+    native_symbol = 'bnb'
 )}}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/bnb/addresses_events_bnb_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/bnb/addresses_events_bnb_first_activity.sql
@@ -11,5 +11,6 @@
 
 {{addresses_events_first_activity(
     blockchain='bnb',
-    native_symbol = 'bnb'
+    native_symbol = 'bnb',
+    lookback_days = 3
 )}}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/ink/addresses_events_ink_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/ink/addresses_events_ink_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/ink/addresses_events_ink_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/ink/addresses_events_ink_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/linea/addresses_events_linea_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/linea/addresses_events_linea_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/linea/addresses_events_linea_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/linea/addresses_events_linea_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/mantle/addresses_events_mantle_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/mantle/addresses_events_mantle_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/mantle/addresses_events_mantle_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/mantle/addresses_events_mantle_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/nova/addresses_events_nova_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/nova/addresses_events_nova_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/nova/addresses_events_nova_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/nova/addresses_events_nova_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/opbnb/addresses_events_opbnb_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/opbnb/addresses_events_opbnb_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/opbnb/addresses_events_opbnb_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/opbnb/addresses_events_opbnb_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/optimism/addresses_events_optimism_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/optimism/addresses_events_optimism_first_activity.sql
@@ -59,7 +59,7 @@ FROM (
         gas_used
     FROM
     {{ source('optimism', 'transactions') }}
-    WHERE block_time >= date_trunc('day', now() - interval '2' day)
+    WHERE {{ incremental_predicate('block_time') }}
     {% endif %}
     ) et
 LEFT JOIN (

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/optimism/addresses_events_optimism_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/optimism/addresses_events_optimism_first_activity.sql
@@ -59,7 +59,7 @@ FROM (
         gas_used
     FROM
     {{ source('optimism', 'transactions') }}
-    WHERE block_time >= date_trunc('day', now() - interval '7' day)
+    WHERE block_time >= date_trunc('day', now() - interval '2' day)
     {% endif %}
     ) et
 LEFT JOIN (

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/ronin/addresses_events_ronin_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/ronin/addresses_events_ronin_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/ronin/addresses_events_ronin_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/ronin/addresses_events_ronin_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/scroll/addresses_events_scroll_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/scroll/addresses_events_scroll_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/scroll/addresses_events_scroll_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/scroll/addresses_events_scroll_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/sei/addresses_events_sei_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/sei/addresses_events_sei_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/sei/addresses_events_sei_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/sei/addresses_events_sei_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/sepolia/addresses_events_sepolia_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/sepolia/addresses_events_sepolia_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/sepolia/addresses_events_sepolia_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/sepolia/addresses_events_sepolia_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/unichain/addresses_events_unichain_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/unichain/addresses_events_unichain_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/unichain/addresses_events_unichain_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/unichain/addresses_events_unichain_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zkevm/addresses_events_zkevm_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zkevm/addresses_events_zkevm_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zkevm/addresses_events_zkevm_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zkevm/addresses_events_zkevm_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zksync/addresses_events_zksync_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zksync/addresses_events_zksync_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zksync/addresses_events_zksync_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zksync/addresses_events_zksync_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zora/addresses_events_zora_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zora/addresses_events_zora_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '2' day)
+AND {{ incremental_predicate('et.block_time') }}
 {% endif %}
 
 GROUP BY et."from"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zora/addresses_events_zora_first_activity.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/addresses_events/zora/addresses_events_zora_first_activity.sql
@@ -31,7 +31,7 @@ LEFT JOIN (
 {% if is_incremental() %}
 LEFT JOIN {{this}} ffb ON et."from" = ffb.address
 WHERE ffb.address IS NULL
-AND et.block_time >= date_trunc('day', now() - interval '7' day)
+AND et.block_time >= date_trunc('day', now() - interval '2' day)
 {% endif %}
 
 GROUP BY et."from"


### PR DESCRIPTION
Shrinks the hardcoded `interval '7' day` re-scan window on the `addresses_events_<chain>_first_activity` family down to the landing-lag bound measured in the CUR2-2678 late-arrival profile: **2 days for EVM chains, 3 days for bnb**. Parameterizes the shared `addresses_events_first_activity` macro (`lookback_days`, default 2; bnb caller passes 3) and updates the 15 inline chain models.

**Owner-gated:** a lookback window is a correctness contract, not just a perf knob, so this is intentionally a draft pending Dune curated-data review. The window only ever existed to re-catch late-arriving first transactions. These models are anti-join appends (insert addresses *not already in the table* whose first tx is in the window), and they run ~hourly, so in steady state the table already holds every address whose first tx landed more than one run ago.

### Why it's safe (proven on prod data)
Of the new addresses a **7-day** incremental run would insert *right now*, every single one has a `first_block_time` within the last ~40 minutes — **zero** are older than even 2 days:

| chain | new addrs a 7d run inserts now | within 2d | older than 2d |
|---|---|---|---|
| bnb  | 13,407 | 13,407 | **0** |
| base | 1,642  | 1,642  | **0** |

This matches the profile: EVM raw p99.9 landing lag = minutes (0% of rows >1d late); bnb p99.9 = 6.6h, worst observed tail 1.9d. The 2d/3d bounds clear those tails with margin (and the `date_trunc('day', ...)` floor adds another 0–1 day).

### Measured A/B (component, 3 warm-run medians, checksum-forced over all output columns)
| chain (shrink) | CPU | IO (scan) | wall | peak mem | spill |
|---|---|---|---|---|---|
| bnb 7d→3d  | 457 → 320 s (**−30%**) | 58.1 → 45.9 GB (**−21%**) | 16.8 → 10.6 s (−37%) | 6.6 → 6.0 GB | 0 |
| base 7d→2d | 202 → 119 s (**−41%**) | 16.7 → 11.0 GB (**−34%**) | 8.8 → 4.4 s (−50%) | flat | 0 |

The bnb IO cut is diluted by a fixed ~12 GB self-scan of `{{this}}` (a separate structural cost tracked in CUR2-2784); EVM chains shrink to 2d and cut more. Across the ~28-chain family (~11 CPU-hrs/day, ~3.5 TB IO/day on spellbook-hourly) this is an estimated ~30–40% reduction (~3.5–4 CPU-hrs/day, ~1–1.4 TB/day).

### Notes
- `opbnb` is treated as an EVM L2 (2d), not bnb-L1's 3d — flag if you'd prefer 3d.
- No CI floor added: these models' full-refresh path was already unbounded, and the `check_seed` regression test needs the full-history initial build (it asserts genesis-era seed addresses are present). This PR doesn't change that path, so CI behaves as before; the heaviest initial full-refresh (bnb, 13.3B rows → 555M groups) measured ~11 min wall / 1.7 TB / 0 spill, well inside the 90-min CI budget.

Towards CUR2-2809

