### PR TITLE
fix(zeroex): drop max-uint corrupted settler trades causing dex_aggregator.trades outliers

### DIFF
--- a/dbt_subprojects/dex/models/_projects/zeroex/zeroex_api_fills_deduped.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/zeroex_api_fills_deduped.sql
@@ -39,6 +39,8 @@
 ] %}
 
 
+SELECT * FROM (
+
 SELECT *
 FROM (
     {% for model in zeroex_models %}
@@ -67,8 +69,8 @@ FROM (
       ,trace_address
       ,evt_index
       ,affiliate_address
-      ,null as zid 
-      ,type 
+      ,null as zid
+      ,type
     FROM {{ model }}
     {% if not loop.last %}
     UNION ALL
@@ -76,7 +78,7 @@ FROM (
     {% endfor %}
 )
 
-UNION ALL 
+UNION ALL
 
 SELECT *
 FROM (
@@ -105,7 +107,7 @@ FROM (
       ,tx_to
       ,trace_address
       ,evt_index
-      ,tag as affiliate_address 
+      ,tag as affiliate_address
       ,zid
       ,type
     FROM {{ model }}
@@ -114,3 +116,14 @@ FROM (
     {% endif %}
     {% endfor %}
 )
+
+)
+-- Corruption guard: drop reconstructions whose raw token amount has the high (sign) bit
+-- set (>= 2^255). 0x Settler trades are rebuilt from matched on-chain logs; signed/negative
+-- int256 deltas in AMM swap events (e.g. Uniswap V3 Swap, encoded as 0xfff...) get picked up
+-- by the fixed-offset byte extraction, yielding type(uint256).max-scale amounts and
+-- astronomically large amount_usd (~1e71) that break the dex_aggregator.trades amount_usd
+-- accepted_range test. A real ERC20 amount never approaches 2^255 (~5.8e76), so this is an
+-- unambiguous, lossless guard (removes ~0.02% of settler rows; all confirmed corrupt).
+WHERE (taker_token_amount_raw IS NULL OR taker_token_amount_raw < power(2, 255))
+  AND (maker_token_amount_raw IS NULL OR maker_token_amount_raw < power(2, 255))


### PR DESCRIPTION
## Summary

Triage + fix for the recurring **`dex.aggregator_trades.dbt_utils_accepted_range_dex_aggregator_trades_amount_usd__1000000000`** failures in the `[test] dex schemas` dbt Cloud job (failing every run since **2026-06-25**).

## Root cause

All outliers are **`project = '0x API'`, `version = 'settler'`** with `amount_usd ≈ 1e71`.

Inspecting the rows, `token_sold_amount_raw = 115792089237316195423570985008687907853269984665640564039457584007913129639935` = exactly **`2^256 - 1` (`type(uint256).max`)**. The actual on-chain transfers for these txs are normal (e.g. the flagged USDC sale was really `142286096` = ~$142).

The bad value is **fabricated by the 0x-Settler trade reconstruction** (`zeroex_v2` macro → `zeroex.api_fills_deduped` → `zeroex.trades` → `dex_aggregator.trades` as an `as_is` source). Settler trades are rebuilt from matched on-chain logs; the macro matches AMM swap events (e.g. Uniswap V3 `Swap`, `topic0 0xc42079…`) whose `data` words are **signed `int256` deltas** encoded as `0xfff…`. The fixed-offset `bytearray_substring(...)` amount extraction picks up those `0xff…` bytes, so the reconstructed raw amount overflows to `~type(uint256).max`. When the token is priced (USDC/USDT/WETH), `amount_usd` explodes to ~1e71.

This is **long-standing data corruption** (present since **2024-11**, ~0.02% of settler rows) — not a new bug. A prior incident (2026-01-10, #9188/#9200) treated a different symptom (bad price feeds), not the corrupt amounts.

## Why it started failing now

The corrupt rows have always existed, but `dex_aggregator.trades` is incremental with a 7-day merge window, so historical bad rows weren't normally (re)asserted. On **2026-06-24 a full refresh re-merged the entire backlog**:

- 5,279 outlier rows, `block_date` from **2024-11-14 → 2026-06-24**, **all** with `_updated_at = 2026-06-24`.

So from 2026-06-25 onward the test sees the full historical backlog and fails every run.

## Fix

Add a **corruption guard** at the zeroex source (`zeroex_api_fills_deduped`, a view — also cleans the exposed `zeroex.trades`): drop any reconstruction whose raw token amount has the **high (sign) bit set (`>= 2^255`)**. A real ERC20 amount never approaches `2^255` (~5.8e76), so the filter is unambiguous and lossless.

### Verification (run on prod via Dune)
- Catches **5,317 / 5,317** settler rows with `amount_usd > 1e9` (**100%**); none fall below `2^255`.
- Removes **~42,555 of 211M** settler rows (**0.02%**).
- Collapses inflated settler volume from **9.5e75 → realistic $63.3B**.

## Follow-ups (not in this PR)
- **Operational:** `dex_aggregator.trades` (and `zeroex.trades` if materialized) needs a **full refresh** to purge the already-merged backlog; the incremental window only self-heals the last 7 days.
- **Deeper fix:** harden the `zeroex_v2` amount extraction so it doesn't pick up signed/negative AMM `Swap` deltas in the first place (this PR is the safe, targeted guard).