### PR TITLE
perf(chainlink): push incremental bound below GROUP BY in ccip_tokens_transferred macro (x7)

### DIFF
--- a/dbt_subprojects/daily_spellbook/macros/project/chainlink/chainlink_ccip_macro.sql
+++ b/dbt_subprojects/daily_spellbook/macros/project/chainlink/chainlink_ccip_macro.sql
@@ -23,7 +23,41 @@ SELECT DISTINCT
     ), 0) AS token_price
 FROM
     {{ref('chainlink_' ~ blockchain ~ '_ccip_tokens_transferred_logs')}} le
-    INNER JOIN {{ref('chainlink_' ~ blockchain ~ '_ccip_send_requested')}} sr ON le.tx_hash = sr.tx_hash
+    -- CUR2-2973: inline chainlink_<chain>_ccip_send_requested instead of ref-ing the view. The view
+    -- groups its source logs by tx_hash and exposes evt_block_time = MAX(block_time), so the post-agg
+    -- incremental_predicate('sr.evt_block_time') (kept below as authoritative) cannot reach the
+    -- <chain>.logs scan and every incremental run full-scans all history (~100B rows) to merge a few
+    -- rows. Pushing incremental_predicate('block_time') into each UNION arm prunes the Delta logs scan
+    -- via block_time file-skipping; sound because one tx = one block, so MAX(block_time) = block_time
+    -- per tx_hash group and the same tx_hash groups are selected.
+    INNER JOIN (
+        SELECT
+            MAX(block_time) AS evt_block_time,
+            MAX(destination_blockchain) AS destination_blockchain,
+            tx_hash
+        FROM (
+            SELECT
+                ccip_logs_v1.block_time,
+                ccip_logs_v1.destination_blockchain,
+                ccip_logs_v1.tx_hash
+            FROM {{ ref('chainlink_' ~ blockchain ~ '_ccip_send_requested_logs_v1') }} ccip_logs_v1
+            {% if is_incremental() %}
+            WHERE {{ incremental_predicate('ccip_logs_v1.block_time') }}
+            {% endif %}
+
+            UNION ALL
+
+            SELECT
+                ccip_logs_v1_2.block_time,
+                ccip_logs_v1_2.destination_blockchain,
+                ccip_logs_v1_2.tx_hash
+            FROM {{ ref('chainlink_' ~ blockchain ~ '_ccip_send_requested_logs_v1_2') }} ccip_logs_v1_2
+            {% if is_incremental() %}
+            WHERE {{ incremental_predicate('ccip_logs_v1_2.block_time') }}
+            {% endif %}
+        ) combined_logs
+        GROUP BY tx_hash
+    ) sr ON le.tx_hash = sr.tx_hash
     AND le.block_time = sr.evt_block_time
     {% if is_incremental() %}
         AND {{ incremental_predicate('sr.evt_block_time') }}


### PR DESCRIPTION
Family follow-up of #9843 / #9852 / #9855 / #9856 under CUR2-2973. The `ccip_tokens_transferred` models (×7 chains: arbitrum, avalanche_c, base, bnb, ethereum, optimism, polygon) are the highest remaining IO in the chainlink family (~2,656 GB/day). They are not a `_daily` aggregation — they're a row-level enrichment built by the shared macro `chainlink_ccip_tokens_transferred`, so this is a single-file fix that covers all 7 chains.

Measuring a representative bnb run showed the cost is **not** in the `evt_Transfer` join (that side already prunes by `block_time` to ~145M rows / 3 days). It's the `ccip_send_requested` view: its `incremental_predicate('sr.evt_block_time')` sits above the view's `GROUP BY tx_hash`, so the bound never reaches the two underlying `logs` scans (the v1.0.0 and v1.2.0 `CCIPSendRequested` topic0 arms). Each arm full-scans the chain's logs — on bnb that's two 52.3B-row scans (104.6B rows / 738 GiB) to merge ~1 row/day.

The fix inlines `ccip_send_requested` into the macro and pushes `incremental_predicate('block_time')` below the per-`tx_hash` GROUP BY into both UNION arms, so the Delta logs scans prune by block_time file-skipping; the post-agg `incremental_predicate('sr.evt_block_time')` is kept authoritative. This is the exact pattern proven in #9843. Sound because every `CCIPSendRequested` log of a transaction shares that transaction's `block_time` (one tx = one block), so `MAX(block_time) = block_time` per `tx_hash` group and the pre-agg bound selects the same groups; the macro's `le.block_time = sr.evt_block_time` join keeps the same window. Incremental-only; full-refresh path unchanged, no backfill.

Proof (read-only, spellbook-sqlmesh; faithful test isolates only the arm push-down — new arms vs a wider old-arm window with every other bound identical):

- Equivalence: `(old EXCEPT new)` and `(new EXCEPT old)` = 0 both ways on all output columns — bnb (695 rows) and avalanche_c (247 rows). `total_tokens` and `token_price` max abs diff exactly 0.0.
- A/B cost (bnb, live 3-day window, medians of 3 warm runs): `physical_input_bytes` 792.1 GB -> 9.47 GB (~84x); `cpu_ms` ~4,401,000 -> 67,462 (~65x); scanned rows 104.6B -> 801M (~131x); wall ~19min -> ~6.2s (~183x); 231 output rows, deterministic.

All 7 prod tables have 0 duplicate keys and 0 null `token_symbol`, so the existing `unique_key` holds. Only the macro file changes; CI's `state:modified.macros` rebuilds all 7 dependent models. Family ~2,656 GB/day -> ~32 GB/day, ~4.2 CPU-hrs/day -> ~0.06.

Towards CUR2-2973
