### PR TITLE
perf(dex): seed uniswap v4 sqrtpricex96 from a latest-price companion (drop full-history self-scan, 3 chains)

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_compatible_liquidity.sql
@@ -11,8 +11,20 @@ cast({{ block_number }} as decimal(38, 0)) * decimal '1000000000000'
     , PoolManager_evt_Initialize = null
     , PoolManager_evt_Swap = null 
     , transactions = null
+    , latest_price_relation = none
     )
 %}
+
+{#
+    latest_price_relation: opt-in perf lever (default none = unchanged, byte-identical output).
+    When set to a ref() of this model's `sqrtpricex96_latest` companion, the incremental seed that
+    recovers each active pool's latest PRIOR price reads that 1-row-per-pool companion instead of
+    re-scanning ALL of {{this}} every run. The companion holds the latest SETTLED price per pool
+    (block_time < the incremental window_start), which is provably equal to the legacy full-history
+    anti-join seed (rows match, EXCEPT=0 both ways). Only worthwhile on high-activity chains where the
+    eliminated self-scan dominates the companion's maintenance cost. See macro
+    uniswap_compatible_v4_liquidity_sqrtpricex96_latest below and CUR2-2835.
+#}
 
 {% if is_incremental() %}
 
@@ -70,6 +82,7 @@ get_active_pools as ( -- get only the pools that were active on incremental run
 ),
 
 get_latest_active_pools as (
+{% if latest_price_relation is none %}
     select 
         th.id
         , 'exclude' as check_filter
@@ -94,6 +107,26 @@ get_latest_active_pools as (
     ) th 
     where base_block_index_sum is null 
     group by 1
+{% else %}
+    -- Perf (CUR2-2835): read each active pool's latest prior price from the forward-filled
+    -- companion (1 row/pool = latest SETTLED price, block_time < window_start) instead of
+    -- re-scanning all of {{this}} every run. The companion is disjoint from base_events
+    -- (settled vs in-window), so the base_events anti-join is unnecessary here. Proven equal
+    -- to the legacy full-history seed (rows match, EXCEPT=0 both ways).
+    select 
+        lp.id
+        , 'exclude' as check_filter
+        , lp.block_time
+        , lp.block_number
+        , lp.evt_index
+        , lp.block_index_sum 
+        , lp.sqrtpricex96
+    from 
+    {{ latest_price_relation }} lp 
+    inner join 
+    get_active_pools ga 
+        on lp.id = ga.id 
+{% endif %}
 
     union all 
 
@@ -189,6 +222,182 @@ sort_table as (
         , sqrtpricex96
     from 
     get_events 
+
+{% endif %}
+
+{% endmacro %}
+
+{% macro uniswap_compatible_v4_liquidity_sqrtpricex96_latest(
+    blockchain = null
+    , project = 'uniswap'
+    , version = '4'
+    , PoolManager_evt_Initialize = null
+    , PoolManager_evt_Swap = null
+    , transactions = null
+    , settled_lookback_days = 7
+    , apply_ci_floor = true
+    )
+%}
+
+{#
+    Forward-filled "latest SETTLED price per pool" companion for the sqrtpricex96 builder
+    (uniswap_compatible_v4_liquidity_sqrtpricex96). Holds exactly one row per (id, blockchain): the
+    price row with the greatest block_index_sum among rows whose block_time is < the builder's
+    incremental window_start (i.e. already SETTLED out of the builder's re-merge window). The builder
+    reads this 1-row-per-pool table to seed each active pool's previous_block_index_sum instead of
+    re-scanning all of {{this}}. CUR2-2835.
+
+    Maintenance (incremental, merge on [id, blockchain]):
+      - self-carry: the companion's own current row per pool, so pools not touched this run are
+        retained -- including pools dormant arbitrarily far back. This is what makes a NARROW source
+        slice safe (the deep history never has to be re-read).
+      - source fold: events that have NEWLY settled since the last run -- a bounded lagged slice
+        [now - settled_lookback_days, window_start). block_index_sum is monotone in block_number, so
+        max_by/max over (self-carry UNION lagged slice) is idempotent under overlap and only needs to
+        catch each settling row once. settled_lookback_days only needs to exceed the longest expected
+        gap between companion runs (outage tolerance); the self-carry covers all older history.
+
+    First build (table absent): latest settled price per pool over ALL source history (full
+    transactions join). This is heavy; in CI it is bounded by the 30-day floor below. In prod, prefer
+    pre-seeding this table ONCE from the existing builder output (it already stores block_index_sum)
+    to skip the full-history transactions join -- see the companion model file's backfill note.
+#}
+
+{%- set time_unit = var('DBT_ENV_INCREMENTAL_TIME_UNIT') -%}
+{%- set window_start = "date_trunc('" ~ time_unit ~ "', now() - interval '" ~ var('DBT_ENV_INCREMENTAL_TIME') ~ "' " ~ time_unit ~ ")" -%}
+{%- set settled_floor = "date_trunc('" ~ time_unit ~ "', now() - interval '" ~ settled_lookback_days ~ "' " ~ time_unit ~ ")" -%}
+
+{% if is_incremental() %}
+
+with
+
+source_settled as ( -- events that newly settled since the last run (bounded lagged slice)
+    select
+        e.id
+        , e.evt_block_time as block_time
+        , e.evt_block_number as block_number
+        , e.evt_index
+        , {{ uniswap_compatible_v4_block_index_sum('e.evt_block_number', 'coalesce(e.evt_tx_index, tx.index)', 'e.evt_index') }} as block_index_sum
+        , e.sqrtpricex96
+    from
+    {{ PoolManager_evt_Initialize }} e
+    left join {{ transactions }} tx
+        on e.evt_tx_index is null
+        and e.evt_tx_hash = tx.hash
+        and e.evt_block_number = tx.block_number
+        and e.evt_block_date = tx.block_date
+        and tx.block_time >= {{ settled_floor }}
+        and tx.block_time < {{ window_start }}
+    where e.sqrtPriceX96 is not null
+    and e.evt_block_time >= {{ settled_floor }}
+    and e.evt_block_time < {{ window_start }}
+
+    union all
+
+    select
+        e.id
+        , e.evt_block_time as block_time
+        , e.evt_block_number as block_number
+        , e.evt_index
+        , {{ uniswap_compatible_v4_block_index_sum('e.evt_block_number', 'coalesce(e.evt_tx_index, tx.index)', 'e.evt_index') }} as block_index_sum
+        , e.sqrtpricex96
+    from
+    {{ PoolManager_evt_Swap }} e
+    left join {{ transactions }} tx
+        on e.evt_tx_index is null
+        and e.evt_tx_hash = tx.hash
+        and e.evt_block_number = tx.block_number
+        and e.evt_block_date = tx.block_date
+        and tx.block_time >= {{ settled_floor }}
+        and tx.block_time < {{ window_start }}
+    where e.sqrtPriceX96 is not null
+    and e.evt_block_time >= {{ settled_floor }}
+    and e.evt_block_time < {{ window_start }}
+),
+
+self_carry as ( -- retain every pool's current latest, incl. ones not in this run's slice
+    select
+        id
+        , block_time
+        , block_number
+        , evt_index
+        , block_index_sum
+        , sqrtpricex96
+    from
+    {{ this }}
+),
+
+unioned as (
+    select * from source_settled
+    union all
+    select * from self_carry
+)
+
+select
+    '{{ blockchain }}' as blockchain
+    , id
+    , max_by(block_time, block_index_sum) as block_time
+    , max_by(block_number, block_index_sum) as block_number
+    , max_by(evt_index, block_index_sum) as evt_index
+    , max(block_index_sum) as block_index_sum
+    , max_by(sqrtpricex96, block_index_sum) as sqrtpricex96
+from
+unioned
+group by id
+
+{% else %}
+
+with
+
+all_events as ( -- first build: latest settled price per pool over ALL history (CI: last 30d only)
+    select
+        e.id
+        , e.evt_block_time as block_time
+        , e.evt_block_number as block_number
+        , e.evt_index
+        , {{ uniswap_compatible_v4_block_index_sum('e.evt_block_number', 'coalesce(e.evt_tx_index, tx.index)', 'e.evt_index') }} as block_index_sum
+        , e.sqrtpricex96
+    from
+    {{ PoolManager_evt_Initialize }} e
+    left join {{ transactions }} tx
+        on e.evt_tx_index is null
+        and e.evt_tx_hash = tx.hash
+        and e.evt_block_number = tx.block_number
+        and e.evt_block_date = tx.block_date
+    where e.sqrtPriceX96 is not null
+    {% if target.name == 'ci' and apply_ci_floor %}and e.evt_block_time >= date_trunc('day', now() - interval '30' day){% endif %}
+
+    union all
+
+    select
+        e.id
+        , e.evt_block_time as block_time
+        , e.evt_block_number as block_number
+        , e.evt_index
+        , {{ uniswap_compatible_v4_block_index_sum('e.evt_block_number', 'coalesce(e.evt_tx_index, tx.index)', 'e.evt_index') }} as block_index_sum
+        , e.sqrtpricex96
+    from
+    {{ PoolManager_evt_Swap }} e
+    left join {{ transactions }} tx
+        on e.evt_tx_index is null
+        and e.evt_tx_hash = tx.hash
+        and e.evt_block_number = tx.block_number
+        and e.evt_block_date = tx.block_date
+    where e.sqrtPriceX96 is not null
+    {% if target.name == 'ci' and apply_ci_floor %}and e.evt_block_time >= date_trunc('day', now() - interval '30' day){% endif %}
+)
+
+select
+    '{{ blockchain }}' as blockchain
+    , id
+    , max_by(block_time, block_index_sum) as block_time
+    , max_by(block_number, block_index_sum) as block_number
+    , max_by(evt_index, block_index_sum) as evt_index
+    , max(block_index_sum) as block_index_sum
+    , max_by(sqrtpricex96, block_index_sum) as sqrtpricex96
+from
+all_events
+group by id
 
 {% endif %}
 

--- a/dbt_subprojects/dex/models/_projects/pancakeswap/bnb/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/pancakeswap/bnb/_schema.yml
@@ -421,3 +421,33 @@ models:
       - &sqrtpricex96
         name: sqrtpricex96
         description: "Pool Price"
+
+  - name: pancakeswap_infinity_cl_bnb_sqrtpricex96_latest
+    meta:
+      blockchain: bnb
+      sector: dex
+      project: pancakeswap
+      contributors: Henrystats
+    config:
+      tags: ['bnb', 'pools', 'liquidity', 'pancakeswap', 'sqrtpricex96']
+    description: >
+      Forward-filled latest settled price (sqrtPriceX96) per pool, one row per pool. Companion that
+      seeds the incremental prior-price lookup in pancakeswap_infinity_cl_bnb_sqrtpricex96 so it no
+      longer re-scans full price history every run.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - id
+    columns:
+      - *blockchain
+      - *id
+      - name: block_time
+        description: "Block time of the latest settled price event"
+      - name: block_number
+        description: "Block number of the latest settled price event"
+      - name: evt_index
+        description: "Event index of the latest settled price event"
+      - *block_index_sum
+      - *sqrtpricex96

--- a/dbt_subprojects/dex/models/_projects/pancakeswap/bnb/pancakeswap_infinity_cl_bnb_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/pancakeswap/bnb/pancakeswap_infinity_cl_bnb_sqrtpricex96.sql
@@ -17,5 +17,6 @@
         , PoolManager_evt_Initialize = source('pancakeswap_infinity_bnb', 'clpoolmanager_evt_initialize')
         , PoolManager_evt_Swap = source('pancakeswap_infinity_bnb', 'ClPoolManager_evt_Swap') 
         , transactions = source('bnb', 'transactions')
+        , latest_price_relation = ref('pancakeswap_infinity_cl_bnb_sqrtpricex96_latest')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/pancakeswap/bnb/pancakeswap_infinity_cl_bnb_sqrtpricex96_latest.sql
+++ b/dbt_subprojects/dex/models/_projects/pancakeswap/bnb/pancakeswap_infinity_cl_bnb_sqrtpricex96_latest.sql
@@ -1,0 +1,35 @@
+{{ config(
+    schema = 'pancakeswap_infinity_cl_bnb'
+    , alias = 'sqrtpricex96_latest'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['id', 'blockchain']
+    )
+}}
+
+-- Forward-filled "latest settled price per pool" companion for
+-- pancakeswap_infinity_cl_bnb_sqrtpricex96. Seeds that builder's incremental prior-price lookup so it
+-- no longer re-scans full history every run. CUR2-2835.
+--
+-- BACKFILL NOTE (one-time, prod): before the first scheduled build, pre-seed this table from the
+-- existing builder output to skip a full-history transactions join:
+--   CREATE TABLE pancakeswap_infinity_cl_bnb.sqrtpricex96_latest AS
+--   SELECT blockchain, id,
+--          max_by(block_time, block_index_sum)    AS block_time,
+--          max_by(block_number, block_index_sum)  AS block_number,
+--          max_by(evt_index, block_index_sum)     AS evt_index,
+--          max(block_index_sum)                   AS block_index_sum,
+--          max_by(sqrtpricex96, block_index_sum)  AS sqrtpricex96
+--   FROM pancakeswap_infinity_cl_bnb.sqrtpricex96 GROUP BY blockchain, id;
+
+{{
+    uniswap_compatible_v4_liquidity_sqrtpricex96_latest(
+          blockchain = 'bnb'
+        , project = 'pancakeswap'
+        , version = 'infinity_cl'
+        , PoolManager_evt_Initialize = source('pancakeswap_infinity_bnb', 'clpoolmanager_evt_initialize')
+        , PoolManager_evt_Swap = source('pancakeswap_infinity_bnb', 'ClPoolManager_evt_Swap')
+        , transactions = source('bnb', 'transactions')
+    )
+}}

--- a/dbt_subprojects/dex/models/_projects/uniswap/base/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/base/_schema.yml
@@ -171,6 +171,36 @@ models:
         name: sqrtpricex96
         description: "Pool Price"
 
+  - name: uniswap_v4_base_sqrtpricex96_latest
+    meta:
+      blockchain: base
+      sector: dex
+      project: uniswap
+      contributors: Henrystats
+    config:
+      tags: ['base', 'pools', 'liquidity', 'uniswap', 'sqrtpricex96']
+    description: >
+      Forward-filled latest settled price (sqrtPriceX96) per pool, one row per pool. Companion that
+      seeds the incremental prior-price lookup in uniswap_v4_base_sqrtpricex96 so it no longer re-scans
+      full price history every run.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - id
+    columns:
+      - *blockchain
+      - *id
+      - name: block_time
+        description: "Block time of the latest settled price event"
+      - name: block_number
+        description: "Block number of the latest settled price event"
+      - name: evt_index
+        description: "Event index of the latest settled price event"
+      - *block_index_sum
+      - *sqrtpricex96
+
   - name: uniswap_v4_base_base_liquidity_events
     meta:
       blockchain: base

--- a/dbt_subprojects/dex/models/_projects/uniswap/base/uniswap_v4_base_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/base/uniswap_v4_base_sqrtpricex96.sql
@@ -17,5 +17,6 @@
         , PoolManager_evt_Initialize = source('uniswap_v4_base', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_base', 'PoolManager_evt_Swap') 
         , transactions = source('base', 'transactions')
+        , latest_price_relation = ref('uniswap_v4_base_sqrtpricex96_latest')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/base/uniswap_v4_base_sqrtpricex96_latest.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/base/uniswap_v4_base_sqrtpricex96_latest.sql
@@ -1,0 +1,34 @@
+{{ config(
+    schema = 'uniswap_v4_base'
+    , alias = 'sqrtpricex96_latest'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['id', 'blockchain']
+    )
+}}
+
+-- Forward-filled "latest settled price per pool" companion for uniswap_v4_base_sqrtpricex96. Seeds that
+-- builder's incremental prior-price lookup so it no longer re-scans full history every run. CUR2-2835.
+--
+-- BACKFILL NOTE (one-time, prod): before the first scheduled build, pre-seed this table from the
+-- existing builder output to skip a full-history transactions join:
+--   CREATE TABLE uniswap_v4_base.sqrtpricex96_latest AS
+--   SELECT blockchain, id,
+--          max_by(block_time, block_index_sum)    AS block_time,
+--          max_by(block_number, block_index_sum)  AS block_number,
+--          max_by(evt_index, block_index_sum)     AS evt_index,
+--          max(block_index_sum)                   AS block_index_sum,
+--          max_by(sqrtpricex96, block_index_sum)  AS sqrtpricex96
+--   FROM uniswap_v4_base.sqrtpricex96 GROUP BY blockchain, id;
+
+{{
+    uniswap_compatible_v4_liquidity_sqrtpricex96_latest(
+          blockchain = 'base'
+        , project = 'uniswap'
+        , version = '4'
+        , PoolManager_evt_Initialize = source('uniswap_v4_base', 'PoolManager_evt_Initialize')
+        , PoolManager_evt_Swap = source('uniswap_v4_base', 'PoolManager_evt_Swap')
+        , transactions = source('base', 'transactions')
+    )
+}}

--- a/dbt_subprojects/dex/models/_projects/uniswap/bnb/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/bnb/_schema.yml
@@ -171,6 +171,36 @@ models:
         name: sqrtpricex96
         description: "Pool Price"
 
+  - name: uniswap_v4_bnb_sqrtpricex96_latest
+    meta:
+      blockchain: bnb
+      sector: dex
+      project: uniswap
+      contributors: Henrystats
+    config:
+      tags: ['bnb', 'pools', 'liquidity', 'uniswap', 'sqrtpricex96']
+    description: >
+      Forward-filled latest settled price (sqrtPriceX96) per pool, one row per pool. Companion that
+      seeds the incremental prior-price lookup in uniswap_v4_bnb_sqrtpricex96 so it no longer re-scans
+      full price history every run.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - id
+    columns:
+      - *blockchain
+      - *id
+      - name: block_time
+        description: "Block time of the latest settled price event"
+      - name: block_number
+        description: "Block number of the latest settled price event"
+      - name: evt_index
+        description: "Event index of the latest settled price event"
+      - *block_index_sum
+      - *sqrtpricex96
+
   - name: uniswap_v4_bnb_base_liquidity_events
     meta:
       blockchain: bnb

--- a/dbt_subprojects/dex/models/_projects/uniswap/bnb/uniswap_v4_bnb_sqrtpricex96.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/bnb/uniswap_v4_bnb_sqrtpricex96.sql
@@ -17,5 +17,6 @@
         , PoolManager_evt_Initialize = source('uniswap_v4_bnb', 'PoolManager_evt_Initialize')
         , PoolManager_evt_Swap = source('uniswap_v4_bnb', 'PoolManager_evt_Swap') 
         , transactions = source('bnb', 'transactions')
+        , latest_price_relation = ref('uniswap_v4_bnb_sqrtpricex96_latest')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/bnb/uniswap_v4_bnb_sqrtpricex96_latest.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/bnb/uniswap_v4_bnb_sqrtpricex96_latest.sql
@@ -1,0 +1,34 @@
+{{ config(
+    schema = 'uniswap_v4_bnb'
+    , alias = 'sqrtpricex96_latest'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['id', 'blockchain']
+    )
+}}
+
+-- Forward-filled "latest settled price per pool" companion for uniswap_v4_bnb_sqrtpricex96. Seeds that
+-- builder's incremental prior-price lookup so it no longer re-scans full history every run. CUR2-2835.
+--
+-- BACKFILL NOTE (one-time, prod): before the first scheduled build, pre-seed this table from the
+-- existing builder output to skip a full-history transactions join:
+--   CREATE TABLE uniswap_v4_bnb.sqrtpricex96_latest AS
+--   SELECT blockchain, id,
+--          max_by(block_time, block_index_sum)    AS block_time,
+--          max_by(block_number, block_index_sum)  AS block_number,
+--          max_by(evt_index, block_index_sum)     AS evt_index,
+--          max(block_index_sum)                   AS block_index_sum,
+--          max_by(sqrtpricex96, block_index_sum)  AS sqrtpricex96
+--   FROM uniswap_v4_bnb.sqrtpricex96 GROUP BY blockchain, id;
+
+{{
+    uniswap_compatible_v4_liquidity_sqrtpricex96_latest(
+          blockchain = 'bnb'
+        , project = 'uniswap'
+        , version = '4'
+        , PoolManager_evt_Initialize = source('uniswap_v4_bnb', 'PoolManager_evt_Initialize')
+        , PoolManager_evt_Swap = source('uniswap_v4_bnb', 'PoolManager_evt_Swap')
+        , transactions = source('bnb', 'transactions')
+    )
+}}


### PR DESCRIPTION
## What

The incremental `sqrtpricex96` builder macro (`uniswap_compatible_v4_liquidity_sqrtpricex96`) recovers each active pool's latest *prior* price (to seed the `previous_block_index_sum` lag) by re-scanning **all of `{{this}}` every run** in `get_latest_active_pools`. That is an unbounded self-scan: on `pancakeswap_infinity_cl_bnb` the rep run read **386M+ rows / ~9.2 GB** and processed ~400M rows to emit ~1 useful row per pool (poor-selectivity 2.5e-9), with the downstream self-join being the dominant CPU cost.

This adds an opt-in `latest_price_relation` parameter. When set to a per-chain `sqrtpricex96_latest` companion — a forward-filled **latest SETTLED price per pool** (1 row/pool), maintained incrementally from source with a bounded lagged slice + self-carry — the builder seeds from that ~85k-row companion instead of self-scanning full history. Default (`none`) renders byte-identical SQL, so unopted chains are unchanged.

Opts in the 3 highest-cost chains (71% of the family's ~8.6 CPU-hrs/day, ~1.86 TB/day):
- `pancakeswap_infinity_cl_bnb` (3.27 CPU-hrs/day)
- `uniswap_v4_bnb` (1.42)
- `uniswap_v4_base` (1.41)

Mirrors the proven curvefi self-seed pattern (#9794 / CUR2-2833). Event-grain sqrtpricex96 can't use curvefi's "latest snapshot partition" trick (no single partition holds every pool's latest price), so it needs a separate forward-filled companion to *be* that deep-carry source.

## Why a companion (not a naive lookback)

A pool active now can have its previous price arbitrarily far back (measured max seed age = **192 days**; a 21-day lookback would corrupt ~18% of seeded pools). The self-carry in the companion retains every pool's latest indefinitely, so the per-run source fold only needs a narrow lagged slice to catch each row once as it settles. `block_index_sum` is monotone in block_number, so `max_by/max` over (self-carry ∪ newly-settled slice) is idempotent.

## Proofs (read-only, prod spellbook-dex, current window)

1. **Builder output equivalence** — reconstructed the builder incremental output both ways (current full-`{{this}}` anti-join seed vs. latest-settled-per-pool seed): `rows_old = rows_new = 4,663,139`, `old_minus_new = 0`, `new_minus_old = 0`. Byte-identical.
2. **bis-match (companion source-fold == stored output)** — over a bounded 7-day settled slice, source-recomputed rows vs. stored `{{this}}` rows: `src = this = 10,015,890`, `src_minus_this = 0`, `this_minus_src = 0`. The `block_index_sum` join key (consumed by `base_liquidity_events` for the price lookup) is reproduced exactly, so the companion's source fold writes exactly what the builder stored.

## Measured cost (component A/B, pancakeswap_infinity_cl_bnb)

| | IO | CPU | rows |
|---|---|---|---|
| Removed: old seed self-scan of `{{this}}` | 9.22 GB | 54.5 CPU-s (+ ~252 CPU-s downstream self-join in the rep) | 386.9M |
| Added: companion 1-day lagged source fold | ~0.4–1 GB | ~10–13 CPU-s | ~11–25M |

The companion add-back is ~10% of what's removed on both axes — a net win on CPU and IO. (The add-back is dominated by the `transactions` join the companion must redo to recompute `block_index_sum`; a narrow 1-day slice minimizes it since the self-carry covers retention.) Whole-model realized numbers will be measured post-merge via `/query-doctor followup`.

## Selective opt-in

The companion's benefit scales with the eliminated self-scan size; its cost scales with the chain's `transactions` volume. So opt-in must be selective — only high-activity chains where the self-scan dominates. Top-3 clearly qualify; the remaining 13 chains are tracked in a follow-up for per-chain assessment.

## Backfill (one-time, prod)

Each companion's first incremental run needs a complete seed. To avoid a heavy full-history `transactions` join, pre-seed each table once from the existing builder output (which already stores `block_index_sum`) — the exact SQL is in a comment at the top of each companion model file. After seeding, incremental runs maintain it from a narrow source slice. The companion's non-incremental branch (full source history) carries a `target.name == 'ci'` 30-day floor so CI's full-refresh build completes under the timeout.

Towards CUR2-2835
