### PR TITLE
fix(dex): drop CoW-nested 0x Settler fills from dex_aggregator

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/zeroex/zeroex_settler_agg.sql
+++ b/dbt_subprojects/dex/macros/models/_project/zeroex/zeroex_settler_agg.sql
@@ -25,11 +25,18 @@
 
 WITH settler AS (
     SELECT
-        tx_hash, block_time, block_number, method_id, settler_address, zid, tag, rn, cow_rn,
+        tx_hash, block_time, block_number, method_id, settler_address, zid, tag, rn,
         buy_token, min_amount_out, settler_msgsender
     FROM {{ ref('zeroex_v2_' ~ blockchain ~ '_settler_txs') }}
     -- exclude the sentinel zid (non-trade fills), matching the zeroex_v2 pipeline this replaces
     WHERE zid != 0xa00000000000000000000000
+      -- Drop 0x Settler fills that execute *inside* a CoW Protocol settlement (cow_rn is set in the
+      -- settler-txs staging when the GPv2Settlement address appears in the Settler call's input). There
+      -- the user's trade is the CoW order — already captured by the cow_protocol model — and the Settler
+      -- call is only the solver's internal routing leg. Emitting it double-counts the same swap and
+      -- collides with the cow_protocol row on the dex_aggregator key (blockchain, tx_hash, evt_index,
+      -- trace_address). (Underlying-venue volume from such fills is still captured in dex.trades.)
+      AND cow_rn IS NULL
     {% if is_incremental() %}
     AND {{ incremental_predicate('block_time') }}
     {% else %}
@@ -60,7 +67,7 @@ txs AS (
 
 calls AS (
     SELECT
-        s.tx_hash, s.block_time, s.block_number, s.settler_address, s.zid, s.tag, s.rn, s.cow_rn,
+        s.tx_hash, s.block_time, s.block_number, s.settler_address, s.zid, s.tag, s.rn,
         -- guard the floor against "no minimum" sentinels (minAmountOut >= 2^128): null them so the
         -- fallback yields null volume rather than an absurd amount. real amounts are far below 2^128.
         CASE WHEN s.min_amount_out < UINT256 '{{ max_plausible_amount }}' THEN s.min_amount_out END AS min_amount_out,
@@ -132,15 +139,13 @@ trades AS (
         c.block_time, c.block_number, c.tx_hash, c.tx_from, c.tx_to, c.zid, c.tag,
         c.rn AS evt_index, c.settler_address AS contract_address, c.receiver AS taker,
         c.buy_token AS token_bought_address,
-        -- CoW-batched settler fills (cow_rn set): tx-level receiver is the CoW solver/settlement, not the user,
-        -- so the receiver-pivot transfer match is unreliable amid the whole batch's transfers. Fall back to the
-        -- deterministic minAmountOut floor for the bought leg and leave the sell leg null rather than risk
-        -- mis-assigning another order's transfer. buyToken itself is still the deterministic calldata value.
-        CASE WHEN c.cow_rn IS NOT NULL THEN c.min_amount_out
-             WHEN l.buy_n = 1 THEN l.buy_amount
+        -- bought leg = the unique Transfer(buyToken, to=receiver); fall back to the deterministic
+        -- minAmountOut floor when the receiver-pivot match isn't unique. (CoW-nested settler fills are
+        -- excluded upstream in the `settler` CTE, so the receiver pivot is reliable for the rows kept here.)
+        CASE WHEN l.buy_n = 1 THEN l.buy_amount
              ELSE c.min_amount_out END AS token_bought_amount_raw,
-        CASE WHEN c.cow_rn IS NULL AND l.sell_n = 1 THEN l.sell_token END AS token_sold_address,
-        CASE WHEN c.cow_rn IS NULL AND l.sell_n = 1 THEN l.sell_amount END AS token_sold_amount_raw
+        CASE WHEN l.sell_n = 1 THEN l.sell_token  END AS token_sold_address,
+        CASE WHEN l.sell_n = 1 THEN l.sell_amount END AS token_sold_amount_raw
     FROM calls c
     LEFT JOIN legs l ON l.tx_hash = c.tx_hash AND l.rn = c.rn
 ),


### PR DESCRIPTION
## Problem

The Snowflake datashare deployment `snowflake-delta_prod-dex_aggregator-trades` has been failing every hour since **2026-06-23 17:00 UTC** with:

```
ProgrammingError: 100090 (42P18): Duplicate row detected during DML action
```

Snowflake's MERGE aborts because two source rows share the datashare key `(blockchain, tx_hash, evt_index, trace_address)`.

## Root cause

The duplicates are **`0x API`/`settler` + `cow_protocol`** pairs for the same on-chain swap. When 0x acts as a **CoW solver**, the settlement runs through CoW's `GPv2Settlement` (`0x9008d19f…`) and the solver routes the fill through 0x's Settler contract *inside* that transaction. `zeroex_settler_agg` then emitted a separate `0x API`/`settler` aggregator row for that internal routing leg — double-counting the trade the `cow_protocol` model already captures, with a colliding key.

Verified end-to-end on tx [`0x6f68618e…1c2ff1`](https://arbiscan.io/tx/0x6f68618ef57b7f13664268dbd2c60df8ea982950dbba9ea5bb0ff5078a1c2ff1) (Arbitrum): `To = CoW GPv2Settlement`, method `settle()`, the only `Trade` event is CoW's, and the call stack is **user CoW order → solver `settle()` → 0x Settler `execute` → Uniswap V4**. The `0x API` row's `taker` is the *solver*, its sell-leg is `NULL`, and its bought amount is the minAmountOut floor — i.e. a degraded phantom, not a user 0x-API trade.

Scope: in the datashare's stuck merge window, **all 48 colliding groups (96 rows)** are this pattern; ~25 phantom rows/day across chains.

## Fix

The settler-txs staging already flags these fills via `cow_rn` (set when the `GPv2Settlement` address appears in the Settler call's input). This PR filters them out in `zeroex_settler_agg` instead of emitting the degraded row, and removes the now-dead `cow_rn` branches.

- **Affected:** aggregator lineage `zeroex_v2_*_trades → zeroex_trades → dex_aggregator.trades` (all 17 chains, one macro).
- **Deliberately unchanged:** the RFQ/PMM path feeding `dex.trades` — there a CoW-solver 0x-RFQ fill is a *legitimate underlying-venue* trade and must be kept.

## Validation

- `dbt compile --select zeroex_v2_arbitrum_trades` passes; the `AND cow_rn IS NULL` predicate is present in the compiled SQL.
- Confirmed via the dune duplicate queries that `(key + project)` is unique, so removing the 0x phantom rows eliminates the collisions at the source.
- After merge + a `dex_aggregator.trades` refresh, the datashare MERGE should succeed (no more 100090). Existing double-counted rows already in Snowflake may need a one-off `cleanup_duplicates.py`.

## Notes / follow-ups
- Datashare key (`tables/prod/snowflake/dex_aggregator.yaml`) is `[blockchain, tx_hash, evt_index, trace_address]` — narrower than the dbt model's `unique_key` (which includes `project`, `version`). Worth aligning as defense-in-depth, but this PR removes the bad rows at the source, which is the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
