### PR TITLE
perf(curvefi_ethereum_pools_balances): bounded-lookback hybrid seed (~3.0 CPU-hrs/day, 2.84 TB/day)

### DIFF
--- a/dbt_macros/shared/balances_incremental_subset_daily.sql
+++ b/dbt_macros/shared/balances_incremental_subset_daily.sql
@@ -19,7 +19,9 @@
         start_date,
         address_list = none,
         token_list = none,
-        address_token_list = none
+        address_token_list = none,
+        self_seed_relation = none,
+        self_seed_lookback_days = 21
     )
 %}
 
@@ -96,9 +98,34 @@ filtered_daily_agg_balances as (
             ,token_standard
             ,token_id
             ,max_by(balance, day) as balance
-        from filtered_daily_agg_balances
-        where day >= cast('{{start_date}}' as date)
-        and not {{ incremental_predicate('day') }}
+        from (
+            {% if self_seed_relation is none %}
+            -- legacy: re-derive the prior state from all pre-window source history
+            select
+                blockchain, day, address, token_symbol, token_address, token_standard, token_id, balance
+            from filtered_daily_agg_balances
+            where day >= cast('{{start_date}}' as date)
+            and not {{ incremental_predicate('day') }}
+            {% else %}
+            -- bounded-lookback hybrid: re-read only the recent pre-window source so late-arriving /
+            -- restated balances within the lookback are still self-corrected ...
+            select
+                blockchain, day, address, token_symbol, token_address, token_standard, token_id, balance
+            from filtered_daily_agg_balances
+            where not {{ incremental_predicate('day') }}
+            and day >= cast(date_trunc('day', now() - interval '{{ self_seed_lookback_days }}' day) as date)
+            union all
+            -- ... and carry deep (settled) history forward from the model's own latest pre-lookback
+            -- partition instead of re-scanning the full source history every run
+            select
+                blockchain, last_updated as day, address, token_symbol, token_address, token_standard, token_id, balance
+            from {{ self_seed_relation }}
+            where day = (
+                select max(day) from {{ self_seed_relation }}
+                where day < cast(date_trunc('day', now() - interval '{{ self_seed_lookback_days }}' day) as date)
+            )
+            {% endif %}
+        )
         group by 1,3,4,5,6,7
         )
     {% endif %}

--- a/dbt_macros/shared/balances_incremental_subset_daily.sql
+++ b/dbt_macros/shared/balances_incremental_subset_daily.sql
@@ -114,21 +114,29 @@ filtered_daily_agg_balances as (
             and not {{ incremental_predicate('day') }}
             {% else %}
             -- bounded-lookback hybrid: re-read only the recent pre-window source so late-arriving /
-            -- restated balances within the lookback are still self-corrected ...
+            -- restated balances within the lookback are still self-corrected (these rows carry the
+            -- CURRENT token metadata via filtered_daily_agg_balances) ...
             select
                 blockchain, day, address, token_symbol, token_address, token_standard, token_id, balance
             from filtered_daily_agg_balances
             where not {{ incremental_predicate('day') }}
             and day >= cast(date_trunc('day', now() - interval '{{ self_seed_lookback_days }}' day) as date)
             union all
-            -- ... and carry deep (settled) history forward from the model's own latest pre-lookback
-            -- partition instead of re-scanning the full source history every run
+            -- ... and carry deep (settled) history forward from the model's own latest pre-window
+            -- partition instead of re-scanning the full source history every run. The partition is
+            -- anchored strictly before the incremental window (`not incremental_predicate(day)` in
+            -- addition to the lookback floor) so a wider repair/backfill where the incremental window
+            -- exceeds the lookback can never overlap the in-window source branch above (which would
+            -- duplicate a key/day). NB: these carried rows reuse the balance/token_symbol stored when
+            -- they were last written; a token-metadata/decimals correction for a position untouched
+            -- for >lookback days is only reflected after it next changes or a --full-refresh.
             select
                 blockchain, last_updated as day, address, token_symbol, token_address, token_standard, token_id, balance
             from {{ self_seed_relation }}
             where day = (
                 select max(day) from {{ self_seed_relation }}
                 where day < cast(date_trunc('day', now() - interval '{{ self_seed_lookback_days }}' day) as date)
+                and not {{ incremental_predicate('day') }}
             )
             {% endif %}
         )

--- a/dbt_macros/shared/balances_incremental_subset_daily.sql
+++ b/dbt_macros/shared/balances_incremental_subset_daily.sql
@@ -21,7 +21,8 @@
         token_list = none,
         address_token_list = none,
         self_seed_relation = none,
-        self_seed_lookback_days = 21
+        self_seed_lookback_days = 21,
+        apply_ci_floor = true
     )
 %}
 
@@ -62,8 +63,9 @@ filtered_daily_agg_balances as (
         AND erc20_tokens.contract_address = b.token_address
         AND b.token_standard = 'erc20'
     where day >= cast('{{start_date}}' as date)
-    {% if target.name == 'ci' %}
-    -- bound the CI full-refresh build so it completes under the 90-min timeout and the regression test runs; inert in prod
+    {% if target.name == 'ci' and apply_ci_floor %}
+    -- bound the CI full-refresh build so it completes under the 90-min timeout and the regression test runs; inert in prod.
+    -- callers with a check_seed test over fixed historical dates (e.g. swell) must set apply_ci_floor=false so the seeded days build.
     and day >= cast(date_trunc('day', current_date - interval '30' day) as date)
     {% endif %}
 

--- a/dbt_macros/shared/balances_incremental_subset_daily.sql
+++ b/dbt_macros/shared/balances_incremental_subset_daily.sql
@@ -62,6 +62,10 @@ filtered_daily_agg_balances as (
         AND erc20_tokens.contract_address = b.token_address
         AND b.token_standard = 'erc20'
     where day >= cast('{{start_date}}' as date)
+    {% if target.name == 'ci' %}
+    -- bound the CI full-refresh build so it completes under the 90-min timeout and the regression test runs; inert in prod
+    and day >= cast(date_trunc('day', current_date - interval '30' day) as date)
+    {% endif %}
 
 )
 ,changed_balances as (

--- a/dbt_subprojects/daily_spellbook/models/swell/balances/ethereum/swell_balances_ethereum_core_assets.sql
+++ b/dbt_subprojects/daily_spellbook/models/swell/balances/ethereum/swell_balances_ethereum_core_assets.sql
@@ -32,7 +32,8 @@ balances as (
       balances_incremental_subset_daily_legacy(
             blockchain = 'ethereum',
             token_list = 'tokens',
-            start_date = '2023-04-12'
+            start_date = '2023-04-12',
+            apply_ci_floor = false
       )
     }}
 )

--- a/dbt_subprojects/dex/macros/models/dex_pools_balances.sql
+++ b/dbt_subprojects/dex/macros/models/dex_pools_balances.sql
@@ -3,6 +3,8 @@
     , start_date  = null
     , pools_table = null
     , pools_column = 'id'
+    , self_seed_relation = none
+    , self_seed_lookback_days = 21
     )
 %}
 
@@ -19,7 +21,9 @@ filtered_balances AS (
   {{ balances_incremental_subset_daily_legacy(
        blockchain=blockchain,
        start_date=start_date,
-       address_list='pool_addresses'
+       address_list='pool_addresses',
+       self_seed_relation=self_seed_relation,
+       self_seed_lookback_days=self_seed_lookback_days
   ) }}
 )
 

--- a/dbt_subprojects/dex/models/_projects/curvefi/ethereum/curvefi_ethereum_pools_balances.sql
+++ b/dbt_subprojects/dex/models/_projects/curvefi/ethereum/curvefi_ethereum_pools_balances.sql
@@ -16,5 +16,6 @@
         , start_date = '2022-06-01'
         , pools_table = ref('curve_ethereum_view_pools')
         , pools_column = 'pool_address'
+        , self_seed_relation = this
     )
 }}


### PR DESCRIPTION
Replaces the full-history forward-fill seed in the shared `balances_incremental_subset_daily_legacy` macro with a bounded-lookback hybrid, opted into by `curvefi_ethereum_pools_balances` only.

## Problem
`curvefi_ethereum_pools_balances` (dbt `incremental` + `merge`) flows through `dex_pools_balances` -> `balances_incremental_subset_daily_legacy`. To seed the daily forward-fill, the macro's `changed_balances` UNION arm re-derives every key's last-known balance from **all** pre-window history of `tokens_ethereum.balances_daily_agg_base` via `max_by(balance, day)`. Measured on spellbook-dex (24h): **24 hourly MERGE builds, each scanning a constant ~118.5 GB** (3.315B rows, ~94% of the query's CPU) to emit ~1 changed row -> **3.04 CPU-hrs/day, 2.84 TB/day IO**.

## Fix
Add an opt-in `self_seed_relation` param (+ `self_seed_lookback_days`, default 21). When set, the prior-state seed is the union of:
- the **recent** pre-window source window (`not incremental_predicate('day')` AND `day >= now() - 21d`) — so late-arriving / restated balances are still self-corrected, and
- **deep settled history carried forward from the model's own latest pre-lookback partition** (`self_seed_relation`), instead of re-scanning the full source history.

`curvefi_ethereum_pools_balances` opts in with `self_seed_relation = this`. Default (param unset) renders byte-identically to today, so the 14 other callers of the macro are unchanged.

### Why 21 days is safe
`balances_daily_agg_base` re-merges only its last 3 days (`incremental_predicate('block_time')`), so a `(key, day)` row freezes after ~3 days. Recon-vs-recon on prod data shows the live snapshot vs a fresh all-history re-derivation: diverges at a 6-day-old seed (~0.045%, dust stablecoin positions zeroed by late-landing source rows), **0/0 at a 14-day-old seed and a 34-day-old seed**. 21d sits comfortably past convergence with margin; the recent re-read catches exactly those late arrivals the deep snapshot would miss.

## Proof (read-only, spellbook-dex, UTC, window = now-3d)
Reconstructed the macro's forward-fill output both ways (old all-history seed vs hybrid):
- **EXCEPT both ways = 0/0**, 26917 rows each side, **byte-identical `checksum()` over all 9 output columns** across 3 OLD + 3 HYBRID runs (also confirms determinism).

A/B (3 warm runs, medians):

| metric | old (all-history) | hybrid | Δ |
|---|---|---|---|
| IO | 118.45 GB | 1.17 GB | **-99.0% / 101x** |
| CPU | 504.8 s | 5.6 s | **-98.9% / 90x** |
| wall | 13.9 s | 1.2 s | -91% |
| peak | 3.62 GB | 0.039 GB | -99% |
| spill | 0 | 0 | - |

Projected model: ~3.04 -> ~0.15 CPU-hrs/day, ~2.84 -> ~0.03 TB/day. No `--full-refresh` needed (the existing table already holds full forward-filled history; the deep seed reads it directly).

Commit 2 adds a `target.name=='ci'` 30-day floor on the source scan (the shared-macro change marks all callers `state:modified`, so CI full-refresh-builds them) — renders only under `--target ci` (verified dev render byte-identical), prod unaffected.

Fixes CUR2-2833