### PR TITLE
Fix GMX Arbitrum order updated merge fanout

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_updated.sql
@@ -201,12 +201,26 @@ WITH evt_data_1 AS (
             AND ED.block_date = EDP.block_date
 )
 
-, order_created AS (
+, order_created_for_update AS (
     SELECT
-        key,
-        MAX(market) AS market
-    FROM {{ ref('gmx_v2_arbitrum_order_created') }}
-    GROUP BY key
+        ED.block_date,
+        ED.tx_hash,
+        ED.index,
+        ARRAY_AGG(
+            OC.market
+            ORDER BY OC.block_number DESC, OC.block_time DESC, OC.index DESC, OC.market DESC
+        )[1] AS market
+    FROM event_data AS ED
+    LEFT JOIN {{ ref('gmx_v2_arbitrum_order_created') }} AS OC
+        ON ED.key = OC.key
+            AND (
+                OC.block_number < ED.block_number
+                OR (
+                    OC.block_number = ED.block_number
+                    AND OC.index <= ED.index
+                )
+            )
+    GROUP BY ED.block_date, ED.tx_hash, ED.index
 )
 
 -- full data 
@@ -248,8 +262,10 @@ WITH evt_data_1 AS (
         ED.tx_to
 
     FROM event_data AS ED
-    LEFT JOIN order_created AS OC
-        ON ED.key = OC.key
+    LEFT JOIN order_created_for_update AS OC
+        ON ED.block_date = OC.block_date
+            AND ED.tx_hash = OC.tx_hash
+            AND ED.index = OC.index
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
         ON OC.market = MD.market
         

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_updated.sql
@@ -206,10 +206,7 @@ WITH evt_data_1 AS (
         ED.block_date,
         ED.tx_hash,
         ED.index,
-        ARRAY_AGG(
-            OC.market
-            ORDER BY OC.block_number DESC, OC.block_time DESC, OC.index DESC, OC.market DESC
-        )[1] AS market
+        MAX_BY(OC.market, (OC.block_number, OC.index)) AS market
     FROM event_data AS ED
     LEFT JOIN {{ ref('gmx_v2_arbitrum_order_created') }} AS OC
         ON ED.key = OC.key

--- a/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_updated.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/gmx/event/arbitrum/gmx_v2_arbitrum_order_updated.sql
@@ -201,6 +201,14 @@ WITH evt_data_1 AS (
             AND ED.block_date = EDP.block_date
 )
 
+, order_created AS (
+    SELECT
+        key,
+        MAX(market) AS market
+    FROM {{ ref('gmx_v2_arbitrum_order_created') }}
+    GROUP BY key
+)
+
 -- full data 
 , full_data AS (
     SELECT 
@@ -240,7 +248,7 @@ WITH evt_data_1 AS (
         ED.tx_to
 
     FROM event_data AS ED
-    LEFT JOIN {{ ref('gmx_v2_arbitrum_order_created') }} AS OC
+    LEFT JOIN order_created AS OC
         ON ED.key = OC.key
     LEFT JOIN {{ ref('gmx_v2_arbitrum_markets_data') }} AS MD
         ON OC.market = MD.market


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description:

Deduplicate the `gmx_v2_arbitrum_order_created` enrichment by `key` before joining it into `gmx_v2_arbitrum_order_updated`.

This keeps the incremental model source one-row-per declared merge key (`block_date`, `tx_hash`, `index`) when `order_created` contains more than one row for an order key, preventing Trino `MERGE_TARGET_ROW_MULTIPLE_MATCHES` failures in the hourly prod run.

Validation:
- `uv run dbt compile -s gmx_v2_arbitrum_order_updated --project-dir dbt_subprojects/hourly_spellbook --profiles-dir dbt_subprojects/hourly_spellbook`

Note: live Dune duplicate probes were not run because this cloud environment has no `DUNE_API_KEY` configured.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duneanalytics.slack.com/archives/C05J73MG5F1/p1782140926994819?thread_ts=1782140926.994819&cid=C05J73MG5F1)

<div><a href="https://cursor.com/agents/bc-fd4862fc-de0f-5bce-8ba6-8051550453f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd4862fc-de0f-5bce-8ba6-8051550453f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

