### PR TITLE
Don't run Upload Contribution Data on forks

### DIFF
--- a/.github/workflows/spellbook_metadata.yml
+++ b/.github/workflows/spellbook_metadata.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   upload_status:
     runs-on: ubuntu-latest
+    if: github.repository == 'duneanalytics/spellbook'
 
     steps:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6


### PR DESCRIPTION
### Description:

Add a conditional to run the "Upload Contribution Data" job only on Spellbook's source repo, as it will fail on forks.

See for example:
https://github.com/cypherpepe/spellbook/actions/workflows/spellbook_metadata.yml

Running daily and failing daily. Adding this conditional will prevent this being broken by default on any new fork 👍

(Of course the fork creator can always remove this conditional, the same way they can change any Github Action and break the project from their fork; but any PR touching these files will be rejected)