### PR TITLE
perf(bridges_ethereum_agglayer_v1_deposits): push block_time into transfers scan

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/platforms/bridges_ethereum_agglayer_v1_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/chains/ethereum/platforms/bridges_ethereum_agglayer_v1_deposits.sql
@@ -45,13 +45,18 @@ WITH bridge_events AS (
     , be.evt_index
     , be.contract_address
     , be.bridge_transfer_id
-    , ROW_NUMBER() OVER (PARTITION BY be.tx_hash, be.evt_index ORDER BY be.evt_index) AS duplicate_index
+    -- block_time in the dedup partition keys is redundant for correctness (tx_hash
+    -- determines the block) but lets the planner push the consumer's incremental
+    -- block_time predicate below this window and, via the equi-join below, into the
+    -- tokens_ethereum.transfers scan instead of reading all history every run
+    , ROW_NUMBER() OVER (PARTITION BY be.block_time, be.tx_hash, be.evt_index ORDER BY be.evt_index) AS duplicate_index
     FROM bridge_events be
     LEFT JOIN {{ source('tokens_ethereum', 'transfers') }} t ON t.block_number=be.block_number
         AND t.tx_hash=be.tx_hash
         AND t.to=be.contract_address
         AND t.amount_raw=be.deposit_amount_raw
         AND t.token_standard='erc20'
+        AND t.block_time=be.block_time
     LEFT JOIN {{ ref('bridges_agglayer_chain_indexes') }} i ON i.id=be.withdrawal_chain_id
     )
 


### PR DESCRIPTION
`bridges_ethereum_agglayer_v1_deposits` LEFT JOINs `tokens_ethereum.transfers` on `(block_number, tx_hash, to, amount_raw, token_standard='erc20')` but never on `block_time`, and its dedup window partitions only by `(tx_hash, evt_index)`. The consumer `bridges_ethereum_deposits` applies the incremental `block_time` predicate above that window, so it can't reach the transfers scan — every hourly build reads all ~3.97B erc20 transfers (~209 GB, the bulk of the model's ~5.18 TB/day and ~2.98 CPU-hrs/day).

This is the residual the layerzero fix (#9757 / CUR2-2767) left behind, and the same P14 pattern: thread `block_time` into both the dedup partition and the transfers equi-join. Both additions are semantic no-ops (`tx_hash` determines the block, hence `block_time`), and they let the planner push the incremental bound below the window and into the transfers scan (Delta file skipping).

### Proof (read-only, prod data via dtrino)

Equivalence — the change removes zero rows:
- Lemma (frozen week 2026-05-01..08): of 226 transfers that match a bridge event, **0** have `t.block_time <> be.block_time` (every matched transfer is in the same tx as its bridge event).
- Full output over the live 3-day incremental window: `count=122` and **identical checksums on all 18 output columns** for current vs. fixed across 3 runs each (order-independent → equivalent to `EXCEPT`=0 both ways).

A/B magnitude (spellbook-hourly, 3 warm runs, medians, checksum-forced over all columns):

| dimension | current | fixed | Δ |
|---|---|---|---|
| IO (`physical_input_bytes`) | 228.7 GB | 2.31 GB | **−99.0% (~99×)** |
| CPU (`cpu_ms`) | 1153 cpu-s | 14 cpu-s | **−98.8% (~82×)** |
| wall | 18.0 s | 2.2 s | **−88%** |
| peak memory | 13.1 GB | 1.5 GB | **−89%** |
| spill | 0 | 0 | — |

Projected whole-model (24 hourly builds): ~5.18 → ~0.23 TB/day IO, ~2.98 → ~0.33 CPU-hrs/day.

No backfill needed — `bridges_ethereum_agglayer_v1_deposits` is a view; only the consumer's per-run scan changes.

Fixes CUR2-2830
