### PR TITLE
CUR2-2871: prepare Spellbook stablecoin foundations cutover

### DIFF
--- a/dbt_subprojects/tokens/models/stablecoins/evm/abstract/tokens_abstract_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/abstract/tokens_abstract_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/abstract/tokens_abstract_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/abstract/tokens_abstract_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/abstract/tokens_abstract_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/abstract/tokens_abstract_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/abstract/transfers/stablecoins_abstract_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/abstract/transfers/stablecoins_abstract_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/abstract/transfers/stablecoins_abstract_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/abstract/transfers/stablecoins_abstract_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/abstract/transfers/stablecoins_abstract_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/abstract/transfers/stablecoins_abstract_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/tokens_arbitrum_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/tokens_arbitrum_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/tokens_arbitrum_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/tokens_arbitrum_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/tokens_arbitrum_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/tokens_arbitrum_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/transfers/stablecoins_arbitrum_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/transfers/stablecoins_arbitrum_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/transfers/stablecoins_arbitrum_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/transfers/stablecoins_arbitrum_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/transfers/stablecoins_arbitrum_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/arbitrum/transfers/stablecoins_arbitrum_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/avalanche_c/tokens_avalanche_c_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/avalanche_c/tokens_avalanche_c_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/avalanche_c/tokens_avalanche_c_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/avalanche_c/tokens_avalanche_c_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/avalanche_c/tokens_avalanche_c_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/avalanche_c/tokens_avalanche_c_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/avalanche_c/transfers/stablecoins_avalanche_c_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/avalanche_c/transfers/stablecoins_avalanche_c_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/avalanche_c/transfers/stablecoins_avalanche_c_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/avalanche_c/transfers/stablecoins_avalanche_c_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/avalanche_c/transfers/stablecoins_avalanche_c_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/avalanche_c/transfers/stablecoins_avalanche_c_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/base/tokens_base_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/base/tokens_base_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/base/tokens_base_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/base/tokens_base_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/base/tokens_base_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/base/tokens_base_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/base/transfers/stablecoins_base_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/base/transfers/stablecoins_base_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/base/transfers/stablecoins_base_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/base/transfers/stablecoins_base_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/base/transfers/stablecoins_base_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/base/transfers/stablecoins_base_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/berachain/tokens_berachain_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/berachain/tokens_berachain_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/berachain/tokens_berachain_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/berachain/tokens_berachain_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/berachain/tokens_berachain_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/berachain/tokens_berachain_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/berachain/transfers/stablecoins_berachain_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/berachain/transfers/stablecoins_berachain_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/berachain/transfers/stablecoins_berachain_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/berachain/transfers/stablecoins_berachain_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/berachain/transfers/stablecoins_berachain_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/berachain/transfers/stablecoins_berachain_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bnb/tokens_bnb_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bnb/tokens_bnb_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bnb/tokens_bnb_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bnb/tokens_bnb_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bnb/tokens_bnb_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bnb/tokens_bnb_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bnb/transfers/stablecoins_bnb_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bnb/transfers/stablecoins_bnb_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bnb/transfers/stablecoins_bnb_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bnb/transfers/stablecoins_bnb_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bnb/transfers/stablecoins_bnb_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bnb/transfers/stablecoins_bnb_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bob/tokens_bob_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bob/tokens_bob_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bob/tokens_bob_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bob/tokens_bob_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bob/tokens_bob_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bob/tokens_bob_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bob/transfers/stablecoins_bob_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bob/transfers/stablecoins_bob_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bob/transfers/stablecoins_bob_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bob/transfers/stablecoins_bob_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/bob/transfers/stablecoins_bob_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/bob/transfers/stablecoins_bob_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/celo/tokens_celo_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/celo/tokens_celo_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/celo/tokens_celo_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/celo/tokens_celo_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/celo/tokens_celo_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/celo/tokens_celo_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/celo/transfers/stablecoins_celo_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/celo/transfers/stablecoins_celo_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/celo/transfers/stablecoins_celo_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/celo/transfers/stablecoins_celo_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/celo/transfers/stablecoins_celo_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/celo/transfers/stablecoins_celo_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/tokens_ethereum_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/tokens_ethereum_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/tokens_ethereum_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/tokens_ethereum_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/tokens_ethereum_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/tokens_ethereum_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/transfers/stablecoins_ethereum_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/transfers/stablecoins_ethereum_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/transfers/stablecoins_ethereum_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/transfers/stablecoins_ethereum_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/transfers/stablecoins_ethereum_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ethereum/transfers/stablecoins_ethereum_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/fantom/tokens_fantom_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/fantom/tokens_fantom_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/fantom/tokens_fantom_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/fantom/tokens_fantom_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/fantom/tokens_fantom_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/fantom/tokens_fantom_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/fantom/transfers/stablecoins_fantom_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/fantom/transfers/stablecoins_fantom_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/fantom/transfers/stablecoins_fantom_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/fantom/transfers/stablecoins_fantom_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/fantom/transfers/stablecoins_fantom_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/fantom/transfers/stablecoins_fantom_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/flare/tokens_flare_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/flare/tokens_flare_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/flare/tokens_flare_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/flare/tokens_flare_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/flare/tokens_flare_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/flare/tokens_flare_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/flare/transfers/stablecoins_flare_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/flare/transfers/stablecoins_flare_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/flare/transfers/stablecoins_flare_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/flare/transfers/stablecoins_flare_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/flare/transfers/stablecoins_flare_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/flare/transfers/stablecoins_flare_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/tokens_gnosis_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/tokens_gnosis_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/tokens_gnosis_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/tokens_gnosis_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/tokens_gnosis_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/tokens_gnosis_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/transfers/stablecoins_gnosis_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/transfers/stablecoins_gnosis_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/transfers/stablecoins_gnosis_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/transfers/stablecoins_gnosis_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/transfers/stablecoins_gnosis_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/gnosis/transfers/stablecoins_gnosis_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hemi/tokens_hemi_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hemi/tokens_hemi_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hemi/tokens_hemi_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hemi/tokens_hemi_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hemi/tokens_hemi_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hemi/tokens_hemi_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hemi/transfers/stablecoins_hemi_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hemi/transfers/stablecoins_hemi_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hemi/transfers/stablecoins_hemi_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hemi/transfers/stablecoins_hemi_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hemi/transfers/stablecoins_hemi_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hemi/transfers/stablecoins_hemi_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/tokens_hyperevm_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/tokens_hyperevm_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/tokens_hyperevm_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/tokens_hyperevm_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/tokens_hyperevm_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/tokens_hyperevm_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/transfers/stablecoins_hyperevm_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/transfers/stablecoins_hyperevm_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/transfers/stablecoins_hyperevm_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/transfers/stablecoins_hyperevm_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/transfers/stablecoins_hyperevm_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/hyperevm/transfers/stablecoins_hyperevm_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ink/tokens_ink_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ink/tokens_ink_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ink/tokens_ink_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ink/tokens_ink_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ink/tokens_ink_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ink/tokens_ink_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ink/transfers/stablecoins_ink_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ink/transfers/stablecoins_ink_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ink/transfers/stablecoins_ink_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ink/transfers/stablecoins_ink_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ink/transfers/stablecoins_ink_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ink/transfers/stablecoins_ink_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/kaia/tokens_kaia_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/kaia/tokens_kaia_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/kaia/tokens_kaia_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/kaia/tokens_kaia_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/kaia/tokens_kaia_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/kaia/tokens_kaia_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/kaia/transfers/stablecoins_kaia_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/kaia/transfers/stablecoins_kaia_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/kaia/transfers/stablecoins_kaia_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/kaia/transfers/stablecoins_kaia_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/kaia/transfers/stablecoins_kaia_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/kaia/transfers/stablecoins_kaia_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/katana/tokens_katana_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/katana/tokens_katana_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/katana/tokens_katana_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/katana/tokens_katana_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/katana/tokens_katana_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/katana/tokens_katana_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/katana/transfers/stablecoins_katana_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/katana/transfers/stablecoins_katana_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/katana/transfers/stablecoins_katana_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/katana/transfers/stablecoins_katana_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/katana/transfers/stablecoins_katana_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/katana/transfers/stablecoins_katana_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/linea/tokens_linea_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/linea/tokens_linea_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/linea/tokens_linea_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/linea/tokens_linea_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/linea/tokens_linea_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/linea/tokens_linea_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/linea/transfers/stablecoins_linea_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/linea/transfers/stablecoins_linea_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/linea/transfers/stablecoins_linea_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/linea/transfers/stablecoins_linea_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/linea/transfers/stablecoins_linea_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/linea/transfers/stablecoins_linea_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/mantle/tokens_mantle_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/mantle/tokens_mantle_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/mantle/tokens_mantle_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/mantle/tokens_mantle_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/mantle/tokens_mantle_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/mantle/tokens_mantle_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/mantle/transfers/stablecoins_mantle_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/mantle/transfers/stablecoins_mantle_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/mantle/transfers/stablecoins_mantle_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/mantle/transfers/stablecoins_mantle_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/mantle/transfers/stablecoins_mantle_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/mantle/transfers/stablecoins_mantle_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/monad/tokens_monad_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/monad/tokens_monad_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/monad/tokens_monad_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/monad/tokens_monad_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/monad/tokens_monad_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/monad/tokens_monad_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/monad/transfers/stablecoins_monad_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/monad/transfers/stablecoins_monad_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/monad/transfers/stablecoins_monad_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/monad/transfers/stablecoins_monad_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/monad/transfers/stablecoins_monad_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/monad/transfers/stablecoins_monad_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/opbnb/tokens_opbnb_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/opbnb/tokens_opbnb_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/opbnb/tokens_opbnb_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/opbnb/tokens_opbnb_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/opbnb/tokens_opbnb_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/opbnb/tokens_opbnb_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/opbnb/transfers/stablecoins_opbnb_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/opbnb/transfers/stablecoins_opbnb_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/opbnb/transfers/stablecoins_opbnb_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/opbnb/transfers/stablecoins_opbnb_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/opbnb/transfers/stablecoins_opbnb_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/opbnb/transfers/stablecoins_opbnb_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/optimism/tokens_optimism_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/optimism/tokens_optimism_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/optimism/tokens_optimism_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/optimism/tokens_optimism_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/optimism/tokens_optimism_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/optimism/tokens_optimism_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/optimism/transfers/stablecoins_optimism_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/optimism/transfers/stablecoins_optimism_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/optimism/transfers/stablecoins_optimism_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/optimism/transfers/stablecoins_optimism_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/optimism/transfers/stablecoins_optimism_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/optimism/transfers/stablecoins_optimism_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/plasma/tokens_plasma_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/plasma/tokens_plasma_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/plasma/tokens_plasma_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/plasma/tokens_plasma_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/plasma/tokens_plasma_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/plasma/tokens_plasma_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/plasma/transfers/stablecoins_plasma_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/plasma/transfers/stablecoins_plasma_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/plasma/transfers/stablecoins_plasma_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/plasma/transfers/stablecoins_plasma_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/plasma/transfers/stablecoins_plasma_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/plasma/transfers/stablecoins_plasma_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/plume/tokens_plume_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/plume/tokens_plume_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/plume/tokens_plume_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/plume/tokens_plume_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/plume/tokens_plume_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/plume/tokens_plume_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/plume/transfers/stablecoins_plume_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/plume/transfers/stablecoins_plume_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/plume/transfers/stablecoins_plume_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/plume/transfers/stablecoins_plume_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/plume/transfers/stablecoins_plume_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/plume/transfers/stablecoins_plume_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/polygon/tokens_polygon_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/polygon/tokens_polygon_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/polygon/tokens_polygon_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/polygon/tokens_polygon_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/polygon/tokens_polygon_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/polygon/tokens_polygon_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/polygon/transfers/stablecoins_polygon_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/polygon/transfers/stablecoins_polygon_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/polygon/transfers/stablecoins_polygon_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/polygon/transfers/stablecoins_polygon_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/polygon/transfers/stablecoins_polygon_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/polygon/transfers/stablecoins_polygon_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ronin/tokens_ronin_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ronin/tokens_ronin_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ronin/tokens_ronin_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ronin/tokens_ronin_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ronin/tokens_ronin_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ronin/tokens_ronin_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ronin/transfers/stablecoins_ronin_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ronin/transfers/stablecoins_ronin_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ronin/transfers/stablecoins_ronin_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ronin/transfers/stablecoins_ronin_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/ronin/transfers/stablecoins_ronin_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/ronin/transfers/stablecoins_ronin_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/scroll/tokens_scroll_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/scroll/tokens_scroll_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/scroll/tokens_scroll_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/scroll/tokens_scroll_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/scroll/tokens_scroll_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/scroll/tokens_scroll_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/scroll/transfers/stablecoins_scroll_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/scroll/transfers/stablecoins_scroll_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/scroll/transfers/stablecoins_scroll_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/scroll/transfers/stablecoins_scroll_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/scroll/transfers/stablecoins_scroll_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/scroll/transfers/stablecoins_scroll_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/sei/tokens_sei_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/sei/tokens_sei_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/sei/tokens_sei_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/sei/tokens_sei_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/sei/tokens_sei_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/sei/tokens_sei_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/sei/transfers/stablecoins_sei_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/sei/transfers/stablecoins_sei_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/sei/transfers/stablecoins_sei_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/sei/transfers/stablecoins_sei_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/sei/transfers/stablecoins_sei_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/sei/transfers/stablecoins_sei_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/somnia/tokens_somnia_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/somnia/tokens_somnia_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/somnia/tokens_somnia_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/somnia/tokens_somnia_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/somnia/tokens_somnia_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/somnia/tokens_somnia_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/somnia/transfers/stablecoins_somnia_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/somnia/transfers/stablecoins_somnia_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/somnia/transfers/stablecoins_somnia_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/somnia/transfers/stablecoins_somnia_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/somnia/transfers/stablecoins_somnia_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/somnia/transfers/stablecoins_somnia_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/sonic/tokens_sonic_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/sonic/tokens_sonic_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/sonic/tokens_sonic_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/sonic/tokens_sonic_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/sonic/tokens_sonic_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/sonic/tokens_sonic_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/sonic/transfers/stablecoins_sonic_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/sonic/transfers/stablecoins_sonic_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/sonic/transfers/stablecoins_sonic_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/sonic/transfers/stablecoins_sonic_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/sonic/transfers/stablecoins_sonic_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/sonic/transfers/stablecoins_sonic_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/stablecoins_evm_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/stablecoins_evm_transfers.sql
@@ -39,6 +39,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_evm',
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/stablecoins_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/stablecoins_transfers.sql
@@ -39,6 +39,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins',
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/story/tokens_story_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/story/tokens_story_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/story/tokens_story_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/story/tokens_story_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/story/tokens_story_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/story/tokens_story_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/story/transfers/stablecoins_story_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/story/transfers/stablecoins_story_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/story/transfers/stablecoins_story_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/story/transfers/stablecoins_story_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/story/transfers/stablecoins_story_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/story/transfers/stablecoins_story_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/taiko/tokens_taiko_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/taiko/tokens_taiko_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/taiko/tokens_taiko_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/taiko/tokens_taiko_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/taiko/tokens_taiko_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/taiko/tokens_taiko_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/taiko/transfers/stablecoins_taiko_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/taiko/transfers/stablecoins_taiko_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/taiko/transfers/stablecoins_taiko_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/taiko/transfers/stablecoins_taiko_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/taiko/transfers/stablecoins_taiko_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/taiko/transfers/stablecoins_taiko_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/tokens_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/tokens_erc20_stablecoins.sql
@@ -42,7 +42,7 @@
     schema = 'tokens',
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     post_hook = '{{ hide_spells() }}'
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/tokens_erc20_stablecoins_metadata.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/tokens_erc20_stablecoins_metadata.sql
@@ -3,7 +3,7 @@
     schema = 'tokens',
     alias = 'erc20_stablecoins_metadata',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     post_hook = '{{ hide_spells() }}'
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/unichain/tokens_unichain_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/unichain/tokens_unichain_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/unichain/tokens_unichain_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/unichain/tokens_unichain_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/unichain/tokens_unichain_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/unichain/tokens_unichain_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/unichain/transfers/stablecoins_unichain_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/unichain/transfers/stablecoins_unichain_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/unichain/transfers/stablecoins_unichain_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/unichain/transfers/stablecoins_unichain_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/unichain/transfers/stablecoins_unichain_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/unichain/transfers/stablecoins_unichain_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/worldchain/tokens_worldchain_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/worldchain/tokens_worldchain_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/worldchain/tokens_worldchain_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/worldchain/tokens_worldchain_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/worldchain/tokens_worldchain_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/worldchain/tokens_worldchain_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/worldchain/transfers/stablecoins_worldchain_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/worldchain/transfers/stablecoins_worldchain_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/worldchain/transfers/stablecoins_worldchain_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/worldchain/transfers/stablecoins_worldchain_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/worldchain/transfers/stablecoins_worldchain_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/worldchain/transfers/stablecoins_worldchain_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/xlayer/tokens_xlayer_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/xlayer/tokens_xlayer_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/xlayer/tokens_xlayer_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/xlayer/tokens_xlayer_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/xlayer/tokens_xlayer_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/xlayer/tokens_xlayer_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/xlayer/transfers/stablecoins_xlayer_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/xlayer/transfers/stablecoins_xlayer_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/xlayer/transfers/stablecoins_xlayer_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/xlayer/transfers/stablecoins_xlayer_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/xlayer/transfers/stablecoins_xlayer_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/xlayer/transfers/stablecoins_xlayer_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/zksync/tokens_zksync_erc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/zksync/tokens_zksync_erc20_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/zksync/tokens_zksync_erc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/zksync/tokens_zksync_erc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/zksync/tokens_zksync_erc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/zksync/tokens_zksync_erc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'erc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/evm/zksync/transfers/stablecoins_zksync_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/zksync/transfers/stablecoins_zksync_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/zksync/transfers/stablecoins_zksync_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/zksync/transfers/stablecoins_zksync_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/evm/zksync/transfers/stablecoins_zksync_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/evm/zksync/transfers/stablecoins_zksync_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/tron/tokens_tron_trc20_stablecoins.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/tron/tokens_tron_trc20_stablecoins.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     schema = 'tokens_' ~ chain,
     alias = 'trc20_stablecoins',
     materialized = 'view',

--- a/dbt_subprojects/tokens/models/stablecoins/tron/tokens_tron_trc20_stablecoins_core.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/tron/tokens_tron_trc20_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'trc20_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/tron/tokens_tron_trc20_stablecoins_extended.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/tron/tokens_tron_trc20_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'trc20_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['prod_exclude', 'static'],
     unique_key = ['contract_address']
   )
 }}

--- a/dbt_subprojects/tokens/models/stablecoins/tron/transfers/stablecoins_tron_core_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/tron/transfers/stablecoins_tron_core_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/tron/transfers/stablecoins_tron_extended_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/tron/transfers/stablecoins_tron_extended_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_transfers',
     materialized = 'incremental',

--- a/dbt_subprojects/tokens/models/stablecoins/tron/transfers/stablecoins_tron_transfers.sql
+++ b/dbt_subprojects/tokens/models/stablecoins/tron/transfers/stablecoins_tron_transfers.sql
@@ -2,6 +2,7 @@
 
 {{
   config(
+    tags = ['prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
     materialized = 'view',


### PR DESCRIPTION
## Summary
- Prod-excludes the in-scope Spellbook stablecoin token-list and transfer writer models under EVM and Tron.
- Prepares Spellbook for the curated-data ownership cutover without changing downstream stablecoin union surfaces.

## Validation
- `uv sync --locked`
- `uv run dbt deps` in `tokens` and `daily_spellbook`
- `uv run dbt parse` in `tokens` and `daily_spellbook`
- `uv run dbt ls --select path:models/stablecoins/evm path:models/stablecoins/tron --exclude tag:prod_exclude --resource-type model --output name` returned no nodes selected
- `uv run dbt compile --select stablecoins_multichain_transfers stablecoins_multichain_tokens`
- `uv run dbt compile --select stablecoins_multichain_tokens`

Made with [Cursor](https://cursor.com)