### PR TITLE
perf(chainlink): push incremental bound below upstream GROUP BY in ccip_send_requested_daily (x7)

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_send_requested_daily.sql
@@ -75,8 +75,11 @@ SELECT
   cast(date_trunc('day', evt_block_time) AS date) AS date_start,
   MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
   SUM(ccip_send_requested.fee_token_amount) as fee_amount,
-  ccip_send_requested.token as token,
-  ccip_send_requested.destination_blockchain AS destination_blockchain,
+  -- coalesce nullable unique_key columns: destination_blockchain is unmapped (always NULL) and
+  -- token is NULL for unmapped fee tokens; a NULL merge key makes the incremental MERGE silently
+  -- double-insert (Trino NULL != NULL), so non-null sentinels keep the key dedup-safe.
+  coalesce(ccip_send_requested.token, 'unknown') as token,
+  coalesce(ccip_send_requested.destination_blockchain, 'unknown') AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
   ccip_send_requested

--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_send_requested_daily.sql
@@ -10,6 +10,65 @@
   )
 }}
 
+-- The upstream view chainlink_arbitrum_ccip_send_requested groups its source logs by tx_hash and
+-- exposes evt_block_time = MAX(block_time), so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the arbitrum.logs scan and forces a
+-- full-history scan (~100B rows/run) to merge a handful of rows. The view body is inlined here so
+-- the incremental time bound applies BELOW the tx_hash aggregation and prunes the Delta logs scan
+-- via block_time file skipping. Every log of a transaction shares that transaction's block_time
+-- (one tx = one block), so MAX(block_time) = block_time per group and the pre-agg bound selects
+-- exactly the same tx_hash groups as the post-agg evt_block_time predicate (kept as authoritative).
+WITH combined_logs AS (
+  SELECT
+    ccip_logs_v1.blockchain,
+    ccip_logs_v1.block_time,
+    ccip_logs_v1.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1.fee_token,
+    ccip_logs_v1.destination_selector,
+    ccip_logs_v1.destination_blockchain,
+    ccip_logs_v1.tx_hash
+  FROM
+    {{ ref('chainlink_arbitrum_ccip_send_requested_logs_v1') }} ccip_logs_v1
+    LEFT JOIN {{ ref('chainlink_arbitrum_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1.block_time') }}
+  {% endif %}
+
+  UNION ALL
+
+  SELECT
+    ccip_logs_v1_2.blockchain,
+    ccip_logs_v1_2.block_time,
+    ccip_logs_v1_2.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1_2.fee_token,
+    ccip_logs_v1_2.destination_selector,
+    ccip_logs_v1_2.destination_blockchain,
+    ccip_logs_v1_2.tx_hash
+  FROM
+    {{ ref('chainlink_arbitrum_ccip_send_requested_logs_v1_2') }} ccip_logs_v1_2
+    LEFT JOIN {{ ref('chainlink_arbitrum_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1_2.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1_2.block_time') }}
+  {% endif %}
+),
+
+ccip_send_requested AS (
+  SELECT
+    MAX(blockchain) AS blockchain,
+    MAX(block_time) AS evt_block_time,
+    SUM(fee_token_amount) AS fee_token_amount,
+    MAX(token) AS token,
+    MAX(fee_token) AS fee_token,
+    MAX(destination_selector) AS destination_selector,
+    MAX(destination_blockchain) AS destination_blockchain,
+    MAX(tx_hash) AS tx_hash
+  FROM
+    combined_logs
+  GROUP BY
+    tx_hash
+)
 
 SELECT
   'arbitrum' as blockchain,
@@ -20,7 +79,7 @@ SELECT
   ccip_send_requested.destination_blockchain AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
-  {{ref('chainlink_arbitrum_ccip_send_requested')}} ccip_send_requested
+  ccip_send_requested
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_send_requested_daily.sql
@@ -10,6 +10,65 @@
   )
 }}
 
+-- The upstream view chainlink_avalanche_c_ccip_send_requested groups its source logs by tx_hash and
+-- exposes evt_block_time = MAX(block_time), so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the avalanche_c.logs scan and forces a
+-- full-history scan (~100B rows/run) to merge a handful of rows. The view body is inlined here so
+-- the incremental time bound applies BELOW the tx_hash aggregation and prunes the Delta logs scan
+-- via block_time file skipping. Every log of a transaction shares that transaction's block_time
+-- (one tx = one block), so MAX(block_time) = block_time per group and the pre-agg bound selects
+-- exactly the same tx_hash groups as the post-agg evt_block_time predicate (kept as authoritative).
+WITH combined_logs AS (
+  SELECT
+    ccip_logs_v1.blockchain,
+    ccip_logs_v1.block_time,
+    ccip_logs_v1.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1.fee_token,
+    ccip_logs_v1.destination_selector,
+    ccip_logs_v1.destination_blockchain,
+    ccip_logs_v1.tx_hash
+  FROM
+    {{ ref('chainlink_avalanche_c_ccip_send_requested_logs_v1') }} ccip_logs_v1
+    LEFT JOIN {{ ref('chainlink_avalanche_c_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1.block_time') }}
+  {% endif %}
+
+  UNION ALL
+
+  SELECT
+    ccip_logs_v1_2.blockchain,
+    ccip_logs_v1_2.block_time,
+    ccip_logs_v1_2.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1_2.fee_token,
+    ccip_logs_v1_2.destination_selector,
+    ccip_logs_v1_2.destination_blockchain,
+    ccip_logs_v1_2.tx_hash
+  FROM
+    {{ ref('chainlink_avalanche_c_ccip_send_requested_logs_v1_2') }} ccip_logs_v1_2
+    LEFT JOIN {{ ref('chainlink_avalanche_c_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1_2.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1_2.block_time') }}
+  {% endif %}
+),
+
+ccip_send_requested AS (
+  SELECT
+    MAX(blockchain) AS blockchain,
+    MAX(block_time) AS evt_block_time,
+    SUM(fee_token_amount) AS fee_token_amount,
+    MAX(token) AS token,
+    MAX(fee_token) AS fee_token,
+    MAX(destination_selector) AS destination_selector,
+    MAX(destination_blockchain) AS destination_blockchain,
+    MAX(tx_hash) AS tx_hash
+  FROM
+    combined_logs
+  GROUP BY
+    tx_hash
+)
 
 SELECT
   'avalanche_c' as blockchain,
@@ -20,7 +79,7 @@ SELECT
   ccip_send_requested.destination_blockchain AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
-  {{ref('chainlink_avalanche_c_ccip_send_requested')}} ccip_send_requested
+  ccip_send_requested
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_send_requested_daily.sql
@@ -75,8 +75,11 @@ SELECT
   cast(date_trunc('day', evt_block_time) AS date) AS date_start,
   MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
   SUM(ccip_send_requested.fee_token_amount) as fee_amount,
-  ccip_send_requested.token as token,
-  ccip_send_requested.destination_blockchain AS destination_blockchain,
+  -- coalesce nullable unique_key columns: destination_blockchain is unmapped (always NULL) and
+  -- token is NULL for unmapped fee tokens; a NULL merge key makes the incremental MERGE silently
+  -- double-insert (Trino NULL != NULL), so non-null sentinels keep the key dedup-safe.
+  coalesce(ccip_send_requested.token, 'unknown') as token,
+  coalesce(ccip_send_requested.destination_blockchain, 'unknown') AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
   ccip_send_requested

--- a/dbt_subprojects/daily_spellbook/models/chainlink/base/chainlink_base_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/base/chainlink_base_ccip_send_requested_daily.sql
@@ -10,6 +10,65 @@
   )
 }}
 
+-- The upstream view chainlink_base_ccip_send_requested groups its source logs by tx_hash and
+-- exposes evt_block_time = MAX(block_time), so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the base.logs scan and forces a
+-- full-history scan (~100B rows/run) to merge a handful of rows. The view body is inlined here so
+-- the incremental time bound applies BELOW the tx_hash aggregation and prunes the Delta logs scan
+-- via block_time file skipping. Every log of a transaction shares that transaction's block_time
+-- (one tx = one block), so MAX(block_time) = block_time per group and the pre-agg bound selects
+-- exactly the same tx_hash groups as the post-agg evt_block_time predicate (kept as authoritative).
+WITH combined_logs AS (
+  SELECT
+    ccip_logs_v1.blockchain,
+    ccip_logs_v1.block_time,
+    ccip_logs_v1.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1.fee_token,
+    ccip_logs_v1.destination_selector,
+    ccip_logs_v1.destination_blockchain,
+    ccip_logs_v1.tx_hash
+  FROM
+    {{ ref('chainlink_base_ccip_send_requested_logs_v1') }} ccip_logs_v1
+    LEFT JOIN {{ ref('chainlink_base_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1.block_time') }}
+  {% endif %}
+
+  UNION ALL
+
+  SELECT
+    ccip_logs_v1_2.blockchain,
+    ccip_logs_v1_2.block_time,
+    ccip_logs_v1_2.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1_2.fee_token,
+    ccip_logs_v1_2.destination_selector,
+    ccip_logs_v1_2.destination_blockchain,
+    ccip_logs_v1_2.tx_hash
+  FROM
+    {{ ref('chainlink_base_ccip_send_requested_logs_v1_2') }} ccip_logs_v1_2
+    LEFT JOIN {{ ref('chainlink_base_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1_2.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1_2.block_time') }}
+  {% endif %}
+),
+
+ccip_send_requested AS (
+  SELECT
+    MAX(blockchain) AS blockchain,
+    MAX(block_time) AS evt_block_time,
+    SUM(fee_token_amount) AS fee_token_amount,
+    MAX(token) AS token,
+    MAX(fee_token) AS fee_token,
+    MAX(destination_selector) AS destination_selector,
+    MAX(destination_blockchain) AS destination_blockchain,
+    MAX(tx_hash) AS tx_hash
+  FROM
+    combined_logs
+  GROUP BY
+    tx_hash
+)
 
 SELECT
   'base' as blockchain,
@@ -20,7 +79,7 @@ SELECT
   ccip_send_requested.destination_blockchain AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
-  {{ref('chainlink_base_ccip_send_requested')}} ccip_send_requested
+  ccip_send_requested
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/base/chainlink_base_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/base/chainlink_base_ccip_send_requested_daily.sql
@@ -75,8 +75,11 @@ SELECT
   cast(date_trunc('day', evt_block_time) AS date) AS date_start,
   MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
   SUM(ccip_send_requested.fee_token_amount) as fee_amount,
-  ccip_send_requested.token as token,
-  ccip_send_requested.destination_blockchain AS destination_blockchain,
+  -- coalesce nullable unique_key columns: destination_blockchain is unmapped (always NULL) and
+  -- token is NULL for unmapped fee tokens; a NULL merge key makes the incremental MERGE silently
+  -- double-insert (Trino NULL != NULL), so non-null sentinels keep the key dedup-safe.
+  coalesce(ccip_send_requested.token, 'unknown') as token,
+  coalesce(ccip_send_requested.destination_blockchain, 'unknown') AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
   ccip_send_requested

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_send_requested_daily.sql
@@ -10,6 +10,65 @@
   )
 }}
 
+-- The upstream view chainlink_bnb_ccip_send_requested groups its source logs by tx_hash and
+-- exposes evt_block_time = MAX(block_time), so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the bnb.logs scan and forces a
+-- full-history scan (~100B rows/run) to merge a handful of rows. The view body is inlined here so
+-- the incremental time bound applies BELOW the tx_hash aggregation and prunes the Delta logs scan
+-- via block_time file skipping. Every log of a transaction shares that transaction's block_time
+-- (one tx = one block), so MAX(block_time) = block_time per group and the pre-agg bound selects
+-- exactly the same tx_hash groups as the post-agg evt_block_time predicate (kept as authoritative).
+WITH combined_logs AS (
+  SELECT
+    ccip_logs_v1.blockchain,
+    ccip_logs_v1.block_time,
+    ccip_logs_v1.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1.fee_token,
+    ccip_logs_v1.destination_selector,
+    ccip_logs_v1.destination_blockchain,
+    ccip_logs_v1.tx_hash
+  FROM
+    {{ ref('chainlink_bnb_ccip_send_requested_logs_v1') }} ccip_logs_v1
+    LEFT JOIN {{ ref('chainlink_bnb_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1.block_time') }}
+  {% endif %}
+
+  UNION ALL
+
+  SELECT
+    ccip_logs_v1_2.blockchain,
+    ccip_logs_v1_2.block_time,
+    ccip_logs_v1_2.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1_2.fee_token,
+    ccip_logs_v1_2.destination_selector,
+    ccip_logs_v1_2.destination_blockchain,
+    ccip_logs_v1_2.tx_hash
+  FROM
+    {{ ref('chainlink_bnb_ccip_send_requested_logs_v1_2') }} ccip_logs_v1_2
+    LEFT JOIN {{ ref('chainlink_bnb_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1_2.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1_2.block_time') }}
+  {% endif %}
+),
+
+ccip_send_requested AS (
+  SELECT
+    MAX(blockchain) AS blockchain,
+    MAX(block_time) AS evt_block_time,
+    SUM(fee_token_amount) AS fee_token_amount,
+    MAX(token) AS token,
+    MAX(fee_token) AS fee_token,
+    MAX(destination_selector) AS destination_selector,
+    MAX(destination_blockchain) AS destination_blockchain,
+    MAX(tx_hash) AS tx_hash
+  FROM
+    combined_logs
+  GROUP BY
+    tx_hash
+)
 
 SELECT
   'bnb' as blockchain,
@@ -20,7 +79,7 @@ SELECT
   ccip_send_requested.destination_blockchain AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
-  {{ref('chainlink_bnb_ccip_send_requested')}} ccip_send_requested
+  ccip_send_requested
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_send_requested_daily.sql
@@ -75,8 +75,11 @@ SELECT
   cast(date_trunc('day', evt_block_time) AS date) AS date_start,
   MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
   SUM(ccip_send_requested.fee_token_amount) as fee_amount,
-  ccip_send_requested.token as token,
-  ccip_send_requested.destination_blockchain AS destination_blockchain,
+  -- coalesce nullable unique_key columns: destination_blockchain is unmapped (always NULL) and
+  -- token is NULL for unmapped fee tokens; a NULL merge key makes the incremental MERGE silently
+  -- double-insert (Trino NULL != NULL), so non-null sentinels keep the key dedup-safe.
+  coalesce(ccip_send_requested.token, 'unknown') as token,
+  coalesce(ccip_send_requested.destination_blockchain, 'unknown') AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
   ccip_send_requested

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_send_requested_daily.sql
@@ -75,8 +75,11 @@ SELECT
   cast(date_trunc('day', evt_block_time) AS date) AS date_start,
   MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
   SUM(ccip_send_requested.fee_token_amount) as fee_amount,
-  ccip_send_requested.token as token,
-  ccip_send_requested.destination_blockchain AS destination_blockchain,
+  -- coalesce nullable unique_key columns: destination_blockchain is unmapped (always NULL) and
+  -- token is NULL for unmapped fee tokens; a NULL merge key makes the incremental MERGE silently
+  -- double-insert (Trino NULL != NULL), so non-null sentinels keep the key dedup-safe.
+  coalesce(ccip_send_requested.token, 'unknown') as token,
+  coalesce(ccip_send_requested.destination_blockchain, 'unknown') AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
   ccip_send_requested

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_send_requested_daily.sql
@@ -10,6 +10,65 @@
   )
 }}
 
+-- The upstream view chainlink_ethereum_ccip_send_requested groups its source logs by tx_hash and
+-- exposes evt_block_time = MAX(block_time), so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the ethereum.logs scan and forces a
+-- full-history scan (~100B rows/run) to merge a handful of rows. The view body is inlined here so
+-- the incremental time bound applies BELOW the tx_hash aggregation and prunes the Delta logs scan
+-- via block_time file skipping. Every log of a transaction shares that transaction's block_time
+-- (one tx = one block), so MAX(block_time) = block_time per group and the pre-agg bound selects
+-- exactly the same tx_hash groups as the post-agg evt_block_time predicate (kept as authoritative).
+WITH combined_logs AS (
+  SELECT
+    ccip_logs_v1.blockchain,
+    ccip_logs_v1.block_time,
+    ccip_logs_v1.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1.fee_token,
+    ccip_logs_v1.destination_selector,
+    ccip_logs_v1.destination_blockchain,
+    ccip_logs_v1.tx_hash
+  FROM
+    {{ ref('chainlink_ethereum_ccip_send_requested_logs_v1') }} ccip_logs_v1
+    LEFT JOIN {{ ref('chainlink_ethereum_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1.block_time') }}
+  {% endif %}
+
+  UNION ALL
+
+  SELECT
+    ccip_logs_v1_2.blockchain,
+    ccip_logs_v1_2.block_time,
+    ccip_logs_v1_2.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1_2.fee_token,
+    ccip_logs_v1_2.destination_selector,
+    ccip_logs_v1_2.destination_blockchain,
+    ccip_logs_v1_2.tx_hash
+  FROM
+    {{ ref('chainlink_ethereum_ccip_send_requested_logs_v1_2') }} ccip_logs_v1_2
+    LEFT JOIN {{ ref('chainlink_ethereum_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1_2.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1_2.block_time') }}
+  {% endif %}
+),
+
+ccip_send_requested AS (
+  SELECT
+    MAX(blockchain) AS blockchain,
+    MAX(block_time) AS evt_block_time,
+    SUM(fee_token_amount) AS fee_token_amount,
+    MAX(token) AS token,
+    MAX(fee_token) AS fee_token,
+    MAX(destination_selector) AS destination_selector,
+    MAX(destination_blockchain) AS destination_blockchain,
+    MAX(tx_hash) AS tx_hash
+  FROM
+    combined_logs
+  GROUP BY
+    tx_hash
+)
 
 SELECT
   'ethereum' as blockchain,
@@ -20,7 +79,7 @@ SELECT
   ccip_send_requested.destination_blockchain AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
-  {{ref('chainlink_ethereum_ccip_send_requested')}} ccip_send_requested
+  ccip_send_requested
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_send_requested_daily.sql
@@ -10,6 +10,65 @@
   )
 }}
 
+-- The upstream view chainlink_optimism_ccip_send_requested groups its source logs by tx_hash and
+-- exposes evt_block_time = MAX(block_time), so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the optimism.logs scan and forces a
+-- full-history scan (~100B rows/run) to merge a handful of rows. The view body is inlined here so
+-- the incremental time bound applies BELOW the tx_hash aggregation and prunes the Delta logs scan
+-- via block_time file skipping. Every log of a transaction shares that transaction's block_time
+-- (one tx = one block), so MAX(block_time) = block_time per group and the pre-agg bound selects
+-- exactly the same tx_hash groups as the post-agg evt_block_time predicate (kept as authoritative).
+WITH combined_logs AS (
+  SELECT
+    ccip_logs_v1.blockchain,
+    ccip_logs_v1.block_time,
+    ccip_logs_v1.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1.fee_token,
+    ccip_logs_v1.destination_selector,
+    ccip_logs_v1.destination_blockchain,
+    ccip_logs_v1.tx_hash
+  FROM
+    {{ ref('chainlink_optimism_ccip_send_requested_logs_v1') }} ccip_logs_v1
+    LEFT JOIN {{ ref('chainlink_optimism_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1.block_time') }}
+  {% endif %}
+
+  UNION ALL
+
+  SELECT
+    ccip_logs_v1_2.blockchain,
+    ccip_logs_v1_2.block_time,
+    ccip_logs_v1_2.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1_2.fee_token,
+    ccip_logs_v1_2.destination_selector,
+    ccip_logs_v1_2.destination_blockchain,
+    ccip_logs_v1_2.tx_hash
+  FROM
+    {{ ref('chainlink_optimism_ccip_send_requested_logs_v1_2') }} ccip_logs_v1_2
+    LEFT JOIN {{ ref('chainlink_optimism_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1_2.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1_2.block_time') }}
+  {% endif %}
+),
+
+ccip_send_requested AS (
+  SELECT
+    MAX(blockchain) AS blockchain,
+    MAX(block_time) AS evt_block_time,
+    SUM(fee_token_amount) AS fee_token_amount,
+    MAX(token) AS token,
+    MAX(fee_token) AS fee_token,
+    MAX(destination_selector) AS destination_selector,
+    MAX(destination_blockchain) AS destination_blockchain,
+    MAX(tx_hash) AS tx_hash
+  FROM
+    combined_logs
+  GROUP BY
+    tx_hash
+)
 
 SELECT
   'optimism' as blockchain,
@@ -20,7 +79,7 @@ SELECT
   ccip_send_requested.destination_blockchain AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
-  {{ref('chainlink_optimism_ccip_send_requested')}} ccip_send_requested
+  ccip_send_requested
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_send_requested_daily.sql
@@ -75,8 +75,11 @@ SELECT
   cast(date_trunc('day', evt_block_time) AS date) AS date_start,
   MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
   SUM(ccip_send_requested.fee_token_amount) as fee_amount,
-  ccip_send_requested.token as token,
-  ccip_send_requested.destination_blockchain AS destination_blockchain,
+  -- coalesce nullable unique_key columns: destination_blockchain is unmapped (always NULL) and
+  -- token is NULL for unmapped fee tokens; a NULL merge key makes the incremental MERGE silently
+  -- double-insert (Trino NULL != NULL), so non-null sentinels keep the key dedup-safe.
+  coalesce(ccip_send_requested.token, 'unknown') as token,
+  coalesce(ccip_send_requested.destination_blockchain, 'unknown') AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
   ccip_send_requested

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_send_requested_daily.sql
@@ -10,6 +10,65 @@
   )
 }}
 
+-- The upstream view chainlink_polygon_ccip_send_requested groups its source logs by tx_hash and
+-- exposes evt_block_time = MAX(block_time), so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the polygon.logs scan and forces a
+-- full-history scan (~100B rows/run) to merge a handful of rows. The view body is inlined here so
+-- the incremental time bound applies BELOW the tx_hash aggregation and prunes the Delta logs scan
+-- via block_time file skipping. Every log of a transaction shares that transaction's block_time
+-- (one tx = one block), so MAX(block_time) = block_time per group and the pre-agg bound selects
+-- exactly the same tx_hash groups as the post-agg evt_block_time predicate (kept as authoritative).
+WITH combined_logs AS (
+  SELECT
+    ccip_logs_v1.blockchain,
+    ccip_logs_v1.block_time,
+    ccip_logs_v1.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1.fee_token,
+    ccip_logs_v1.destination_selector,
+    ccip_logs_v1.destination_blockchain,
+    ccip_logs_v1.tx_hash
+  FROM
+    {{ ref('chainlink_polygon_ccip_send_requested_logs_v1') }} ccip_logs_v1
+    LEFT JOIN {{ ref('chainlink_polygon_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1.block_time') }}
+  {% endif %}
+
+  UNION ALL
+
+  SELECT
+    ccip_logs_v1_2.blockchain,
+    ccip_logs_v1_2.block_time,
+    ccip_logs_v1_2.fee_token_amount / 1e18 AS fee_token_amount,
+    token_addresses.token_symbol AS token,
+    ccip_logs_v1_2.fee_token,
+    ccip_logs_v1_2.destination_selector,
+    ccip_logs_v1_2.destination_blockchain,
+    ccip_logs_v1_2.tx_hash
+  FROM
+    {{ ref('chainlink_polygon_ccip_send_requested_logs_v1_2') }} ccip_logs_v1_2
+    LEFT JOIN {{ ref('chainlink_polygon_ccip_token_meta') }} token_addresses ON token_addresses.token_contract = ccip_logs_v1_2.fee_token
+  {% if is_incremental() %}
+  WHERE {{ incremental_predicate('ccip_logs_v1_2.block_time') }}
+  {% endif %}
+),
+
+ccip_send_requested AS (
+  SELECT
+    MAX(blockchain) AS blockchain,
+    MAX(block_time) AS evt_block_time,
+    SUM(fee_token_amount) AS fee_token_amount,
+    MAX(token) AS token,
+    MAX(fee_token) AS fee_token,
+    MAX(destination_selector) AS destination_selector,
+    MAX(destination_blockchain) AS destination_blockchain,
+    MAX(tx_hash) AS tx_hash
+  FROM
+    combined_logs
+  GROUP BY
+    tx_hash
+)
 
 SELECT
   'polygon' as blockchain,
@@ -20,7 +79,7 @@ SELECT
   ccip_send_requested.destination_blockchain AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
-  {{ref('chainlink_polygon_ccip_send_requested')}} ccip_send_requested
+  ccip_send_requested
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_send_requested_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_send_requested_daily.sql
@@ -75,8 +75,11 @@ SELECT
   cast(date_trunc('day', evt_block_time) AS date) AS date_start,
   MAX(cast(date_trunc('month', evt_block_time) AS date)) AS date_month,
   SUM(ccip_send_requested.fee_token_amount) as fee_amount,
-  ccip_send_requested.token as token,
-  ccip_send_requested.destination_blockchain AS destination_blockchain,
+  -- coalesce nullable unique_key columns: destination_blockchain is unmapped (always NULL) and
+  -- token is NULL for unmapped fee tokens; a NULL merge key makes the incremental MERGE silently
+  -- double-insert (Trino NULL != NULL), so non-null sentinels keep the key dedup-safe.
+  coalesce(ccip_send_requested.token, 'unknown') as token,
+  coalesce(ccip_send_requested.destination_blockchain, 'unknown') AS destination_blockchain,
   COUNT(ccip_send_requested.destination_blockchain) AS count
 FROM
   ccip_send_requested


### PR DESCRIPTION
Family follow-up of #9838 (`automation_performed_daily` x5) and #9766 (polygon vrf). Same incremental-bound-stranded-above-GROUP-BY pattern, now the `ccip_send_requested_daily` sub-family on spellbook-daily (7 chains: arbitrum, avalanche_c, base, bnb, ethereum, optimism, polygon).

Each `chainlink_<chain>_ccip_send_requested_daily` aggregates the upstream `ccip_send_requested` view, which groups its source logs by `tx_hash` and exposes `evt_block_time = MAX(block_time)`. The daily model's `WHERE incremental_predicate('evt_block_time')` sits above that GROUP BY, so the bound never reaches the `<chain>.logs` scan — every incremental run full-scans the chain's logs (bnb ~104.5B rows / 787 GB) with only a topic0 local filter, to merge ~4 rows/day.

The fix inlines the view body into each daily model and applies `incremental_predicate('<logs>.block_time')` below the `tx_hash` aggregation, so the Delta logs scan prunes by block_time file-skipping; the post-agg `evt_block_time` predicate is kept as authoritative. Every log of a transaction shares that transaction's `block_time` (one tx = one block), so `MAX(block_time) = block_time` per group and the pre-agg bound selects exactly the same `tx_hash` groups. Incremental-only change; the full-refresh path is unaffected and no backfill is needed.

Proof (read-only, spellbook-sqlmesh):

- Equivalence: `(current EXCEPT rewrite)` and `(rewrite EXCEPT current)` = 0 both ways on all key columns over a frozen 6-week window — bnb (46 rows) and polygon (49 rows). The `fee_amount` double differs only at the floating-point floor (6.66e-16 bnb / 1.7e-13 polygon vs max values 1.32 / 691.26).
- A/B cost (bnb, live 3-day window, medians of 3 warm runs): `physical_input_bytes` 787.47 GB -> 5.49 GB (143x); `cpu_ms` 1,169,996 -> 6,386 (183x); wall 42,199 ms -> 1,056 ms (40x); scanned rows 104.5B -> 615M (170x); peak memory 4.34 GB -> 8.06 MB; spill 0 -> 0.

Family baseline ~3.36 CPU-hrs/day, ~2,636 GB/day IO, expected to drop to ~0.02 CPU-hrs/day and ~18 GB/day.

Towards CUR2-2973

---

**Also fixes a pre-existing duplicate-row bug (surfaced by slim CI).** These models key the incremental MERGE on `unique_key=[date_start, token, destination_blockchain]`, but `destination_blockchain` is unmapped and **100% NULL** on every row, and `token` is NULL for unmapped fee tokens. A NULL merge key never matches (`NULL != NULL` in Trino), so each incremental run re-inserts rather than updates — prod has silently accumulated **~75% duplicate rows** (e.g. ethereum 799 rows / 601 dup, bnb 402 / 312, over 90 days). Slim CI is the first thing to rebuild these models fresh-then-incremental, so it's the first to fail the `unique_combination_of_columns` test.

The second commit coalesces both nullable key columns to a non-null sentinel (`'unknown'`), mirroring how the sibling automation fix (#9838) coalesced its key. This is grain-preserving — `GROUP BY` already collapses each column's NULLs into a single group — so the only output change is `NULL -> 'unknown'` on those columns plus removal of the MERGE-artifact duplicates (a one-time ~75% row drop on next build). Proven `EXCEPT = 0` both ways vs the current logic with the same coalesce, with zero per-build duplicate keys (bnb and ethereum, 47 / 92 rows).
