### PR TITLE
feat(cronos): add CoinPaprika token prices (prices_cronos_tokens)

### DIFF
--- a/dbt_subprojects/tokens/models/prices/cronos/_schema.yml
+++ b/dbt_subprojects/tokens/models/prices/cronos/_schema.yml
@@ -1,0 +1,32 @@
+version: 2
+
+models:
+  - name: prices_cronos_tokens
+    meta:
+      blockchain: cronos
+      sector: prices
+      contributors: hosuke
+    config:
+      tags: ['prices', 'tokens', 'usd', 'cronos']
+    description: "Price tokens on Cronos EVM chain"
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - contract_address
+      - test_prices_tokens_against_erc20
+    columns:
+      - name: token_id
+        description: "Id of the token at coinpaprika. This id is required to pull the price feed data. NOTE: Not all tokens are listed at coinpaprika - consider using price data from DEX sources in this case or submit a listing request at coinpaprika."
+      - name: blockchain
+        description: "Native blockchain of the token, if any"
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [ "cronos" ]
+      - name: contract_address
+        description: "Contract address of the token, if any"
+      - name: symbol
+        description: "Token symbol"
+      - name: decimals
+        description: "Number of decimals for the token contract"

--- a/dbt_subprojects/tokens/models/prices/cronos/prices_cronos_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/cronos/prices_cronos_tokens.sql
@@ -1,0 +1,28 @@
+{% set blockchain = 'cronos' %}
+
+{{ config(
+    schema = 'prices_' + blockchain,
+    alias = 'tokens',
+    materialized = 'table',
+    file_format = 'delta',
+    tags = ['static']
+    )
+}}
+
+SELECT
+    token_id
+    , '{{ blockchain }}' as blockchain
+    , symbol
+    , contract_address
+    , decimals
+FROM
+(
+    VALUES
+    ('wcro-wrapped-cro', 'WCRO', 0x5C7F8A570d578ED84E63fdFA7b1eE72dEae1AE23, 18)
+    , ('vvs-vvs-finance', 'VVS', 0x2D03bECE6747ADc00E1a131BBA1469C15fD11e03, 18)
+    , ('usdc-usd-coin', 'USDC', 0xc21223249CA28397B4B6541dfFaEcC539BfF0c59, 6)
+    , ('usdt-tether', 'USDT', 0x66e428c3f67a68878562e79A0234c1F83c208770, 6)
+    , ('dai-dai', 'DAI', 0xF2001B145b43032AAF5Ee2884e456CCd805F677D, 18)
+    , ('weth-weth', 'WETH', 0xe44Fd7fCb2b1581822D0c862B68222998a0c299a, 18)
+    , ('wbtc-wrapped-bitcoin', 'WBTC', 0x062E66477Faf219F25D27dCED647BF57C3107d52, 8)
+) as temp (token_id, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/prices_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_tokens.sql
@@ -24,6 +24,7 @@
     ,ref('prices_cardano_tokens')
     ,ref('prices_celo_tokens')
     ,ref('prices_corn_tokens')
+    ,ref('prices_cronos_tokens')
     ,ref('prices_degen_tokens')
     ,ref('prices_ethereum_tokens')
     ,ref('prices_fantom_tokens')


### PR DESCRIPTION
## Summary

- New `prices_cronos_tokens`: 7 Cronos tokens (WCRO, VVS, USDC, USDT, DAI, WETH, WBTC) mapped to CoinPaprika ids, wired into `prices_tokens` between corn and degen.
- WCRO uses `wcro-wrapped-cro` (the Cronos-EVM wrapper). Note: the original spec had `cro-cronos`, which is the Tendermint chain coin, not the EVM wrapper; corrected here.
- Part of Cronos curated-data onboarding (CUR2-2098 prices track). Intentionally **prices-only**: the evms views and base-sources land separately, and SQLMesh metadata (CUR2-2095) is the upstream gate, so this avoids jumping ahead of base-sources.

## Verification
`prices_cronos_tokens` and `prices_tokens` compile clean in the tokens subproject.
