### PR TITLE
perf(dex): single-pass modify/fees fan-out in uniswap v4 base_liquidity_events

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
@@ -457,6 +457,9 @@ swap_fees_paid as (
 ),
 
 liquidity_change_base as (
+    -- scan modify_liquidity_events once and fan out the modify_liquidity and
+    -- fees_accrued rows via UNNEST; referencing the CTE twice inlines into a
+    -- second full pass over sqrtpricex96/traces_decoded/logs_decoded
     select 
         ml.id
         , ml.tx_from 
@@ -464,11 +467,11 @@ liquidity_change_base as (
         , ml.block_number 
         , ml.tx_hash 
         , ml.evt_index 
-        , ml.event_type 
+        , u.event_type 
         , ml.token0 
         , ml.token1 
-        , ml.amount0
-        , ml.amount1
+        , u.amount0
+        , u.amount1
         , ml.liquidityDelta
         , ml.sqrtPriceX96
         , ml.tickLower
@@ -476,29 +479,11 @@ liquidity_change_base as (
         , ml.salt
     from 
     modify_liquidity_events ml 
-
-    union all 
-
-    select 
-        ml.id
-        , ml.tx_from 
-        , ml.block_time
-        , ml.block_number 
-        , ml.tx_hash 
-        , ml.evt_index 
-        , 'fees_accrued' as event_type
-        , ml.token0 
-        , ml.token1 
-        , ml.fee_amount0 
-        , ml.fee_amount1 
-        , ml.liquidityDelta
-        , ml.sqrtPriceX96
-        , ml.tickLower
-        , ml.tickUpper
-        , ml.salt
-    from 
-    modify_liquidity_events ml 
-    where not (fee_amount0 = 0 and fee_amount1 = 0) -- remove events with zero fees 
+    cross join unnest(array[
+        row(cast(ml.event_type as varchar), ml.amount0, ml.amount1)
+        , row(cast('fees_accrued' as varchar), ml.fee_amount0, ml.fee_amount1)
+    ]) as u(event_type, amount0, amount1)
+    where not (u.event_type = 'fees_accrued' and ml.fee_amount0 = 0 and ml.fee_amount1 = 0) -- remove fees_accrued events with zero fees 
 
     union all 
 


### PR DESCRIPTION
The `uniswap_compatible_v4_base_liquidity_events` macro referenced the `modify_liquidity_events` CTE twice in the final `liquidity_change_base` UNION (once for `modify_liquidity` rows, once for `fees_accrued`). Trino does not share CTE scans, so each reference inlined a full pass over the upstream `sqrtpricex96` price table (scanned 8x per run), plus `traces_decoded` (2x) and the ModifyLiquidity decoded logs (2x). The price table is ~193M rows and is ~92% of all rows scanned.

This collapses the two references into a single scan + `CROSS JOIN UNNEST` that fans out the `(event_type, amount0, amount1)` tuples for both event types, halving the price/trace/log scans to 4x/1x/1x. Both branches already emit int256 amounts, so the UNNEST is type-safe. Applies to all 14 uniswap v4 `base_liquidity_events` chain models through the shared macro.

## Proof (frozen base window 2026-06-10, 2,153,174 output rows)
- `current EXCEPT rewrite` = 0 and `rewrite EXCEPT current` = 0
- identical `checksum()` across all 21 output columns, 3 warm runs each side (also confirms determinism)

## A/B (spellbook-tokens, 3 warm-run medians)
| metric | current | rewrite | delta |
|---|---|---|---|
| cpu_ms | 698.2 s | 354.4 s | -49% |
| physical_input_bytes | 43.97 GB | 23.05 GB | -48% |
| peak_user_memory | 45.6 GB | 23.9 GB | -48% |
| spill | 0 | 0 | - |

Projected family impact: ~14.25 -> ~7.3 CPU-hrs/day (-7), ~2.6 -> ~1.35 TB/day IO, and per-run peak memory ~48 -> ~24 GB (the prod MERGE flagged memory-pressure at 48.8 GB peak).

Fixes CUR2-2821
Towards CUR2-2702
