### PR TITLE
fix(solana): align daily balances merge grain

### DIFF
--- a/dbt_subprojects/solana/models/solana_utils/_schema.yml
+++ b/dbt_subprojects/solana/models/solana_utils/_schema.yml
@@ -48,6 +48,12 @@ models:
       tags: ['solana','balances']
     description: >
         get the daily balances for each address, from which we can materialize a latest balance later on.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - day
+              - address
     columns:
       - &day
         name: day

--- a/dbt_subprojects/solana/models/solana_utils/solana_utils_daily_balances.sql
+++ b/dbt_subprojects/solana/models/solana_utils/solana_utils_daily_balances.sql
@@ -47,7 +47,7 @@ SELECT
       , token_balance_owner
       , block_time
       , block_slot
-      , {{ dbt_utils.generate_surrogate_key(['address', 'token_mint_address', 'day']) }} as unique_address_key
+      , {{ dbt_utils.generate_surrogate_key(['address', 'day']) }} as unique_address_key
       , now() as updated_at
 FROM updated_balances
 WHERE latest_balance = 1


### PR DESCRIPTION
Fixes the incremental merge key for solana_utils.daily_balances so it matches the model's address/day output grain. Adds a dbt uniqueness test for that grain; existing duplicate rows will still require a full refresh/backfill of the table.