### PR TITLE
feat(prices): add CoinPaprika feeds for 12 EVM tokens missing USD coverage

### DIFF
--- a/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
@@ -243,5 +243,9 @@ FROM
     ('superoeth-super-oeth', 'base', 'superOETHb', 0xDBFeFD2e8460a6Ee4955A68582F85708BAEA60A3, 18),
     ('phnm-phenom', 'base', 'PHNM', 0x3fda9cc61b1fef8b2ffd715f0a9eef7182e48f37, 18),
     ('up-superform', 'base', 'UP', 0x5b2193fDc451C1f847bE09CA9d13A4Bf60f8c86B, 18),
-    ('fun-sportfun', 'base', 'FUN', 0x16EE7ecAc70d1028E7712751E2Ee6BA808a7dd92, 18)
+    ('fun-sportfun', 'base', 'FUN', 0x16EE7ecAc70d1028E7712751E2Ee6BA808a7dd92, 18),
+    ('ctr-citrea', 'base', 'CTR', 0x11030f79109269d796fd0FB956D6244e502757f7, 18),
+    ('velvet-velvet', 'base', 'VELVET', 0xbF927b841994731C573BDF09ceB0c6B0Aa887cDd, 18),
+    ('wusd-worldwide-usd', 'base', 'WUSD', 0xb4bB2032A73A53C0Aa7Dc9ee2d9658a978fA7bC2, 18),
+    ('sol-base-bridged-sol-base', 'base', 'SOL', 0x311935Cd80B76769bF2ecC9D8Ab7635b2139cf82, 9)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/berachain/prices_berachain_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/berachain/prices_berachain_tokens.sql
@@ -35,4 +35,5 @@ FROM
     , ('yeet3-yeet', 'YEET', 0x08a38caa631de329ff2dad1656ce789f31af3142, 18)
     , ('ibgt-infrared-bgt', 'iBGT', 0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b, 18)
     , ('usdbr-usdbr', 'USDBr', 0x6d4223dae2a8744a85a6d44e97f3f61679f87ee6, 18)
+    , ('osbgt-openstate-bgt', 'osBGT', 0xD2C41BF4033A83C0FC3A7F58a392Bf37d6dCDb58, 18)
 ) as temp (token_id, symbol, contract_address, decimals) 

--- a/dbt_subprojects/tokens/models/prices/hyperevm/prices_hyperevm_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/hyperevm/prices_hyperevm_tokens.sql
@@ -24,4 +24,5 @@ FROM
     , ('btc-bitcoin', 'UBTC', 0x9fdbda0a5e284c32744d2f17ee5c74b284993463, 8)
     , ('pump-pumpfun', 'UPUMP', 0x27ec642013bcb3d80ca3706599d3cda04f6f4452, 6)
     , ('sol-solana', 'USOL', 0x068f321fa8fb9f0d135f290ef6a3e2813e1c8a29, 9)
+    , ('usdc-usdc', 'USDC', 0xb88339CB7199b77E23DB6E890353E22632Ba630f, 6)
 ) as temp (token_id, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/polygon/prices_polygon_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/polygon/prices_polygon_tokens.sql
@@ -158,8 +158,11 @@ FROM
     ('om-mantra-dao', 'polygon', 'OM', 0xc3ec80343d2bae2f8e680fdadde7c17e71e114ea, 18),     
     ('glm-golem', 'polygon', 'GLM', 0x0B220b82F3eA3B7F6d9A1D8ab58930C064A2b5Bf, 18),     
     ('super-superfarm', 'polygon', 'SUPER', 0xa1428174f516f527fafdd146b883bb4428682737, 18),
-    ('pkr-polker', 'polygon', 'PKR', 0x140a4e80dd8184536acc45f1c452d7540472e6e1, 18)
+    ('pkr-polker', 'polygon', 'PKR', 0x140a4e80dd8184536acc45f1c452d7540472e6e1, 18),
     
+    ('pusd-polymarket-usd', 'polygon', 'pUSD', 0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB, 6),
+    ('lgns-origin-lgns', 'polygon', 'LGNS', 0xeB51D9A39AD5EEF215dC0Bf39a8821ff804A0F01, 9),
+    ('as-akas-1', 'polygon', 'AS', 0x6A92B1E99De09f71CD96BC91F934826d96B8b26E, 9)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)
 where contract_address not in (
     0xef938b6da8576a896f6e0321ef80996f4890f9c4 -- DG, bad price feed

--- a/dbt_subprojects/tokens/models/prices/worldchain/prices_worldchain_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/worldchain/prices_worldchain_tokens.sql
@@ -25,4 +25,5 @@ FROM
     , ('sdai-savings-dai', 'sDAI', 0x859DBE24b90C9f2f7742083d3cf59cA41f55Be5d, 18)
     , ('oro-oro', 'ORO', 0xcd1E32B86953D79a6AC58e813D2EA7a1790cAb63, 18)
     , ('usdt-tether', 'USD₮0', 0x102d758f688a4c1c5a80b116bd945d4455460282, 6)
+    , ('sushi-sushi', 'SUSHI', 0xab09A728E53d3d6BC438BE95eeD46Da0Bbe7FB38, 18)
 ) as temp (token_id, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/xlayer/prices_xlayer_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/xlayer/prices_xlayer_tokens.sql
@@ -27,4 +27,6 @@ FROM
     , ('usdce-usd-coine', 'USDC.e', 0xa8ce8aee21bc2a48a5ef670afcc9274c7bbbc035, 6)
     , ('wbtc-wrapped-bitcoin', 'WBTC', 0xea034fb02eb1808c2cc3adbc15f447b93cbe08e1, 8)
     , ('dai-dai', 'DAI', 0xc5015b9d9161dca7e18e32f6f25c4ad850731fd4, 18)
+    , ('usdg-global-dollar', 'USDG', 0x4ae46a509F6b1D9056937BA4500cb143933D2dc8, 6)
+    , ('okb-okb', 'OKB-1', 0xBff976F8874814E6f2EE98d559826812fF26597F, 18)
 ) as temp (token_id, symbol, contract_address, decimals)


### PR DESCRIPTION
## What

Adds CoinPaprika price-feed mappings for 12 high-activity EVM ERC20 tokens
flagged as missing USD pricing by the curated-token-price-coverage agent
(Dune query 7738743, 3-day lookback). Each token was resolved to a CoinPaprika
api_id via contract lookup, symbol-by-rank search, or canonical inference;
tokens without a confident match were omitted.

## Rows added (`chain | api_id | symbol | address | decimals`)
```
polygon | pusd-polymarket-usd | pUSD | 0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb | 6
polygon | lgns-origin-lgns | LGNS | 0xeb51d9a39ad5eef215dc0bf39a8821ff804a0f01 | 9
polygon | as-akas-1 | AS | 0x6a92b1e99de09f71cd96bc91f934826d96b8b26e | 9
hyperevm | usdc-usdc | USDC | 0xb88339cb7199b77e23db6e890353e22632ba630f | 6
base | ctr-citrea | CTR | 0x11030f79109269d796fd0fb956d6244e502757f7 | 18
base | velvet-velvet | VELVET | 0xbf927b841994731c573bdf09ceb0c6b0aa887cdd | 18
base | wusd-worldwide-usd | WUSD | 0xb4bb2032a73a53c0aa7dc9ee2d9658a978fa7bc2 | 18
base | sol-base-bridged-sol-base | SOL | 0x311935cd80b76769bf2ecc9d8ab7635b2139cf82 | 9
berachain | osbgt-openstate-bgt | osBGT | 0xd2c41bf4033a83c0fc3a7f58a392bf37d6dcdb58 | 18
xlayer | usdg-global-dollar | USDG | 0x4ae46a509f6b1d9056937ba4500cb143933d2dc8 | 6
xlayer | okb-okb | OKB-1 | 0xbff976f8874814e6f2ee98d559826812ff26597f | 18
worldchain | sushi-sushi | SUSHI | 0xab09a728e53d3d6bc438be95eed46da0bbe7fb38 | 18
```

🤖 Generated by the curated-token-price-coverage agent.
