### PR TITLE
perf(frax_finance_bnb_bribes): floor bribe_base scan to post-2023 bsc.logs

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/frax_finance/bnb/frax_finance_bnb_bribes.sql
+++ b/dbt_subprojects/daily_spellbook/models/frax_finance/bnb/frax_finance_bnb_bribes.sql
@@ -331,6 +331,9 @@ bribe_base as (
     where
         topic0 = 0x6a6f77044107a33658235d41bedbbaf2fe9ccdceb313143c947a5e76e1ec8474
         and bytearray_substring(data, 1, 32) = 0x000000000000000000000000e48a3d7d0bc88d552f730b62c006bc925eadb9ee
+        -- bribe contracts were first deployed 2023-01-06, so no qualifying event predates this floor;
+        -- it prunes pre-2023 bsc.logs files (the other two logs scans already carry the same bound)
+        and block_time > cast('2023-01-02' as date)
         and contract_address in (
             select
                 bribe_address


### PR DESCRIPTION
`frax_finance_bnb_bribes` is a daily full-rebuild that scans `delta_prod.bnb.logs` (`bsc.logs_0003`, ~51B rows) three times. The two `topic0=0x540798…` scans already carry a `block_time > 2023-01-02` bound, but the `bribe_base` scan (`topic0=0x6a6f77…`, the FXS bribe-deposit event) had no time floor, so it alone read the full 51.1B-row history every run. That single scan is **65.75% of the model's IO and ~76% of its CPU** (stage 50, the query's hotspot) — and `frax_finance_bnb_bribes` is the **largest single-model IO on spellbook-daily** at ~1.5 TB/day.

This adds the same `block_time > cast('2023-01-02' as date)` bound to `bribe_base`. It is provably a no-op on output: the Thena bribe contracts were first deployed `2023-01-06` (min `call_block_time` over both `BribeFactoryV2_call_createBribe` tables), the earliest qualifying bribe event is `2023-01-13`, and the model's week spine starts `2023-01-05` — so no event can predate the floor. The floor only lets Delta file-skip the pre-2023 BSC files.

**Equivalence (read-only, prod):**
- `bribe_base` rows with `block_time <= 2023-01-02` = **0** → `old EXCEPT new` and `new EXCEPT old` are both empty by construction.
- Isolated `bribe_base` count + `checksum()` over all four output columns (`block_time`, `bribe_address`, `amount`, `start_time`): **565 rows, bit-identical checksums** old vs new.

**Component A/B** (isolated `bribe_base` scan, spellbook-dex, count+checksum forced):

| metric | old (no floor) | new (floored) | Δ |
|---|---|---|---|
| rows scanned | 51.1B | 39.5B | −22.7% |
| physical input | 1015.4 GB | 802.0 GB | **−213 GB (−21%)** |
| cpu | 8,532 s | 6,024 s | −2,508 s (−29%) |
| wall | 500 s | 393 s | −21% |
| peak mem | 2.14 GB | 2.00 GB | flat |

Whole-model projection (scan is 65.75% IO / ~76% CPU of the build): daily build ~1,525 GB / ~2.35 CPU-hrs → roughly **~1,330 GB/day (−≈195 GB/day) and ~1.85 CPU-hrs/day (−≈0.5)**. Pure IO/CPU reduction, output unchanged; full-refresh path unaffected.

Two further levers on this model are left for a structural pass and tracked on the issue: fusing the two identical `topic0=0x540798…` scans (they differ only by the bribe/Fee `c_type` split — ~10% more IO but grain-sensitive), and sourcing a decoded Thena bribe-event table instead of hand-decoding raw `bnb.logs` (P2, the large lever).

Towards CUR2-2819
