### PR TITLE
fix(dex): use sold-token ERC4626 price for Balancer V3 `amount_usd` fallback

### DIFF
--- a/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
+++ b/dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql
@@ -126,7 +126,7 @@ SELECT
     , COALESCE(
         dexs.amount_usd,
         dexs.token_bought_amount * erc4626a.price,
-        dexs.token_sold_amount * erc4626a.price
+        dexs.token_sold_amount * erc4626b.price
     ) AS amount_usd
     , COALESCE(erc4626a.underlying_token, 
         token_bought_address) AS token_bought_address


### PR DESCRIPTION
## Summary

- Fixes a bug in `enrich_balancer_v3_dex_trades` where the ERC4626 fallback for `amount_usd` multiplied `token_sold_amount` by the **bought** token price (`erc4626a.price`) instead of the **sold** token price (`erc4626b.price`).
- Aligns the sold-side USD fallback with the existing joins: `erc4626a` is keyed on `token_bought_address`, `erc4626b` on `token_sold_address`.

## Context

When `add_amount_usd_dex_trades` does not produce `amount_usd`, the macro falls back to ERC4626 median prices:

```sql
COALESCE(
    dexs.amount_usd,
    dexs.token_bought_amount * erc4626a.price,
    dexs.token_sold_amount * erc4626b.price  -- was erc4626a.price
) AS amount_usd
```

Using the bought-token price for sold quantity understated or overstated USD volume on trades where only the sold leg is an ERC4626 wrapper and the bought leg is not (or has no price at that minute).

## Files changed

| File | Change |
|------|--------|
| `dbt_subprojects/dex/macros/models/enrich_balancer_v3_dex_trades.sql` | `token_sold_amount * erc4626a.price` → `erc4626b.price` |
