### PR TITLE
perf(pancakeswap_tvl_daily): bound forward-fill calendar range-join to anchor window

### DIFF
--- a/dbt_subprojects/dex/models/_projects/pancakeswap/pancakeswap_tvl_daily.sql
+++ b/dbt_subprojects/dex/models/_projects/pancakeswap/pancakeswap_tvl_daily.sql
@@ -97,6 +97,10 @@ days as (
         timestamp as day 
     from 
     {{ source('utils','days') }}
+    -- bound the calendar to the forward-fill window: the join below only matches days >= the earliest
+    -- anchor (block_date), so earlier days can never join. Without this, ~6.4k days of full history get
+    -- cross-joined against every anchor row, exploding into a nested-loop scan (the model's top cost).
+    where timestamp >= (select min(block_date) from daily_events_final)
 ),
 
 tvl_daily as (
@@ -215,6 +219,11 @@ daily_events as (
         , amount1
     from 
     {{ ref('pancakeswap_daily_agg_liquidity_events') }}
+    {% if target.name == 'ci' %}
+    -- bound the CI full-refresh scan so the initial build completes under the 90-min timeout and the
+    -- unique_combination_of_columns test runs on real CI data; prod renders without this.
+    where block_date >= current_date - interval '14' day
+    {% endif %}
 ),
 
 daily_cum as (
@@ -234,6 +243,9 @@ days as (
         timestamp as day 
     from 
     {{ source('utils','days') }}
+    -- bound the calendar to the forward-fill window (see incremental branch); prunes the same
+    -- full-history cross-join on a full refresh.
+    where timestamp >= (select min(block_date) from daily_events)
 ),
 
 tvl_daily as (


### PR DESCRIPTION
Same fix as #9750 (uniswap_tvl_daily), applied to `pancakeswap_tvl_daily` — the second-biggest model on spellbook-dex and the largest unshipped `tvl_daily` sibling.

The `tvl_daily` CTE forward-fills `daily_cum` across the full ~6.4k-day `utils.days` calendar via an inequality range-join (`c.block_date <= d.day and d.day < c.next_day`), which Trino executes as a NestedLoopJoin — cross-joining every anchor row against all of history. Bounding `days` to `timestamp >= (select min(block_date) from <anchor>)` removes only calendar days that can never satisfy `c.block_date <= d.day` (they fall below every anchor's `block_date`), so the output is identical by construction. Applied to both branches (incremental anchor `daily_events_final`, full-refresh anchor `daily_events`), plus a CI-only 14-day floor on the full-refresh scan so the initial CI build finishes under the 90-min timeout and the `unique_combination_of_columns` test runs (inert in prod).

### Correctness evidence is the prod A/B below — not CI

The equivalence proof was run on **prod data on a prod cluster (spellbook-tokens), over the full cumulative history** that the prod-cadence incremental window forward-fills — it does **not** rely on the CI relation in any way. The CI-only 14-day floor is purely a buildability escape hatch for the initial slim-CI full build; it intentionally yields a 14-day slice whose cumulative balances are **not** prod-equivalent, and it is **not** part of the correctness argument here (the only CI assertion is `unique_combination_of_columns`, a key-uniqueness check, not value parity). The `days`-bound change itself is `target.name`-independent and is what the prod proof exercises.

Proof (spellbook-tokens, prod data, `SET TIME ZONE 'UTC'`, frozen 3-day incremental window = prod cadence):

- Equivalence at the calendar-join boundary, OLD (unbounded) vs NEW (bounded) in one query so `current_timestamp` cannot drift: `old EXCEPT new = 0`, `new EXCEPT old = 0`, identical totals (13,010,668 rows/side).
- Full incremental SELECT A/B, `checksum()` over all 16 output columns, 3 warm interleaved runs: identical count (10,412,641) and identical checksums on all 14 structural columns — **this includes the cumulative balance columns** `token0_balance_raw`, `token1_balance_raw`, `token0_balance`, `token1_balance` (bit-exact OLD vs NEW). The only 2 columns that vary are the price-derived USD valuations (`*_balance ... _usd`), and that variance is pre-existing `max_by(price, minute)` price-data nondeterminism — it varies OLD-vs-OLD too and is independent of this change.
- Cost (medians of 3 warm runs): CPU **479.3 → 62.4 s (−87%, 7.7×)**; wall 21.3 → 8.1 s (−62%); IO 1.04 → 1.05 GB (flat — the nested loop is CPU-bound, not IO); peak 0.51 → 0.66 GB; spill 0.

Projected end-to-end: ~3.99 → ~1.2 CPU-hrs/day on spellbook-dex. Generalises P11 (bound a forward-fill calendar range-join to its anchor window) across the `tvl_daily` family.

Fixes CUR2-2826
Towards CUR2-2707
