### PR TITLE
CUR2-2873: prepare stablecoin balance cutover

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/abstract/balances/stablecoins_abstract_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/abstract/balances/stablecoins_abstract_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/abstract/balances/stablecoins_abstract_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/abstract/balances/stablecoins_abstract_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/abstract/balances/stablecoins_abstract_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/abstract/balances/stablecoins_abstract_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/abstract/balances/stablecoins_abstract_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/abstract/balances/stablecoins_abstract_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/abstract/balances/stablecoins_abstract_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/abstract/balances/stablecoins_abstract_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/apechain/balances/stablecoins_apechain_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/apechain/balances/stablecoins_apechain_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/apechain/balances/stablecoins_apechain_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/apechain/balances/stablecoins_apechain_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/apechain/balances/stablecoins_apechain_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/apechain/balances/stablecoins_apechain_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/apechain/balances/stablecoins_apechain_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/apechain/balances/stablecoins_apechain_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/apechain/balances/stablecoins_apechain_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/apechain/balances/stablecoins_apechain_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/arbitrum/balances/stablecoins_arbitrum_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/arbitrum/balances/stablecoins_arbitrum_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/arbitrum/balances/stablecoins_arbitrum_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/arbitrum/balances/stablecoins_arbitrum_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/arbitrum/balances/stablecoins_arbitrum_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/arbitrum/balances/stablecoins_arbitrum_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/arbitrum/balances/stablecoins_arbitrum_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/arbitrum/balances/stablecoins_arbitrum_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/arbitrum/balances/stablecoins_arbitrum_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/arbitrum/balances/stablecoins_arbitrum_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/avalanche_c/balances/stablecoins_avalanche_c_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/avalanche_c/balances/stablecoins_avalanche_c_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 -- union of seed and latest enriched balances
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/avalanche_c/balances/stablecoins_avalanche_c_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/avalanche_c/balances/stablecoins_avalanche_c_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/avalanche_c/balances/stablecoins_avalanche_c_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/avalanche_c/balances/stablecoins_avalanche_c_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- core balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/avalanche_c/balances/stablecoins_avalanche_c_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/avalanche_c/balances/stablecoins_avalanche_c_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/avalanche_c/balances/stablecoins_avalanche_c_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/avalanche_c/balances/stablecoins_avalanche_c_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- extended balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/b3/balances/stablecoins_b3_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/b3/balances/stablecoins_b3_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/b3/balances/stablecoins_b3_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/b3/balances/stablecoins_b3_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/b3/balances/stablecoins_b3_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/b3/balances/stablecoins_b3_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/b3/balances/stablecoins_b3_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/b3/balances/stablecoins_b3_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/b3/balances/stablecoins_b3_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/b3/balances/stablecoins_b3_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/base/balances/stablecoins_base_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/base/balances/stablecoins_base_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 -- union of seed and latest enriched balances
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/base/balances/stablecoins_base_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/base/balances/stablecoins_base_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/base/balances/stablecoins_base_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/base/balances/stablecoins_base_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- core balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/base/balances/stablecoins_base_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/base/balances/stablecoins_base_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/base/balances/stablecoins_base_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/base/balances/stablecoins_base_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- extended balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/berachain/balances/stablecoins_berachain_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/berachain/balances/stablecoins_berachain_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/berachain/balances/stablecoins_berachain_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/berachain/balances/stablecoins_berachain_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/berachain/balances/stablecoins_berachain_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/berachain/balances/stablecoins_berachain_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/berachain/balances/stablecoins_berachain_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/berachain/balances/stablecoins_berachain_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/berachain/balances/stablecoins_berachain_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/berachain/balances/stablecoins_berachain_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bnb/balances/stablecoins_bnb_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bnb/balances/stablecoins_bnb_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 -- union of seed and latest enriched balances
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bnb/balances/stablecoins_bnb_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bnb/balances/stablecoins_bnb_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bnb/balances/stablecoins_bnb_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bnb/balances/stablecoins_bnb_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- core balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bnb/balances/stablecoins_bnb_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bnb/balances/stablecoins_bnb_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bnb/balances/stablecoins_bnb_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bnb/balances/stablecoins_bnb_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- extended balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bob/balances/stablecoins_bob_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bob/balances/stablecoins_bob_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bob/balances/stablecoins_bob_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bob/balances/stablecoins_bob_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bob/balances/stablecoins_bob_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bob/balances/stablecoins_bob_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bob/balances/stablecoins_bob_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bob/balances/stablecoins_bob_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bob/balances/stablecoins_bob_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/bob/balances/stablecoins_bob_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/boba/balances/stablecoins_boba_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/boba/balances/stablecoins_boba_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/boba/balances/stablecoins_boba_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/boba/balances/stablecoins_boba_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/boba/balances/stablecoins_boba_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/boba/balances/stablecoins_boba_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/boba/balances/stablecoins_boba_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/boba/balances/stablecoins_boba_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/boba/balances/stablecoins_boba_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/boba/balances/stablecoins_boba_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/celo/balances/stablecoins_celo_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/celo/balances/stablecoins_celo_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/celo/balances/stablecoins_celo_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/celo/balances/stablecoins_celo_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/celo/balances/stablecoins_celo_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/celo/balances/stablecoins_celo_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/celo/balances/stablecoins_celo_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/celo/balances/stablecoins_celo_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/celo/balances/stablecoins_celo_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/celo/balances/stablecoins_celo_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/corn/balances/stablecoins_corn_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/corn/balances/stablecoins_corn_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/corn/balances/stablecoins_corn_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/corn/balances/stablecoins_corn_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/corn/balances/stablecoins_corn_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/corn/balances/stablecoins_corn_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/corn/balances/stablecoins_corn_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/corn/balances/stablecoins_corn_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/corn/balances/stablecoins_corn_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/corn/balances/stablecoins_corn_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/degen/balances/stablecoins_degen_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/degen/balances/stablecoins_degen_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/degen/balances/stablecoins_degen_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/degen/balances/stablecoins_degen_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/degen/balances/stablecoins_degen_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/degen/balances/stablecoins_degen_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/degen/balances/stablecoins_degen_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/degen/balances/stablecoins_degen_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/degen/balances/stablecoins_degen_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/degen/balances/stablecoins_degen_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ethereum/balances/stablecoins_ethereum_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ethereum/balances/stablecoins_ethereum_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 -- union of seed and latest enriched balances
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ethereum/balances/stablecoins_ethereum_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ethereum/balances/stablecoins_ethereum_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ethereum/balances/stablecoins_ethereum_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ethereum/balances/stablecoins_ethereum_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- core balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ethereum/balances/stablecoins_ethereum_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ethereum/balances/stablecoins_ethereum_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ethereum/balances/stablecoins_ethereum_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ethereum/balances/stablecoins_ethereum_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- extended balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/fantom/balances/stablecoins_fantom_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/fantom/balances/stablecoins_fantom_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/fantom/balances/stablecoins_fantom_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/fantom/balances/stablecoins_fantom_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/fantom/balances/stablecoins_fantom_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/fantom/balances/stablecoins_fantom_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/fantom/balances/stablecoins_fantom_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/fantom/balances/stablecoins_fantom_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/fantom/balances/stablecoins_fantom_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/fantom/balances/stablecoins_fantom_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flare/balances/stablecoins_flare_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flare/balances/stablecoins_flare_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flare/balances/stablecoins_flare_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flare/balances/stablecoins_flare_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flare/balances/stablecoins_flare_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flare/balances/stablecoins_flare_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flare/balances/stablecoins_flare_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flare/balances/stablecoins_flare_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flare/balances/stablecoins_flare_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flare/balances/stablecoins_flare_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flow/balances/stablecoins_flow_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flow/balances/stablecoins_flow_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flow/balances/stablecoins_flow_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flow/balances/stablecoins_flow_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flow/balances/stablecoins_flow_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flow/balances/stablecoins_flow_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flow/balances/stablecoins_flow_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flow/balances/stablecoins_flow_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flow/balances/stablecoins_flow_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/flow/balances/stablecoins_flow_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/gnosis/balances/stablecoins_gnosis_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/gnosis/balances/stablecoins_gnosis_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/gnosis/balances/stablecoins_gnosis_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/gnosis/balances/stablecoins_gnosis_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/gnosis/balances/stablecoins_gnosis_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/gnosis/balances/stablecoins_gnosis_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/gnosis/balances/stablecoins_gnosis_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/gnosis/balances/stablecoins_gnosis_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/gnosis/balances/stablecoins_gnosis_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/gnosis/balances/stablecoins_gnosis_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hemi/balances/stablecoins_hemi_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hemi/balances/stablecoins_hemi_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hemi/balances/stablecoins_hemi_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hemi/balances/stablecoins_hemi_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hemi/balances/stablecoins_hemi_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hemi/balances/stablecoins_hemi_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hemi/balances/stablecoins_hemi_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hemi/balances/stablecoins_hemi_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hemi/balances/stablecoins_hemi_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hemi/balances/stablecoins_hemi_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/henesys/balances/stablecoins_henesys_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/henesys/balances/stablecoins_henesys_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/henesys/balances/stablecoins_henesys_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/henesys/balances/stablecoins_henesys_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/henesys/balances/stablecoins_henesys_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/henesys/balances/stablecoins_henesys_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/henesys/balances/stablecoins_henesys_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/henesys/balances/stablecoins_henesys_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/henesys/balances/stablecoins_henesys_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/henesys/balances/stablecoins_henesys_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hyperevm/balances/stablecoins_hyperevm_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hyperevm/balances/stablecoins_hyperevm_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hyperevm/balances/stablecoins_hyperevm_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hyperevm/balances/stablecoins_hyperevm_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hyperevm/balances/stablecoins_hyperevm_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hyperevm/balances/stablecoins_hyperevm_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hyperevm/balances/stablecoins_hyperevm_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hyperevm/balances/stablecoins_hyperevm_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hyperevm/balances/stablecoins_hyperevm_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/hyperevm/balances/stablecoins_hyperevm_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ink/balances/stablecoins_ink_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ink/balances/stablecoins_ink_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ink/balances/stablecoins_ink_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ink/balances/stablecoins_ink_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ink/balances/stablecoins_ink_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ink/balances/stablecoins_ink_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ink/balances/stablecoins_ink_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ink/balances/stablecoins_ink_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ink/balances/stablecoins_ink_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ink/balances/stablecoins_ink_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/kaia/balances/stablecoins_kaia_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/kaia/balances/stablecoins_kaia_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 -- union of seed and latest enriched balances
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/kaia/balances/stablecoins_kaia_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/kaia/balances/stablecoins_kaia_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/kaia/balances/stablecoins_kaia_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/kaia/balances/stablecoins_kaia_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- core balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/kaia/balances/stablecoins_kaia_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/kaia/balances/stablecoins_kaia_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/kaia/balances/stablecoins_kaia_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/kaia/balances/stablecoins_kaia_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- extended balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/katana/balances/stablecoins_katana_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/katana/balances/stablecoins_katana_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/katana/balances/stablecoins_katana_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/katana/balances/stablecoins_katana_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/katana/balances/stablecoins_katana_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/katana/balances/stablecoins_katana_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/katana/balances/stablecoins_katana_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/katana/balances/stablecoins_katana_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/katana/balances/stablecoins_katana_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/katana/balances/stablecoins_katana_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/linea/balances/stablecoins_linea_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/linea/balances/stablecoins_linea_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 -- union of seed and latest enriched balances
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/linea/balances/stablecoins_linea_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/linea/balances/stablecoins_linea_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/linea/balances/stablecoins_linea_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/linea/balances/stablecoins_linea_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- core balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/linea/balances/stablecoins_linea_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/linea/balances/stablecoins_linea_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/linea/balances/stablecoins_linea_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/linea/balances/stablecoins_linea_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- extended balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/mantle/balances/stablecoins_mantle_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/mantle/balances/stablecoins_mantle_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/mantle/balances/stablecoins_mantle_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/mantle/balances/stablecoins_mantle_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/mantle/balances/stablecoins_mantle_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/mantle/balances/stablecoins_mantle_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/mantle/balances/stablecoins_mantle_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/mantle/balances/stablecoins_mantle_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/mantle/balances/stablecoins_mantle_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/mantle/balances/stablecoins_mantle_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/megaeth/balances/stablecoins_megaeth_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/monad/balances/stablecoins_monad_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/monad/balances/stablecoins_monad_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/monad/balances/stablecoins_monad_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/monad/balances/stablecoins_monad_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/monad/balances/stablecoins_monad_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/monad/balances/stablecoins_monad_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/monad/balances/stablecoins_monad_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/monad/balances/stablecoins_monad_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/monad/balances/stablecoins_monad_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/monad/balances/stablecoins_monad_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/nova/balances/stablecoins_nova_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/nova/balances/stablecoins_nova_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/nova/balances/stablecoins_nova_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/nova/balances/stablecoins_nova_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/nova/balances/stablecoins_nova_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/nova/balances/stablecoins_nova_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/nova/balances/stablecoins_nova_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/nova/balances/stablecoins_nova_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/nova/balances/stablecoins_nova_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/nova/balances/stablecoins_nova_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/opbnb/balances/stablecoins_opbnb_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/opbnb/balances/stablecoins_opbnb_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/opbnb/balances/stablecoins_opbnb_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/opbnb/balances/stablecoins_opbnb_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/opbnb/balances/stablecoins_opbnb_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/opbnb/balances/stablecoins_opbnb_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/opbnb/balances/stablecoins_opbnb_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/opbnb/balances/stablecoins_opbnb_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/opbnb/balances/stablecoins_opbnb_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/opbnb/balances/stablecoins_opbnb_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/optimism/balances/stablecoins_optimism_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/optimism/balances/stablecoins_optimism_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 -- union of seed and latest enriched balances
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/optimism/balances/stablecoins_optimism_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/optimism/balances/stablecoins_optimism_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/optimism/balances/stablecoins_optimism_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/optimism/balances/stablecoins_optimism_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- core balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/optimism/balances/stablecoins_optimism_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/optimism/balances/stablecoins_optimism_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/optimism/balances/stablecoins_optimism_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/optimism/balances/stablecoins_optimism_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- extended balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/peaq/balances/stablecoins_peaq_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/peaq/balances/stablecoins_peaq_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/peaq/balances/stablecoins_peaq_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/peaq/balances/stablecoins_peaq_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/peaq/balances/stablecoins_peaq_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/peaq/balances/stablecoins_peaq_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/peaq/balances/stablecoins_peaq_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/peaq/balances/stablecoins_peaq_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/peaq/balances/stablecoins_peaq_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/peaq/balances/stablecoins_peaq_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plasma/balances/stablecoins_plasma_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plasma/balances/stablecoins_plasma_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plasma/balances/stablecoins_plasma_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plasma/balances/stablecoins_plasma_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plasma/balances/stablecoins_plasma_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plasma/balances/stablecoins_plasma_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plasma/balances/stablecoins_plasma_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plasma/balances/stablecoins_plasma_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plasma/balances/stablecoins_plasma_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plasma/balances/stablecoins_plasma_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plume/balances/stablecoins_plume_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plume/balances/stablecoins_plume_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plume/balances/stablecoins_plume_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plume/balances/stablecoins_plume_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plume/balances/stablecoins_plume_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plume/balances/stablecoins_plume_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plume/balances/stablecoins_plume_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plume/balances/stablecoins_plume_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plume/balances/stablecoins_plume_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/plume/balances/stablecoins_plume_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/polygon/balances/stablecoins_polygon_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/polygon/balances/stablecoins_polygon_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 -- union of seed and latest enriched balances
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/polygon/balances/stablecoins_polygon_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/polygon/balances/stablecoins_polygon_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/polygon/balances/stablecoins_polygon_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/polygon/balances/stablecoins_polygon_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- core balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/polygon/balances/stablecoins_polygon_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/polygon/balances/stablecoins_polygon_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/polygon/balances/stablecoins_polygon_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/polygon/balances/stablecoins_polygon_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- extended balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ronin/balances/stablecoins_ronin_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ronin/balances/stablecoins_ronin_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ronin/balances/stablecoins_ronin_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ronin/balances/stablecoins_ronin_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ronin/balances/stablecoins_ronin_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ronin/balances/stablecoins_ronin_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ronin/balances/stablecoins_ronin_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ronin/balances/stablecoins_ronin_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ronin/balances/stablecoins_ronin_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/ronin/balances/stablecoins_ronin_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/scroll/balances/stablecoins_scroll_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/scroll/balances/stablecoins_scroll_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 -- union of seed and latest enriched balances
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/scroll/balances/stablecoins_scroll_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/scroll/balances/stablecoins_scroll_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/scroll/balances/stablecoins_scroll_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/scroll/balances/stablecoins_scroll_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- core balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/scroll/balances/stablecoins_scroll_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/scroll/balances/stablecoins_scroll_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/scroll/balances/stablecoins_scroll_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/scroll/balances/stablecoins_scroll_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- extended balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sei/balances/stablecoins_sei_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sei/balances/stablecoins_sei_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sei/balances/stablecoins_sei_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sei/balances/stablecoins_sei_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sei/balances/stablecoins_sei_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sei/balances/stablecoins_sei_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sei/balances/stablecoins_sei_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sei/balances/stablecoins_sei_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sei/balances/stablecoins_sei_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sei/balances/stablecoins_sei_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sepolia/balances/stablecoins_sepolia_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sepolia/balances/stablecoins_sepolia_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sepolia/balances/stablecoins_sepolia_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sepolia/balances/stablecoins_sepolia_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sepolia/balances/stablecoins_sepolia_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sepolia/balances/stablecoins_sepolia_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sepolia/balances/stablecoins_sepolia_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sepolia/balances/stablecoins_sepolia_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sepolia/balances/stablecoins_sepolia_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sepolia/balances/stablecoins_sepolia_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/shape/balances/stablecoins_shape_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/shape/balances/stablecoins_shape_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/shape/balances/stablecoins_shape_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/shape/balances/stablecoins_shape_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/shape/balances/stablecoins_shape_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/shape/balances/stablecoins_shape_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/shape/balances/stablecoins_shape_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/shape/balances/stablecoins_shape_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/shape/balances/stablecoins_shape_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/shape/balances/stablecoins_shape_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/somnia/balances/stablecoins_somnia_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/somnia/balances/stablecoins_somnia_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/somnia/balances/stablecoins_somnia_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/somnia/balances/stablecoins_somnia_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/somnia/balances/stablecoins_somnia_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/somnia/balances/stablecoins_somnia_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/somnia/balances/stablecoins_somnia_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/somnia/balances/stablecoins_somnia_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/somnia/balances/stablecoins_somnia_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/somnia/balances/stablecoins_somnia_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sonic/balances/stablecoins_sonic_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sonic/balances/stablecoins_sonic_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sonic/balances/stablecoins_sonic_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sonic/balances/stablecoins_sonic_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sonic/balances/stablecoins_sonic_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sonic/balances/stablecoins_sonic_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sonic/balances/stablecoins_sonic_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sonic/balances/stablecoins_sonic_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sonic/balances/stablecoins_sonic_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sonic/balances/stablecoins_sonic_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sophon/balances/stablecoins_sophon_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sophon/balances/stablecoins_sophon_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sophon/balances/stablecoins_sophon_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sophon/balances/stablecoins_sophon_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sophon/balances/stablecoins_sophon_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sophon/balances/stablecoins_sophon_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sophon/balances/stablecoins_sophon_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sophon/balances/stablecoins_sophon_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sophon/balances/stablecoins_sophon_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/sophon/balances/stablecoins_sophon_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/stablecoins_evm_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/stablecoins_evm_balances.sql
@@ -39,7 +39,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_evm',
     alias = 'balances',
     materialized = 'view',
@@ -49,6 +49,7 @@
         contributors = \'["tomfutago"]\') }}'
   )
 }}
+-- ci-stamp: 1
 
 select *
 from (

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/story/balances/stablecoins_story_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/story/balances/stablecoins_story_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/story/balances/stablecoins_story_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/story/balances/stablecoins_story_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/story/balances/stablecoins_story_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/story/balances/stablecoins_story_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/story/balances/stablecoins_story_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/story/balances/stablecoins_story_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/story/balances/stablecoins_story_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/story/balances/stablecoins_story_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/superseed/balances/stablecoins_superseed_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/superseed/balances/stablecoins_superseed_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/superseed/balances/stablecoins_superseed_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/superseed/balances/stablecoins_superseed_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/superseed/balances/stablecoins_superseed_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/superseed/balances/stablecoins_superseed_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/superseed/balances/stablecoins_superseed_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/superseed/balances/stablecoins_superseed_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/superseed/balances/stablecoins_superseed_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/superseed/balances/stablecoins_superseed_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/tac/balances/stablecoins_tac_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/tac/balances/stablecoins_tac_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/tac/balances/stablecoins_tac_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/tac/balances/stablecoins_tac_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/tac/balances/stablecoins_tac_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/tac/balances/stablecoins_tac_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/tac/balances/stablecoins_tac_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/tac/balances/stablecoins_tac_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/tac/balances/stablecoins_tac_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/tac/balances/stablecoins_tac_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/taiko/balances/stablecoins_taiko_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/taiko/balances/stablecoins_taiko_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/taiko/balances/stablecoins_taiko_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/taiko/balances/stablecoins_taiko_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/taiko/balances/stablecoins_taiko_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/taiko/balances/stablecoins_taiko_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/taiko/balances/stablecoins_taiko_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/taiko/balances/stablecoins_taiko_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/taiko/balances/stablecoins_taiko_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/taiko/balances/stablecoins_taiko_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/unichain/balances/stablecoins_unichain_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/unichain/balances/stablecoins_unichain_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/unichain/balances/stablecoins_unichain_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/unichain/balances/stablecoins_unichain_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/unichain/balances/stablecoins_unichain_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/unichain/balances/stablecoins_unichain_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/unichain/balances/stablecoins_unichain_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/unichain/balances/stablecoins_unichain_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/unichain/balances/stablecoins_unichain_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/unichain/balances/stablecoins_unichain_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/viction/balances/stablecoins_viction_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/viction/balances/stablecoins_viction_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/viction/balances/stablecoins_viction_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/viction/balances/stablecoins_viction_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/viction/balances/stablecoins_viction_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/viction/balances/stablecoins_viction_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/viction/balances/stablecoins_viction_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/viction/balances/stablecoins_viction_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/viction/balances/stablecoins_viction_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/viction/balances/stablecoins_viction_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/worldchain/balances/stablecoins_worldchain_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/worldchain/balances/stablecoins_worldchain_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 -- union of seed and latest enriched balances
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/worldchain/balances/stablecoins_worldchain_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/worldchain/balances/stablecoins_worldchain_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/worldchain/balances/stablecoins_worldchain_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/worldchain/balances/stablecoins_worldchain_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- core balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/worldchain/balances/stablecoins_worldchain_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/worldchain/balances/stablecoins_worldchain_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/worldchain/balances/stablecoins_worldchain_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/worldchain/balances/stablecoins_worldchain_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- extended balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/xlayer/balances/stablecoins_xlayer_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/xlayer/balances/stablecoins_xlayer_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/xlayer/balances/stablecoins_xlayer_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/xlayer/balances/stablecoins_xlayer_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/xlayer/balances/stablecoins_xlayer_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/xlayer/balances/stablecoins_xlayer_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/xlayer/balances/stablecoins_xlayer_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/xlayer/balances/stablecoins_xlayer_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/xlayer/balances/stablecoins_xlayer_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/xlayer/balances/stablecoins_xlayer_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zkevm/balances/stablecoins_zkevm_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zkevm/balances/stablecoins_zkevm_balances.sql
@@ -9,6 +9,7 @@
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zkevm/balances/stablecoins_zkevm_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zkevm/balances/stablecoins_zkevm_core_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zkevm/balances/stablecoins_zkevm_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zkevm/balances/stablecoins_zkevm_core_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zkevm/balances/stablecoins_zkevm_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zkevm/balances/stablecoins_zkevm_extended_balances.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zkevm/balances/stablecoins_zkevm_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zkevm/balances/stablecoins_zkevm_extended_balances_enriched.sql
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zksync/balances/stablecoins_zksync_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zksync/balances/stablecoins_zksync_balances.sql
@@ -2,13 +2,14 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view'
     , post_hook='{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 -- union of seed and latest enriched balances
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zksync/balances/stablecoins_zksync_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zksync/balances/stablecoins_zksync_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zksync/balances/stablecoins_zksync_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zksync/balances/stablecoins_zksync_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- core balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zksync/balances/stablecoins_zksync_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zksync/balances/stablecoins_zksync_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zksync/balances/stablecoins_zksync_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/evm/zksync/balances/stablecoins_zksync_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 -- extended balances enriched with token metadata and usd prices
 {{
   balances_incremental_subset_daily_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_balances.sql
@@ -1,12 +1,13 @@
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins',
     alias = 'balances',
     materialized = 'view',
     post_hook = '{{ hide_spells() }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,
@@ -21,4 +22,4 @@ select
   balance_usd,
   currency,
   last_updated
-from {{ ref('stablecoins_evm_balances') }}
+from {{ source('stablecoins_evm', 'balances') }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_multichain_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_multichain_balances.sql
@@ -41,7 +41,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_multichain',
     alias = 'balances',
     materialized = 'view',
@@ -51,6 +51,7 @@
         contributors = \'["tomfutago"]\') }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,
@@ -65,7 +66,7 @@ select
   balance_usd,
   currency,
   last_updated
-from {{ ref('stablecoins_evm_balances') }}
+from {{ source('stablecoins_evm', 'balances') }}
 union all
 select
   blockchain,
@@ -95,4 +96,4 @@ select
   balance_usd,
   currency,
   last_updated
-from {{ ref('stablecoins_tron_balances') }}
+from {{ source('stablecoins_tron', 'balances') }}

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_multichain_tokens.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_multichain_tokens.sql
@@ -41,7 +41,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_multichain',
     alias = 'tokens',
     materialized = 'table',
@@ -51,6 +51,7 @@
         contributors = \'["tomfutago"]\') }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   s.blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_multichain_transfers.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/stablecoins_multichain_transfers.sql
@@ -41,7 +41,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_multichain',
     alias = 'transfers',
     materialized = 'view',
@@ -51,6 +51,7 @@
         contributors = \'["tomfutago"]\') }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'balances',
     materialized = 'view',
@@ -12,6 +12,7 @@
         \'["tomfutago"]\') }}'
   )
 }}
+-- ci-stamp: 1
 
 select
   blockchain,

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_core_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_core_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- core balances: tracks balances (from transfers) for stablecoins in the frozen core list
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_core_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_core_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'core_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   stablecoins_tron_balances_from_transfers_enrich(

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_extended_balances.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_extended_balances.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 -- extended balances: tracks balances (from transfers) for newly added stablecoins
 

--- a/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_extended_balances_enriched.sql
+++ b/dbt_subprojects/daily_spellbook/models/stablecoins/tron/balances/stablecoins_tron_extended_balances_enriched.sql
@@ -2,7 +2,7 @@
 
 {{
   config(
-    tags = ['stablecoins'],
+    tags = ['stablecoins', 'prod_exclude'],
     schema = 'stablecoins_' ~ chain,
     alias = 'extended_balances_enriched',
     materialized = 'incremental',
@@ -13,6 +13,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')]
   )
 }}
+-- ci-stamp: 1
 
 {{
   stablecoins_tron_balances_from_transfers_enrich(

--- a/sources/_subprojects_outputs/tokens/_sources.yml
+++ b/sources/_subprojects_outputs/tokens/_sources.yml
@@ -1191,12 +1191,14 @@ sources:
 
   - name: stablecoins_evm
     tables:
+      - name: balances
       - name: transfers
         meta:
           docs_slug: /curated/stablecoins/transfers/stablecoins-evm-transfers
 
   - name: stablecoins_tron
     tables:
+      - name: balances
       - name: core_transfers
       - name: extended_transfers
       - name: transfers


### PR DESCRIPTION
## Summary
- Add `prod_exclude` tags and CI body stamps to legacy daily Spellbook EVM/Tron stablecoin balance writers ahead of curated-data cutover.
- Mark stablecoin multichain writers as `prod_exclude` and switch balance readers to canonical `source()` references for EVM/Tron balances.
- Declare canonical `stablecoins_evm.balances` and `stablecoins_tron.balances` sources for downstream compile resolution.

## Test plan
- `uv run dbt deps --project-dir dbt_subprojects/daily_spellbook/`
- `uv run dbt ls --project-dir dbt_subprojects/daily_spellbook/ --profiles-dir dbt_subprojects/daily_spellbook/ --select stablecoins_balances stablecoins_evm_balances stablecoins_tron_balances stablecoins_multichain_balances stablecoins_multichain_tokens stablecoins_multichain_transfers`
- `uv run dbt compile --project-dir dbt_subprojects/daily_spellbook/ --profiles-dir dbt_subprojects/daily_spellbook/ --select stablecoins_balances stablecoins_evm_balances stablecoins_tron_balances stablecoins_multichain_balances stablecoins_multichain_tokens stablecoins_multichain_transfers --no-populate-cache`
- `uv run dbt ls --project-dir dbt_subprojects/daily_spellbook/ --profiles-dir dbt_subprojects/daily_spellbook/ --select tag:prod_exclude,stablecoins_balances tag:prod_exclude,stablecoins_evm_balances tag:prod_exclude,stablecoins_tron_balances tag:prod_exclude,stablecoins_multichain_balances tag:prod_exclude,stablecoins_multichain_tokens tag:prod_exclude,stablecoins_multichain_transfers`

Made with [Cursor](https://cursor.com)