### PR TITLE
perf(tokens_solana): drop redundant net_transfers re-aggregation in net_transfers_daily_asset

### DIFF
--- a/dbt_subprojects/solana/models/_sector/transfers/tokens_solana_net_transfers_daily_asset.sql
+++ b/dbt_subprojects/solana/models/_sector/transfers/tokens_solana_net_transfers_daily_asset.sql
@@ -28,6 +28,10 @@ with raw_transfers as (
         {% if is_incremental() %}
         and {{ incremental_predicate('block_date') }}
         {% endif %}
+        {% if target.name == 'ci' %}
+        -- bound the full-refresh scan in CI so the build completes within the 90-min cap; prod is unaffected
+        and block_date >= current_date - interval '3' day
+        {% endif %}
     group by
         'solana'
         , block_date
@@ -55,6 +59,10 @@ with raw_transfers as (
         and action != 'wrap'
         {% if is_incremental() %}
         and {{ incremental_predicate('block_date') }}
+        {% endif %}
+        {% if target.name == 'ci' %}
+        -- bound the full-refresh scan in CI so the build completes within the 90-min cap; prod is unaffected
+        and block_date >= current_date - interval '3' day
         {% endif %}
     group by
         'solana'

--- a/dbt_subprojects/solana/models/_sector/transfers/tokens_solana_net_transfers_daily_asset.sql
+++ b/dbt_subprojects/solana/models/_sector/transfers/tokens_solana_net_transfers_daily_asset.sql
@@ -82,37 +82,20 @@ with raw_transfers as (
         , t.contract_address
         , t.symbol
         , t.address
-), net_transfers as (
-    select
-        blockchain
-        , block_date
-        , contract_address
-        , symbol
-        , address
-        , sum(coalesce(transfer_amount_usd_sent, 0)) as transfer_amount_usd_sent
-        , sum(coalesce(transfer_amount_usd_received, 0)) as transfer_amount_usd_received
-        , sum(coalesce(transfer_amount_usd_received, 0)) + sum(coalesce(transfer_amount_usd_sent, 0)) as net_transfer_amount_usd
-        , sum(transfer_count) as transfer_count
-        , max(max_block_time) as max_block_time  -- Preserve max block_time
-    from
-        transfers_amount
-    group by
-        blockchain
-        , block_date
-        , contract_address
-        , symbol
-        , address
 )
+-- transfers_amount is already at the (contract_address, address) grain, so the
+-- per-address net (received + sent) can be aggregated straight to the asset level
+-- without a redundant intermediate group-by over the same keys.
 select
     blockchain
     , block_date
     , contract_address
     , max_by(symbol, max_block_time) as symbol
-    , sum(net_transfer_amount_usd) as net_transfer_amount_usd
+    , sum(coalesce(transfer_amount_usd_received, 0) + coalesce(transfer_amount_usd_sent, 0)) as net_transfer_amount_usd
 from
-    net_transfers
+    transfers_amount
 where
-    net_transfer_amount_usd > 0
+    (coalesce(transfer_amount_usd_received, 0) + coalesce(transfer_amount_usd_sent, 0)) > 0
 group by
     blockchain
     , block_date


### PR DESCRIPTION
`tokens_solana.net_transfers_daily_asset` had a `net_transfers` CTE that grouped `transfers_amount` by the exact same keys it was already aggregated on (`blockchain, block_date, contract_address, symbol, address`), so its `sum()`/`max()` were identity ops over single-row groups — a redundant HashAgg pass over the full per-address set. This inlines the per-address net (`received + sent`) straight into the final asset-level aggregation and deletes the CTE.

The change only removes a no-op group-by, so it's exactly equivalent. Proven on 2026-06-12 (prod, spellbook-hourly, UTC, checksum over all output columns): the model's non-FP output columns (`blockchain, block_date, contract_address, symbol`) are bit-identical to the current model whenever the row set coincides. The model is already FP-non-deterministic at the `net_transfer_amount_usd > 0` boundary — an A-vs-A control shows the *current* model alone yields 408/409/410 rows across repeated runs — and this PR doesn't change that (it removes one float sum, so it's marginally more stable).

Interleaved A/B under identical load (1-day window, 3 warm runs/side, medians):

| metric | current | this PR | Δ |
|---|---|---|---|
| cpu_ms | ~488 s | ~455 s | −6.8% |
| wall | ~34.6 s | ~18.2 s | −47% |
| scan IO | 9.06 GB | 9.06 GB | flat |
| peak mem | ~16.7 GB | ~16.3 GB | ~flat |

IO is unchanged (the removed stage sits downstream of the scan); the win is the eliminated aggregation stage — ~7% less CPU and roughly half the wall. Whole-model: ~0.79 → ~0.73 CPU-hrs/day, with each of the 4 heavy runs/day ~halving its wall.

Towards CUR2-2703



---

**CI note:** slim CI builds this model with a fresh (non-incremental) full-history first build, which scans the entire `tokens_solana.transfers` history and exceeds the 90-min CI cap. Added a `target.name == 'ci'`-only `block_date >= current_date - interval '3' day` floor (same idiom as `phantom_swapper_solana_fee_payments_raw`) so the CI build completes; prod (incremental) is unaffected. The only test is `unique_combination_of_columns`, which holds on any window.
