### PR TITLE
fix(balancer): exclude TORUS from prices.day in protocol fee USD conversion

### DIFF
--- a/dbt_macros/shared/balancer/balancer_protocol_fee_macro.sql
+++ b/dbt_macros/shared/balancer/balancer_protocol_fee_macro.sql
@@ -223,7 +223,7 @@ WITH pool_labels AS (
             price
         FROM {{ source('prices', 'day') }}
         WHERE blockchain = '{{blockchain}}'
-
+        AND contract_address NOT IN (0xb47f575807fc5466285e1277ef8acfbb5c6686e8)
     ),
 
     dex_prices_1 AS (


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

## Summary
Excludes TORUS (`0xb47f575807fc5466285e1277ef8acfbb5c6686e8`) from the `prices.day` lookup in `balancer_v3_compatible_protocol_fee_macro`, preventing inflated Swap Fee USD values caused by a bad upstream DEX-derived price.
A dust trade in `dex.trades` with a very small TORUS amount (`~0.000006`) and `$0.214` notional produced an implied price of ~34,659 USD via `amount_usd / token_amount`. That value flowed through the SQLMesh pricing pipeline into `prices.day` (`source = 'dex.trades'`) and was consumed by `balancer.protocol_fee`, causing an abnormal ~600k USD Swap Fee spike. Normal TORUS trades imply ~0.016 USD.




---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
