### PR TITLE
perf(chainlink): push incremental bound below upstream GROUP BY in fm_reward_evt_transfer_daily (x8)

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_fm_reward_evt_transfer_daily.sql
@@ -10,6 +10,38 @@
   )
 }}
 
+-- CUR2-2973: the chainlink_arbitrum_fm_reward_evt_transfer view is inlined as a CTE so the
+-- incremental window can be pushed BELOW its per-(evt_tx_hash, evt_index, to) GROUP BY onto the
+-- erc20_arbitrum.evt_Transfer scan (predicate on the evt_block_date partition column -> Delta
+-- file-skipping). Without this the predicate stranded above the aggregate and every incremental run
+-- full-scanned all-history transfers. The contract set comes from the static price_feeds_oracle_addresses
+-- VALUES table (all-history), so bounding the transfer scan by its own block_date is sound: each reward
+-- transfer's date_start depends only on its own evt_block_time. The outer
+-- incremental_predicate('evt_block_time') is kept authoritative. Proven EXCEPT=0 both ways
+-- (bnb 917 rows, gnosis 261 rows) with token sums at the floating-point floor; ~144x IO / ~247x CPU on bnb.
+-- Incremental-only; the full-refresh path is unchanged.
+
+WITH fm_reward_evt_transfer AS (
+  SELECT
+    'arbitrum' as blockchain,
+    to as admin_address,
+    MAX(operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_arbitrum', 'evt_Transfer') }} reward_evt_transfer
+    RIGHT JOIN {{ ref('chainlink_arbitrum_price_feeds_oracle_addresses') }} price_feeds ON price_feeds.aggregator_address = reward_evt_transfer."from"
+    LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (price_feeds.aggregator_address)
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+    {% endif %}
+  GROUP BY
+    evt_tx_hash,
+    evt_index,
+    to
+)
 
 SELECT
   'arbitrum' as blockchain,
@@ -19,7 +51,7 @@ SELECT
   MAX(fm_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_arbitrum_fm_reward_evt_transfer')}} fm_reward_evt_transfer
+  fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_arbitrum_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_fm_reward_evt_transfer_daily.sql
@@ -10,6 +10,38 @@
   )
 }}
 
+-- CUR2-2973: the chainlink_avalanche_c_fm_reward_evt_transfer view is inlined as a CTE so the
+-- incremental window can be pushed BELOW its per-(evt_tx_hash, evt_index, to) GROUP BY onto the
+-- erc20_avalanche_c.evt_Transfer scan (predicate on the evt_block_date partition column -> Delta
+-- file-skipping). Without this the predicate stranded above the aggregate and every incremental run
+-- full-scanned all-history transfers. The contract set comes from the static price_feeds_oracle_addresses
+-- VALUES table (all-history), so bounding the transfer scan by its own block_date is sound: each reward
+-- transfer's date_start depends only on its own evt_block_time. The outer
+-- incremental_predicate('evt_block_time') is kept authoritative. Proven EXCEPT=0 both ways
+-- (bnb 917 rows, gnosis 261 rows) with token sums at the floating-point floor; ~144x IO / ~247x CPU on bnb.
+-- Incremental-only; the full-refresh path is unchanged.
+
+WITH fm_reward_evt_transfer AS (
+  SELECT
+    'avalanche_c' as blockchain,
+    to as admin_address,
+    MAX(operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_avalanche_c', 'evt_Transfer') }} reward_evt_transfer
+    RIGHT JOIN {{ ref('chainlink_avalanche_c_price_feeds_oracle_addresses') }} price_feeds ON price_feeds.aggregator_address = reward_evt_transfer."from"
+    LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (price_feeds.aggregator_address)
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+    {% endif %}
+  GROUP BY
+    evt_tx_hash,
+    evt_index,
+    to
+)
 
 SELECT
   'avalanche_c' as blockchain,
@@ -19,7 +51,7 @@ SELECT
   MAX(fm_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_avalanche_c_fm_reward_evt_transfer')}} fm_reward_evt_transfer
+  fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_avalanche_c_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_fm_reward_evt_transfer_daily.sql
@@ -10,6 +10,38 @@
   )
 }}
 
+-- CUR2-2973: the chainlink_bnb_fm_reward_evt_transfer view is inlined as a CTE so the
+-- incremental window can be pushed BELOW its per-(evt_tx_hash, evt_index, to) GROUP BY onto the
+-- erc20_bnb.evt_Transfer scan (predicate on the evt_block_date partition column -> Delta
+-- file-skipping). Without this the predicate stranded above the aggregate and every incremental run
+-- full-scanned all-history transfers. The contract set comes from the static price_feeds_oracle_addresses
+-- VALUES table (all-history), so bounding the transfer scan by its own block_date is sound: each reward
+-- transfer's date_start depends only on its own evt_block_time. The outer
+-- incremental_predicate('evt_block_time') is kept authoritative. Proven EXCEPT=0 both ways
+-- (bnb 917 rows, gnosis 261 rows) with token sums at the floating-point floor; ~144x IO / ~247x CPU on bnb.
+-- Incremental-only; the full-refresh path is unchanged.
+
+WITH fm_reward_evt_transfer AS (
+  SELECT
+    'bnb' as blockchain,
+    to as admin_address,
+    MAX(operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_bnb', 'evt_Transfer') }} reward_evt_transfer
+    RIGHT JOIN {{ ref('chainlink_bnb_price_feeds_oracle_addresses') }} price_feeds ON price_feeds.aggregator_address = reward_evt_transfer."from"
+    LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (price_feeds.aggregator_address)
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+    {% endif %}
+  GROUP BY
+    evt_tx_hash,
+    evt_index,
+    to
+)
 
 SELECT
   'bnb' as blockchain,
@@ -19,7 +51,7 @@ SELECT
   MAX(fm_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_bnb_fm_reward_evt_transfer')}} fm_reward_evt_transfer
+  fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_bnb_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_fm_reward_evt_transfer_daily.sql
@@ -10,6 +10,38 @@
   )
 }}
 
+-- CUR2-2973: the chainlink_ethereum_fm_reward_evt_transfer view is inlined as a CTE so the
+-- incremental window can be pushed BELOW its per-(evt_tx_hash, evt_index, to) GROUP BY onto the
+-- erc20_ethereum.evt_Transfer scan (predicate on the evt_block_date partition column -> Delta
+-- file-skipping). Without this the predicate stranded above the aggregate and every incremental run
+-- full-scanned all-history transfers. The contract set comes from the static price_feeds_oracle_addresses
+-- VALUES table (all-history), so bounding the transfer scan by its own block_date is sound: each reward
+-- transfer's date_start depends only on its own evt_block_time. The outer
+-- incremental_predicate('evt_block_time') is kept authoritative. Proven EXCEPT=0 both ways
+-- (bnb 917 rows, gnosis 261 rows) with token sums at the floating-point floor; ~144x IO / ~247x CPU on bnb.
+-- Incremental-only; the full-refresh path is unchanged.
+
+WITH fm_reward_evt_transfer AS (
+  SELECT
+    'ethereum' as blockchain,
+    to as admin_address,
+    MAX(operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_ethereum', 'evt_Transfer') }} reward_evt_transfer
+    RIGHT JOIN {{ ref('chainlink_ethereum_price_feeds_oracle_addresses') }} price_feeds ON price_feeds.aggregator_address = reward_evt_transfer."from"
+    LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (price_feeds.aggregator_address)
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+    {% endif %}
+  GROUP BY
+    evt_tx_hash,
+    evt_index,
+    to
+)
 
 SELECT
   'ethereum' as blockchain,
@@ -19,7 +51,7 @@ SELECT
   MAX(fm_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_ethereum_fm_reward_evt_transfer')}} fm_reward_evt_transfer
+  fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_ethereum_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_fm_reward_evt_transfer_daily.sql
@@ -10,6 +10,38 @@
   )
 }}
 
+-- CUR2-2973: the chainlink_fantom_fm_reward_evt_transfer view is inlined as a CTE so the
+-- incremental window can be pushed BELOW its per-(evt_tx_hash, evt_index, to) GROUP BY onto the
+-- erc20_fantom.evt_Transfer scan (predicate on the evt_block_date partition column -> Delta
+-- file-skipping). Without this the predicate stranded above the aggregate and every incremental run
+-- full-scanned all-history transfers. The contract set comes from the static price_feeds_oracle_addresses
+-- VALUES table (all-history), so bounding the transfer scan by its own block_date is sound: each reward
+-- transfer's date_start depends only on its own evt_block_time. The outer
+-- incremental_predicate('evt_block_time') is kept authoritative. Proven EXCEPT=0 both ways
+-- (bnb 917 rows, gnosis 261 rows) with token sums at the floating-point floor; ~144x IO / ~247x CPU on bnb.
+-- Incremental-only; the full-refresh path is unchanged.
+
+WITH fm_reward_evt_transfer AS (
+  SELECT
+    'fantom' as blockchain,
+    to as admin_address,
+    MAX(operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_fantom', 'evt_Transfer') }} reward_evt_transfer
+    RIGHT JOIN {{ ref('chainlink_fantom_price_feeds_oracle_addresses') }} price_feeds ON price_feeds.aggregator_address = reward_evt_transfer."from"
+    LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (price_feeds.aggregator_address)
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+    {% endif %}
+  GROUP BY
+    evt_tx_hash,
+    evt_index,
+    to
+)
 
 SELECT
   'fantom' as blockchain,
@@ -19,7 +51,7 @@ SELECT
   MAX(fm_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_fantom_fm_reward_evt_transfer')}} fm_reward_evt_transfer
+  fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_fantom_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_fm_reward_evt_transfer_daily.sql
@@ -10,6 +10,38 @@
   )
 }}
 
+-- CUR2-2973: the chainlink_gnosis_fm_reward_evt_transfer view is inlined as a CTE so the
+-- incremental window can be pushed BELOW its per-(evt_tx_hash, evt_index, to) GROUP BY onto the
+-- erc20_gnosis.evt_Transfer scan (predicate on the evt_block_date partition column -> Delta
+-- file-skipping). Without this the predicate stranded above the aggregate and every incremental run
+-- full-scanned all-history transfers. The contract set comes from the static price_feeds_oracle_addresses
+-- VALUES table (all-history), so bounding the transfer scan by its own block_date is sound: each reward
+-- transfer's date_start depends only on its own evt_block_time. The outer
+-- incremental_predicate('evt_block_time') is kept authoritative. Proven EXCEPT=0 both ways
+-- (bnb 917 rows, gnosis 261 rows) with token sums at the floating-point floor; ~144x IO / ~247x CPU on bnb.
+-- Incremental-only; the full-refresh path is unchanged.
+
+WITH fm_reward_evt_transfer AS (
+  SELECT
+    'gnosis' as blockchain,
+    to as admin_address,
+    MAX(operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_gnosis', 'evt_Transfer') }} reward_evt_transfer
+    RIGHT JOIN {{ ref('chainlink_gnosis_price_feeds_oracle_addresses') }} price_feeds ON price_feeds.aggregator_address = reward_evt_transfer."from"
+    LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (price_feeds.aggregator_address)
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+    {% endif %}
+  GROUP BY
+    evt_tx_hash,
+    evt_index,
+    to
+)
 
 SELECT
   'gnosis' as blockchain,
@@ -19,7 +51,7 @@ SELECT
   MAX(fm_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_gnosis_fm_reward_evt_transfer')}} fm_reward_evt_transfer
+  fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_gnosis_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_fm_reward_evt_transfer_daily.sql
@@ -10,6 +10,38 @@
   )
 }}
 
+-- CUR2-2973: the chainlink_optimism_fm_reward_evt_transfer view is inlined as a CTE so the
+-- incremental window can be pushed BELOW its per-(evt_tx_hash, evt_index, to) GROUP BY onto the
+-- erc20_optimism.evt_Transfer scan (predicate on the evt_block_date partition column -> Delta
+-- file-skipping). Without this the predicate stranded above the aggregate and every incremental run
+-- full-scanned all-history transfers. The contract set comes from the static price_feeds_oracle_addresses
+-- VALUES table (all-history), so bounding the transfer scan by its own block_date is sound: each reward
+-- transfer's date_start depends only on its own evt_block_time. The outer
+-- incremental_predicate('evt_block_time') is kept authoritative. Proven EXCEPT=0 both ways
+-- (bnb 917 rows, gnosis 261 rows) with token sums at the floating-point floor; ~144x IO / ~247x CPU on bnb.
+-- Incremental-only; the full-refresh path is unchanged.
+
+WITH fm_reward_evt_transfer AS (
+  SELECT
+    'optimism' as blockchain,
+    to as admin_address,
+    MAX(operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_optimism', 'evt_Transfer') }} reward_evt_transfer
+    RIGHT JOIN {{ ref('chainlink_optimism_price_feeds_oracle_addresses') }} price_feeds ON price_feeds.aggregator_address = reward_evt_transfer."from"
+    LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (price_feeds.aggregator_address)
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+    {% endif %}
+  GROUP BY
+    evt_tx_hash,
+    evt_index,
+    to
+)
 
 SELECT
   'optimism' as blockchain,
@@ -19,7 +51,7 @@ SELECT
   MAX(fm_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_optimism_fm_reward_evt_transfer')}} fm_reward_evt_transfer
+  fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_optimism_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reward_evt_transfer_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_fm_reward_evt_transfer_daily.sql
@@ -10,6 +10,38 @@
   )
 }}
 
+-- CUR2-2973: the chainlink_polygon_fm_reward_evt_transfer view is inlined as a CTE so the
+-- incremental window can be pushed BELOW its per-(evt_tx_hash, evt_index, to) GROUP BY onto the
+-- erc20_polygon.evt_Transfer scan (predicate on the evt_block_date partition column -> Delta
+-- file-skipping). Without this the predicate stranded above the aggregate and every incremental run
+-- full-scanned all-history transfers. The contract set comes from the static price_feeds_oracle_addresses
+-- VALUES table (all-history), so bounding the transfer scan by its own block_date is sound: each reward
+-- transfer's date_start depends only on its own evt_block_time. The outer
+-- incremental_predicate('evt_block_time') is kept authoritative. Proven EXCEPT=0 both ways
+-- (bnb 917 rows, gnosis 261 rows) with token sums at the floating-point floor; ~144x IO / ~247x CPU on bnb.
+-- Incremental-only; the full-refresh path is unchanged.
+
+WITH fm_reward_evt_transfer AS (
+  SELECT
+    'polygon' as blockchain,
+    to as admin_address,
+    MAX(operator_name) as operator_name,
+    MAX(reward_evt_transfer.evt_block_time) as evt_block_time,
+    MAX(cast(reward_evt_transfer.value as double) / 1e18) as token_value
+  FROM
+    {{ source('erc20_polygon', 'evt_Transfer') }} reward_evt_transfer
+    RIGHT JOIN {{ ref('chainlink_polygon_price_feeds_oracle_addresses') }} price_feeds ON price_feeds.aggregator_address = reward_evt_transfer."from"
+    LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = reward_evt_transfer.to
+  WHERE
+    reward_evt_transfer."from" IN (price_feeds.aggregator_address)
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('reward_evt_transfer.evt_block_date') }}
+    {% endif %}
+  GROUP BY
+    evt_tx_hash,
+    evt_index,
+    to
+)
 
 SELECT
   'polygon' as blockchain,
@@ -19,7 +51,7 @@ SELECT
   MAX(fm_reward_evt_transfer.operator_name) as operator_name,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_polygon_fm_reward_evt_transfer')}} fm_reward_evt_transfer
+  fm_reward_evt_transfer
   LEFT JOIN {{ ref('chainlink_polygon_ocr_operator_admin_meta') }} fm_operator_admin_meta ON fm_operator_admin_meta.admin_address = fm_reward_evt_transfer.admin_address
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}


### PR DESCRIPTION
Family follow-up of #9843 (`ccip_send_requested_daily`) and #9852 (`ocr_reward` family), the `fm_reward_evt_transfer_daily` sub-family of CUR2-2973 on spellbook-daily (8 chains: arbitrum, avalanche_c, bnb, ethereum, fantom, gnosis, optimism, polygon).

Each `chainlink_<chain>_fm_reward_evt_transfer_daily` aggregates the upstream `fm_reward_evt_transfer` view, which groups `erc20_<chain>.evt_Transfer` by `(evt_tx_hash, evt_index, to)` and exposes `evt_block_time = MAX(...)`. The daily model's `WHERE incremental_predicate('evt_block_time')` sits above that GROUP BY, so the bound never reaches the transfer scan — every incremental run full-scans all-history transfers (bnb ~30.1B rows / 857 GB) to merge ~1 row/day.

Unlike the `ocr_reward` family, fm's reward-distributor contract set comes from the **static** `chainlink_<chain>_price_feeds_oracle_addresses` VALUES table (all-history, already cheap), so the *only* heavy scan is the unbounded `evt_Transfer`. The fix is a clean in-model push-down: inline the view body as a CTE and apply `incremental_predicate('reward_evt_transfer.evt_block_date')` **below** the per-tx GROUP BY, so the Delta `evt_Transfer` scan prunes by its `evt_block_date` partition (the `evt_block_time` timestamp does not prune). The post-agg `evt_block_time` predicate is kept authoritative. No new tables, no materialization change, no schema change — only the 8 daily model bodies.

Soundness: the contract set is static/all-history (no lagged-row drop), and each reward transfer's `date_start` depends only on its own `evt_block_time`, so bounding the transfer scan by its own `evt_block_date` is exact. Incremental-only; the full-refresh path is unchanged and no backfill is needed.

Proof (read-only, spellbook-sqlmesh; `a` = current stored daily table, `b` = inlined rewrite + `evt_block_date` bound, over a frozen closed window):

- Equivalence: `(a EXCEPT b)` and `(b EXCEPT a)` = 0 both ways on all key columns, with `date_month` and `operator_name` matching and zero duplicate keys — bnb [2024-01-01..2024-09-30] 917 rows, gnosis [2025-01-01..2025-06-30] 261 rows. `token_amount` (double) differs only at the floating-point floor (5.68e-13 bnb / 4.26e-14 gnosis vs max values 687.05 / 115.56).
- A/B cost (bnb, live 3-day window, medians of 3 warm runs): `physical_input_bytes` 857.4 GB -> 5.95 GB (144x); `cpu_ms` ~7,038,000 -> 28,510 (247x); scanned rows 30.07B -> 161.5M (186x); wall ~2,475,253 ms -> 5,356 ms (462x); peak memory 740 MB; spill 0 -> 0.

Family baseline ~3.70 CPU-hrs/day, ~1,549 GB/day IO, expected to drop to ~0.05 CPU-hrs/day and ~10-15 GB/day. No added recurring build cost (the price_feeds source is already cheap).

Towards CUR2-2973
