### PR TITLE
fix(dex): guard 0x Settler sell leg against unlimited-permit sentinels (CUR2-2903)

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/zeroex/zeroex_settler_agg.sql
+++ b/dbt_subprojects/dex/macros/models/_project/zeroex/zeroex_settler_agg.sql
@@ -88,8 +88,13 @@ calls AS (
         CASE WHEN s.buy_token IN {{ native_tokens }} THEN nt.token_address ELSE s.buy_token END AS buy_token,
         nt.token_address AS native_addr,
         s.trace_address,
-        s.sell_token_decoded,
-        s.sell_amount_decoded,
+        -- guard the permit-decoded sell leg against "unlimited permit" sentinels (permitted amount
+        -- >= 2^128, e.g. uint256.max): that word is then a Permit2 allowance cap, not the real fill
+        -- size, so null BOTH the token and the amount and let the sell leg fall through to native/null
+        -- (volume still prices off the buy side). Mirrors the min_amount_out floor guard above; without
+        -- it these emit token_sold_amount_raw = uint256.max and absurd volume (~1e71 USD). (CUR2-2903)
+        CASE WHEN s.sell_amount_decoded < UINT256 '{{ max_plausible_amount }}' THEN s.sell_token_decoded END AS sell_token_decoded,
+        CASE WHEN s.sell_amount_decoded < UINT256 '{{ max_plausible_amount }}' THEN s.sell_amount_decoded END AS sell_amount_decoded,
         -- native sell amount: NATIVE_CHECK.msgValue (calldata; robust to nested/AllowanceHolder/4337 calls
         -- where the top-level tx.value is 0), else the top-level tx.value. NULLIF so a decoded 0 (e.g. a
         -- zero-msgValue NATIVE_CHECK) falls through to tx.value instead of sticking at 0.


### PR DESCRIPTION
## Summary

Fixes the `dex_aggregator.trades` (and `dex.trades`) `amount_usd` outliers (~1e71 USD) that have been failing the `[test] dex schemas` job's `dbt_utils.accepted_range(max_value=1e9)` test since ~2026-06-24.

**Root cause is a missing plausibility guard on the 0x Settler sell-leg calldata decode** — not a price feed and not (as an earlier draft wrongly concluded from stale code) a Uniswap event read.

## Why now / lineage

The deterministic settler decoder (`zeroex_settler_agg.sql`, introduced #9800, sell-leg added #9825) resolves the sell leg in precedence:
1. transfer-pivot (`sell_n = 1`) — exact on-chain amount,
2. **calldata permit decode (`sell_amount_decoded`)**,
3. native (`NATIVE_CHECK.msgValue` / `tx.value`).

`sell_amount_decoded` reads the **Permit2 `permitted.amount` word straight from settler calldata** (`zeroex_settler_txs_cte.sql` → `fa_decode`), gated on selector / zero-padding / `> 0` / non-native — but with **no upper-bound guard**. The buy-side floor (`min_amount_out`) *is* capped at `< 2^128` (`zeroex_settler_agg.sql` line 81); the sell side was not.

When a take/VIP action carries an **"unlimited" Permit2 permit**, that word is the allowance cap (commonly `uint256.max`), not the real fill size → `token_sold_amount_raw = 2^256-1` → once the sold token is priced, `volume_usd ≈ 1e71`.

### Verified on-chain
- Example tx `0x82ed…ed872`: staging `sell_amount_decoded = 2^256-1` (uint256.max), `sell_token = USDC`, real USDC transfer was only `142286096` ($142). Sell transfer-pivot legitimately misses (`sell_n=0`: the user's USDC is pulled via Permit2 from a non-receiver address), so it falls back to the sentinel permit amount.
- Ethereum `settler_txs` since 2024-11: **31,858 / 5.40M (0.59%)** decoded sell rows carry a `≥ 2^128` permit amount; every `dex_aggregator` settler outlier (`amount_usd > 1e9`) maps to one of these.

## Fix

Apply the **same `< 2^128` (`max_plausible_amount`) guard** already used for the buy-side floor. When the permit amount is a sentinel, null **both** the decoded sell token and amount so the sell leg falls through to native/NULL; **volume still prices off the buy leg**.

### Validation (fixed decoder re-run on known-bad txs)
| tx | before | after |
|---|---|---|
| `0x82ed…` | taker raw `2^256-1`, vol `1.16e71` | taker NULL, maker AUTO 4611, vol NULL (AUTO unpriced) |
| `0xe804…` | max-uint, ~1e71 | taker NULL, maker USDC, **vol \$267,203** |
| `0x546f…` | max-uint, ~1e71 | taker NULL, maker USDC, **vol \$14,092** |
| `0x2a15…` | max-uint, ~1e71 | taker NULL, maker AUTO, vol NULL |

Real sub-`2^128` permit amounts and transfer-pivot sells are unchanged. `dbt compile` clean. Shared macro → fixes all 17 settler chains at once.

## Operational follow-up (not code)
A coordinated **full-refresh** of `zeroex_v2_<chain>_trades` → `dex_aggregator_trades` is still required to purge the already-written sentinel rows — the incremental merge self-heals only the trailing 7-day window (same caveat #9823 documented).

## Note
Supersedes my earlier draft #9836, which was written against a stale local checkout (pre-#9800) and guarded the wrong layer.