### PR TITLE
feat: add Cronos foundational metadata (chain onboarding step 1, CUR2-2095)

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/evms/evms_info.sql
+++ b/dbt_subprojects/daily_spellbook/models/evms/evms_info.sql
@@ -100,4 +100,5 @@ FROM (
         , (4217, 'tempo', 'Tempo', 'Layer 1', NULL, 'USD', 0x20c0000000000000000000000000000000000000, 'https://explorer.tempo.xyz/', timestamp '2026-01-16 20:51', NULL, NULL, NULL, true, NULL)
         , (42793, 'tezos_evm', 'Tezos EVM', 'Layer 2', 'Optimistic Rollup', 'XTZ', 0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb, 'https://explorer.etherlink.com/', timestamp '2024-05-02 13:25:55', 'Tezos Smart Rollup EVM stack', 'Tezos L1', 'Tezos', true, 'Tezos')
         , (2818, 'morph', 'Morph', 'Layer 2', 'Optimistic Rollup', 'ETH', 0x5300000000000000000000000000000000000011, 'https://explorer.morphl2.io/', timestamp '2024-10-21 06:00:00', 'Morph', 'Ethereum Blobs', 'Ethereum', true, NULL)
+        , (25, 'cronos', 'Cronos', 'Layer 1', NULL, 'CRO', 0x5c7f8a570d578ed84e63fdfa7b1ee72deae1ae23, 'https://cronoscan.com/', timestamp '2021-11-08 00:00', NULL, NULL, NULL, true, NULL)
 ) AS temp_table (chain_id, blockchain, name, chain_type, rollup_type, native_token_symbol, wrapped_native_token_address, explorer_link, first_block_time, codebase, data_availability, settlement, is_on_dune, ecosystem)


### PR DESCRIPTION
## Summary
- `evms_info`: add the Cronos row (chain_id 25, native CRO, WCRO 0x5c7f8a570d578ed84e63fdfa7b1ee72deae1ae23, `is_on_dune = true`). This creates the `tokens.native` Cronos row that gates transfers (CUR2-2096) and DEX (CUR2-2097).
- Step 1 of Cronos onboarding (CUR2-2095). Plain dbt, no SQLMesh.

## Scope note
- This PR is the `evms_info` row only. The per-chain `tokens_cronos_v1_erc20` static seed + its `_schema.yml` + the `tokens_v1_erc20` aggregator registration are dropped here because the `tokens_<chain>_v1_erc20` layout (PR #8940) is not on main yet, so there is nothing to mirror or register against. The erc20-metadata half lands as a follow-up once that layout merges.
- `evms_info` is independent of #8940 and compiles on current main on its own.

## Notes
- Draft: held until the platform-side enablement lands. Cronos must exist in `dune.blockchains` (chain_id 25) and `definedfi.dataset_tokens` before the erc20 source yields rows.
- Native row mirrors boba (corn's wrapped_native is NULL so it gets no native row). `tokens.native` filters `wrapped_native_token_address IS NOT NULL AND is_on_dune`; both are satisfied by this row.
