### PR TITLE
perf(chainlink): bound the unbounded join side in gas-cost tx-enrichment models (ccip_transmitted_reverted x7, ocr_fulfilled_transactions x8, vrf_fulfilled_transactions x6)

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_reverted.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ccip_transmitted_reverted.sql
@@ -12,6 +12,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   arbitrum_usd AS (
     SELECT
@@ -45,6 +52,7 @@ WITH
       tx2.success = false
       {% if is_incremental() %}
         AND {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('tx2.block_time') }}
       {% endif %}
     GROUP BY
       tx.tx_hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_ocr_fulfilled_transactions.sql
@@ -13,6 +13,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   arbitrum_usd AS (
     SELECT
@@ -43,6 +50,7 @@ WITH
       LEFT JOIN arbitrum_usd ON date_trunc('minute', tx.block_time) = arbitrum_usd.block_time
     {% if is_incremental() %}
       WHERE {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('ocr_gas_transmission_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/arbitrum/chainlink_arbitrum_vrf_fulfilled_transactions.sql
@@ -11,6 +11,13 @@
   )
 }}
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   arbitrum_usd AS (
     SELECT
@@ -47,6 +54,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('vrf_v1_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,
@@ -76,6 +84,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('vrf_v2_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_reverted.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ccip_transmitted_reverted.sql
@@ -12,6 +12,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   avalanche_c_usd AS (
     SELECT
@@ -45,6 +52,7 @@ WITH
       tx2.success = false
       {% if is_incremental() %}
         AND {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('tx2.block_time') }}
       {% endif %}
     GROUP BY
       tx.tx_hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_ocr_fulfilled_transactions.sql
@@ -13,6 +13,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   avalanche_c_usd AS (
     SELECT
@@ -41,6 +48,7 @@ WITH
       LEFT JOIN avalanche_c_usd ON date_trunc('minute', tx.block_time) = avalanche_c_usd.block_time
     {% if is_incremental() %}
       WHERE {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('ocr_gas_transmission_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/avalanche_c/chainlink_avalanche_c_vrf_fulfilled_transactions.sql
@@ -11,6 +11,13 @@
   )
 }}
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   avalanche_c_usd AS (
     SELECT
@@ -47,6 +54,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('vrf_v1_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,
@@ -76,6 +84,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('vrf_v2_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_reverted.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/base/chainlink_base_ccip_transmitted_reverted.sql
@@ -12,6 +12,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   base_usd AS (
     SELECT
@@ -45,6 +52,7 @@ WITH
       tx2.success = false
       {% if is_incremental() %}
         AND {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('tx2.block_time') }}
       {% endif %}
     GROUP BY
       tx.tx_hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_reverted.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ccip_transmitted_reverted.sql
@@ -12,6 +12,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   bnb_usd AS (
     SELECT
@@ -45,6 +52,7 @@ WITH
       tx2.success = false
       {% if is_incremental() %}
         AND {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('tx2.block_time') }}
       {% endif %}
     GROUP BY
       tx.tx_hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_ocr_fulfilled_transactions.sql
@@ -13,6 +13,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   bnb_usd AS (
     SELECT
@@ -41,6 +48,7 @@ WITH
       LEFT JOIN bnb_usd ON date_trunc('minute', tx.block_time) = bnb_usd.block_time
     {% if is_incremental() %}
       WHERE {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('ocr_gas_transmission_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/bnb/chainlink_bnb_vrf_fulfilled_transactions.sql
@@ -11,6 +11,13 @@
   )
 }}
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   bnb_usd AS (
     SELECT
@@ -47,6 +54,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('vrf_v1_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,
@@ -76,6 +84,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('vrf_v2_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_reverted.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ccip_transmitted_reverted.sql
@@ -12,6 +12,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   ethereum_usd AS (
     SELECT
@@ -45,6 +52,7 @@ WITH
       tx2.success = false
       {% if is_incremental() %}
         AND {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('tx2.block_time') }}
       {% endif %}
     GROUP BY
       tx.tx_hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_ocr_fulfilled_transactions.sql
@@ -13,6 +13,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   ethereum_usd AS (
     SELECT
@@ -41,6 +48,7 @@ WITH
       LEFT JOIN ethereum_usd ON date_trunc('minute', tx.block_time) = ethereum_usd.block_time
     {% if is_incremental() %}
       WHERE {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('ocr_gas_transmission_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/ethereum/chainlink_ethereum_vrf_fulfilled_transactions.sql
@@ -11,6 +11,13 @@
   )
 }}
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   ethereum_usd AS (
     SELECT
@@ -47,6 +54,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('vrf_v1_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,
@@ -76,6 +84,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('vrf_v2_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_ocr_fulfilled_transactions.sql
@@ -13,6 +13,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   fantom_usd AS (
     SELECT
@@ -41,6 +48,7 @@ WITH
       LEFT JOIN fantom_usd ON date_trunc('minute', tx.block_time) = fantom_usd.block_time
     {% if is_incremental() %}
       WHERE {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('ocr_gas_transmission_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/fantom/chainlink_fantom_vrf_fulfilled_transactions.sql
@@ -11,6 +11,13 @@
   )
 }}
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   fantom_usd AS (
     SELECT
@@ -45,6 +52,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('vrf_v1_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,
@@ -72,6 +80,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('vrf_v2_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/gnosis/chainlink_gnosis_ocr_fulfilled_transactions.sql
@@ -13,6 +13,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   gnosis_usd AS (
     SELECT
@@ -41,6 +48,7 @@ WITH
       LEFT JOIN gnosis_usd ON date_trunc('minute', tx.block_time) = gnosis_usd.block_time
     {% if is_incremental() %}
       WHERE {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('ocr_gas_transmission_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_reverted.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ccip_transmitted_reverted.sql
@@ -12,6 +12,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   optimism_usd AS (
     SELECT
@@ -45,6 +52,7 @@ WITH
       tx2.success = false
       {% if is_incremental() %}
         AND {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('tx2.block_time') }}
       {% endif %}
     GROUP BY
       tx.tx_hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/optimism/chainlink_optimism_ocr_fulfilled_transactions.sql
@@ -13,6 +13,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   optimism_usd AS (
     SELECT
@@ -43,6 +50,7 @@ WITH
       LEFT JOIN optimism_usd ON date_trunc('minute', tx.block_time) = optimism_usd.block_time
     {% if is_incremental() %}
       WHERE {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('ocr_gas_transmission_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_reverted.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ccip_transmitted_reverted.sql
@@ -12,6 +12,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   polygon_usd AS (
     SELECT
@@ -45,6 +52,7 @@ WITH
       tx2.success = false
       {% if is_incremental() %}
         AND {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('tx2.block_time') }}
       {% endif %}
     GROUP BY
       tx.tx_hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_ocr_fulfilled_transactions.sql
@@ -13,6 +13,13 @@
 }}
 
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   polygon_usd AS (
     SELECT
@@ -41,6 +48,7 @@ WITH
       LEFT JOIN polygon_usd ON date_trunc('minute', tx.block_time) = polygon_usd.block_time
     {% if is_incremental() %}
       WHERE {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('ocr_gas_transmission_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,

--- a/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_fulfilled_transactions.sql
+++ b/dbt_subprojects/daily_spellbook/models/chainlink/polygon/chainlink_polygon_vrf_fulfilled_transactions.sql
@@ -11,6 +11,13 @@
   )
 }}
 
+
+-- CUR2-2973: bound the previously-unbounded side of the logs<->transactions join by its own
+-- block_time so the incremental run prunes it via Delta file-skipping. The added predicate is
+-- logically redundant -- the joined log and transaction are in the same block, so their
+-- block_time is identical, and the other side is already bounded to the incremental window --
+-- so results are unchanged (proven EXCEPT=0); it only stops the full-history scan. Incremental-only.
+
 WITH
   polygon_usd AS (
     SELECT
@@ -47,6 +54,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('vrf_v1_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,
@@ -76,6 +84,7 @@ WITH
     {% if is_incremental() %}
       WHERE
         {{ incremental_predicate('tx.block_time') }}
+        AND {{ incremental_predicate('vrf_v2_logs.block_time') }}
     {% endif %}
     GROUP BY
       tx.hash,


### PR DESCRIPTION
Bundles the three remaining "verify shape" chainlink sub-families of CUR2-2973. All three are per-tx gas-cost enrichment models (not `_daily` aggregations) that join a chainlink logs view to the chain's `transactions` table. Each already bounds **one** side of that join by `incremental_predicate`, but leaves the **other** side unbounded, so every incremental run full-scans tens of billions of rows to merge a handful.

Measured on bnb/polygon samples, the unbounded side is the dominant scan in each family:

- **`ccip_transmitted_reverted` ×7** — the `transactions` side is unbounded (bnb: 13.5B rows / 477 GB, 99% CPU); the `ccip_transmitted_logs` view is already bounded. Fix: add `incremental_predicate('tx2.block_time')`.
- **`ocr_fulfilled_transactions` ×8** — the `ocr_gas_transmission_logs` view is unbounded (bnb: 52.3B rows / 421 GB, 95% CPU); `transactions` is already bounded. Fix: add `incremental_predicate('ocr_gas_transmission_logs.block_time')`.
- **`vrf_fulfilled_transactions` ×6** — both `vrf_v1/v2_random_fulfilled_logs` views are unbounded (bnb: 2×52.3B rows); `transactions` is already bounded. Fix: add `incremental_predicate('<logs>.block_time')` to each of the two UNION arms.

The added predicate is **logically redundant**: the joined log and its transaction are in the same block, so `<logs>.block_time = <transactions>.block_time` exactly for every matched row, and the other side is already bounded to the incremental window. It only enables Delta file-skipping — it cannot change results. This is a pure in-model bound; no config, schema, materialization, or macro changes.

Soundness proven (read-only, frozen windows):

- `ocr_fulfilled_transactions` bnb: `(old EXCEPT new)` and `(new EXCEPT old)` = 0 over a month window (643 rows each), and a direct invariant `count_if(logs.block_time <> tx.block_time)` over matched pairs = 0 / 643.
- `vrf_fulfilled_transactions` polygon: EXCEPT = 0 both ways (1,821 rows each), invariant 0 mismatch.
- `ccip_transmitted_reverted` bnb: invariant 0 / 212,492 matched pairs. **Note:** all 7 `ccip_transmitted_reverted` prod tables are currently empty (reverted CCIP transmits essentially never occur), so this model produces no rows yet full-scans ~13.5B txns/day — equivalence is trivially preserved (empty → empty), and it may be a deprecation candidate (separate owner decision).

A/B (NEW path, 3 warm-run medians, live 3-day window vs per-day prod baseline):

| family (heaviest chain) | IO/day | NEW IO | CPU/day | NEW CPU |
| --- | --- | --- | --- | --- |
| ccip_transmitted_reverted (bnb) | 486.6 GB | 6.92 GB (~70×) | 2,808k ms | 22.8k ms (~123×) |
| ocr_fulfilled_transactions (bnb) | 429.5 GB | 6.43 GB (~67×) | 1,789k ms | 14.4k ms (~124×) |
| vrf_fulfilled_transactions (polygon) | 554.4 GB | 3.65 GB (~152×) | 3,121k ms | 16.2k ms (~193×) |

Family totals ~1,313 + ~954 + ~1,099 = ~3.37 TB/day IO and ~5.5 CPU-hrs/day, expected to drop to ~40 GB/day and ~0.1 CPU-hrs/day. Incremental-only; full-refresh path unchanged; no backfill.

Towards CUR2-2973
