### PR TITLE
Fix Uniswap V4 sqrt price ordering

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/pancakeswap_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/pancakeswap_compatible_liquidity.sql
@@ -25,7 +25,7 @@ get_pools as (
 get_events as (
     select 
         *,
-        evt_block_number + evt_index/1e6 as block_index_sum
+        {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_tx_hash', 'evt_index') }} as block_index_sum
 
     from 
     {{ PoolManager_evt_ModifyLiquidity }}
@@ -192,6 +192,7 @@ modify_liquidity_events as (
             evt_block_number,
             evt_block_date,
             evt_index,
+            block_index_sum,
             id,                -- pool id lives here
             sender,            -- caller/sender (useful metadata)
             tickLower,
@@ -211,7 +212,7 @@ modify_liquidity_events as (
             , e.evt_block_number as block_number 
             , e.evt_tx_hash as tx_hash
             , e.evt_index
-            , e.evt_block_number + e.evt_index/1e6 as block_index_sum
+            , e.block_index_sum
             , 'modify_liquidity' as event_type 
             , cd.currency0 as token0 
             , cd.currency1 as token1

--- a/dbt_subprojects/dex/macros/models/_project/pancakeswap_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/pancakeswap_compatible_liquidity.sql
@@ -7,6 +7,7 @@
     , PoolManager_call_ModifyLiquidity = null
     , liquidity_pools = null
     , liquidity_sqrtpricex96 = null
+    , transactions = null
     )
 %}
 
@@ -24,13 +25,19 @@ get_pools as (
 
 get_events as (
     select 
-        *,
-        {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_tx_hash', 'evt_index') }} as block_index_sum
+        e.*,
+        {{ uniswap_compatible_v4_block_index_sum('e.evt_block_number', 'coalesce(e.evt_tx_index, tx.index)', 'e.evt_index') }} as block_index_sum
 
     from 
-    {{ PoolManager_evt_ModifyLiquidity }}
+    {{ PoolManager_evt_ModifyLiquidity }} e
+    left join {{ transactions }} tx
+        on e.evt_tx_index is null
+        and e.evt_tx_hash = tx.hash
+        and e.evt_block_number = tx.block_number
+        and e.evt_block_date = tx.block_date
     {%- if is_incremental() %}
-    where {{ incremental_predicate('evt_block_time') }}
+        and {{ incremental_predicate('tx.block_time') }}
+    where {{ incremental_predicate('e.evt_block_time') }}
     {%- endif %}
 ),
 

--- a/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
@@ -1,9 +1,6 @@
-{% macro uniswap_compatible_v4_block_index_sum(block_number, tx_index, tx_hash, evt_index) -%}
-cast({{ block_number }} as decimal(38, 0)) * decimal '10000000000000000000000000'
-    + coalesce(
-        cast({{ tx_index }} as decimal(38, 0))
-        , cast(bitwise_and(varbinary_to_bigint(varbinary_substring({{ tx_hash }}, 1, 8)), 9223372036854775807) as decimal(38, 0))
-    ) * decimal '1000000'
+{% macro uniswap_compatible_v4_block_index_sum(block_number, tx_index, evt_index) -%}
+cast({{ block_number }} as decimal(38, 0)) * decimal '1000000000000'
+    + cast({{ tx_index }} as decimal(38, 0)) * decimal '1000000'
     + cast({{ evt_index }} as decimal(38, 0))
 {%- endmacro %}
 
@@ -13,6 +10,7 @@ cast({{ block_number }} as decimal(38, 0)) * decimal '10000000000000000000000000
     , version = '4'
     , PoolManager_evt_Initialize = null
     , PoolManager_evt_Swap = null 
+    , transactions = null
     )
 %}
 
@@ -24,32 +22,44 @@ with
 
 base_events as (
     select 
-        id
+        e.id
         , 'include' as check_filter
-        , evt_block_time as block_time
-        , evt_block_number as block_number
-        , evt_index
-        , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_tx_hash', 'evt_index') }} as block_index_sum
-        , sqrtpricex96
+        , e.evt_block_time as block_time
+        , e.evt_block_number as block_number
+        , e.evt_index
+        , {{ uniswap_compatible_v4_block_index_sum('e.evt_block_number', 'coalesce(e.evt_tx_index, tx.index)', 'e.evt_index') }} as block_index_sum
+        , e.sqrtpricex96
     from 
-    {{ PoolManager_evt_Initialize }}
-    where sqrtPriceX96 is not null 
-    and {{ incremental_predicate('evt_block_time') }}
+    {{ PoolManager_evt_Initialize }} e
+    left join {{ transactions }} tx
+        on e.evt_tx_index is null
+        and e.evt_tx_hash = tx.hash
+        and e.evt_block_number = tx.block_number
+        and e.evt_block_date = tx.block_date
+        and {{ incremental_predicate('tx.block_time') }}
+    where e.sqrtPriceX96 is not null 
+    and {{ incremental_predicate('e.evt_block_time') }}
 
     union all 
 
     select 
-        id
+        e.id
         , 'include' as check_filter
-        , evt_block_time as block_time
-        , evt_block_number as block_number
-        , evt_index
-        , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_tx_hash', 'evt_index') }} as block_index_sum 
-        , sqrtpricex96
+        , e.evt_block_time as block_time
+        , e.evt_block_number as block_number
+        , e.evt_index
+        , {{ uniswap_compatible_v4_block_index_sum('e.evt_block_number', 'coalesce(e.evt_tx_index, tx.index)', 'e.evt_index') }} as block_index_sum 
+        , e.sqrtpricex96
     from 
-    {{ PoolManager_evt_Swap }}
-    where sqrtPriceX96 is not null 
-    and {{ incremental_predicate('evt_block_time') }}
+    {{ PoolManager_evt_Swap }} e
+    left join {{ transactions }} tx
+        on e.evt_tx_index is null
+        and e.evt_tx_hash = tx.hash
+        and e.evt_block_number = tx.block_number
+        and e.evt_block_date = tx.block_date
+        and {{ incremental_predicate('tx.block_time') }}
+    where e.sqrtPriceX96 is not null 
+    and {{ incremental_predicate('e.evt_block_time') }}
 ),
 
 get_active_pools as ( -- get only the pools that were active on incremental run
@@ -131,28 +141,38 @@ sort_table as (
 
     get_events as (
         select 
-            id
-            , evt_block_time as block_time
-            , evt_block_number as block_number
-            , evt_index 
-            , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_tx_hash', 'evt_index') }} as block_index_sum 
-            , sqrtpricex96
+            e.id
+            , e.evt_block_time as block_time
+            , e.evt_block_number as block_number
+            , e.evt_index 
+            , {{ uniswap_compatible_v4_block_index_sum('e.evt_block_number', 'coalesce(e.evt_tx_index, tx.index)', 'e.evt_index') }} as block_index_sum 
+            , e.sqrtpricex96
         from 
-        {{ PoolManager_evt_Initialize }}
-        where sqrtPriceX96 is not null 
+        {{ PoolManager_evt_Initialize }} e
+        left join {{ transactions }} tx
+            on e.evt_tx_index is null
+            and e.evt_tx_hash = tx.hash
+            and e.evt_block_number = tx.block_number
+            and e.evt_block_date = tx.block_date
+        where e.sqrtPriceX96 is not null 
 
         union all 
 
         select 
-            id
-            , evt_block_time as block_time
-            , evt_block_number as block_number
-            , evt_index 
-            , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_tx_hash', 'evt_index') }} as block_index_sum
-            , sqrtpricex96 
+            e.id
+            , e.evt_block_time as block_time
+            , e.evt_block_number as block_number
+            , e.evt_index 
+            , {{ uniswap_compatible_v4_block_index_sum('e.evt_block_number', 'coalesce(e.evt_tx_index, tx.index)', 'e.evt_index') }} as block_index_sum
+            , e.sqrtpricex96 
         from 
-        {{ PoolManager_evt_Swap }}
-        where sqrtPriceX96 is not null 
+        {{ PoolManager_evt_Swap }} e
+        left join {{ transactions }} tx
+            on e.evt_tx_index is null
+            and e.evt_tx_hash = tx.hash
+            and e.evt_block_number = tx.block_number
+            and e.evt_block_date = tx.block_date
+        where e.sqrtPriceX96 is not null 
     )
     
 
@@ -183,6 +203,7 @@ sort_table as (
     , PoolManager_call_ModifyLiquidity = null
     , liquidity_pools = null
     , liquidity_sqrtpricex96 = null
+    , transactions = null
     )
 %}
 
@@ -201,13 +222,19 @@ get_pools as (
 
 get_events as (
     select 
-        *,
-        {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_tx_hash', 'evt_index') }} as block_index_sum
+        e.*,
+        {{ uniswap_compatible_v4_block_index_sum('e.evt_block_number', 'coalesce(e.evt_tx_index, tx.index)', 'e.evt_index') }} as block_index_sum
 
     from 
-    {{ PoolManager_evt_ModifyLiquidity }}
+    {{ PoolManager_evt_ModifyLiquidity }} e
+    left join {{ transactions }} tx
+        on e.evt_tx_index is null
+        and e.evt_tx_hash = tx.hash
+        and e.evt_block_number = tx.block_number
+        and e.evt_block_date = tx.block_date
     {%- if is_incremental() %}
-    where {{ incremental_predicate('evt_block_time') }}
+        and {{ incremental_predicate('tx.block_time') }}
+    where {{ incremental_predicate('e.evt_block_time') }}
     {%- endif %}
 ),
 

--- a/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
@@ -1,3 +1,9 @@
+{% macro uniswap_compatible_v4_block_index_sum(block_number, tx_index, evt_index) -%}
+cast({{ block_number }} as decimal(38, 0)) * decimal '1000000000000'
+    + cast({{ tx_index }} as decimal(38, 0)) * decimal '1000000'
+    + cast({{ evt_index }} as decimal(38, 0))
+{%- endmacro %}
+
 {% macro uniswap_compatible_v4_liquidity_sqrtpricex96(
     blockchain = null
     , project = 'uniswap'
@@ -20,7 +26,7 @@ base_events as (
         , evt_block_time as block_time
         , evt_block_number as block_number
         , evt_index
-        , evt_block_number + evt_index/1e6 as block_index_sum
+        , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_index') }} as block_index_sum
         , sqrtpricex96
     from 
     {{ PoolManager_evt_Initialize }}
@@ -35,7 +41,7 @@ base_events as (
         , evt_block_time as block_time
         , evt_block_number as block_number
         , evt_index
-        , evt_block_number + evt_index/1e6 as block_index_sum 
+        , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_index') }} as block_index_sum 
         , sqrtpricex96
     from 
     {{ PoolManager_evt_Swap }}
@@ -93,7 +99,7 @@ get_latest_active_pools as (
 sort_table as (
     select 
         *
-        , lag(block_index_sum, 1, 0) over (partition by id order by block_index_sum) as previous_block_index_sum
+        , lag(block_index_sum, 1, decimal '0') over (partition by id order by block_index_sum) as previous_block_index_sum
     from 
     get_latest_active_pools
 )
@@ -126,7 +132,7 @@ sort_table as (
             , evt_block_time as block_time
             , evt_block_number as block_number
             , evt_index 
-            , evt_block_number + evt_index/1e6 as block_index_sum 
+            , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_index') }} as block_index_sum 
             , sqrtpricex96
         from 
         {{ PoolManager_evt_Initialize }}
@@ -139,7 +145,7 @@ sort_table as (
             , evt_block_time as block_time
             , evt_block_number as block_number
             , evt_index 
-            , evt_block_number + evt_index/1e6 as block_index_sum
+            , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_index') }} as block_index_sum
             , sqrtpricex96 
         from 
         {{ PoolManager_evt_Swap }}
@@ -156,7 +162,7 @@ sort_table as (
         , block_number
         , evt_index 
         , block_index_sum 
-        , lag(block_index_sum, 1, 0) over (partition by id order by block_index_sum) as previous_block_index_sum
+        , lag(block_index_sum, 1, decimal '0') over (partition by id order by block_index_sum) as previous_block_index_sum
         , sqrtpricex96
     from 
     get_events 
@@ -193,7 +199,7 @@ get_pools as (
 get_events as (
     select 
         *,
-        evt_block_number + evt_index/1e6 as block_index_sum
+        {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_index') }} as block_index_sum
 
     from 
     {{ PoolManager_evt_ModifyLiquidity }}
@@ -379,7 +385,7 @@ modify_liquidity_events as (
             , e.evt_block_number as block_number 
             , e.evt_tx_hash as tx_hash
             , e.evt_index
-            , e.evt_block_number + e.evt_index/1e6 as block_index_sum
+            , {{ uniswap_compatible_v4_block_index_sum('e.evt_block_number', 'e.evt_tx_index', 'e.evt_index') }} as block_index_sum
             , 'modify_liquidity' as event_type 
             , cd.currency0 as token0 
             , cd.currency1 as token1

--- a/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
@@ -1,6 +1,9 @@
-{% macro uniswap_compatible_v4_block_index_sum(block_number, tx_index, evt_index) -%}
-cast({{ block_number }} as decimal(38, 0)) * decimal '1000000000000'
-    + cast({{ tx_index }} as decimal(38, 0)) * decimal '1000000'
+{% macro uniswap_compatible_v4_block_index_sum(block_number, tx_index, tx_hash, evt_index) -%}
+cast({{ block_number }} as decimal(38, 0)) * decimal '10000000000000000000000000'
+    + coalesce(
+        cast({{ tx_index }} as decimal(38, 0))
+        , cast(bitwise_and(varbinary_to_bigint(varbinary_substring({{ tx_hash }}, 1, 8)), 9223372036854775807) as decimal(38, 0))
+    ) * decimal '1000000'
     + cast({{ evt_index }} as decimal(38, 0))
 {%- endmacro %}
 
@@ -26,7 +29,7 @@ base_events as (
         , evt_block_time as block_time
         , evt_block_number as block_number
         , evt_index
-        , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_index') }} as block_index_sum
+        , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_tx_hash', 'evt_index') }} as block_index_sum
         , sqrtpricex96
     from 
     {{ PoolManager_evt_Initialize }}
@@ -41,7 +44,7 @@ base_events as (
         , evt_block_time as block_time
         , evt_block_number as block_number
         , evt_index
-        , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_index') }} as block_index_sum 
+        , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_tx_hash', 'evt_index') }} as block_index_sum 
         , sqrtpricex96
     from 
     {{ PoolManager_evt_Swap }}
@@ -132,7 +135,7 @@ sort_table as (
             , evt_block_time as block_time
             , evt_block_number as block_number
             , evt_index 
-            , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_index') }} as block_index_sum 
+            , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_tx_hash', 'evt_index') }} as block_index_sum 
             , sqrtpricex96
         from 
         {{ PoolManager_evt_Initialize }}
@@ -145,7 +148,7 @@ sort_table as (
             , evt_block_time as block_time
             , evt_block_number as block_number
             , evt_index 
-            , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_index') }} as block_index_sum
+            , {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_tx_hash', 'evt_index') }} as block_index_sum
             , sqrtpricex96 
         from 
         {{ PoolManager_evt_Swap }}
@@ -199,7 +202,7 @@ get_pools as (
 get_events as (
     select 
         *,
-        {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_index') }} as block_index_sum
+        {{ uniswap_compatible_v4_block_index_sum('evt_block_number', 'evt_tx_index', 'evt_tx_hash', 'evt_index') }} as block_index_sum
 
     from 
     {{ PoolManager_evt_ModifyLiquidity }}

--- a/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
@@ -366,6 +366,7 @@ modify_liquidity_events as (
             evt_block_number,
             evt_block_date,
             evt_index,
+            block_index_sum,
             id,                -- pool id lives here
             sender,            -- caller/sender (useful metadata)
             tickLower,
@@ -385,7 +386,7 @@ modify_liquidity_events as (
             , e.evt_block_number as block_number 
             , e.evt_tx_hash as tx_hash
             , e.evt_index
-            , {{ uniswap_compatible_v4_block_index_sum('e.evt_block_number', 'e.evt_tx_index', 'e.evt_index') }} as block_index_sum
+            , e.block_index_sum
             , 'modify_liquidity' as event_type 
             , cd.currency0 as token0 
             , cd.currency1 as token1

--- a/dbt_subprojects/dex/models/_projects/pancakeswap/base/base_liquidity_events/pancakeswap_infinity_cl_base_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/pancakeswap/base/base_liquidity_events/pancakeswap_infinity_cl_base_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('pancakeswap_infinity_cl_base_pools')
         , liquidity_sqrtpricex96 = ref('pancakeswap_infinity_cl_base_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('pancakeswap_infinity_base', 'clpoolmanager_call_modifyliquidity')
+        , transactions = source('base', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/pancakeswap/base/pancakeswap_infinity_cl_base_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/pancakeswap/base/pancakeswap_infinity_cl_base_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = 'infinity_cl'
         , PoolManager_evt_Initialize = source('pancakeswap_infinity_base', 'clpoolmanager_evt_initialize')
         , PoolManager_evt_Swap = source('pancakeswap_infinity_base', 'ClPoolManager_evt_Swap') 
+        , transactions = source('base', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/pancakeswap/bnb/base_liquidity_events/pancakeswap_infinity_cl_bnb_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/pancakeswap/bnb/base_liquidity_events/pancakeswap_infinity_cl_bnb_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('pancakeswap_infinity_cl_bnb_pools')
         , liquidity_sqrtpricex96 = ref('pancakeswap_infinity_cl_bnb_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('pancakeswap_infinity_bnb', 'clpoolmanager_call_modifyliquidity')
+        , transactions = source('bnb', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/pancakeswap/bnb/pancakeswap_infinity_cl_bnb_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/pancakeswap/bnb/pancakeswap_infinity_cl_bnb_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = 'infinity_cl'
         , PoolManager_evt_Initialize = source('pancakeswap_infinity_bnb', 'clpoolmanager_evt_initialize')
         , PoolManager_evt_Swap = source('pancakeswap_infinity_bnb', 'ClPoolManager_evt_Swap') 
+        , transactions = source('bnb', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/arbitrum/base_liquidity_events/uniswap_v4_arbitrum_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/arbitrum/base_liquidity_events/uniswap_v4_arbitrum_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('uniswap_v4_arbitrum_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_arbitrum_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_arbitrum', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('arbitrum', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/arbitrum/uniswap_v4_arbitrum_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/arbitrum/uniswap_v4_arbitrum_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_arbitrum', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_arbitrum', 'PoolManager_evt_Swap') 
+        , transactions = source('arbitrum', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/avalanche_c/base_liquidity_events/uniswap_v4_avalanche_c_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/avalanche_c/base_liquidity_events/uniswap_v4_avalanche_c_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('uniswap_v4_avalanche_c_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_avalanche_c_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_avalanche_c', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('avalanche_c', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/avalanche_c/uniswap_v4_avalanche_c_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/avalanche_c/uniswap_v4_avalanche_c_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_avalanche_c', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_avalanche_c', 'PoolManager_evt_Swap') 
+        , transactions = source('avalanche_c', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/base/base_liquidity_events/uniswap_v4_base_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/base/base_liquidity_events/uniswap_v4_base_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('uniswap_v4_base_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_base_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_base', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('base', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/base/uniswap_v4_base_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/base/uniswap_v4_base_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_base', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_base', 'PoolManager_evt_Swap') 
+        , transactions = source('base', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/blast/base_liquidity_events/uniswap_v4_blast_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/blast/base_liquidity_events/uniswap_v4_blast_base_liquidity_events.sql
@@ -21,5 +21,6 @@
         , liquidity_pools = ref('uniswap_v4_blast_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_blast_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_blast', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('blast', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/blast/uniswap_v4_blast_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/blast/uniswap_v4_blast_sqrtpricex96.sql
@@ -18,5 +18,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_blast', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_blast', 'PoolManager_evt_Swap') 
+        , transactions = source('blast', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/bnb/base_liquidity_events/uniswap_v4_bnb_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/bnb/base_liquidity_events/uniswap_v4_bnb_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('uniswap_v4_bnb_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_bnb_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_bnb', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('bnb', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/bnb/uniswap_v4_bnb_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/bnb/uniswap_v4_bnb_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_bnb', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_bnb', 'PoolManager_evt_Swap') 
+        , transactions = source('bnb', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/celo/base_liquidity_events/uniswap_v4_celo_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/celo/base_liquidity_events/uniswap_v4_celo_base_liquidity_events.sql
@@ -20,5 +20,6 @@
         , liquidity_pools = ref('uniswap_v4_celo_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_ethereum_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_celo', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('celo', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/celo/uniswap_v4_celo_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/celo/uniswap_v4_celo_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_celo', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_celo', 'PoolManager_evt_Swap') 
+        , transactions = source('celo', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/ethereum/base_liquidity_events/uniswap_v4_ethereum_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/ethereum/base_liquidity_events/uniswap_v4_ethereum_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('uniswap_v4_ethereum_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_ethereum_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_ethereum', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('ethereum', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/ethereum/uniswap_v4_ethereum_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/ethereum/uniswap_v4_ethereum_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_ethereum', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_ethereum', 'PoolManager_evt_Swap') 
+        , transactions = source('ethereum', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/ink/base_liquidity_events/uniswap_v4_ink_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/ink/base_liquidity_events/uniswap_v4_ink_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('uniswap_v4_ink_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_ink_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_ink', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('ink', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/ink/uniswap_v4_ink_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/ink/uniswap_v4_ink_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_ink', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_ink', 'PoolManager_evt_Swap') 
+        , transactions = source('ink', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/monad/base_liquidity_events/uniswap_v4_monad_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/monad/base_liquidity_events/uniswap_v4_monad_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('uniswap_v4_monad_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_monad_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_monad', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('monad', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/monad/uniswap_v4_monad_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/monad/uniswap_v4_monad_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_monad', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_monad', 'PoolManager_evt_Swap') 
+        , transactions = source('monad', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/optimism/base_liquidity_events/uniswap_v4_optimism_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/optimism/base_liquidity_events/uniswap_v4_optimism_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('uniswap_v4_optimism_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_optimism_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_optimism', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('optimism', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/optimism/uniswap_v4_optimism_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/optimism/uniswap_v4_optimism_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_optimism', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_optimism', 'PoolManager_evt_Swap') 
+        , transactions = source('optimism', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/polygon/base_liquidity_events/uniswap_v4_polygon_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/polygon/base_liquidity_events/uniswap_v4_polygon_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('uniswap_v4_polygon_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_polygon_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_polygon', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('polygon', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/polygon/uniswap_v4_polygon_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/polygon/uniswap_v4_polygon_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_polygon', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_polygon', 'PoolManager_evt_Swap') 
+        , transactions = source('polygon', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/unichain/base_liquidity_events/uniswap_v4_unichain_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/unichain/base_liquidity_events/uniswap_v4_unichain_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('uniswap_v4_unichain_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_unichain_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_unichain', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('unichain', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/unichain/uniswap_v4_unichain_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/unichain/uniswap_v4_unichain_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_unichain', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_unichain', 'PoolManager_evt_Swap') 
+        , transactions = source('unichain', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/worldchain/base_liquidity_events/uniswap_v4_worldchain_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/worldchain/base_liquidity_events/uniswap_v4_worldchain_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('uniswap_v4_worldchain_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_worldchain_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_worldchain', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('worldchain', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/worldchain/uniswap_v4_worldchain_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/worldchain/uniswap_v4_worldchain_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_worldchain', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_worldchain', 'PoolManager_evt_Swap') 
+        , transactions = source('worldchain', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/zora/base_liquidity_events/uniswap_v4_zora_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/zora/base_liquidity_events/uniswap_v4_zora_base_liquidity_events.sql
@@ -19,5 +19,6 @@
         , liquidity_pools = ref('uniswap_v4_zora_pools')
         , liquidity_sqrtpricex96 = ref('uniswap_v4_zora_sqrtpricex96')
         , PoolManager_call_ModifyLiquidity = source ('uniswap_v4_zora', 'PoolManager_call_ModifyLiquidity')
+        , transactions = source('zora', 'transactions')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/zora/uniswap_v4_zora_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/zora/uniswap_v4_zora_sqrtpricex96.sql
@@ -16,5 +16,6 @@
         , version = '4'
         , PoolManager_evt_Initialize = source('uniswap_v4_zora', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_zora', 'PoolManager_evt_Swap') 
+        , transactions = source('zora', 'transactions')
     )
 }}


### PR DESCRIPTION
## Summary
- Replace Uniswap V4 `block_index_sum` ordering with a deterministic key using block number, transaction index, and event index.
- Use decoded `evt_tx_index` when populated, and fall back to the canonical chain `transactions.index` when decoded event rows have null transaction indexes.
- Apply the corrected ordering consistently to sqrt price history and Uniswap/PancakeSwap base liquidity event interval joins.

## Root Cause
This was likely not caused by a SQL logic change in today's deployed PRs, but was surfaced by #9785 causing the affected macro file to rerun.

The failing model, `uniswap_v4_arbitrum_sqrtpricex96`, was not itself changed today. The relevant deployed PR was #9785 (`0c70be4f5`), which changed `dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql`. That file contains both the downstream liquidity macro and the `sqrtpricex96` macro, so dbt state selection can rerun `uniswap_v4_arbitrum_sqrtpricex96` even though the model wrapper did not change.

The actual root cause is that the previous merge key was too weak: `['id', 'blockchain', 'block_index_sum']`, where `block_index_sum = evt_block_number + evt_index / 1e6`. On Arbitrum, `evt_index` can repeat across different transactions in the same block, so this value is not a true event-ordering key.

Investigation evidence from the last 3-day incremental window:
- Previous source rows: `105,411`
- Distinct previous merge keys: `105,409`
- Distinct keys when transaction identity is included: `105,411`

Concrete collision found:
- Pool: `0x864abca0a6202dba5b8868772308da953ff125b0f95015adbf89aaf579e903a8`
- Block: `476185398`, `evt_index = 5`
- Two different swap transaction hashes shared the same previous merge key.
- The target already had two rows for that key, so a later incremental merge could hit `MERGE_TARGET_ROW_MULTIPLE_MATCHES`.

A hash-derived fallback was considered and briefly tested, but it is not valid here because `block_index_sum` is also the sqrt-price interval ordering boundary. Hash order is deterministic but not chain transaction order. Follow-up diagnostics on BNB showed hash order disagreed with real transaction order for many same-pool/same-block groups, so this PR uses `transactions.index` instead.

## Test Plan
- Dune diagnostic: corrected Arbitrum 3-day source key check returned `rows = 106300`, `corrected_key_count = 106300`, `duplicate_keys = 0`.
- Dune diagnostic: previous hash-order validation showed the reviewer finding was valid: Uniswap BNB 7d had `665,864` rows with hash order different from tx order across `280,528` pool-blocks; PancakeSwap BNB 7d had `2,860,102` rows different across `1,019,332` pool-blocks.
- Dune diagnostic: transaction-index ordering returned `null_order_keys = 0` and `duplicate_keys = 0` for Uniswap BNB, Uniswap Ethereum, PancakeSwap BNB, Uniswap Optimism, and Uniswap Polygon 3-day windows.
- Dune diagnostic: all 14 checked V4-compatible chains have `transactions` tables, and all 32 V4-compatible model wrappers now pass a `transactions` relation.
- CI: pending for latest commit `95326542f`.