### PR TITLE
fix(dex): guard 0x settler volume_usd against mismatched maker leg

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/zeroex/zeroex_v2.sql
+++ b/dbt_subprojects/dex/macros/models/_project/zeroex/zeroex_v2.sql
@@ -358,6 +358,15 @@ select * from tbl_trades
 {%- if target.name == 'ci' -%}
     {%- set start_date = (modules.datetime.date.today() - modules.datetime.timedelta(days=14)).strftime('%Y-%m-%d') -%}
 {%- endif -%}
+{# Leg-divergence guard: a settler trade's two priced legs (sold vs bought) should be
+   close in USD. In bundled / multi-path settler txs (e.g. Relay-routed orders) the
+   heuristically-matched maker (bought/output) leg can latch onto an unrelated side-swap
+   transfer, distorting volume_usd. The taker (sold) leg is the deterministic settler
+   input (the user's actual deposit, matched first), so it is the trustworthy anchor.
+   When both legs are priced and diverge by at least this factor, fall back to the
+   sold-leg value rather than the mismatch-prone maker leg (which can be a tiny side-swap
+   amount -> understatement, or a large intermediate hop -> overstatement). #}
+{%- set leg_divergence_tolerance = 5 -%}
 WITH token_metadata AS (
     SELECT 
         blockchain, 
@@ -450,7 +459,17 @@ SELECT
         maker_token_amount,
         taker_token_amount_raw,
         maker_token_amount_raw,
-        amount_usd as volume_usd,
+        -- Guard against the maker leg being mismatched to an unrelated side-swap transfer
+        -- (see leg_divergence_tolerance above): when both legs are priced and diverge
+        -- implausibly, anchor on the deterministic sold (taker) leg rather than the
+        -- mismatch-prone maker leg that produced the collapsed amount_usd.
+        CASE
+            WHEN taker_amount > 0
+                AND maker_amount > 0
+                AND greatest(taker_amount, maker_amount) / least(taker_amount, maker_amount) >= {{ leg_divergence_tolerance }}
+            THEN taker_amount
+            ELSE amount_usd
+        END AS volume_usd,
         taker_token,
         maker_token,
         taker,


### PR DESCRIPTION
## Summary

The 0x settler decoder (`zeroex_v2` macro, all 17 chains) matches the **maker (bought) leg heuristically**. In bundled / multi-path settler transactions (e.g. Relay-routed orders), it can latch onto an **unrelated side-swap transfer**, so `volume_usd` collapses to a tiny, wrong amount.

**Reported example** — tx [`0xf61374…bf57`](https://etherscan.io/tx/0xf61374cd7cb16534b510450a45b9b33054b8298e6827df1e66c33d458767bf57): a ~$499 RLUSD→cbBTC trade was reported as **$0.75**, because the maker leg was matched to a parallel RLUSD→USDC fee hop (0.750073 USDC) instead of the real cbBTC output.

```
sold: RLUSD 499.25 ($499.35)   bought: USDC 0.750073 ($0.75)   divergence 666x
volume_usd: $0.75  ->  $499.35
```

## Fix

Add a **leg-divergence guard** in `zeroex_v2_trades_detail`: when both priced legs diverge by ≥ `leg_divergence_tolerance` (5×), anchor `volume_usd` on the **deterministic sold (taker) leg** — the user's actual settler input, matched first/most reliably — instead of the mismatch-prone maker leg.

- The taker/sold leg is the reliable anchor; the maker/output leg is where the heuristic mis-binds.
- Fixes **understatement** (tiny mismatched maker, the reported case) **and** a smaller set of **overstatement** cases (maker matched to a large intermediate hop, e.g. WETH→wstETH inflated ~3000×).
- All non-divergent rows are **byte-identical** (only the final `volume_usd` expression changes, via `ELSE amount_usd`).
- Deliberately **does not** touch the shared `add_amount_usd` macro or the fragile maker/taker matching logic.

## Scope / impact (Ethereum, 60d; cross-chain is larger)

| status | trades | old volume | new volume |
|---|--:|--:|--:|
| unchanged | ~948k | \$5.1467B | \$5.1467B (identical) |
| corrected **up** (understated) | ~2.6k | \$1.81M | \$97.6M (+\$95.8M) |
| corrected **down** (overstated) | ~1.1k | \$5.18M | \$0.40M (−\$4.8M) |

Cross-chain (all 17 chains, 30d): ~93.9k clearly-divergent (≥10×) 0x trades, ~\$82.7M of understated volume.

## Notes / follow-up

- This is a **volume-only** correction. It does **not** re-derive the misattributed `maker_token` / `maker_token_amount` columns (the example still shows USDC instead of cbBTC). Correctly re-selecting the maker leg from the transfer graph is a tracked follow-up.
- `leg_divergence_tolerance` is a tunable Jinja var (default 5×); ≥10× is the bulk of the impact, and <2× legitimate slippage is untouched.
- Pre-existing issue — matching logic unchanged since Apr 2025; not introduced by the recent perf refactors (#9734/#9744, proven row-equivalent).

## Test plan

- [x] `dbt compile -s zeroex_v2_ethereum_trades` passes; guard renders with `taker_amount`/`maker_amount` resolving.
- [x] Regression simulated on prod `zeroex_v2_ethereum.trades` (60d): consistent population unchanged to the cent; divergent rows corrected toward the sold-leg value.
- [x] Flagged tx `0xf61374…` resolves $0.75 → $499.35.
- [ ] CI `dbt slim ci` builds the modified `zeroex_v2_*_trades` models across chains.

Made with [Cursor](https://cursor.com)