### PR TITLE
fix(dex): add trace_address to zeroex_v2_*_trades unique_key (incremental merge regression)

### DIFF
--- a/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_arbitrum_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_arbitrum_schema.yml
@@ -310,6 +310,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - *blockchain
       - *block_date

--- a/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_v2_arbitrum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/arbitrum/zeroex_v2_arbitrum_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_avalanche_c_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_avalanche_c_schema.yml
@@ -215,6 +215,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - *blockchain
       - *block_date

--- a/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_v2_avalanche_c_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_v2_avalanche_c_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_base_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_base_schema.yml
@@ -197,6 +197,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - *blockchain
       - *block_date

--- a/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_v2_base_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_v2_base_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/berachain/zeroex_berachain_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/berachain/zeroex_berachain_schema.yml
@@ -62,6 +62,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - &blockchain
         name: blockchain

--- a/dbt_subprojects/dex/models/_projects/zeroex/berachain/zeroex_v2_berachain_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/berachain/zeroex_v2_berachain_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/blast/zeroex_blast_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/blast/zeroex_blast_schema.yml
@@ -62,6 +62,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - &blockchain
         name: blockchain

--- a/dbt_subprojects/dex/models/_projects/zeroex/blast/zeroex_v2_blast_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/blast/zeroex_v2_blast_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/bnb/zeroex_bnb_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/bnb/zeroex_bnb_schema.yml
@@ -282,6 +282,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - *blockchain
       - *block_date

--- a/dbt_subprojects/dex/models/_projects/zeroex/bnb/zeroex_v2_bnb_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/bnb/zeroex_v2_bnb_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_ethereum_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_ethereum_schema.yml
@@ -272,6 +272,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - *blockchain
       - *block_date

--- a/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_v2_ethereum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/ethereum/zeroex_v2_ethereum_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/ink/zeroex_ink_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/ink/zeroex_ink_schema.yml
@@ -62,6 +62,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - &blockchain
         name: blockchain

--- a/dbt_subprojects/dex/models/_projects/zeroex/ink/zeroex_v2_ink_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/ink/zeroex_v2_ink_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/linea/zeroex_linea_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/linea/zeroex_linea_schema.yml
@@ -62,6 +62,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - &blockchain
         name: blockchain

--- a/dbt_subprojects/dex/models/_projects/zeroex/linea/zeroex_v2_linea_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/linea/zeroex_v2_linea_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/mantle/zeroex_mantle_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/mantle/zeroex_mantle_schema.yml
@@ -62,6 +62,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - &blockchain
         name: blockchain

--- a/dbt_subprojects/dex/models/_projects/zeroex/mantle/zeroex_v2_mantle_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/mantle/zeroex_v2_mantle_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/mode/zeroex_mode_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/mode/zeroex_mode_schema.yml
@@ -62,6 +62,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - &blockchain
         name: blockchain

--- a/dbt_subprojects/dex/models/_projects/zeroex/mode/zeroex_v2_mode_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/mode/zeroex_v2_mode_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/monad/zeroex_monad_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/monad/zeroex_monad_schema.yml
@@ -62,6 +62,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - &blockchain
         name: blockchain

--- a/dbt_subprojects/dex/models/_projects/zeroex/monad/zeroex_v2_monad_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/monad/zeroex_v2_monad_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/optimism/zeroex_optimism_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/optimism/zeroex_optimism_schema.yml
@@ -266,6 +266,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - *blockchain
       - *block_date

--- a/dbt_subprojects/dex/models/_projects/zeroex/optimism/zeroex_v2_optimism_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/optimism/zeroex_v2_optimism_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/polygon/zeroex_polygon_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/polygon/zeroex_polygon_schema.yml
@@ -359,6 +359,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - *blockchain
       - *block_date

--- a/dbt_subprojects/dex/models/_projects/zeroex/polygon/zeroex_v2_polygon_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/polygon/zeroex_v2_polygon_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/scroll/zeroex_scroll_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/scroll/zeroex_scroll_schema.yml
@@ -62,6 +62,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - &blockchain
         name: blockchain

--- a/dbt_subprojects/dex/models/_projects/zeroex/scroll/zeroex_v2_scroll_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/scroll/zeroex_v2_scroll_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/unichain/zeroex_unichain_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/unichain/zeroex_unichain_schema.yml
@@ -62,6 +62,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - &blockchain
         name: blockchain

--- a/dbt_subprojects/dex/models/_projects/zeroex/unichain/zeroex_v2_unichain_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/unichain/zeroex_v2_unichain_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/worldchain/zeroex_v2_worldchain_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/worldchain/zeroex_v2_worldchain_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized='incremental',
     partition_by = ['block_month'],
-    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+    unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
     on_schema_change='sync_all_columns',
     file_format ='delta',
     incremental_strategy='merge',

--- a/dbt_subprojects/dex/models/_projects/zeroex/worldchain/zeroex_worldchain_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/worldchain/zeroex_worldchain_schema.yml
@@ -62,6 +62,7 @@ models:
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
     columns:
       - &blockchain
         name: blockchain


### PR DESCRIPTION
## Problem

After #9823 merged, the incremental dbt runs fail across **all 11 settler chains** ([run 70471885328709](https://nd058.us1.dbt.com/deploy/58579/projects/372284/runs/70471885328709/)):

```
TrinoUserError(MERGE_TARGET_ROW_MULTIPLE_MATCHES,
  "One MERGE target table row matched more than one source row")
```

`dex_aggregator.dex_aggregator_trades` is then **SKIPPED** (`PASS=0 ERROR=11 SKIP=1`), so `dex_aggregator.trades` stops updating.

## Root cause

#9823 set `evt_index = CAST(-1 AS integer)` for every 0x Settler aggregator row (plus the real `trace_address`). That fixed the **datashare** collision — its merge key `(blockchain, tx_hash, evt_index, trace_address)` includes `trace_address`.

But the upstream `zeroex_v2_<chain>_trades` incremental models key their **own** merge on `['block_month','block_date','tx_hash','evt_index']` — **no `trace_address`**. With `evt_index` collapsed to the constant `-1`, a tx with ≥2 settler calls now yields ≥2 rows sharing `(block_month, block_date, tx_hash, -1)`, so the incremental `merge` matches one target row to multiple source rows.

The 16:42 full-refresh masked it (CTAS inserts dupes without a merge); the incremental run right after did not.

`paraswap_v6` uses `evt_index = -1` safely **only because its `unique_key` includes `trace_address`**. The `zeroex_v2` models' did not — so `evt_index = -1` needed a matching key change that wasn't made.

## Fix

Add `'trace_address'` to the `unique_key` of all 17 `zeroex_v2_<chain>_trades` models (keep `evt_index = -1`). The real per-call trace path disambiguates multi-settler-call txs — same pattern as `paraswap_v6`.

```diff
- unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index'],
+ unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
```

## Validation

- Verified on the rebuilt data (`block_date ≥ 2026-06-22`, `0x API`/`settler`): `(blockchain, tx_hash, evt_index)` has **366k+ colliding groups**, but `(blockchain, tx_hash, evt_index, trace_address)` has **0** — `trace_address` fully disambiguates.
- **No full-refresh needed**: existing rows are already distinct on the new key, so the next incremental `merge` keys correctly against them.
- `dbt compile --select zeroex_v2_arbitrum_trades` passes.
- Proven precedent: `paraswap_v6_*_trades` already ships `evt_index = -1` with `trace_address` in `unique_key` on the same trino/dunesql merge adapter.

## Scope
17 model configs, one line each. No SQL/logic change; `evt_index = -1` and the real `trace_address` from #9823 are retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
