### PR TITLE
fix(thorchain): pending_liquidity silver adds _inserted_timestamp on incremental (unblocks prod cadence)

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_pending_liquidity_events.sql
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_pending_liquidity_events.sql
@@ -6,6 +6,7 @@
     incremental_strategy = 'merge',
     unique_key = ['block_month', 'event_id'],
     partition_by = ['block_month'],
+    on_schema_change = 'append_new_columns',
     tags = ['thorchain', 'liquidity', 'pending']
 ) }}
 


### PR DESCRIPTION
## Summary

- `thorchain_silver_pending_liquidity_events` gets `on_schema_change = 'append_new_columns'`. This fixes the prod cadence failure `COLUMN_NOT_FOUND "_inserted_timestamp"` on `thorchain_defi_pending_liquidity_events` (dbt Cloud run 70471887325976, query_id 20260707_152523_09882_ba5wi).

## Root cause

#9872 added `current_timestamp AS _inserted_timestamp` to `thorchain_silver_pending_liquidity_events` and repointed the `thorchain_defi_pending_liquidity_events` incremental predicate to that column. The silver is an incremental model with `on_schema_change` unset, so the default `ignore` applied: the new column was never added to the existing prod table. The gold's incremental run then filtered on `silver._inserted_timestamp`, which doesn't exist on the un-refreshed table, and errored.

CI didn't catch it because CI builds fresh (`is_incremental()` is false), so the silver table is created with the column every time and the gold resolves. The failure only appears on the incremental path against a pre-existing table.

pending_liquidity is the only one of the #9872 models where a new column was added to an incremental silver. The other silvers (loan_open, loan_repayment, stake, withdraw, update_node) already emitted `_inserted_timestamp` before #9872, so their tables already carry it.

## Fix

`append_new_columns` lets the next incremental silver run ALTER the table to add `_inserted_timestamp` (NULL on pre-existing rows, `current_timestamp` on newly merged rows). The daily/hourly cadence clones main at run time, so the next scheduled cadence self-heals once this merges. A `--full-refresh` of the silver (as the pending CUR2-3130 deploy does) also resolves it.

## Verification

- `dbt run --select thorchain_silver_pending_liquidity_events thorchain_defi_pending_liquidity_events` on the incremental path resolves `_inserted_timestamp` after the silver adds the column.
