### PR TITLE
perf(tokens_solana_nft): bound cNFT idempotency self-scan to incremental window

### DIFF
--- a/dbt_subprojects/solana/models/tokens/solana/_schema.yml
+++ b/dbt_subprojects/solana/models/tokens/solana/_schema.yml
@@ -36,6 +36,12 @@ models:
     config:
       tags: ['table', 'metadata', 'fungible', 'solana']
     description: "NFTs minted using the Metaplex standard, with a master edition or cNFT tree"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - unique_key
+              - block_date
     columns:
       - name: account_mint_authority
         description: "mint authority for the account. this is set so that the account cannot mint more tokens"
@@ -74,6 +80,8 @@ models:
         description: "only applies to cNFTs — inner instruction index of the mint call. NULL for Token Metadata rows."
       - name: block_date
         description: "date(call_block_time). Stable per row; used as the partition column and as part of the merge unique key."
+        data_tests:
+          - not_null
       - name: unique_key
         description: "merge identifier; surrogate hash of (version, account_metadata) for Token Metadata rows and (version, account_merkle_tree, call_tx_id, call_outer_instruction_index, call_inner_instruction_index) for cNFT rows."
         data_tests:

--- a/dbt_subprojects/solana/models/tokens/solana/tokens_solana_nft.sql
+++ b/dbt_subprojects/solana/models/tokens/solana/tokens_solana_nft.sql
@@ -238,6 +238,13 @@ with
             WHERE NOT EXISTS (
                 SELECT 1 FROM {{ this }} t
                 WHERE t.version = 'cNFT'
+                  -- Prune this idempotency self-scan to the incremental window's
+                  -- partitions. A duplicate of a windowed `src` mint shares the same
+                  -- mint identity, hence the same call_block_time (>= the window floor),
+                  -- hence the same block_date (>= the window floor day) — so a
+                  -- window-bounded block_date can never drop a true collision. Without
+                  -- this the anti-join re-scans all ~924M cNFT rows (~53 GB) every run.
+                  AND {{ incremental_predicate('t.block_date') }}
                   AND t.account_merkle_tree = src.account_merkleTree
                   AND t.call_tx_id = src.call_tx_id
                   AND coalesce(t.call_outer_instruction_index, -1) = coalesce(src.call_outer_instruction_index, -1)


### PR DESCRIPTION
The cNFT branch's `NOT EXISTS` idempotency check — which skips Bubblegum mints already in the table so the per-tree `leaf_id` window isn't double-assigned — re-scanned the entire ~924M-row output table (~53.4 GB) on every build, because nothing bounded the `{{this}}` self-scan in time. `tokens_solana_nft` builds 4×/day and every MERGE pays this scan: in the representative run `20260613_191301_01040_9nn7e` the cNFT self-scan plus its anti-join hash build were ~73% of the model's CPU and ~55% of its IO.

The fix adds the standard `{{ incremental_predicate('t.block_date') }}` inside the `NOT EXISTS`, so the self-scan prunes to the incremental window's `block_date` partitions. This is sound: a duplicate of a windowed `src` mint shares the same mint identity, hence the same `call_block_time` (≥ the window floor), hence the same `block_date` (≥ the window floor day) — so a window-bounded `block_date` can never drop a true collision. The predicate only renders on incremental runs, so full refreshes are unchanged.

Proof (read-only, spellbook-hourly, UTC). Equivalence: the produced new-mint set is identical — a single drift-cancelling query gave `old_minus_new = 0` and `new_minus_old = 0` over all four identity columns. Isolated anti-join A/B (warm medians): scan IO **53.62 GB → 0.24 GB (~223×)**, CPU **~909 → ~5.8 cpu_s (~157×)**, peak mem **~3.2 → ~0.10 GB**.

Projected whole-model impact (the realized number lands post-merge): IO **385 → ~171 GB/day (−56%)**, CPU **1.68 → ~0.44 CPU-hrs/day (−74%)**.

Fixes CUR2-2820
