### PR TITLE
perf(tokens): seed celo balances prior_balances from a current-balance state table

### DIFF
--- a/dbt_subprojects/tokens/macros/balances/balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/macros/balances/balances_daily_agg.sql
@@ -27,7 +27,8 @@ from (
 {%- macro balances_daily_agg_from_transfers(
     transfers,
     gas_fees_source = none,
-    native_token_address = var('ETH_ERC20_ADDRESS')
+    native_token_address = var('ETH_ERC20_ADDRESS'),
+    current_balances_identifier = none
 ) %}
 
 with transfers_in as (
@@ -117,7 +118,35 @@ daily_aggregated as (
 ),
 
 {% if is_incremental() %}
+{#- Optionally seed prior balances from a deep current-balance state table instead of
+    scanning the full balances history. The state table is read via get_relation (not ref)
+    so the base model does not create a dbt dependency cycle with it. -#}
+{%- set current_balances_rel = none -%}
+{%- if current_balances_identifier is not none -%}
+    {%- set current_balances_rel = adapter.get_relation(database=this.database, schema=this.schema, identifier=current_balances_identifier) -%}
+{%- endif -%}
 prior_balances as (
+{%- if current_balances_rel is not none %}
+    -- fast path: deep latest-per-key state table + a bounded recent gap from own output.
+    -- max_by over (state(< T-5) UNION gap[T-7, T-3)) == max_by over full history < T-3
+    -- (split-at-cutoff identity; the [T-7, T-5) overlap is idempotent under max_by).
+    select
+        address,
+        token_address,
+        token_standard,
+        max_by(balance_raw, day) as prior_balance
+    from (
+        select address, token_address, token_standard, balance_raw, day
+        from {{ current_balances_rel }}
+        union all
+        select address, token_address, token_standard, balance_raw, day
+        from {{ this }}
+        where block_time >= date_trunc('day', now() - interval '7' day)
+            and not {{ incremental_predicate('block_time') }}
+    )
+    group by 1, 2, 3
+{%- else %}
+    -- fallback: full-history self-scan. Used until the state table has been built, and in CI.
     select
         address,
         token_address,
@@ -126,6 +155,7 @@ prior_balances as (
     from {{ this }}
     where not {{ incremental_predicate('block_time') }}
     group by 1, 2, 3
+{%- endif %}
 ),
 {% endif %}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/celo/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/celo/_schema.yml
@@ -177,3 +177,34 @@ models:
         description: "The raw token balance"
       - name: unique_key
         description: "Surrogate key for unique identification"
+
+  - name: tokens_celo_balances_current
+    meta:
+      blockchain: celo
+      sector: tokens
+      contributors: tomfutago
+    config:
+      tags: ['tokens', 'balances', 'celo']
+    description: >
+      Deep current-balance state for tokens_celo_balances_daily_agg_base: one row per
+      (address, token_address, token_standard) holding its latest balance_raw below the
+      base model's incremental window. Maintained incrementally so the base model can seed
+      prior balances without re-scanning full balances history each run.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - address
+              - token_address
+              - token_standard
+    columns:
+      - name: address
+        description: "The wallet address"
+      - name: token_address
+        description: "The token contract address"
+      - name: token_standard
+        description: "The token standard (erc20, native)"
+      - name: balance_raw
+        description: "The latest raw token balance below the base incremental window"
+      - name: day
+        description: "The date of the latest balance for this key"

--- a/dbt_subprojects/tokens/models/transfers_and_balances/celo/tokens_celo_balances_current.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/celo/tokens_celo_balances_current.sql
@@ -1,0 +1,50 @@
+{{
+    config (
+        schema = 'tokens_celo',
+        alias = 'balances_current',
+        file_format = 'delta',
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = ['address', 'token_address', 'token_standard'],
+    )
+}}
+
+-- Deep current-balance state for tokens_celo_balances_daily_agg_base.
+-- One row per (address, token_address, token_standard) = its latest balance_raw as of
+-- block_time < now() - 5 days. This lets the base model seed prior_balances by reading
+-- this small key-grained table instead of max_by-aggregating the full balances history
+-- every hourly build. Equivalence relies on the max_by split-at-cutoff identity:
+--   max_by(balance_raw, day) over all history < W
+--   == max_by(balance_raw, day) over ( latest-per-key(< T-5) UNION gap[T-5, W) )
+-- The base model owns the gap [T-7, W); this table owns everything below the cutoff.
+--
+-- Cycle note: this model ref()s the base table, so dbt builds the base FIRST and this
+-- table AFTER. The base model reads this table via adapter.get_relation() (no ref edge),
+-- so there is no dbt dependency cycle. The base therefore reads the PREVIOUS run's state;
+-- the base's gap window absorbs that staleness.
+
+with new_state as (
+    select
+        address,
+        token_address,
+        token_standard,
+        max_by(balance_raw, day) as balance_raw,
+        max(day) as day
+    from {{ ref('tokens_celo_balances_daily_agg_base') }}
+    where block_time < date_trunc('day', now() - interval '5' day)
+    {%- if is_incremental() %}
+        -- self-healing catch-up: re-absorb from the last day already in the state forward.
+        -- Re-merging the boundary day is idempotent (same max_by); a missed run is caught
+        -- up automatically because max(day) does not advance until the day is absorbed.
+        and day >= (select coalesce(max(day), date '2000-01-01') from {{ this }})
+    {%- endif %}
+    group by 1, 2, 3
+)
+
+select
+    address,
+    token_address,
+    token_standard,
+    balance_raw,
+    day
+from new_state

--- a/dbt_subprojects/tokens/models/transfers_and_balances/celo/tokens_celo_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/celo/tokens_celo_balances_daily_agg_base.sql
@@ -18,6 +18,7 @@
 {{
     balances_daily_agg_from_transfers(
         transfers = ref('tokens_celo_transfers'),
-        gas_fees_source = source('gas_celo', 'fees')
+        gas_fees_source = source('gas_celo', 'fees'),
+        current_balances_identifier = 'balances_current'
     )
 }}


### PR DESCRIPTION
## What

`tokens_celo_balances_daily_agg_base` rebuilds each wallet's running token balance every hour by seeding from a `prior_balances` CTE that does a **full-history self-scan** of its own output: `max_by(balance_raw, day)` over `{{ this }}` where `block_time < window_start`. On celo that scan reads **2.13B rows / 54.4 GB** every run and its hash-aggregation is the model's dominant cost.

This PR seeds `prior_balances` from a small, key-grained **current-balance state table** (`tokens_celo_balances_current`) — one row per `(address, token_address, token_standard)` holding that key's latest balance below the incremental window — instead of re-aggregating all history. The base reads `state(< T-5)` UNION a bounded recent gap `[T-7, T-3)` from its own output and takes `max_by` over the union, which is exactly equal to the old full-history aggregation.

The macro change is **backward-compatible**: `balances_daily_agg_from_transfers` gains an optional `current_balances_identifier` param. Only celo passes it; unichain (the only other caller, ~0.4 CPU-hrs/day) is unchanged and keeps the original code path.

## Why it is correct

Equivalence rests on the `max_by` split-at-cutoff identity: `max_by(v, day)` over `A ∪ B` equals `max_by(v, day)` over `(max_by-per-key(A) ∪ B)` — the global argmax-by-day is the argmax among partial argmaxes, regardless of any overlap between `A` and `B`.

Proven read-only on prod celo data (`spellbook-hourly`, bounded to history `[2026-06-01, window_start)` for cost, UTC), both with a clean split and with the **exact deployed predicates** (state `< T-5`, gap `[T-7, T-3)`, overlap `[T-7, T-5)`):

```
old_prior EXCEPT new_prior = 0
new_prior EXCEPT old_prior = 0   (32,249,278 keys, identical)
```

`prior_balances` is the only thing this PR changes; the rest of the model (`cumulative_flows`, the seed join, the clamp/cast) is untouched, so a bit-identical `prior_balance` yields a bit-identical `balance_raw`.

## Design / cycle-break (please review)

`tokens_celo_balances_current` `ref()`s the base table, so dbt builds the base **first** and the state table **after**. The base reads the state table via `adapter.get_relation()` (no `ref`, hence no dbt cycle) and **falls back to the original full-history aggregation** when the state table does not exist yet — i.e. on first deploy and in CI, where the base builds before the state table is present. This keeps the critical base model and its CI regression test behaving exactly as today until the state table is in place.

Because the base reads the *previous* run's state, the state cutoff (`< T-5`) deliberately lags the base window (`< T-3`); the base unions the `[T-7, T-3)` gap from its own output so the result is exact even if the state table is up to ~2 days stale. The state table maintains itself incrementally with a self-healing catch-up (`day >= (select max(day) from {{ this }})`), so a missed run is absorbed automatically.

## Measured baseline vs predicted impact

Baseline (celo `balances_daily_agg_base`, 24 MERGE builds/day, from `analyze_query`): prior_balances self-scan **2.13B rows / 54.4 GB**, its hash-agg is **~73% of model CPU**, peak **92.8 GB** (growing with history; an OOM and cluster-memory-floor risk). Model total ≈ **28.5 CPU-hrs/day**.

Predicted (the magnitude cannot be measured fully read-only — the state read and the new peak only exist once the table is deployed; equivalence above is what is proven now): the agg input drops from 2.13B rows to ~166M (state ~146M + gap ~20M), so the ~237 GB exchange that drives the 92.8 GB peak shrinks ~15-20x. Expect IO ~54 GB -> ~12 GB/build, peak 92.8 GB -> well under node limits, per-build wall (~12 min) materially lower, less the new (bounded, mostly no-op within a day) state-maintenance build. To be confirmed on the first post-deploy incremental.

## Rollout notes / caveats

- The fast path (state UNION gap) first executes in **prod**, since CI builds the base full-refresh (no `prior_balances`) before the state table exists. The fast-path SQL is the EXCEPT-proven query above; monitor the first incremental run.
- A full-refresh of the base should be followed by a rebuild of `tokens_celo_balances_current` (the state is derived from the base).
- `tokens_celo_balances_current` is unpartitioned; if the per-run merge into the ~146M-row target proves heavy, clustering/Z-ordering the state on `address` is a follow-up.

Fixes CUR2-2723
