### PR TITLE
fix(prices): add cronos native token price mapping

### DIFF
--- a/dbt_subprojects/tokens/models/prices/prices_native_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_native_tokens.sql
@@ -30,6 +30,7 @@ with prices_native_tokens as (
         , ('boba', 'eth-ethereum')
         , ('celo', 'celo-celo')
         , ('corn', 'corn-corn2')
+        , ('cronos', 'cro-cryptocom-chain')
         , ('degen', 'degen-degen-base')
         , ('ethereum', 'eth-ethereum')
         , ('fantom', 'ftm-fantom')


### PR DESCRIPTION
## Summary
- Cronos is missing from `prices_native_tokens.sql`, so native CRO transfers/gas fees resolve `amount_usd`/`tx_fee_usd` to NULL (confirmed via PR #9862 CI tables: native CRO shows 0/84.7M rows priced, while ERC20s like WCRO/USDC/USDT/WETH/WBTC populate correctly).
- Adds `('cronos', 'cro-cryptocom-chain')`, alphabetically between `corn` and `degen`, matching the existing list convention.
- CoinPaprika id verified directly against the live API (`/v1/coins/cro-cryptocom-chain`, `/v1/tickers/cro-cryptocom-chain`) — resolves to Cronos/CRO, rank 51.

## Test plan
- [x] `dbt compile --select prices_native_tokens --project-dir dbt_subprojects/tokens/` passes
- [ ] Confirm on CI that `prices_native.tokens` picks up the cronos row (requires `dune.blockchains` to have a `cronos` entry, already required by the in-flight cronos transfers PR #9862)
- [ ] Once merged, re-check `tokens_cronos_transfers`/`gas_cronos_fees` CI or prod output for native CRO `amount_usd`/`tx_fee_usd` population

🤖 Generated with [Claude Code](https://claude.com/claude-code)