### PR TITLE
perf(chainlink): incrementalize ocr_reward_transmission_logs + bound reward scan (x8)

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_evt_transfer_daily.sql
@@ -12,6 +12,37 @@
   )
 }}
 
+-- Performance (CUR2-2973): the upstream ocr_reward_evt_transfer view joined the full
+-- erc20 evt_Transfer history against an unbounded NewTransmission logs view, so each
+-- incremental run re-scanned tens of billions of rows to merge ~1 row/day. The view is
+-- inlined below: the reward-distributor contract set is read from the now-incremental
+-- ocr_reward_transmission_logs table (all-history, so no lagged-transfer drop), and the
+-- evt_Transfer scan is bounded by its evt_block_date partition on incremental runs. Each
+-- output day depends only on its own transfers' block_time, so the date bound is sound.
+
+WITH ocr_reward_evt_transfer AS (
+  SELECT
+    'arbitrum' as blockchain,
+    reward_evt_transfer.to as admin_address,
+    MAX(ocr_operator_admin_meta.operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_arbitrum', 'evt_Transfer') }} reward_evt_transfer
+    LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (
+      SELECT contract_address
+      FROM {{ ref('chainlink_arbitrum_ocr_reward_transmission_logs') }}
+    )
+{% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+{% endif %}
+  GROUP BY
+    reward_evt_transfer.evt_tx_hash,
+    reward_evt_transfer.evt_index,
+    reward_evt_transfer.to
+)
 
 SELECT
   'arbitrum' as blockchain,
@@ -21,7 +52,7 @@ SELECT
   MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_arbitrum_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_transmission_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_reward_transmission_logs.sql
@@ -2,10 +2,18 @@
   config(
     
     alias='ocr_reward_transmission_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'index']
     , post_hook='{{ hide_spells() }}'
   )
 }}
+
+-- Performance (CUR2-2973): materialized as an incremental table instead of a view so the
+-- full <chain>.logs scan by topic0 (tens of billions of rows) is not repeated on every
+-- downstream run. The NewTransmission set is append-only, so the table accumulates the
+-- all-history reward-distributor contract set; incremental runs only harvest new logs.
 
 SELECT
   'arbitrum' as blockchain,
@@ -25,3 +33,6 @@ FROM
   {{ source('arbitrum', 'logs') }} logs
 WHERE
   topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_schema.yml
@@ -304,6 +304,12 @@ models:
       tags: ["chainlink", "ocr", "reward", "transmission", "logs", "arbitrum"]
     description: >
       Chainlink OCR Reward Transmission Logs
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - tx_hash
+              - index
     columns:
       - *blockchain
       - *block_hash

--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_schema.yml
@@ -319,10 +319,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_arbitrum_ocr_reward_evt_transfer

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_evt_transfer_daily.sql
@@ -12,6 +12,37 @@
   )
 }}
 
+-- Performance (CUR2-2973): the upstream ocr_reward_evt_transfer view joined the full
+-- erc20 evt_Transfer history against an unbounded NewTransmission logs view, so each
+-- incremental run re-scanned tens of billions of rows to merge ~1 row/day. The view is
+-- inlined below: the reward-distributor contract set is read from the now-incremental
+-- ocr_reward_transmission_logs table (all-history, so no lagged-transfer drop), and the
+-- evt_Transfer scan is bounded by its evt_block_date partition on incremental runs. Each
+-- output day depends only on its own transfers' block_time, so the date bound is sound.
+
+WITH ocr_reward_evt_transfer AS (
+  SELECT
+    'avalanche_c' as blockchain,
+    reward_evt_transfer.to as admin_address,
+    MAX(ocr_operator_admin_meta.operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_avalanche_c', 'evt_Transfer') }} reward_evt_transfer
+    LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (
+      SELECT contract_address
+      FROM {{ ref('chainlink_avalanche_c_ocr_reward_transmission_logs') }}
+    )
+{% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+{% endif %}
+  GROUP BY
+    reward_evt_transfer.evt_tx_hash,
+    reward_evt_transfer.evt_index,
+    reward_evt_transfer.to
+)
 
 SELECT
   'avalanche_c' as blockchain,
@@ -21,7 +52,7 @@ SELECT
   MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_avalanche_c_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
@@ -30,6 +61,3 @@ GROUP BY
   2, 4
 ORDER BY
   2, 4
-
-
-

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_transmission_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_reward_transmission_logs.sql
@@ -2,10 +2,18 @@
   config(
     
     alias='ocr_reward_transmission_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'index']
     , post_hook='{{ hide_spells() }}'
   )
 }}
+
+-- Performance (CUR2-2973): materialized as an incremental table instead of a view so the
+-- full <chain>.logs scan by topic0 (tens of billions of rows) is not repeated on every
+-- downstream run. The NewTransmission set is append-only, so the table accumulates the
+-- all-history reward-distributor contract set; incremental runs only harvest new logs.
 
 SELECT
   'avalanche_c' as blockchain,
@@ -25,3 +33,6 @@ FROM
   {{ source('avalanche_c', 'logs') }} logs
 WHERE
   topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_schema.yml
@@ -305,6 +305,12 @@ models:
         ["chainlink", "ocr", "reward", "transmission", "logs", "avalanche_c"]
     description: >
       Chainlink OCR Reward Transmission Logs
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - tx_hash
+              - index
     columns:
       - *blockchain
       - *block_hash

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_schema.yml
@@ -320,10 +320,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_avalanche_c_ocr_reward_evt_transfer

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reward_evt_transfer_daily.sql
@@ -12,6 +12,37 @@
   )
 }}
 
+-- Performance (CUR2-2973): the upstream ocr_reward_evt_transfer view joined the full
+-- erc20 evt_Transfer history against an unbounded NewTransmission logs view, so each
+-- incremental run re-scanned tens of billions of rows to merge ~1 row/day. The view is
+-- inlined below: the reward-distributor contract set is read from the now-incremental
+-- ocr_reward_transmission_logs table (all-history, so no lagged-transfer drop), and the
+-- evt_Transfer scan is bounded by its evt_block_date partition on incremental runs. Each
+-- output day depends only on its own transfers' block_time, so the date bound is sound.
+
+WITH ocr_reward_evt_transfer AS (
+  SELECT
+    'bnb' as blockchain,
+    reward_evt_transfer.to as admin_address,
+    MAX(ocr_operator_admin_meta.operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_bnb', 'evt_Transfer') }} reward_evt_transfer
+    LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (
+      SELECT contract_address
+      FROM {{ ref('chainlink_bnb_ocr_reward_transmission_logs') }}
+    )
+{% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+{% endif %}
+  GROUP BY
+    reward_evt_transfer.evt_tx_hash,
+    reward_evt_transfer.evt_index,
+    reward_evt_transfer.to
+)
 
 SELECT
   'bnb' as blockchain,
@@ -21,7 +52,7 @@ SELECT
   MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_bnb_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
@@ -30,6 +61,3 @@ GROUP BY
   2, 4
 ORDER BY
   2, 4
-
-
-

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reward_transmission_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_reward_transmission_logs.sql
@@ -2,10 +2,18 @@
   config(
     
     alias='ocr_reward_transmission_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'index']
     , post_hook='{{ hide_spells() }}'
   )
 }}
+
+-- Performance (CUR2-2973): materialized as an incremental table instead of a view so the
+-- full <chain>.logs scan by topic0 (tens of billions of rows) is not repeated on every
+-- downstream run. The NewTransmission set is append-only, so the table accumulates the
+-- all-history reward-distributor contract set; incremental runs only harvest new logs.
 
 SELECT
   'bnb' as blockchain,
@@ -25,3 +33,6 @@ FROM
   {{ source('bnb', 'logs') }} logs
 WHERE
   topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_schema.yml
@@ -319,10 +319,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_bnb_ocr_reward_evt_transfer

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_schema.yml
@@ -304,6 +304,12 @@ models:
       tags: ["chainlink", "ocr", "reward", "transmission", "logs", "bnb"]
     description: >
       Chainlink OCR Reward Transmission Logs
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - tx_hash
+              - index
     columns:
       - *blockchain
       - *block_hash

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_evt_transfer_daily.sql
@@ -12,6 +12,37 @@
   )
 }}
 
+-- Performance (CUR2-2973): the upstream ocr_reward_evt_transfer view joined the full
+-- erc20 evt_Transfer history against an unbounded NewTransmission logs view, so each
+-- incremental run re-scanned tens of billions of rows to merge ~1 row/day. The view is
+-- inlined below: the reward-distributor contract set is read from the now-incremental
+-- ocr_reward_transmission_logs table (all-history, so no lagged-transfer drop), and the
+-- evt_Transfer scan is bounded by its evt_block_date partition on incremental runs. Each
+-- output day depends only on its own transfers' block_time, so the date bound is sound.
+
+WITH ocr_reward_evt_transfer AS (
+  SELECT
+    'ethereum' as blockchain,
+    reward_evt_transfer.to as admin_address,
+    MAX(ocr_operator_admin_meta.operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_ethereum', 'evt_Transfer') }} reward_evt_transfer
+    LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (
+      SELECT contract_address
+      FROM {{ ref('chainlink_ethereum_ocr_reward_transmission_logs') }}
+    )
+{% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+{% endif %}
+  GROUP BY
+    reward_evt_transfer.evt_tx_hash,
+    reward_evt_transfer.evt_index,
+    reward_evt_transfer.to
+)
 
 SELECT
   'ethereum' as blockchain,
@@ -21,7 +52,7 @@ SELECT
   MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_ethereum_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
@@ -30,6 +61,3 @@ GROUP BY
   2, 4
 ORDER BY
   2, 4
-
-
-

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_transmission_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_reward_transmission_logs.sql
@@ -2,10 +2,18 @@
   config(
     
     alias='ocr_reward_transmission_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'index']
     , post_hook='{{ hide_spells() }}'
   )
 }}
+
+-- Performance (CUR2-2973): materialized as an incremental table instead of a view so the
+-- full <chain>.logs scan by topic0 (tens of billions of rows) is not repeated on every
+-- downstream run. The NewTransmission set is append-only, so the table accumulates the
+-- all-history reward-distributor contract set; incremental runs only harvest new logs.
 
 SELECT
   'ethereum' as blockchain,
@@ -25,3 +33,6 @@ FROM
   {{ source('ethereum', 'logs') }} logs
 WHERE
   topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_schema.yml
@@ -319,10 +319,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_ethereum_ocr_reward_evt_transfer

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_schema.yml
@@ -304,6 +304,12 @@ models:
       tags: ["chainlink", "ocr", "reward", "transmission", "logs", "ethereum"]
     description: >
       Chainlink OCR Reward Transmission Logs
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - tx_hash
+              - index
     columns:
       - *blockchain
       - *block_hash

--- a/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reward_evt_transfer_daily.sql
@@ -12,6 +12,37 @@
   )
 }}
 
+-- Performance (CUR2-2973): the upstream ocr_reward_evt_transfer view joined the full
+-- erc20 evt_Transfer history against an unbounded NewTransmission logs view, so each
+-- incremental run re-scanned tens of billions of rows to merge ~1 row/day. The view is
+-- inlined below: the reward-distributor contract set is read from the now-incremental
+-- ocr_reward_transmission_logs table (all-history, so no lagged-transfer drop), and the
+-- evt_Transfer scan is bounded by its evt_block_date partition on incremental runs. Each
+-- output day depends only on its own transfers' block_time, so the date bound is sound.
+
+WITH ocr_reward_evt_transfer AS (
+  SELECT
+    'fantom' as blockchain,
+    reward_evt_transfer.to as admin_address,
+    MAX(ocr_operator_admin_meta.operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_fantom', 'evt_Transfer') }} reward_evt_transfer
+    LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (
+      SELECT contract_address
+      FROM {{ ref('chainlink_fantom_ocr_reward_transmission_logs') }}
+    )
+{% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+{% endif %}
+  GROUP BY
+    reward_evt_transfer.evt_tx_hash,
+    reward_evt_transfer.evt_index,
+    reward_evt_transfer.to
+)
 
 SELECT
   'fantom' as blockchain,
@@ -21,7 +52,7 @@ SELECT
   MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_fantom_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
@@ -30,6 +61,3 @@ GROUP BY
   2, 4
 ORDER BY
   2, 4
-
-
-

--- a/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reward_transmission_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_reward_transmission_logs.sql
@@ -2,10 +2,18 @@
   config(
     
     alias='ocr_reward_transmission_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'index']
     , post_hook='{{ hide_spells() }}'
   )
 }}
+
+-- Performance (CUR2-2973): materialized as an incremental table instead of a view so the
+-- full <chain>.logs scan by topic0 (tens of billions of rows) is not repeated on every
+-- downstream run. The NewTransmission set is append-only, so the table accumulates the
+-- all-history reward-distributor contract set; incremental runs only harvest new logs.
 
 SELECT
   'fantom' as blockchain,
@@ -25,3 +33,6 @@ FROM
   {{ source('fantom', 'logs') }} logs
 WHERE
   topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_schema.yml
@@ -319,10 +319,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_fantom_ocr_reward_evt_transfer

--- a/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_schema.yml
@@ -304,6 +304,12 @@ models:
       tags: ["chainlink", "ocr", "reward", "transmission", "logs", "fantom"]
     description: >
       Chainlink OCR Reward Transmission Logs
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - tx_hash
+              - index
     columns:
       - *blockchain
       - *block_hash

--- a/dbt_subprojects/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_evt_transfer_daily.sql
@@ -12,6 +12,37 @@
   )
 }}
 
+-- Performance (CUR2-2973): the upstream ocr_reward_evt_transfer view joined the full
+-- erc20 evt_Transfer history against an unbounded NewTransmission logs view, so each
+-- incremental run re-scanned tens of billions of rows to merge ~1 row/day. The view is
+-- inlined below: the reward-distributor contract set is read from the now-incremental
+-- ocr_reward_transmission_logs table (all-history, so no lagged-transfer drop), and the
+-- evt_Transfer scan is bounded by its evt_block_date partition on incremental runs. Each
+-- output day depends only on its own transfers' block_time, so the date bound is sound.
+
+WITH ocr_reward_evt_transfer AS (
+  SELECT
+    'gnosis' as blockchain,
+    reward_evt_transfer.to as admin_address,
+    MAX(ocr_operator_admin_meta.operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_gnosis', 'evt_Transfer') }} reward_evt_transfer
+    LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (
+      SELECT contract_address
+      FROM {{ ref('chainlink_gnosis_ocr_reward_transmission_logs') }}
+    )
+{% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+{% endif %}
+  GROUP BY
+    reward_evt_transfer.evt_tx_hash,
+    reward_evt_transfer.evt_index,
+    reward_evt_transfer.to
+)
 
 SELECT
   'gnosis' as blockchain,
@@ -21,7 +52,7 @@ SELECT
   MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_gnosis_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
@@ -30,6 +61,3 @@ GROUP BY
   2, 4
 ORDER BY
   2, 4
-
-
-

--- a/dbt_subprojects/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_transmission_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_reward_transmission_logs.sql
@@ -2,10 +2,18 @@
   config(
     
     alias='ocr_reward_transmission_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'index']
     , post_hook='{{ hide_spells() }}'
   )
 }}
+
+-- Performance (CUR2-2973): materialized as an incremental table instead of a view so the
+-- full <chain>.logs scan by topic0 (tens of billions of rows) is not repeated on every
+-- downstream run. The NewTransmission set is append-only, so the table accumulates the
+-- all-history reward-distributor contract set; incremental runs only harvest new logs.
 
 SELECT
   'gnosis' as blockchain,
@@ -25,3 +33,6 @@ FROM
   {{ source('gnosis', 'logs') }} logs
 WHERE
   topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_schema.yml
@@ -304,6 +304,12 @@ models:
       tags: ["chainlink", "ocr", "reward", "transmission", "logs", "gnosis"]
     description: >
       Chainlink OCR Reward Transmission Logs
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - tx_hash
+              - index
     columns:
       - *blockchain
       - *block_hash

--- a/dbt_subprojects/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_schema.yml
@@ -319,10 +319,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_gnosis_ocr_reward_evt_transfer

--- a/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reward_evt_transfer_daily.sql
@@ -12,6 +12,37 @@
   )
 }}
 
+-- Performance (CUR2-2973): the upstream ocr_reward_evt_transfer view joined the full
+-- erc20 evt_Transfer history against an unbounded NewTransmission logs view, so each
+-- incremental run re-scanned tens of billions of rows to merge ~1 row/day. The view is
+-- inlined below: the reward-distributor contract set is read from the now-incremental
+-- ocr_reward_transmission_logs table (all-history, so no lagged-transfer drop), and the
+-- evt_Transfer scan is bounded by its evt_block_date partition on incremental runs. Each
+-- output day depends only on its own transfers' block_time, so the date bound is sound.
+
+WITH ocr_reward_evt_transfer AS (
+  SELECT
+    'optimism' as blockchain,
+    reward_evt_transfer.to as admin_address,
+    MAX(ocr_operator_admin_meta.operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_optimism', 'evt_Transfer') }} reward_evt_transfer
+    LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (
+      SELECT contract_address
+      FROM {{ ref('chainlink_optimism_ocr_reward_transmission_logs') }}
+    )
+{% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+{% endif %}
+  GROUP BY
+    reward_evt_transfer.evt_tx_hash,
+    reward_evt_transfer.evt_index,
+    reward_evt_transfer.to
+)
 
 SELECT
   'optimism' as blockchain,
@@ -21,7 +52,7 @@ SELECT
   MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_optimism_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
@@ -30,6 +61,3 @@ GROUP BY
   2, 4
 ORDER BY
   2, 4
-
-
-

--- a/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reward_transmission_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_reward_transmission_logs.sql
@@ -2,10 +2,18 @@
   config(
     
     alias='ocr_reward_transmission_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'index']
     , post_hook='{{ hide_spells() }}'
   )
 }}
+
+-- Performance (CUR2-2973): materialized as an incremental table instead of a view so the
+-- full <chain>.logs scan by topic0 (tens of billions of rows) is not repeated on every
+-- downstream run. The NewTransmission set is append-only, so the table accumulates the
+-- all-history reward-distributor contract set; incremental runs only harvest new logs.
 
 SELECT
   'optimism' as blockchain,
@@ -25,3 +33,6 @@ FROM
   {{ source('optimism', 'logs') }} logs
 WHERE
   topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_schema.yml
@@ -304,6 +304,12 @@ models:
       tags: ["chainlink", "ocr", "reward", "transmission", "logs", "optimism"]
     description: >
       Chainlink OCR Reward Transmission Logs
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - tx_hash
+              - index
     columns:
       - *blockchain
       - *block_hash

--- a/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_schema.yml
@@ -319,10 +319,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_optimism_ocr_reward_evt_transfer

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reward_evt_transfer_daily.sql
@@ -12,6 +12,37 @@
   )
 }}
 
+-- Performance (CUR2-2973): the upstream ocr_reward_evt_transfer view joined the full
+-- erc20 evt_Transfer history against an unbounded NewTransmission logs view, so each
+-- incremental run re-scanned tens of billions of rows to merge ~1 row/day. The view is
+-- inlined below: the reward-distributor contract set is read from the now-incremental
+-- ocr_reward_transmission_logs table (all-history, so no lagged-transfer drop), and the
+-- evt_Transfer scan is bounded by its evt_block_date partition on incremental runs. Each
+-- output day depends only on its own transfers' block_time, so the date bound is sound.
+
+WITH ocr_reward_evt_transfer AS (
+  SELECT
+    'polygon' as blockchain,
+    reward_evt_transfer.to as admin_address,
+    MAX(ocr_operator_admin_meta.operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_polygon', 'evt_Transfer') }} reward_evt_transfer
+    LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (
+      SELECT contract_address
+      FROM {{ ref('chainlink_polygon_ocr_reward_transmission_logs') }}
+    )
+{% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+{% endif %}
+  GROUP BY
+    reward_evt_transfer.evt_tx_hash,
+    reward_evt_transfer.evt_index,
+    reward_evt_transfer.to
+)
 
 SELECT
   'polygon' as blockchain,
@@ -21,7 +52,7 @@ SELECT
   MAX(ocr_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_polygon_ocr_reward_evt_transfer')}} ocr_reward_evt_transfer
+  ocr_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_admin_meta') }} ocr_operator_admin_meta ON ocr_operator_admin_meta.admin_address = ocr_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
@@ -30,6 +61,3 @@ GROUP BY
   2, 4
 ORDER BY
   2, 4
-
-
-

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reward_transmission_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_reward_transmission_logs.sql
@@ -2,10 +2,18 @@
   config(
     
     alias='ocr_reward_transmission_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    unique_key=['tx_hash', 'index']
     , post_hook='{{ hide_spells() }}'
   )
 }}
+
+-- Performance (CUR2-2973): materialized as an incremental table instead of a view so the
+-- full <chain>.logs scan by topic0 (tens of billions of rows) is not repeated on every
+-- downstream run. The NewTransmission set is append-only, so the table accumulates the
+-- all-history reward-distributor contract set; incremental runs only harvest new logs.
 
 SELECT
   'polygon' as blockchain,
@@ -25,3 +33,6 @@ FROM
   {{ source('polygon', 'logs') }} logs
 WHERE
   topic0 = 0xd0d9486a2c673e2a4b57fc82e4c8a556b3e2b82dd5db07e2c04a920ca0f469b6
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_schema.yml
@@ -304,6 +304,12 @@ models:
       tags: ["chainlink", "ocr", "reward", "transmission", "logs", "polygon"]
     description: >
       Chainlink OCR Reward Transmission Logs
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - tx_hash
+              - index
     columns:
       - *blockchain
       - *block_hash

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_schema.yml
@@ -319,10 +319,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_polygon_ocr_reward_evt_transfer


### PR DESCRIPTION
Family follow-up of #9843 / CUR2-2973, the `ocr_reward_evt_transfer_daily` sub-family on spellbook-daily (8 chains: arbitrum, avalanche_c, bnb, ethereum, fantom, gnosis, optimism, polygon).

Measuring where the bytes actually go re-attributed the cost away from the issue's stated `evt_block_time` hypothesis. The dominant scan is the `ocr_reward_transmission_logs` **view**, which re-scans the full `<chain>.logs` by topic0 on every incremental run (bnb: 52.3B rows / 165 GB to produce ~30k rows). The reward `evt_Transfer` side is secondary and already prunes on its `evt_block_date` partition. Crucially, the logs scan **cannot be soundly time-bounded**: reward transfers can lag their contract's transmission, so a window-bounded contract set drops real transfers (proven — bounding the logs diverged `token_amount` by 93.37 on gnosis). The contract set must come from all history.

The fix has two halves:

1. **`chainlink_<chain>_ocr_reward_transmission_logs`: view -> incremental delta table** (`unique_key=['tx_hash','index']`, both non-null; merge; no partition — ~30k rows/chain). The same 13-column `NewTransmission` harvest, now with `incremental_predicate('block_time')` so each run appends only new transmissions (block_time file-skips the block_date-partitioned logs). The table accumulates the all-history contract set monotonically, which is what makes the downstream bound sound.

2. **`chainlink_<chain>_ocr_reward_evt_transfer_daily`: inline the upstream reward view as a CTE** that reads the new table for the contract set (`"from" IN (SELECT contract_address FROM ... transmission_logs)`) and bounds `evt_Transfer` by `incremental_predicate('evt_block_date')` below the per-tx aggregation. The outer aggregation, the `evt_block_time` predicate, and the grain are kept byte-identical, so output equals the current stored table.

Proof (read-only, spellbook-sqlmesh; `b` reads the all-history contract set, simulating the accumulated table, vs `a` = current stored daily table):

- Equivalence: `(a EXCEPT b)` and `(b EXCEPT a)` = 0 both ways on keys, with matching `token_amount`/`date_month`/`operator_name` and 0 duplicate keys — bnb (43 rows, token diff 3.55e-15) and **gnosis (320 rows, token diff 3.41e-13)**. Gnosis is the chain that exposed the unsound logs-bound divergence; with the all-history contract set it is exact.
- A/B cost (bnb, live 3-day window, medians of 3 warm runs), new reward daily + new logs build vs the current daily MERGE: `physical_input_bytes` 1019 GB -> ~6.6 GB (~154x); `cpu_ms` ~6,912,000 -> ~24,000 (~288x); scanned rows 82B -> ~435M (~189x); wall ~41 min -> ~4.5 s; spill 0.

Family baseline ~3.94 CPU-hrs/day, ~1,929 GB/day IO, expected to drop to ~0.1 CPU-hrs/day and ~25-30 GB/day. No NULL-key risk (ocr has 0 duplicate keys and 0 null `admin_address` across all 8 prod tables). Incremental-only; full-refresh path unchanged. The cross-chain union `chainlink_ocr_reward_transmission_logs` is preserved (same 13 columns). The now-orphaned per-chain `ocr_reward_evt_transfer` views are left in place (zero-cost) to keep this PR scoped.

The identical-shape `fm_reward_evt_transfer_daily` x8 family is a direct follow-up.

Towards CUR2-2973
