### PR TITLE
perf(pancakeswap): single-pass modify/fees fan-out in infinity liquidity macro

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/pancakeswap_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/pancakeswap_compatible_liquidity.sql
@@ -289,6 +289,9 @@ swap_fees_paid as (
 ),
 
 liquidity_change_base as (
+    -- scan modify_liquidity_events once and fan out the modify_liquidity and
+    -- fees_accrued rows via UNNEST; referencing the CTE twice inlines into a
+    -- second full pass over sqrtpricex96 (8x), the ModifyLiquidity event, and the call decode
     select 
         ml.id
         , ml.tx_from 
@@ -296,11 +299,11 @@ liquidity_change_base as (
         , ml.block_number 
         , ml.tx_hash 
         , ml.evt_index 
-        , ml.event_type 
+        , u.event_type 
         , ml.token0 
         , ml.token1 
-        , ml.amount0
-        , ml.amount1
+        , u.amount0
+        , u.amount1
         , ml.liquidityDelta
         , ml.sqrtPriceX96
         , ml.tickLower
@@ -308,29 +311,11 @@ liquidity_change_base as (
         , ml.salt
     from 
     modify_liquidity_events ml 
-
-    union all 
-
-    select 
-        ml.id
-        , ml.tx_from 
-        , ml.block_time
-        , ml.block_number 
-        , ml.tx_hash 
-        , ml.evt_index 
-        , 'fees_accrued' as event_type
-        , ml.token0 
-        , ml.token1 
-        , ml.fee_amount0 
-        , ml.fee_amount1 
-        , ml.liquidityDelta
-        , ml.sqrtPriceX96
-        , ml.tickLower
-        , ml.tickUpper
-        , ml.salt
-    from 
-    modify_liquidity_events ml 
-    where not (fee_amount0 = 0 and fee_amount1 = 0) -- remove events with zero fees 
+    cross join unnest(array[
+        row(cast(ml.event_type as varchar), ml.amount0, ml.amount1)
+        , row(cast('fees_accrued' as varchar), ml.fee_amount0, ml.fee_amount1)
+    ]) as u(event_type, amount0, amount1)
+    where not (u.event_type = 'fees_accrued' and ml.fee_amount0 = 0 and ml.fee_amount1 = 0) -- remove fees_accrued events with zero fees 
 
     union all 
 


### PR DESCRIPTION
The `pancakeswap_compatible_infinity_base_liquidity_events` macro referenced the `modify_liquidity_events` CTE twice in the final `liquidity_change_base` UNION (the `modify_liquidity` and `fees_accrued` branches). Trino inlines CTEs, so the whole modify subtree ran twice — and because `get_prices` references the ref'd `sqrtpricex96` model 2x and `enrich_liquidity_events` references `get_prices` 2x, `sqrtpricex96` was scanned **8x per run**. That drives the memory-pressure (peak 49.9 GB) and scan-too-large findings on a heavy MERGE (rep: 926 cpu-s / 33.7 GB / 49.9 GB peak / 164 s).

This collapses the two references into a single scan of `modify_liquidity_events` plus a `cross join unnest` that fans out the modify_liquidity and fees_accrued rows, halving everything downstream (sqrtpricex96 8x->4x, ModifyLiquidity event 2x->1x, call decode 2x->1x). Same pattern already shipped on the uniswap v4 macro (#9785) and v3 macro (#9782). Covers both callers: `pancakeswap_infinity_cl_bnb_base_liquidity_events` and `pancakeswap_infinity_cl_base_base_liquidity_events`.

Proof (read-only, spellbook-tokens, frozen 3-day window 2026-06-10..06-13):
- Equivalence: `(old EXCEPT new)` and `(new EXCEPT old)` both **0 rows** (9,933,192 rows/side); identical `checksum()` over all 16 output columns across 3 OLD + 3 NEW warm runs (also confirms determinism).
- A/B medians: CPU **424.3 -> 224.2 s (-47%)**, IO **18.91 -> 10.25 GB (-46%)**, peak **47.95 -> 24.13 GB (-50%)**, spill 0 both.

Baseline (24h query_history, both callers): **5.32 CPU-hrs/day, 0.61 TB/day IO**. Projected **~2.8 CPU-hrs/day (~2.5 saved), ~0.33 TB/day (~280 GB/day)**, per-run peak 49.9 -> ~25 GB.

Fixes CUR2-2824