### PR TITLE
perf(chainlink): push incremental bound below upstream GROUP BY in automation_performed_daily

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_performed_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_automation_performed_daily.sql
@@ -11,6 +11,33 @@
   )
 }}
 
+-- The upstream view chainlink_avalanche_c_automation_performed computes
+-- evt_block_time = MAX(block_time) above a GROUP BY, so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the avalanche_c.logs scan and
+-- forces a full-history scan (~52B rows/run) to merge a handful of rows. The view
+-- body is inlined here so the incremental time bound applies BELOW the aggregation
+-- and prunes the Delta scan via block_time file skipping. Each (tx_hash, index,
+-- tx_from) group is a single log, so MAX(block_time) = block_time and the pre-agg
+-- bound selects exactly the same groups as the post-agg evt_block_time predicate
+-- (kept as authoritative).
+WITH automation_performed AS (
+  SELECT
+    'avalanche_c' as blockchain,
+    MAX(operator_name) as operator_name,
+    MAX(COALESCE(keeper_address, automation_logs.tx_from)) as keeper_address,
+    MAX(automation_logs.block_time) as evt_block_time,
+    MAX(bytearray_to_uint256(bytearray_substring(data, 21, 12)) / 1e18) as token_value
+  FROM
+    {{ ref('chainlink_avalanche_c_automation_upkeep_performed_logs') }} automation_logs
+    LEFT JOIN {{ ref('chainlink_avalanche_c_automation_meta') }} automation_meta ON automation_meta.keeper_address = automation_logs.tx_from
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('automation_logs.block_time') }}
+  {% endif %}
+  GROUP BY
+    tx_hash,
+    index,
+    tx_from
+)
 
 SELECT
   'avalanche_c' as blockchain,
@@ -20,7 +47,7 @@ SELECT
   MAX(automation_performed.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_avalanche_c_automation_performed')}} automation_performed
+  automation_performed
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_performed_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_automation_performed_daily.sql
@@ -11,6 +11,33 @@
   )
 }}
 
+-- The upstream view chainlink_bnb_automation_performed computes
+-- evt_block_time = MAX(block_time) above a GROUP BY, so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the bnb.logs scan and
+-- forces a full-history scan (~52B rows/run) to merge a handful of rows. The view
+-- body is inlined here so the incremental time bound applies BELOW the aggregation
+-- and prunes the Delta scan via block_time file skipping. Each (tx_hash, index,
+-- tx_from) group is a single log, so MAX(block_time) = block_time and the pre-agg
+-- bound selects exactly the same groups as the post-agg evt_block_time predicate
+-- (kept as authoritative).
+WITH automation_performed AS (
+  SELECT
+    'bnb' as blockchain,
+    MAX(operator_name) as operator_name,
+    MAX(COALESCE(keeper_address, automation_logs.tx_from)) as keeper_address,
+    MAX(automation_logs.block_time) as evt_block_time,
+    MAX(bytearray_to_uint256(bytearray_substring(data, 21, 12)) / 1e18) as token_value
+  FROM
+    {{ ref('chainlink_bnb_automation_upkeep_performed_logs') }} automation_logs
+    LEFT JOIN {{ ref('chainlink_bnb_automation_meta') }} automation_meta ON automation_meta.keeper_address = automation_logs.tx_from
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('automation_logs.block_time') }}
+  {% endif %}
+  GROUP BY
+    tx_hash,
+    index,
+    tx_from
+)
 
 SELECT
   'bnb' as blockchain,
@@ -20,7 +47,7 @@ SELECT
   MAX(automation_performed.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_bnb_automation_performed')}} automation_performed
+  automation_performed
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_performed_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_automation_performed_daily.sql
@@ -11,6 +11,33 @@
   )
 }}
 
+-- The upstream view chainlink_ethereum_automation_performed computes
+-- evt_block_time = MAX(block_time) above a GROUP BY, so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the ethereum.logs scan and
+-- forces a full-history scan (~52B rows/run) to merge a handful of rows. The view
+-- body is inlined here so the incremental time bound applies BELOW the aggregation
+-- and prunes the Delta scan via block_time file skipping. Each (tx_hash, index,
+-- tx_from) group is a single log, so MAX(block_time) = block_time and the pre-agg
+-- bound selects exactly the same groups as the post-agg evt_block_time predicate
+-- (kept as authoritative).
+WITH automation_performed AS (
+  SELECT
+    'ethereum' as blockchain,
+    MAX(operator_name) as operator_name,
+    MAX(COALESCE(keeper_address, automation_logs.tx_from)) as keeper_address,
+    MAX(automation_logs.block_time) as evt_block_time,
+    MAX(bytearray_to_uint256(bytearray_substring(data, 21, 12)) / 1e18) as token_value
+  FROM
+    {{ ref('chainlink_ethereum_automation_upkeep_performed_logs') }} automation_logs
+    LEFT JOIN {{ ref('chainlink_ethereum_automation_meta') }} automation_meta ON automation_meta.keeper_address = automation_logs.tx_from
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('automation_logs.block_time') }}
+  {% endif %}
+  GROUP BY
+    tx_hash,
+    index,
+    tx_from
+)
 
 SELECT
   'ethereum' as blockchain,
@@ -20,7 +47,7 @@ SELECT
   MAX(automation_performed.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_ethereum_automation_performed')}} automation_performed
+  automation_performed
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_performed_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_automation_performed_daily.sql
@@ -11,6 +11,33 @@
   )
 }}
 
+-- The upstream view chainlink_fantom_automation_performed computes
+-- evt_block_time = MAX(block_time) above a GROUP BY, so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the fantom.logs scan and
+-- forces a full-history scan (~52B rows/run) to merge a handful of rows. The view
+-- body is inlined here so the incremental time bound applies BELOW the aggregation
+-- and prunes the Delta scan via block_time file skipping. Each (tx_hash, index,
+-- tx_from) group is a single log, so MAX(block_time) = block_time and the pre-agg
+-- bound selects exactly the same groups as the post-agg evt_block_time predicate
+-- (kept as authoritative).
+WITH automation_performed AS (
+  SELECT
+    'fantom' as blockchain,
+    MAX(operator_name) as operator_name,
+    MAX(COALESCE(keeper_address, automation_logs.tx_from)) as keeper_address,
+    MAX(automation_logs.block_time) as evt_block_time,
+    MAX(bytearray_to_uint256(bytearray_substring(data, 21, 12)) / 1e18) as token_value
+  FROM
+    {{ ref('chainlink_fantom_automation_upkeep_performed_logs') }} automation_logs
+    LEFT JOIN {{ ref('chainlink_fantom_automation_meta') }} automation_meta ON automation_meta.keeper_address = automation_logs.tx_from
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('automation_logs.block_time') }}
+  {% endif %}
+  GROUP BY
+    tx_hash,
+    index,
+    tx_from
+)
 
 SELECT
   'fantom' as blockchain,
@@ -20,7 +47,7 @@ SELECT
   MAX(automation_performed.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_fantom_automation_performed')}} automation_performed
+  automation_performed
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_performed_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_automation_performed_daily.sql
@@ -11,6 +11,33 @@
   )
 }}
 
+-- The upstream view chainlink_polygon_automation_performed computes
+-- evt_block_time = MAX(block_time) above a GROUP BY, so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the polygon.logs scan and
+-- forces a full-history scan (~52B rows/run) to merge a handful of rows. The view
+-- body is inlined here so the incremental time bound applies BELOW the aggregation
+-- and prunes the Delta scan via block_time file skipping. Each (tx_hash, index,
+-- tx_from) group is a single log, so MAX(block_time) = block_time and the pre-agg
+-- bound selects exactly the same groups as the post-agg evt_block_time predicate
+-- (kept as authoritative).
+WITH automation_performed AS (
+  SELECT
+    'polygon' as blockchain,
+    MAX(operator_name) as operator_name,
+    MAX(COALESCE(keeper_address, automation_logs.tx_from)) as keeper_address,
+    MAX(automation_logs.block_time) as evt_block_time,
+    MAX(bytearray_to_uint256(bytearray_substring(data, 21, 12)) / 1e18) as token_value
+  FROM
+    {{ ref('chainlink_polygon_automation_upkeep_performed_logs') }} automation_logs
+    LEFT JOIN {{ ref('chainlink_polygon_automation_meta') }} automation_meta ON automation_meta.keeper_address = automation_logs.tx_from
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('automation_logs.block_time') }}
+  {% endif %}
+  GROUP BY
+    tx_hash,
+    index,
+    tx_from
+)
 
 SELECT
   'polygon' as blockchain,
@@ -20,7 +47,7 @@ SELECT
   MAX(automation_performed.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_polygon_automation_performed')}} automation_performed
+  automation_performed
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}


### PR DESCRIPTION
The five `chainlink_<chain>_automation_performed_daily` models (polygon, bnb, ethereum, avalanche_c, fantom) re-scan their chain's entire `logs` table on every incremental run to merge a handful of daily rows. This pushes the incremental time bound below the upstream aggregation so the Delta scan prunes by `block_time` file-skipping.

## Root cause (incremental predicate stranded above an upstream GROUP BY)

`chainlink_<chain>_automation_performed` is a view that computes `evt_block_time = MAX(block_time)` above `GROUP BY tx_hash, index, tx_from`. The daily model filtered the view output with `WHERE incremental_predicate('evt_block_time')` — but `evt_block_time` is an aggregate, so the predicate cannot reach the `<chain>.logs` scan. Every run scanned full history (polygon: 52.3B rows / 1536 GB) with only the topic0 `IN` filter applied locally (selectivity 0.000043), then dropped ~everything by the post-aggregation date filter. Same pattern fixed for `chainlink_polygon_vrf_request_fulfilled_daily` in #9766.

## Fix

Inline the view body into each daily model and add `WHERE incremental_predicate('automation_logs.block_time')` **below** the `GROUP BY`, keeping the post-agg `evt_block_time` predicate as authoritative. Each `(tx_hash, index, tx_from)` group is a single log, so `MAX(block_time) = block_time` and the pre-agg bound selects exactly the same groups.

## Proof (read-only, prod, UTC)

Equivalence via per-key `FULL OUTER JOIN` of OLD-recon (input buffered 7d below the boundary, post-agg filter only) vs NEW-recon (pre-agg + post-agg):

| chain | keys | unmatched | date_month diff | operator_name diff | token_amount diff >1e-6 | max rel token diff |
|---|---|---|---|---|---|---|
| polygon | 166 | 0 | 0 | 0 | 0 | 1.3e-15 |
| bnb | 81 | 0 | 0 | 0 | 0 | 9.6e-16 |
| ethereum | 81 | 0 | 0 | 0 | 0 | 3.0e-16 |
| avalanche_c | 46 | 0 | 0 | 0 | 0 | 0.0 (bit-identical) |
| fantom (wide window) | 3876 | 0 | 0 | 0 | 0 | 7.7e-16 |

All non-double columns are bit-identical; `token_amount` differs only at FP-noise scale (`SUM(double)` non-associativity, max relative diff 1.3e-15). The exactness invariant `count(distinct block_time) > 1 per (tx_hash, index, tx_from) group = 0` was confirmed (each group is one log).

## A/B (3 warm runs, median; spellbook-sqlmesh)

| chain | metric | OLD (prod MERGE) | NEW (3-day bound) | Δ |
|---|---|---|---|---|
| polygon | IO | 1536 GB | 7.43 GB | ~207× |
| polygon | CPU | 7,394 cpu_s | 15.3 cpu_s | scan was 99% of CPU |
| polygon | peak / spill | 4.35 GB / 27 MB | 0.07 GB / 0 | |
| bnb | IO | 1291 GB | 8.08 GB | ~160× |
| bnb | CPU | 4,690 cpu_s | 12.6 cpu_s | |

Scan rows polygon 52.3B → 308M (block_time file-skipping to the 3-day incremental window).

## Expected family impact (spellbook-daily)

Five models combined: IO ~3196 GB/day → ~35 GB/day (**~−3.16 TB/day**), CPU ~3.90 → ~0.1 CPU-hrs/day (**~−3.8 CPU-hrs/day**), per-build wall ~108 min/day → seconds, peak 4.35 → 0.07 GB, spill eliminated. The change lives entirely in the `is_incremental()` branch, so full-refresh is unaffected (the output is identical; no backfill needed).

Fixes CUR2-2972
