### PR TITLE
perf(angstrom_ethereum_base_trades): materialize bundle transactions staging

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/angstrom/utils/angstrom_tx_data.sql
+++ b/dbt_subprojects/dex/macros/models/_project/angstrom/utils/angstrom_tx_data.sql
@@ -6,21 +6,26 @@
     )
 %}
 
-SELECT 
+{% if blockchain == 'ethereum' %}
+-- Read the shared, pre-materialized bundle-transactions staging model instead of re-scanning
+-- the raw transactions table. The varbinary_substring(data,1,4) selector filter is non-pushable,
+-- so each inlined copy re-scanned the full transactions window: the recursive bundle decoder and
+-- nested order macros expand this CTE into ~300 transactions scan operators per build
+-- (~85% of the model's physical IO). See angstrom_ethereum_bundle_transactions / CUR2-2709.
+SELECT
     block_number,
     block_time,
-    hash AS tx_hash,
-    index AS tx_index,
-    to AS angstrom_address,
-    data AS tx_data
-FROM {{ source(blockchain, 'transactions') }}
-WHERE 
-    success = true AND
-    block_number >= {{ earliest_block }} AND
-    to = {{ angstrom_contract_addr }} AND 
-    varbinary_substring(data, 1, 4) = 0x09c5eabe
+    tx_hash,
+    tx_index,
+    angstrom_address,
+    tx_data
+FROM {{ ref('angstrom_ethereum_bundle_transactions') }}
 {% if is_incremental() %}
-    AND {{ incremental_predicate('block_time') }}
+WHERE {{ incremental_predicate('block_time') }}
+{% endif %}
+
+{% else %}
+{{ angstrom_tx_data_raw(angstrom_contract_addr, earliest_block, blockchain) }}
 {% endif %}
 
 

--- a/dbt_subprojects/dex/macros/models/_project/angstrom/utils/angstrom_tx_data_raw.sql
+++ b/dbt_subprojects/dex/macros/models/_project/angstrom/utils/angstrom_tx_data_raw.sql
@@ -1,0 +1,27 @@
+{% macro
+    angstrom_tx_data_raw(
+        angstrom_contract_addr,
+        earliest_block,
+        blockchain
+    )
+%}
+
+SELECT 
+    block_number,
+    block_time,
+    hash AS tx_hash,
+    index AS tx_index,
+    to AS angstrom_address,
+    data AS tx_data
+FROM {{ source(blockchain, 'transactions') }}
+WHERE 
+    success = true AND
+    block_number >= {{ earliest_block }} AND
+    to = {{ angstrom_contract_addr }} AND 
+    varbinary_substring(data, 1, 4) = 0x09c5eabe
+{% if is_incremental() %}
+    AND {{ incremental_predicate('block_time') }}
+{% endif %}
+
+
+{% endmacro %}

--- a/dbt_subprojects/dex/models/_projects/angstrom/ethereum/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/angstrom/ethereum/_schema.yml
@@ -1,6 +1,40 @@
 version: 2
 
 models:
+  - name: angstrom_ethereum_bundle_transactions
+    meta:
+      blockchain: ethereum
+      sector: dex
+      contributors: jnoorchashm37
+    config:
+      tags: ['ethereum', 'angstrom', 'trades']
+    description: >
+      Pre-materialized Angstrom bundle transactions on Ethereum, extracted once from
+      ethereum.transactions. Shared staging model for angstrom_ethereum_base_trades so the
+      non-pushable bundle-calldata scan runs a single time per build instead of being
+      re-inlined into ~300 transactions scan operators by the recursive bundle decoder.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+    columns:
+      - name: block_number
+        description: "Block number of the Angstrom bundle transaction"
+      - name: block_time
+        description: "Block time of the transaction"
+      - name: tx_hash
+        description: "Transaction hash of the Angstrom bundle (execute) call"
+      - name: tx_index
+        description: "Index of the transaction within its block"
+      - name: angstrom_address
+        description: "Angstrom contract address called by the transaction"
+      - name: tx_data
+        description: "Raw calldata of the bundle transaction, decoded downstream"
+      - name: block_month
+        description: "Month partition derived from block_time"
+
   - name: angstrom_ethereum_trades
     meta:
       blockchain: ethereum

--- a/dbt_subprojects/dex/models/_projects/angstrom/ethereum/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/angstrom/ethereum/_schema.yml
@@ -26,6 +26,8 @@ models:
         description: "Block time of the transaction"
       - name: tx_hash
         description: "Transaction hash of the Angstrom bundle (execute) call"
+        data_tests:
+          - not_null
       - name: tx_index
         description: "Index of the transaction within its block"
       - name: angstrom_address
@@ -34,6 +36,8 @@ models:
         description: "Raw calldata of the bundle transaction, decoded downstream"
       - name: block_month
         description: "Month partition derived from block_time"
+        data_tests:
+          - not_null
 
   - name: angstrom_ethereum_trades
     meta:

--- a/dbt_subprojects/dex/models/_projects/angstrom/ethereum/angstrom_ethereum_bundle_transactions.sql
+++ b/dbt_subprojects/dex/models/_projects/angstrom/ethereum/angstrom_ethereum_bundle_transactions.sql
@@ -1,0 +1,42 @@
+{{
+    config(
+        schema = 'angstrom_ethereum',
+        alias = 'bundle_transactions',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set angstrom_contract_addr = '0x0000000aa232009084Bd71A5797d089AA4Edfad4' %}
+{% set earliest_block = '22971781' %}
+{% set blockchain = 'ethereum' %}
+
+-- Shared staging model for Angstrom bundle transactions on Ethereum.
+-- Materializing the bundle-calldata scan once breaks the CTE inlining that previously
+-- re-scanned ethereum.transactions ~300x per angstrom_ethereum_base_trades build: the
+-- recursive bundle decoder and nested order macros expand the tx_data CTE into ~300 scan
+-- operators, and the varbinary_substring(data,1,4) selector filter is non-pushable so each
+-- one read the full transactions window (~85% of the model's physical IO). CUR2-2709.
+select
+    bundle_txs.*,
+    cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        angstrom_tx_data_raw(
+            angstrom_contract_addr = angstrom_contract_addr,
+            earliest_block = earliest_block,
+            blockchain = blockchain
+        )
+    }}
+) as bundle_txs
+{% if target.name == 'ci' %}
+-- CI-only floor: this state:new model would otherwise full-refresh scan ~1yr of
+-- ethereum.transactions calldata and blow the 90-min CI timeout. Renders only under
+-- --target ci, so prod (the one-time backfill + incremental runs) is unaffected. CUR2-2709.
+where block_time >= current_date - interval '14' day
+{% endif %}


### PR DESCRIPTION
`angstrom_ethereum_base_trades` is the single largest IO consumer on the spellbook-dex cluster (24h reality-check: 20.17 CPU-hrs/day, 18.52 TB/day scanned, ~1055 GB per build for 1 merged output row). The bundle-calldata source scan lives in the `angstrom_tx_data` macro, which filters `ethereum.transactions` by `to = <angstrom>` AND a non-pushable `varbinary_substring(data, 1, 4) = 0x09c5eabe` selector. That CTE is referenced ~11x across the recursive bundle decoder (`angstrom_bundle_decoding_recursive_offset`) and the nested order macros, and Trino inlines each reference back into an independent scan.

`EXPLAIN ANALYZE` on a full build shows the inlining expands into **~300 `ethereum.transactions` scan operator instances** totalling **2.57B rows / 606 GB physical input — 85% of the model's IO**. Each instance re-reads the full transactions window (~8M rows / ~2 GB) only to re-derive the same ~6k bundle rows, because the selector predicate is filtered locally rather than pushed to the connector.

This PR extracts the scan once into a shared staging model, `angstrom_ethereum_bundle_transactions`, and points the `ethereum` branch of `angstrom_tx_data` at it. The ~300 transactions scans collapse to ~300 reads of a tiny (~6.3k-row / 4.3 MB) pre-filtered table plus one staging build.

## Change

- New macro `angstrom_tx_data_raw` — the original raw `ethereum.transactions` scan body, verbatim.
- New staging model `angstrom_ethereum_bundle_transactions` (incremental/merge, partitioned by `block_month`, `unique_key = [block_month, tx_hash]`) — wraps `angstrom_tx_data_raw` for Ethereum. Carries a CI-only 14-day floor so the `state:new` model doesn't full-refresh ~1yr of calldata and blow the 90-min CI budget; prod backfill/incremental runs are unaffected.
- `angstrom_tx_data` now reads the staging model for `ethereum` (re-applying the incremental window) and falls back to `angstrom_tx_data_raw` for any other chain. Pure source-swap — no decoding logic changed.

## Proof (read-only, spellbook-hourly, UTC)

Equivalence — the staging definition vs the original inline filter, projected to the 6 emitted columns, over a 3-day window:

- `(original EXCEPT staging)` = **0 rows**, `(staging EXCEPT original)` = **0 rows**.
- Merge-key uniqueness over [06-11, 06-14): `rows = distinct(tx_hash) = distinct(block_month, tx_hash) = 4123` — lossless.

A/B (median of 3 warm runs, `checksum()` over all output columns, never bare `count(*)`):

| metric | before | after (projected) | Δ |
|---|---|---|---|
| physical input / build | ~717 GB | ~114 GB | **-84%** |
| ...of which `ethereum.transactions` | 606 GB (300 scans) | ~3.6 GB (1 build + ~300 tiny reads) | -99% |
| reported scan / day | ~18.5 TB | ~3.1 TB | **-84%** |
| cpu | ~3331 cpu-s | ~1550 cpu-s | **~-47%** |
| peak memory | 9.6 GB | unchanged / better | — |
| spill | 0 | 0 | — |

The staging table is tiny and pre-filtered, so the ~300 inlined references now read kilobytes instead of re-scanning the full transactions window. IO is the headline; the CPU drop follows from eliminating 299 redundant scan+selector passes. The recursive decode, `pool_info` log scan, and block joins are untouched, so model output is identical (boundary EXCEPT = 0 both ways).

Realized whole-model numbers will be measured post-merge via the follow-up recipe (48h soak).

Towards CUR2-2709
