### PR TITLE
perf(curve_optimism_pools): window metapool Transfer scan + dedup agg_pools

### DIFF
--- a/dbt_subprojects/dex/models/_projects/curvefi/optimism/curve_optimism_pools.sql
+++ b/dbt_subprojects/dex/models/_projects/curvefi/optimism/curve_optimism_pools.sql
@@ -70,6 +70,13 @@ WITH
       AND et.to = et.contract_address
       AND et.evt_block_number = mps.evt_block_number
       AND et.evt_block_time >= TIMESTAMP '2022-01-17'
+      -- A new metapool's LP-token mint Transfer shares the deployment block, so a newly
+      -- deployed metapool is captured by the run window; already-known metapools persist
+      -- via the merge. This bounds the otherwise full-history scan of optimism.evt_Transfer
+      -- (~2.75B rows, ~99% of this model's IO) to the incremental window.
+      {% if is_incremental() %}
+      AND {{ incremental_predicate('et.evt_block_time') }}
+      {% endif %}
     GROUP BY
       tokenid,
       token,
@@ -210,26 +217,48 @@ WITH
       tokenid,
       token,
       pool --unique
+  ),
+  -- Union the factory-derived pools with the hardcoded custom pools, dropping a custom
+  -- pool whose address is already produced by a factory. Referencing agg_pools a single
+  -- time (and resolving the anti-join with a window over the union) avoids re-expanding
+  -- the decoded scans: the original `NOT IN (SELECT pool FROM agg_pools)` made Trino
+  -- inline agg_pools a second time, doubling every underlying scan.
+  combined AS (
+    SELECT
+      version,
+      CAST(tokenid as INT256) as tokenid,
+      token,
+      pool,
+      true as is_agg
+    FROM
+      agg_pools
+    UNION ALL
+    SELECT
+      version,
+      CAST(tokenid as INT256) as tokenid,
+      token,
+      pool,
+      false as is_agg
+    FROM
+      custom_pools
   )
 SELECT
   version,
-  CAST(tokenid as INT256) as tokenid,
+  tokenid,
   token,
   pool
 FROM
-  agg_pools
-UNION ALL
-SELECT
-  version,
-  CAST(tokenid as INT256) as tokenid,
-  token,
-  pool
-FROM
-  custom_pools
-WHERE
-  pool NOT IN (
+  (
     SELECT
-      pool
+      version,
+      tokenid,
+      token,
+      pool,
+      is_agg,
+      bool_or(is_agg) OVER (PARTITION BY pool) as pool_in_agg
     FROM
-      agg_pools
-  ) --avoid dupes that are caught by factories
+      combined
+  )
+WHERE
+  is_agg
+  OR NOT pool_in_agg --keep custom pools only when no factory produced that pool

--- a/dbt_subprojects/dex/models/_projects/curvefi/optimism/curve_optimism_pools.sql
+++ b/dbt_subprojects/dex/models/_projects/curvefi/optimism/curve_optimism_pools.sql
@@ -70,10 +70,20 @@ WITH
       AND et.to = et.contract_address
       AND et.evt_block_number = mps.evt_block_number
       AND et.evt_block_time >= TIMESTAMP '2022-01-17'
-      -- A new metapool's LP-token mint Transfer shares the deployment block, so a newly
-      -- deployed metapool is captured by the run window; already-known metapools persist
-      -- via the merge. This bounds the otherwise full-history scan of optimism.evt_Transfer
-      -- (~2.75B rows, ~99% of this model's IO) to the incremental window.
+      -- Bound the otherwise full-history scan of optimism.evt_Transfer (~2.75B rows,
+      -- ~99% of this model's IO) to the incremental window. A metapool's LP-token mint
+      -- Transfer shares its deployment block, so a metapool deployed within the window is
+      -- still captured; MetaPoolDeployed and the Base/Basic pool scans stay full-history,
+      -- so the actively-deploying pool types are never at risk.
+      --
+      -- ACCEPTED TRADEOFF (PR #9792 review): if a metapool's MetaPoolDeployed event or its
+      -- LP-mint Transfer is decoded/backfilled more than the window late, that one metapool
+      -- is missed until a `dbt --full-refresh` (which rebuilds the full registry unwindowed
+      -- and recovers it). Intentionally accepted for Optimism Curve metapools: the factory is
+      -- dormant (42 deployments, last 2023-11). A self-healing gate keyed on un-resolved
+      -- metapools is not viable here -- the 42 deploys share only 19 distinct coins, so there
+      -- is no clean per-metapool key in the output to detect a missed one without re-scanning
+      -- all history (which is the cost this change removes).
       {% if is_incremental() %}
       AND {{ incremental_predicate('et.evt_block_time') }}
       {% endif %}


### PR DESCRIPTION
`model.dex.curve_optimism_pools` is configured `materialized='incremental'` with `incremental_strategy='merge'` but had **no `is_incremental()` guard**, so every hourly run re-derived the entire pools registry from all-history decoded scans and then merged the (mostly no-op) result. It maintains a tiny **573-row append-only dimension** (175 pools) yet scans **~3.62 TB/day** (151 GB per build, 24 builds/day, ~4.7 CPU-hrs/day) to write 0–4 rows — the largest unshipped IO on spellbook-dex.

The dominant cost is `erc20_optimism.evt_Transfer`: a `from = 0x0 AND to = contract_address` mint lookup that doesn't push down (varbinary, ~0.01% selectivity), scanned over all of `optimism.logs_decoded` (**2.75B rows**) and, because the `custom_pools ... NOT IN (SELECT pool FROM agg_pools)` anti-join makes Trino inline `agg_pools` a second time, run **2×** (the decoded `traces_decoded` scans likewise fan out to 14×).

Two changes, both contained to this model:

- **Window the Transfer scan.** A metapool's LP-token mint Transfer shares its deployment block, so a newly deployed metapool is still captured by the incremental run window; already-known metapools persist via the merge (never deleted). `base_pools`/`basic_pools`/`MetaPoolDeployed` stay full-history — they're cheap push-down scans, so the *actively deploying* pool types (Base/Basic; the ng factory still deploys) are recomputed in full every run and carry **zero** late-arrival risk. Only the 2.75B-row Transfer is bounded.
- **De-dup `agg_pools`.** Resolve the custom-pool anti-join in a single pass (`bool_or(is_agg) over (partition by pool)` across the union) instead of `NOT IN (SELECT pool FROM agg_pools)`, so the decoded scans are not inlined a second time.

No config change and **no `--full-refresh` backfill needed** — the table is already complete and the merge preserves history; runs just get cheaper going forward.

### Proof (read-only, prod data, UTC)

- **Equivalence (de-dup).** Full-window rewrite vs current, multiset symmetric-difference both directions: `only_orig=0, only_new=0, count_mismatch=0`, 573 = 573 rows. Bit-exact.
- **Incremental decomposition.** With the 3-day window the rewrite emits Base 3 + Basic 422 (identical to current, incl. the 7 custom rows) + Meta 0 = 425 rows; the 148 historical Meta Pool rows are unchanged and persist via the merge (no metapool deployed since 2023-11).
- **A/B magnitude** (compiled SELECT, checksum over all 4 output columns, 4 interleaved warm runs, medians, spellbook-daily):

| | current (full rebuild) | rewrite (3-day window) | Δ |
|---|---|---|---|
| IO (`physical_input_bytes`) | 151.13 GB | 1.35 GB | **−99.1% (112×)** |
| CPU (`cpu_ms`) | ~1060 s | ~36.5 s | **−96.6% (29×)** |
| wall | ~6.1 s | ~2.2 s | ~3× |
| peak memory | ~3.5 GB | ~0.72 GB | −79% |
| spill | 0 | 0 | — |

Projected steady-state: **~4.7 → <0.2 CPU-hrs/day, ~3.62 TB/day → ~0.03 TB/day.**

### Caveat

A metapool deployed and decoded **more than the 3-day window late** would be missed until a `--full-refresh` — negligible here (0 new metapools since 2023; the active Base/Basic types stay full-history). The window follows the repo `incremental_predicate` default (3 days).

The two related IO-heavy hourly pool-rebuilds noted in the issue (`curvefi_ethereum_pools_balances`, `dex_raw_pool_pre_materialized_traces`) are different chains/shapes and are left as separate follow-ups.

Fixes CUR2-2827
