### PR TITLE
CUR2-2872: Prepare Spellbook Solana stablecoins cutover

### DIFF
--- a/dbt_subprojects/solana/models/stablecoins/_list/tokens_solana_spl_stablecoins.sql
+++ b/dbt_subprojects/solana/models/stablecoins/_list/tokens_solana_spl_stablecoins.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'spl_stablecoins',
     materialized = 'view',
-    tags = ['static'],
+    tags = ['static', 'prod_exclude'],
     unique_key = ['token_mint_address']
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/_list/tokens_solana_spl_stablecoins_core.sql
+++ b/dbt_subprojects/solana/models/stablecoins/_list/tokens_solana_spl_stablecoins_core.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'spl_stablecoins_core',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['static', 'prod_exclude'],
     unique_key = ['token_mint_address']
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/_list/tokens_solana_spl_stablecoins_extended.sql
+++ b/dbt_subprojects/solana/models/stablecoins/_list/tokens_solana_spl_stablecoins_extended.sql
@@ -5,7 +5,7 @@
     schema = 'tokens_' ~ chain,
     alias = 'spl_stablecoins_extended',
     materialized = 'table',
-    tags = ['static'],
+    tags = ['static', 'prod_exclude'],
     unique_key = ['token_mint_address']
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_balances.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_balances.sql
@@ -4,7 +4,8 @@
   config(
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
-    materialized = 'view'
+    materialized = 'view',
+    tags = ['prod_exclude']
     , post_hook='{{ expose_spells(\'["solana"]\',
         "sector",
         "stablecoins_solana",

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_core_balances.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_core_balances.sql
@@ -9,6 +9,7 @@
     incremental_strategy = 'merge',
     partition_by = ['day'],
     unique_key = ['day', 'address', 'token_mint_address'],
+    tags = ['prod_exclude'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_core_balances_enriched.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_core_balances_enriched.sql
@@ -9,6 +9,7 @@
     incremental_strategy = 'merge',
     partition_by = ['day'],
     unique_key = ['day', 'address', 'token_address'],
+    tags = ['prod_exclude'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_extended_balances.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_extended_balances.sql
@@ -9,6 +9,7 @@
     incremental_strategy = 'merge',
     partition_by = ['day'],
     unique_key = ['day', 'address', 'token_mint_address'],
+    tags = ['prod_exclude'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_extended_balances_enriched.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_extended_balances_enriched.sql
@@ -9,6 +9,7 @@
     incremental_strategy = 'merge',
     partition_by = ['day'],
     unique_key = ['day', 'address', 'token_address'],
+    tags = ['prod_exclude'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_non_circulating_inventory_accounts.sql
+++ b/dbt_subprojects/solana/models/stablecoins/balances/stablecoins_solana_non_circulating_inventory_accounts.sql
@@ -7,7 +7,8 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['token_mint_address', 'token_account']
+    unique_key = ['token_mint_address', 'token_account'],
+    tags = ['prod_exclude']
   )
 }}
 

--- a/dbt_subprojects/solana/models/stablecoins/stablecoins_svm_balances.sql
+++ b/dbt_subprojects/solana/models/stablecoins/stablecoins_svm_balances.sql
@@ -6,7 +6,8 @@
   config(
     schema = 'stablecoins_svm',
     alias = 'balances',
-    materialized = 'view'
+    materialized = 'view',
+    tags = ['prod_exclude']
   )
 }}
 

--- a/dbt_subprojects/solana/models/stablecoins/stablecoins_svm_transfers.sql
+++ b/dbt_subprojects/solana/models/stablecoins/stablecoins_svm_transfers.sql
@@ -6,7 +6,8 @@
   config(
     schema = 'stablecoins_svm',
     alias = 'transfers',
-    materialized = 'view'
+    materialized = 'view',
+    tags = ['prod_exclude']
     , post_hook='{{ hide_spells() }}'
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_core_transfers.sql
+++ b/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_core_transfers.sql
@@ -11,6 +11,7 @@
     batch_size = var('stablecoins_solana_batch_size', 'day'),
     partition_by = ['block_month'],
     unique_key = ['block_month', 'block_date', 'unique_key'],
+    tags = ['prod_exclude'],
     lookback = 1
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_core_transfers_enriched.sql
+++ b/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_core_transfers_enriched.sql
@@ -10,6 +10,7 @@
     on_schema_change = 'sync_all_columns',
     partition_by = ['block_month'],
     unique_key = ['block_month', 'block_date', 'unique_key'],
+    tags = ['prod_exclude'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_extended_transfers.sql
+++ b/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_extended_transfers.sql
@@ -11,6 +11,7 @@
     batch_size = var('stablecoins_solana_batch_size', 'day'),
     partition_by = ['block_month'],
     unique_key = ['block_month', 'block_date', 'unique_key'],
+    tags = ['prod_exclude'],
     lookback = 1
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_extended_transfers_enriched.sql
+++ b/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_extended_transfers_enriched.sql
@@ -10,6 +10,7 @@
     on_schema_change = 'sync_all_columns',
     partition_by = ['block_month'],
     unique_key = ['block_month', 'block_date', 'unique_key'],
+    tags = ['prod_exclude'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
   )
 }}

--- a/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_transfers.sql
+++ b/dbt_subprojects/solana/models/stablecoins/transfers/stablecoins_solana_transfers.sql
@@ -4,7 +4,8 @@
   config(
     schema = 'stablecoins_' ~ chain,
     alias = 'transfers',
-    materialized = 'view'
+    materialized = 'view',
+    tags = ['prod_exclude']
     , post_hook='{{ expose_spells(\'["solana"]\',
         "sector",
         "stablecoins_solana",

--- a/sources/_subprojects_outputs/solana/_sources.yml
+++ b/sources/_subprojects_outputs/solana/_sources.yml
@@ -15,3 +15,22 @@ sources:
     tables:
       - name: balances
       - name: transfers
+  - name: stablecoins_solana
+    tables:
+      - name: balances
+      - name: core_balances
+      - name: core_balances_enriched
+      - name: core_transfers
+      - name: core_transfers_enriched
+        config:
+          event_time: block_date
+      - name: extended_balances
+      - name: extended_balances_enriched
+      - name: extended_transfers
+      - name: extended_transfers_enriched
+        config:
+          event_time: block_date
+      - name: non_circulating_inventory_accounts
+      - name: transfers
+        config:
+          event_time: block_date

--- a/sources/_subprojects_outputs/tokens/transfers.yml
+++ b/sources/_subprojects_outputs/tokens/transfers.yml
@@ -307,6 +307,8 @@ sources:
       - name: net_transfers_daily
       - name: net_transfers_daily_asset
       - name: spl_stablecoins
+      - name: spl_stablecoins_core
+      - name: spl_stablecoins_extended
 
   - name: tokens_sui
     tables:


### PR DESCRIPTION
## Summary
- Add `prod_exclude` to Spellbook Solana stablecoin writer models ahead of curated-data cutover.
- Add source declarations for canonical `tokens_solana` and `stablecoins_solana` relations so Solana readers can resolve migrated outputs.

## Test plan
- `uv run dbt parse` from `dbt_subprojects/solana`
- `uv run dbt compile --select source:tokens_solana.transfers+ source:tokens_solana.fungible+ source:stablecoins_svm.transfers+ source:stablecoins_svm.balances+ --exclude tag:prod_exclude` from `dbt_subprojects/solana`
- Local Bugbot review: no bugs found


Made with [Cursor](https://cursor.com)