### PR TITLE
perf(angstrom_ethereum_base_trades): materialize pool_info fee_events scan (~93% IO, ~82% CPU)

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/angstrom/utils/angstrom_fee_events_raw.sql
+++ b/dbt_subprojects/dex/macros/models/_project/angstrom/utils/angstrom_fee_events_raw.sql
@@ -1,0 +1,53 @@
+{% macro
+    angstrom_fee_events_raw(
+        angstrom_contract_addr,
+        controller_v1_contract_addr,
+        earliest_block,
+        blockchain,
+        controller_pool_configured_log_topic0
+    )
+%}
+
+SELECT
+    block_number,
+    block_time,
+    varbinary_to_integer(varbinary_substring(l.data, 31, 2))  AS tick_spacing,
+    varbinary_to_integer(varbinary_substring(l.data, 62, 3)) AS bundle_fee,
+    varbinary_to_integer(varbinary_substring(l.data, 94, 3)) AS unlocked_fee,
+    varbinary_to_integer(varbinary_substring(l.data, 126, 3)) AS protocol_unlocked_fee,
+    topic1,
+    topic2,
+    CONCAT(
+        '0x',
+        LOWER(
+        to_hex(
+            keccak(
+            FROM_HEX(
+                CONCAT(
+                LPAD(LOWER(to_hex(varbinary_substring(l.topic1, 13, 20))), 64, '0'),
+                LPAD(LOWER(to_hex(varbinary_substring(l.topic2, 13, 20))), 64, '0'),
+                LPAD('800000', 64, '0'),
+                LPAD(
+                    LOWER(
+                    to_base(
+                        bitwise_and(CAST(varbinary_to_integer(varbinary_substring(l.data, 31, 2)) AS BIGINT), 16777215),
+                        16
+                    )
+                    ),
+                    64,
+                    '0'
+                ),
+                LPAD(substr(CAST({{ angstrom_contract_addr }} AS VARCHAR), 3), 64, '0')
+                )
+            )
+            )
+        )
+        )
+    ) AS pool_id
+FROM {{ source(blockchain, 'logs') }} AS l
+WHERE
+    block_number >= {{ earliest_block }} AND
+    contract_address = {{ controller_v1_contract_addr }} AND
+    topic0 = {{ controller_pool_configured_log_topic0 }}
+
+{% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/angstrom/utils/angstrom_pool_info.sql
+++ b/dbt_subprojects/dex/macros/models/_project/angstrom/utils/angstrom_pool_info.sql
@@ -9,46 +9,37 @@
 %}
 
 WITH fee_events AS (
-    SELECT 
+    -- The ConfigurePool log scan is non-pushable (contract_address + topic0 varbinary equality)
+    -- so each inlined copy re-scans the full ethereum.logs window. angstrom_pool_info is referenced
+    -- across three base_trades lineage branches and the recursive/nested order macros expand it into
+    -- 18 logs scan operators (~99% of the model's physical IO). For ethereum we read the shared
+    -- pre-materialized staging model instead; the forward-fill below needs the FULL config history,
+    -- so this read is intentionally NOT windowed by the incremental predicate. CUR2-2837.
+    {%- if blockchain == 'ethereum' %}
+    SELECT
         block_number,
-        varbinary_to_integer(varbinary_substring(l.data, 31, 2))  AS tick_spacing,
-        varbinary_to_integer(varbinary_substring(l.data, 62, 3)) AS bundle_fee,
-        varbinary_to_integer(varbinary_substring(l.data, 94, 3)) AS unlocked_fee,
-        varbinary_to_integer(varbinary_substring(l.data, 126, 3)) AS protocol_unlocked_fee,
+        tick_spacing,
+        bundle_fee,
+        unlocked_fee,
+        protocol_unlocked_fee,
         topic1,
         topic2,
-        CONCAT(
-            '0x',
-            LOWER(
-            to_hex(
-                keccak(
-                FROM_HEX(
-                    CONCAT(
-                    LPAD(LOWER(to_hex(varbinary_substring(l.topic1, 13, 20))), 64, '0'),
-                    LPAD(LOWER(to_hex(varbinary_substring(l.topic2, 13, 20))), 64, '0'),
-                    LPAD('800000', 64, '0'),
-                    LPAD(
-                        LOWER(
-                        to_base(
-                            bitwise_and(CAST(varbinary_to_integer(varbinary_substring(l.data, 31, 2)) AS BIGINT), 16777215),
-                            16
-                        )
-                        ),
-                        64,
-                        '0'
-                    ),
-                    LPAD(substr(CAST({{ angstrom_contract_addr }} AS VARCHAR), 3), 64, '0')
-                    )
-                )
-                )
-            )
-            )
-        ) AS pool_id
-    FROM {{ source(blockchain, 'logs') }} AS l
-    WHERE 
-        block_number >= {{ earliest_block }} AND
-        contract_address = {{ controller_v1_contract_addr }} AND 
-        topic0 = {{ controller_pool_configured_log_topic0 }}
+        pool_id
+    FROM {{ ref('angstrom_ethereum_fee_events') }}
+    {%- else %}
+    SELECT
+        block_number,
+        tick_spacing,
+        bundle_fee,
+        unlocked_fee,
+        protocol_unlocked_fee,
+        topic1,
+        topic2,
+        pool_id
+    FROM (
+        {{ angstrom_fee_events_raw(angstrom_contract_addr, controller_v1_contract_addr, earliest_block, blockchain, controller_pool_configured_log_topic0) }}
+    )
+    {%- endif %}
 ),
 block_range AS (
     SELECT number AS block_number

--- a/dbt_subprojects/dex/models/_projects/angstrom/ethereum/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/angstrom/ethereum/_schema.yml
@@ -39,6 +39,48 @@ models:
         data_tests:
           - not_null
 
+  - name: angstrom_ethereum_fee_events
+    meta:
+      blockchain: ethereum
+      sector: dex
+      contributors: jnoorchashm37
+    config:
+      tags: ['ethereum', 'angstrom', 'trades']
+    description: >
+      Pre-materialized Angstrom pool fee-configuration (ConfigurePool) events on Ethereum,
+      extracted once from ethereum.logs. Shared staging model for angstrom_pool_info so the
+      non-pushable controller log scan runs a single time per build instead of being re-inlined
+      into 18 ethereum.logs scan operators across the angstrom_ethereum_base_trades lineage.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_number
+              - pool_id
+    columns:
+      - name: block_number
+        description: "Block number of the ConfigurePool event"
+        data_tests:
+          - not_null
+      - name: block_time
+        description: "Block time of the ConfigurePool event"
+      - name: tick_spacing
+        description: "Pool tick spacing decoded from the log data"
+      - name: bundle_fee
+        description: "Bundle fee decoded from the log data"
+      - name: unlocked_fee
+        description: "Unlocked (LP) fee decoded from the log data"
+      - name: protocol_unlocked_fee
+        description: "Protocol unlocked fee decoded from the log data"
+      - name: topic1
+        description: "First indexed token of the pool pair (log topic1)"
+      - name: topic2
+        description: "Second indexed token of the pool pair (log topic2)"
+      - name: pool_id
+        description: "Derived Angstrom pool id (keccak of token0, token1, tick_spacing, angstrom address)"
+        data_tests:
+          - not_null
+
   - name: angstrom_ethereum_trades
     meta:
       blockchain: ethereum

--- a/dbt_subprojects/dex/models/_projects/angstrom/ethereum/angstrom_ethereum_fee_events.sql
+++ b/dbt_subprojects/dex/models/_projects/angstrom/ethereum/angstrom_ethereum_fee_events.sql
@@ -1,0 +1,41 @@
+{{
+    config(
+        schema = 'angstrom_ethereum',
+        alias = 'fee_events',
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        unique_key = ['block_number', 'pool_id'],
+        on_schema_change = 'sync_all_columns',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set angstrom_contract_addr = '0x0000000aa232009084Bd71A5797d089AA4Edfad4' %}
+{% set controller_v1_contract_addr = '0x1746484EA5e11C75e009252c102C8C33e0315fD4' %}
+{% set earliest_block = '22971781' %}
+{% set blockchain = 'ethereum' %}
+{% set controller_pool_configured_log_topic0 = '0xf325a037d71efc98bc41dc5257edefd43a1d1162e206373e53af271a7a3224e9' %}
+
+-- Shared staging model for Angstrom pool fee-configuration (ConfigurePool) events on Ethereum.
+-- Materializing this scan once breaks the CTE inlining that previously re-scanned ethereum.logs
+-- 18x per angstrom_ethereum_base_trades build: angstrom_pool_info is called in three base_trades
+-- lineage branches and the recursive/nested order macros expand its fee_events scan into 18 scan
+-- operators, each reading the full ethereum.logs window (~34.9B rows / 105 GiB, ~99% of the model's
+-- physical IO) only to find the same ~6 events. The contract_address + topic0 varbinary filter is
+-- non-pushable, so nothing prunes. CUR2-2837 (follow-up to CUR2-2709 / PR #9797).
+select fee_events.*
+from (
+    {{
+        angstrom_fee_events_raw(
+            angstrom_contract_addr = angstrom_contract_addr,
+            controller_v1_contract_addr = controller_v1_contract_addr,
+            earliest_block = earliest_block,
+            blockchain = blockchain,
+            controller_pool_configured_log_topic0 = controller_pool_configured_log_topic0
+        )
+    }}
+) as fee_events
+{% if is_incremental() %}
+where {{ incremental_predicate('block_time') }}
+{% endif %}


### PR DESCRIPTION
Follow-up to CUR2-2709 / #9797. After #9797 materialized the bundle-transactions scan, the dominant remaining cost in `angstrom_ethereum_base_trades` is `angstrom_pool_info`'s fee-events scan of `ethereum.logs`.

`angstrom_pool_info` is called in three base_trades lineage branches (composable trades, tob order volume, user order volume) plus the `angstrom_ethereum_pools` view. Trino inlines it and the recursive/nested order macros expand its `fee_events` CTE into **18 `ethereum.logs` scan operators**, each reading the full window (~34.9B rows / ~105 GiB, ~99% of the model's physical IO) only to find the same ~6 `ConfigurePool` events. The `contract_address` + `topic0` varbinary filter is non-pushable, so nothing prunes, and the scan grows daily (no `block_time` bound).

This materializes the scan once into a shared incremental staging model `angstrom_ethereum_fee_events` (~6 rows) and reads it from `angstrom_pool_info` for ethereum; other chains keep the inline scan via the new `angstrom_fee_events_raw` macro. The forward-fill needs the full config history, so the staging read is intentionally **not** windowed by the incremental predicate. Mirrors the `bundle_transactions` staging pattern from #9797. The staging full scan is only 5.82 GB / ~1 s, so no CI floor is needed (CI full-refresh stays cheap and gives base_trades real config data).

## Proof (read-only, prod data)

**Equivalence (all 0/0):**
- `angstrom_fee_events_raw` (8-col projection) `EXCEPT` original inline `fee_events`, both ways = 0 (n=6) — scan byte-identical.
- `fee_events` = 6 rows, 6 distinct `(block_number, pool_id)`, 0 null keys — `unique_key` valid.
- Deployed `angstrom_ethereum.pools` (live oracle) `EXCEPT` new compiled pools-select, both ways = 0 — full forward-fill + collapse identical.
- **Full `base_trades` model** over a frozen 3-day window, OLD (18× inline scan) vs NEW (staging): byte-identical output (13,591 rows, identical 21-col checksums, 3 runs each side).

**Magnitude (frozen 3-day window, 3 warm runs, medians):**

| metric | OLD | NEW | Δ |
|---|---|---|---|
| physical_input_bytes | 108.97 GB | 7.81 GB | **−92.8%** |
| physical_input_rows | 34.95B | 37.4M | −99.9% |
| cpu | 563.6 cpu-s | 104.2 cpu-s | **−81.5%** |
| wall | 96.5 s | 92.6 s | ~flat (noisy) |
| peak | 2.15 GB | 6.09 GB | +2.8× (VALUES-relation A/B artifact; real Delta staging read should behave like a tiny scan — prod already runs at 4.8 GB peak; will confirm in realized followup) |

Current prod build: ~113 GB / 627 cpu-s / 2.63 TB/day / 3.84 CPU-hrs/day. Projected post-fix: model build ~12 GB / ~165 cpu-s; ~0.2 TB/day, ~0.7 CPU-hrs/day, plus a ~1.6 GB/build incremental staging scan.

`dbt parse` + `dbt compile` clean; compiled `base_trades` has 0 raw `ethereum.logs` scans (was 18) and reads the 6-row `angstrom_ethereum.fee_events` table.

Fixes CUR2-2837