### PR TITLE
chore(zeroex): prod_exclude 4 dead api_fills chains (~1.27 CPU-hrs/day + 0.36 TB/day for 0 rows)

### DIFF
--- a/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_avalanche_c_api_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_avalanche_c_api_fills.sql
@@ -1,5 +1,5 @@
 {{  config(
-        tags=['prod_exclude'],
+        tags=['static'],
         schema = 'zeroex_avalance_c',
         alias = 'api_fills',
         materialized='incremental',

--- a/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_avalanche_c_api_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/avalanche_c/zeroex_avalanche_c_api_fills.sql
@@ -1,4 +1,5 @@
 {{  config(
+        tags=['prod_exclude'],
         schema = 'zeroex_avalance_c',
         alias = 'api_fills',
         materialized='incremental',

--- a/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_base_api_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_base_api_fills.sql
@@ -1,5 +1,5 @@
 {{  config(
-        tags=['prod_exclude'],
+        tags=['static'],
 
     schema = 'zeroex_base',
         alias = 'api_fills',

--- a/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_base_api_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/base/zeroex_base_api_fills.sql
@@ -1,4 +1,5 @@
 {{  config(
+        tags=['prod_exclude'],
 
     schema = 'zeroex_base',
         alias = 'api_fills',

--- a/dbt_subprojects/dex/models/_projects/zeroex/celo/zeroex_celo_api_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/celo/zeroex_celo_api_fills.sql
@@ -1,5 +1,5 @@
 {{  config(
-        tags=['prod_exclude'],
+        tags=['static'],
 
         schema = 'zeroex_celo',
         alias = 'api_fills',

--- a/dbt_subprojects/dex/models/_projects/zeroex/celo/zeroex_celo_api_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/celo/zeroex_celo_api_fills.sql
@@ -1,4 +1,5 @@
 {{  config(
+        tags=['prod_exclude'],
 
         schema = 'zeroex_celo',
         alias = 'api_fills',

--- a/dbt_subprojects/dex/models/_projects/zeroex/fantom/zeroex_fantom_api_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/fantom/zeroex_fantom_api_fills.sql
@@ -1,4 +1,5 @@
 {{  config(
+        tags=['prod_exclude'],
         schema = 'zeroex_fantom',
         alias = 'api_fills',
         materialized='incremental',

--- a/dbt_subprojects/dex/models/_projects/zeroex/fantom/zeroex_fantom_api_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/fantom/zeroex_fantom_api_fills.sql
@@ -1,5 +1,5 @@
 {{  config(
-        tags=['prod_exclude'],
+        tags=['static'],
         schema = 'zeroex_fantom',
         alias = 'api_fills',
         materialized='incremental',


### PR DESCRIPTION
Four chains in the `zeroex_<chain>_api_fills` family are dead — they emit 0 output rows yet keep re-scanning `<chain>.traces` ~240x/day with a non-pushable affiliate-selector calldata search to produce nothing. This adds `tags=['prod_exclude']` to the four dead base models so the prod build stops rebuilding them.

Reality-checked live on `spellbook-dex` (2026-06-29):

| chain | CPU-hrs/day | IO TB/day | rows last 90d | last real output row |
|---|---|---|---|---|
| base | 1.11 | 0.271 | 0 | 2026-02-11 (~4.5mo dead) |
| celo | 0.12 | 0.072 | 0 | 2025-06-29 (~1yr) |
| fantom | 0.03 | 0.007 | 0 | 2025-06-30 (~1yr) |
| avalanche_c | 0.01 | 0.005 | 0 | 2025-06-30 (~1yr) |
| **total** | **~1.27** | **~0.355** | **0** | — |

base peaked ~1.5M rows/month in 2024, declined to ~13K by mid-2025, and ~0 since — a genuine 0x routing-volume decline, not a recent decode break. ethereum/optimism still trickle (18/5 rows in 90d) and are deliberately left untouched.

Using `prod_exclude` rather than removing the chains from the cross-chain unions (`zeroex_api_fills`, `zeroex_api_fills_deduped`) is deliberate: the unions still `ref()` the now-frozen per-chain tables, so all historical rows remain visible in the user-facing `zeroex.api_fills` / `api_fills_deduped` / `zeroex.trades` — output is unchanged. Only the go-forward (empty) rebuild is stopped. Fully reversible by removing the tag if 0x resumes routing on a chain. Mirrors the existing `prod_exclude` precedent already used on ~29 dex models (including `zeroex_polygon_nft_fills`).

This is a P5 cost-governance change (owner-gated): no SQL rewrite, so no EXCEPT proof — the evidence is the measured deadness above, sourced from `query_history` (24h cost) and the output-table row counts in `hive.zeroex_<chain>.api_fills`.

`dbt parse` (dex) passes.

Fixes CUR2-2812
