### PR TITLE
perf(chainlink): incrementalize vrf_v1_random_request_logs + bound fulfilled scans in vrf_request_fulfilled_daily (x5)

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_schema.yml
@@ -701,8 +701,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - blockchain
-              - block_number
               - tx_hash
               - index
     columns:
@@ -714,10 +712,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_arbitrum_vrf_v2_random_fulfilled_logs

--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_request_fulfilled_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_request_fulfilled_daily.sql
@@ -11,6 +11,52 @@
   )
 }}
 
+-- CUR2-2973: the upstream view chainlink_arbitrum_vrf_request_fulfilled computes
+-- evt_block_time = MAX(block_time) above a GROUP BY, so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the arbitrum.logs scans
+-- (3 full all-history scans per run to merge a handful of rows). The view body is
+-- inlined here so the time bounds apply BELOW the aggregations and prune the Delta
+-- scans via block_time file skipping. Replicates the proven #9766 polygon fix.
+WITH vrf_request_fulfilled AS (
+  SELECT
+    'arbitrum' as blockchain,
+    MAX(bytearray_to_uint256(bytearray_substring(v1_request.data, 110, 19)) / 1e18) AS token_value,
+    MAX(v1_fulfilled.tx_from) as operator_address,
+    MAX(v1_fulfilled.block_time) as evt_block_time
+  FROM
+    {{ ref('chainlink_arbitrum_vrf_v1_random_request_logs') }} v1_request
+    INNER JOIN {{ ref('chainlink_arbitrum_vrf_v1_random_fulfilled_logs') }} v1_fulfilled ON bytearray_substring(v1_fulfilled.data, 1, 32) = bytearray_substring(v1_request.data, 129, 32)
+  {% if is_incremental() %}
+  -- The request side is a materialized table read in full, so no request-side
+  -- lookback is needed. The fulfilled-side bound is exact: a group passes the
+  -- post-agg evt_block_time predicate iff its MAX(fulfilled.block_time) row is in
+  -- the window, and dropping older sibling fulfillments cannot change MAX() or the
+  -- request-side values.
+  WHERE {{ incremental_predicate('v1_fulfilled.block_time') }}
+  {% endif %}
+  GROUP BY
+    v1_request.tx_hash,
+    v1_fulfilled.tx_from
+
+  UNION
+
+  SELECT
+    'arbitrum' as blockchain,
+    MAX(bytearray_to_uint256(bytearray_substring(v2_fulfilled.data, 33, 32)) / 1e18) AS token_value,
+    MAX(v2_fulfilled.tx_from) as operator_address,
+    MAX(v2_fulfilled.block_time) as evt_block_time
+  FROM
+    {{ ref('chainlink_arbitrum_vrf_v2_random_fulfilled_logs') }} v2_fulfilled
+  {% if is_incremental() %}
+  -- exact: each group is a single log row (tx_hash + index), so the pre-agg bound
+  -- is equivalent to the post-agg evt_block_time predicate
+  WHERE {{ incremental_predicate('v2_fulfilled.block_time') }}
+  {% endif %}
+  GROUP BY
+    v2_fulfilled.tx_hash,
+    v2_fulfilled.tx_from,
+    v2_fulfilled.index
+)
 
 SELECT
   'arbitrum' as blockchain,
@@ -19,7 +65,7 @@ SELECT
   vrf_request_fulfilled.operator_address,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_arbitrum_vrf_request_fulfilled')}} vrf_request_fulfilled
+  vrf_request_fulfilled
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_v1_random_request_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_v1_random_request_logs.sql
@@ -1,10 +1,19 @@
 {{
   config(
-    
+
     alias='vrf_v1_random_request_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key=['tx_hash', 'index']
   )
 }}
+
+-- CUR2-2973: materialized (was a view) so downstream consumers join the full
+-- request-log history without rescanning arbitrum.logs (tens of billions of rows)
+-- on every run. Logs are append-only, so an incremental block_time window is exact.
+-- Replicates the proven #9766 polygon fix.
 
 SELECT
   'arbitrum' as blockchain,
@@ -24,3 +33,6 @@ FROM
   {{ source('arbitrum', 'logs') }} logs
 WHERE
   topic0 = 0x56bd374744a66d531874338def36c906e3a6cf31176eb1e9afd9f1de69725d51 -- RandomnessRequest
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_schema.yml
@@ -939,8 +939,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - blockchain
-              - block_number
               - tx_hash
               - index
     columns:
@@ -952,10 +950,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_avalanche_c_vrf_v2_random_fulfilled_logs

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_request_fulfilled_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_request_fulfilled_daily.sql
@@ -11,6 +11,52 @@
   )
 }}
 
+-- CUR2-2973: the upstream view chainlink_avalanche_c_vrf_request_fulfilled computes
+-- evt_block_time = MAX(block_time) above a GROUP BY, so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the avalanche_c.logs scans
+-- (3 full all-history scans per run to merge a handful of rows). The view body is
+-- inlined here so the time bounds apply BELOW the aggregations and prune the Delta
+-- scans via block_time file skipping. Replicates the proven #9766 polygon fix.
+WITH vrf_request_fulfilled AS (
+  SELECT
+    'avalanche_c' as blockchain,
+    MAX(bytearray_to_uint256(bytearray_substring(v1_request.data, 110, 19)) / 1e18) AS token_value,
+    MAX(v1_fulfilled.tx_from) as operator_address,
+    MAX(v1_fulfilled.block_time) as evt_block_time
+  FROM
+    {{ ref('chainlink_avalanche_c_vrf_v1_random_request_logs') }} v1_request
+    INNER JOIN {{ ref('chainlink_avalanche_c_vrf_v1_random_fulfilled_logs') }} v1_fulfilled ON bytearray_substring(v1_fulfilled.data, 1, 32) = bytearray_substring(v1_request.data, 129, 32)
+  {% if is_incremental() %}
+  -- The request side is a materialized table read in full, so no request-side
+  -- lookback is needed. The fulfilled-side bound is exact: a group passes the
+  -- post-agg evt_block_time predicate iff its MAX(fulfilled.block_time) row is in
+  -- the window, and dropping older sibling fulfillments cannot change MAX() or the
+  -- request-side values.
+  WHERE {{ incremental_predicate('v1_fulfilled.block_time') }}
+  {% endif %}
+  GROUP BY
+    v1_request.tx_hash,
+    v1_fulfilled.tx_from
+
+  UNION
+
+  SELECT
+    'avalanche_c' as blockchain,
+    MAX(bytearray_to_uint256(bytearray_substring(v2_fulfilled.data, 33, 32)) / 1e18) AS token_value,
+    MAX(v2_fulfilled.tx_from) as operator_address,
+    MAX(v2_fulfilled.block_time) as evt_block_time
+  FROM
+    {{ ref('chainlink_avalanche_c_vrf_v2_random_fulfilled_logs') }} v2_fulfilled
+  {% if is_incremental() %}
+  -- exact: each group is a single log row (tx_hash + index), so the pre-agg bound
+  -- is equivalent to the post-agg evt_block_time predicate
+  WHERE {{ incremental_predicate('v2_fulfilled.block_time') }}
+  {% endif %}
+  GROUP BY
+    v2_fulfilled.tx_hash,
+    v2_fulfilled.tx_from,
+    v2_fulfilled.index
+)
 
 SELECT
   'avalanche_c' as blockchain,
@@ -19,7 +65,7 @@ SELECT
   vrf_request_fulfilled.operator_address,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_avalanche_c_vrf_request_fulfilled')}} vrf_request_fulfilled
+  vrf_request_fulfilled
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_v1_random_request_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_v1_random_request_logs.sql
@@ -1,10 +1,19 @@
 {{
   config(
-    
+
     alias='vrf_v1_random_request_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key=['tx_hash', 'index']
   )
 }}
+
+-- CUR2-2973: materialized (was a view) so downstream consumers join the full
+-- request-log history without rescanning avalanche_c.logs (tens of billions of rows)
+-- on every run. Logs are append-only, so an incremental block_time window is exact.
+-- Replicates the proven #9766 polygon fix.
 
 SELECT
   'avalanche_c' as blockchain,
@@ -24,3 +33,6 @@ FROM
   {{ source('avalanche_c', 'logs') }} logs
 WHERE
   topic0 = 0x56bd374744a66d531874338def36c906e3a6cf31176eb1e9afd9f1de69725d51 -- RandomnessRequest
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_schema.yml
@@ -916,8 +916,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - blockchain
-              - block_number
               - tx_hash
               - index
     columns:
@@ -929,10 +927,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_bnb_vrf_v2_random_fulfilled_logs

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_request_fulfilled_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_request_fulfilled_daily.sql
@@ -11,6 +11,52 @@
   )
 }}
 
+-- CUR2-2973: the upstream view chainlink_bnb_vrf_request_fulfilled computes
+-- evt_block_time = MAX(block_time) above a GROUP BY, so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the bnb.logs scans
+-- (3 full all-history scans per run to merge a handful of rows). The view body is
+-- inlined here so the time bounds apply BELOW the aggregations and prune the Delta
+-- scans via block_time file skipping. Replicates the proven #9766 polygon fix.
+WITH vrf_request_fulfilled AS (
+  SELECT
+    'bnb' as blockchain,
+    MAX(bytearray_to_uint256(bytearray_substring(v1_request.data, 110, 19)) / 1e18) AS token_value,
+    MAX(v1_fulfilled.tx_from) as operator_address,
+    MAX(v1_fulfilled.block_time) as evt_block_time
+  FROM
+    {{ ref('chainlink_bnb_vrf_v1_random_request_logs') }} v1_request
+    INNER JOIN {{ ref('chainlink_bnb_vrf_v1_random_fulfilled_logs') }} v1_fulfilled ON bytearray_substring(v1_fulfilled.data, 1, 32) = bytearray_substring(v1_request.data, 129, 32)
+  {% if is_incremental() %}
+  -- The request side is a materialized table read in full, so no request-side
+  -- lookback is needed. The fulfilled-side bound is exact: a group passes the
+  -- post-agg evt_block_time predicate iff its MAX(fulfilled.block_time) row is in
+  -- the window, and dropping older sibling fulfillments cannot change MAX() or the
+  -- request-side values.
+  WHERE {{ incremental_predicate('v1_fulfilled.block_time') }}
+  {% endif %}
+  GROUP BY
+    v1_request.tx_hash,
+    v1_fulfilled.tx_from
+
+  UNION
+
+  SELECT
+    'bnb' as blockchain,
+    MAX(bytearray_to_uint256(bytearray_substring(v2_fulfilled.data, 33, 32)) / 1e18) AS token_value,
+    MAX(v2_fulfilled.tx_from) as operator_address,
+    MAX(v2_fulfilled.block_time) as evt_block_time
+  FROM
+    {{ ref('chainlink_bnb_vrf_v2_random_fulfilled_logs') }} v2_fulfilled
+  {% if is_incremental() %}
+  -- exact: each group is a single log row (tx_hash + index), so the pre-agg bound
+  -- is equivalent to the post-agg evt_block_time predicate
+  WHERE {{ incremental_predicate('v2_fulfilled.block_time') }}
+  {% endif %}
+  GROUP BY
+    v2_fulfilled.tx_hash,
+    v2_fulfilled.tx_from,
+    v2_fulfilled.index
+)
 
 SELECT
   'bnb' as blockchain,
@@ -19,7 +65,7 @@ SELECT
   vrf_request_fulfilled.operator_address,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_bnb_vrf_request_fulfilled')}} vrf_request_fulfilled
+  vrf_request_fulfilled
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_v1_random_request_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_v1_random_request_logs.sql
@@ -1,10 +1,19 @@
 {{
   config(
-    
+
     alias='vrf_v1_random_request_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key=['tx_hash', 'index']
   )
 }}
+
+-- CUR2-2973: materialized (was a view) so downstream consumers join the full
+-- request-log history without rescanning bnb.logs (tens of billions of rows)
+-- on every run. Logs are append-only, so an incremental block_time window is exact.
+-- Replicates the proven #9766 polygon fix.
 
 SELECT
   'bnb' as blockchain,
@@ -24,3 +33,6 @@ FROM
   {{ source('bnb', 'logs') }} logs
 WHERE
   topic0 = 0x56bd374744a66d531874338def36c906e3a6cf31176eb1e9afd9f1de69725d51 -- RandomnessRequest
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_schema.yml
@@ -912,8 +912,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - blockchain
-              - block_number
               - tx_hash
               - index
     columns:
@@ -925,10 +923,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_ethereum_vrf_v2_random_fulfilled_logs

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_request_fulfilled_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_request_fulfilled_daily.sql
@@ -11,6 +11,52 @@
   )
 }}
 
+-- CUR2-2973: the upstream view chainlink_ethereum_vrf_request_fulfilled computes
+-- evt_block_time = MAX(block_time) above a GROUP BY, so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the ethereum.logs scans
+-- (3 full all-history scans per run to merge a handful of rows). The view body is
+-- inlined here so the time bounds apply BELOW the aggregations and prune the Delta
+-- scans via block_time file skipping. Replicates the proven #9766 polygon fix.
+WITH vrf_request_fulfilled AS (
+  SELECT
+    'ethereum' as blockchain,
+    MAX(bytearray_to_uint256(bytearray_substring(v1_request.data, 110, 19)) / 1e18) AS token_value,
+    MAX(v1_fulfilled.tx_from) as operator_address,
+    MAX(v1_fulfilled.block_time) as evt_block_time
+  FROM
+    {{ ref('chainlink_ethereum_vrf_v1_random_request_logs') }} v1_request
+    INNER JOIN {{ ref('chainlink_ethereum_vrf_v1_random_fulfilled_logs') }} v1_fulfilled ON bytearray_substring(v1_fulfilled.data, 1, 32) = bytearray_substring(v1_request.data, 129, 32)
+  {% if is_incremental() %}
+  -- The request side is a materialized table read in full, so no request-side
+  -- lookback is needed. The fulfilled-side bound is exact: a group passes the
+  -- post-agg evt_block_time predicate iff its MAX(fulfilled.block_time) row is in
+  -- the window, and dropping older sibling fulfillments cannot change MAX() or the
+  -- request-side values.
+  WHERE {{ incremental_predicate('v1_fulfilled.block_time') }}
+  {% endif %}
+  GROUP BY
+    v1_request.tx_hash,
+    v1_fulfilled.tx_from
+
+  UNION
+
+  SELECT
+    'ethereum' as blockchain,
+    MAX(bytearray_to_uint256(bytearray_substring(v2_fulfilled.data, 33, 32)) / 1e18) AS token_value,
+    MAX(v2_fulfilled.tx_from) as operator_address,
+    MAX(v2_fulfilled.block_time) as evt_block_time
+  FROM
+    {{ ref('chainlink_ethereum_vrf_v2_random_fulfilled_logs') }} v2_fulfilled
+  {% if is_incremental() %}
+  -- exact: each group is a single log row (tx_hash + index), so the pre-agg bound
+  -- is equivalent to the post-agg evt_block_time predicate
+  WHERE {{ incremental_predicate('v2_fulfilled.block_time') }}
+  {% endif %}
+  GROUP BY
+    v2_fulfilled.tx_hash,
+    v2_fulfilled.tx_from,
+    v2_fulfilled.index
+)
 
 SELECT
   'ethereum' as blockchain,
@@ -19,7 +65,7 @@ SELECT
   vrf_request_fulfilled.operator_address,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_ethereum_vrf_request_fulfilled')}} vrf_request_fulfilled
+  vrf_request_fulfilled
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_v1_random_request_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_v1_random_request_logs.sql
@@ -1,10 +1,19 @@
 {{
   config(
-    
+
     alias='vrf_v1_random_request_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key=['tx_hash', 'index']
   )
 }}
+
+-- CUR2-2973: materialized (was a view) so downstream consumers join the full
+-- request-log history without rescanning ethereum.logs (tens of billions of rows)
+-- on every run. Logs are append-only, so an incremental block_time window is exact.
+-- Replicates the proven #9766 polygon fix.
 
 SELECT
   'ethereum' as blockchain,
@@ -24,3 +33,6 @@ FROM
   {{ source('ethereum', 'logs') }} logs
 WHERE
   topic0 = 0x56bd374744a66d531874338def36c906e3a6cf31176eb1e9afd9f1de69725d51 -- RandomnessRequest
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_schema.yml
@@ -916,8 +916,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - blockchain
-              - block_number
               - tx_hash
               - index
     columns:
@@ -929,10 +927,16 @@ models:
       - *topic1
       - *topic2
       - *topic3
-      - *tx_hash
+      - name: tx_hash
+        description: "Transaction Hash"
+        data_tests:
+          - not_null
       - *block_number
       - *block_time
-      - *index
+      - name: index
+        description: "Index"
+        data_tests:
+          - not_null
       - *tx_index
 
   - name: chainlink_fantom_vrf_v2_random_fulfilled_logs

--- a/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_request_fulfilled_daily.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_request_fulfilled_daily.sql
@@ -11,6 +11,58 @@
   )
 }}
 
+-- CUR2-2973: the upstream view chainlink_fantom_vrf_request_fulfilled computes
+-- evt_block_time = MAX(block_time) above a GROUP BY, so filtering its output with
+-- incremental_predicate('evt_block_time') cannot reach the fantom.logs scans
+-- (3 full all-history scans per run to merge a handful of rows). The view body is
+-- inlined here so the time bounds apply BELOW the aggregations and prune the Delta
+-- scans via block_time file skipping. Replicates the proven #9766 polygon fix.
+WITH vrf_request_fulfilled AS (
+  SELECT
+    'fantom' as blockchain,
+    MAX(bytearray_to_uint256(bytearray_substring(v1_request.data, 110, 19)) / 1e18) AS token_value,
+    MAX(v1_fulfilled.tx_from) as operator_address,
+    MAX(v1_fulfilled.block_time) as evt_block_time
+  FROM
+    {{ ref('chainlink_fantom_vrf_v1_random_request_logs') }} v1_request
+    INNER JOIN {{ ref('chainlink_fantom_vrf_v1_random_fulfilled_logs') }} v1_fulfilled ON bytearray_substring(v1_fulfilled.data, 1, 32) = bytearray_substring(v1_request.data, 129, 32)
+  {% if is_incremental() %}
+  -- The request side is a materialized table read in full, so no request-side
+  -- lookback is needed. The fulfilled-side bound is exact: a group passes the
+  -- post-agg evt_block_time predicate iff its MAX(fulfilled.block_time) row is in
+  -- the window, and dropping older sibling fulfillments cannot change MAX() or the
+  -- request-side values.
+  WHERE {{ incremental_predicate('v1_fulfilled.block_time') }}
+  {% endif %}
+  GROUP BY
+    v1_request.tx_hash,
+    v1_fulfilled.tx_from
+
+  UNION
+
+  SELECT
+    'fantom' as blockchain,
+    MAX(bytearray_to_uint256(bytearray_substring(v2_fulfilled.data, 33, 32)) / 1e18) AS token_value,
+    MAX(COALESCE(v2_fulfilled.tx_from, tx."from")) as operator_address,
+    MAX(v2_fulfilled.block_time) as evt_block_time
+  FROM
+    {{ ref('chainlink_fantom_vrf_v2_random_fulfilled_logs') }} v2_fulfilled
+    LEFT JOIN {{ source('fantom', 'transactions') }} tx ON tx.hash = v2_fulfilled.tx_hash
+    {% if is_incremental() %}
+    -- tx.hash = v2_fulfilled.tx_hash => same transaction => same block, so bounding
+    -- the transactions side by the same window drops no matched row.
+    AND {{ incremental_predicate('tx.block_time') }}
+    {% endif %}
+  {% if is_incremental() %}
+  -- exact: each group is a single log row (tx_hash + index), so the pre-agg bound
+  -- is equivalent to the post-agg evt_block_time predicate
+  WHERE {{ incremental_predicate('v2_fulfilled.block_time') }}
+  {% endif %}
+  GROUP BY
+    v2_fulfilled.tx_hash,
+    v2_fulfilled.tx_from,
+    v2_fulfilled.index
+)
 
 SELECT
   'fantom' as blockchain,
@@ -19,7 +71,7 @@ SELECT
   vrf_request_fulfilled.operator_address,
   SUM(token_value) as token_amount
 FROM
-  {{ref('chainlink_fantom_vrf_request_fulfilled')}} vrf_request_fulfilled
+  vrf_request_fulfilled
 {% if is_incremental() %}
   WHERE {{ incremental_predicate('evt_block_time') }}
 {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_v1_random_request_logs.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_v1_random_request_logs.sql
@@ -1,10 +1,19 @@
 {{
   config(
-    
+
     alias='vrf_v1_random_request_logs',
-    materialized='view'
+    materialized='incremental',
+    file_format='delta',
+    incremental_strategy='merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key=['tx_hash', 'index']
   )
 }}
+
+-- CUR2-2973: materialized (was a view) so downstream consumers join the full
+-- request-log history without rescanning fantom.logs (tens of billions of rows)
+-- on every run. Logs are append-only, so an incremental block_time window is exact.
+-- Replicates the proven #9766 polygon fix.
 
 SELECT
   'fantom' as blockchain,
@@ -24,3 +33,6 @@ FROM
   {{ source('fantom', 'logs') }} logs
 WHERE
   topic0 = 0x56bd374744a66d531874338def36c906e3a6cf31176eb1e9afd9f1de69725d51 -- RandomnessRequest
+{% if is_incremental() %}
+  AND {{ incremental_predicate('block_time') }}
+{% endif %}


### PR DESCRIPTION
Family follow-up of merged #9766 (which fixed `chainlink_polygon_vrf_request_fulfilled_daily`). Replicates that exact pattern across the remaining 5 chains: arbitrum, avalanche_c, bnb, ethereum, fantom.

Each `chainlink_<chain>_vrf_request_fulfilled_daily` aggregates an upstream `vrf_request_fulfilled` view that decodes three raw `<chain>.logs` sources (a `RandomnessRequest` request log plus the v1 and v2 fulfilled logs). The daily model's incremental `WHERE` sits above that view's per-tx GROUP BY, so the bound never reaches the log scans — every incremental run full-scans all three log streams over all history (bnb ~1,180 GB/day) to merge ~1 row/day.

The fix has two halves, mirroring #9766:

1. **`chainlink_<chain>_vrf_v1_random_request_logs` view → incremental table.** The fulfilled side can reference an arbitrarily old request, so the request key set must stay all-history; materializing it (merge on `[tx_hash, index]`, `block_time` file-skipping on the incremental harvest) means the daily reads a compact accumulated table instead of re-scanning the full `logs` for `RandomnessRequest` every run.
2. **Inline the `vrf_request_fulfilled` view into each daily model** and push `incremental_predicate(...block_time)` below the per-tx GROUP BY onto the v1/v2 *fulfilled* view scans (these are bounded — a fulfillment's `date_start` derives from its own `block_time`). The outer `incremental_predicate('evt_block_time')` is kept authoritative.

Soundness: the request set is all-history (no dropped late fulfillments), and each fulfilled scan is bounded by its own block_time. Fantom's v2 arm additionally `LEFT JOIN`s `fantom.transactions` for `tx_from`; that join is bounded by `tx.block_time` too, which is sound because `tx.hash = fulfilled.tx_hash` ⇒ same block ⇒ same `block_time`, so the window drops no matched row.

Proof (read-only, spellbook-sqlmesh; old inner-unbounded path vs new inner-bounded path under the same frozen outer window, which isolates the inline+push-down from the model's own MERGE/late-arrival behavior):

- `(old EXCEPT new)` and `(new EXCEPT old)` = 0 both ways — bnb (738 rows, validates the 4 uniform chains) and fantom (62 rows, validates the bounded `transactions` join). Token sums match at the floating-point floor (bnb 1.07e-14; fantom exact 0.0).
- A/B cost (bnb, 3 warm-run medians): request-table incremental build 0.565 GB + bounded v1/v2 fulfilled scans 1.607 GB + ~435k-row table read ≈ **~2.2 GB/run** vs the current **~1,180 GB/day** — roughly **~530× IO** and **~90× CPU**. The larger ratio vs the ccip/ocr/fm siblings is because vrf eliminates three full all-history log scans, not one.

Family baseline ~1,711 GB/day + ~1.64 CPU-hrs/day across the 5 chains, expected to drop to ~15-20 GB/day. Prod check: all 5 daily tables have 0 duplicate keys and 0 null `operator_address` (no null-key hazard). The v1/v2 fulfilled-log models stay views.

Towards CUR2-2973
