### PR TITLE
chore(gas): tag gas_*_fees family with 'gas_fees' for scheduler split (CUR2-2765)

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/abstract/gas_abstract_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/abstract/gas_abstract_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/apechain/gas_apechain_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/apechain/gas_apechain_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/aptos/gas_aptos_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/aptos/gas_aptos_fees.sql
@@ -9,7 +9,8 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_month', 'tx_hash'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    tags = ['gas_fees']
   )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/arbitrum/gas_arbitrum_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/arbitrum/gas_arbitrum_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/avalanche_c/gas_avalanche_c_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/avalanche_c/gas_avalanche_c_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/b3/gas_b3_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/b3/gas_b3_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/base/gas_base_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/base/gas_base_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/berachain/gas_berachain_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/berachain/gas_berachain_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/blast/gas_blast_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/blast/gas_blast_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/bnb/gas_bnb_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/bnb/gas_bnb_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/bob/gas_bob_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/bob/gas_bob_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/boba/gas_boba_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/boba/gas_boba_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/celo/gas_celo_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/celo/gas_celo_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/corn/gas_corn_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/corn/gas_corn_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ arbitrum_orbit_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/degen/gas_degen_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/degen/gas_degen_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ arbitrum_orbit_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/ethereum/gas_ethereum_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/ethereum/gas_ethereum_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/fantom/gas_fantom_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/fantom/gas_fantom_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/flare/gas_flare_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/flare/gas_flare_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/flow/gas_flow_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/flow/gas_flow_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/gnosis/gas_gnosis_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/gnosis/gas_gnosis_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/hemi/gas_hemi_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/hemi/gas_hemi_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/henesys/gas_henesys_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/henesys/gas_henesys_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/hyperevm/gas_hyperevm_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/hyperevm/gas_hyperevm_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/ink/gas_ink_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/ink/gas_ink_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/kaia/gas_kaia_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/kaia/gas_kaia_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/katana/gas_katana_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/katana/gas_katana_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/lens/gas_lens_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/lens/gas_lens_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/linea/gas_linea_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/linea/gas_linea_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/mantle/gas_mantle_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/mantle/gas_mantle_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/megaeth/gas_megaeth_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/megaeth/gas_megaeth_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash', 'tx_index']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/mezo/gas_mezo_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/mezo/gas_mezo_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/monad/gas_monad_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/monad/gas_monad_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/morph/gas_morph_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/morph/gas_morph_fees.sql
@@ -9,7 +9,8 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_month', 'tx_hash'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    tags = ['gas_fees']
   )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/nova/gas_nova_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/nova/gas_nova_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/opbnb/gas_opbnb_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/opbnb/gas_opbnb_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/optimism/gas_optimism_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/optimism/gas_optimism_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/peaq/gas_peaq_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/peaq/gas_peaq_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/plasma/gas_plasma_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/plasma/gas_plasma_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/plume/gas_plume_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/plume/gas_plume_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/polygon/gas_polygon_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/polygon/gas_polygon_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/rise/gas_rise_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/rise/gas_rise_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/robinhood/gas_robinhood_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/robinhood/gas_robinhood_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/ronin/gas_ronin_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/ronin/gas_ronin_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/scroll/gas_scroll_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/scroll/gas_scroll_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/sei/gas_sei_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/sei/gas_sei_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/shape/gas_shape_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/shape/gas_shape_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/somnia/gas_somnia_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/somnia/gas_somnia_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/sonic/gas_sonic_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/sonic/gas_sonic_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/sophon/gas_sophon_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/sophon/gas_sophon_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/story/gas_story_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/story/gas_story_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/superseed/gas_superseed_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/superseed/gas_superseed_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/tac/gas_tac_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/tac/gas_tac_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/taiko/gas_taiko_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/taiko/gas_taiko_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ evm_l1_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/tempo/gas_tempo_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/tempo/gas_tempo_fees.sql
@@ -13,6 +13,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/tezos_evm/gas_tezos_evm_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/tezos_evm/gas_tezos_evm_fees.sql
@@ -9,7 +9,8 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_month', 'tx_hash'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    tags = ['gas_fees']
   )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/tron/gas_tron_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/tron/gas_tron_fees.sql
@@ -7,6 +7,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/unichain/gas_unichain_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/unichain/gas_unichain_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/viction/gas_viction_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/viction/gas_viction_fees.sql
@@ -9,7 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
-    ,tags = ['prod_exclude']
+    ,tags = ['prod_exclude', 'gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/worldchain/gas_worldchain_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/worldchain/gas_worldchain_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 {{ op_stack_gas_fees(blockchain) }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/xlayer/gas_xlayer_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/xlayer/gas_xlayer_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/xrpl/gas_xrpl_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/xrpl/gas_xrpl_fees.sql
@@ -8,6 +8,7 @@
     incremental_strategy = 'merge',
     unique_key = ['block_month', 'tx_hash'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')],
+    tags = ['gas_fees']
   )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/zkevm/gas_zkevm_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/zkevm/gas_zkevm_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/zksync/gas_zksync_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/zksync/gas_zksync_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/zora/gas_zora_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/zora/gas_zora_fees.sql
@@ -9,6 +9,7 @@
     ,incremental_strategy='merge'
     ,unique_key = ['block_month', 'tx_hash']
     ,incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    ,tags = ['gas_fees']
     )
 }}
 


### PR DESCRIPTION
## What

Adds `tags = ['gas_fees']` to all 64 `gas_<chain>_fees` models under `dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/`. Extends `viction`'s existing `['prod_exclude']` to `['prod_exclude', 'gas_fees']`.

**No SQL, macro, env, or schema changes.** MERGE semantics and `unique_key` unchanged.

## Why

Enables ops to select the whole gas fees family via `tag:gas_fees` on the dbt Cloud scheduler. This unblocks two paths tracked in [CUR2-2765](https://linear.app/dune/issue/CUR2-2765/) for the family's ~103 CPU-hrs/day (15.8% of `spellbook-hourly`, largest wall footprint on cluster).

### Interim path: /4 cadence via scheduler (ops-side, not in this PR)

- Same 3-day `incremental_predicate` window; MERGE is idempotent on `(block_month, tx_hash)`, so overlap is a harmless rewrite.
- 24 runs/day → 6 runs/day.
- Expected ~4× write-merge cut, ~40 CPU-hrs/day off family, cluster share ~15.8% → ~11–12%.
- Freshness SLO relaxes p99 ≤1h → ≤4h (ops must confirm with downstream before flipping).

### M6 split-path (Comment 2 by @andrecl on CUR2-2765)

- Two `tag:gas_fees` dbt Cloud jobs: hourly with `DBT_ENV_INCREMENTAL_TIME=6h` + daily reconciliation with 4d.
- Expected ~7× write-merge cut.
- **Blocked** pending composite late-arrival study (raw + price + backfill p99.9).

## Why tag-only for the spellbook PR

- `DBT_ENV_INCREMENTAL_TIME` is a global variable shared across the whole hourly job; shrinking it in `dbt_project.yml` would break unrelated hourly models. Confirmed on CUR2-2765.
- Per-model window shrink without the late-arrival study is a silent correctness regression risk.
- Scheduler-level splits and env overrides are the correct lever, but they're **not** spellbook artifacts — they live on dbt Cloud. This PR gives ops the selector to configure them.

## What CI does (and does not) do here

`tags` is not on the CI body-stamp list (`materialized`, `partition_by`, `incremental_strategy`, `file_format`, `schema`, `alias`) per `AGENTS.md`. Slim CI's `state:modified.body` / `state:modified.macros` filter recognizes these models as un-affected physical outputs, so CI does **not** trigger 64 chain-scale rebuilds. Precisely the "minimal / representative" shape the M5 backlog asked for.

## Verification

- Batch-edit script wrote `tags = ['gas_fees']` into two config-block styles present in the family:
  - Style A (comma-leading, 60 files): `,tags = ['gas_fees']` after `incremental_predicates`.
  - Style B (trailing-comma, 4 files: aptos, morph, tezos_evm, xrpl): `tags = ['gas_fees']` after `incremental_predicates`, comma appended on the predicates line where missing.
  - Extended viction's existing `,tags = ['prod_exclude']` → `,tags = ['prod_exclude', 'gas_fees']`.
- `git diff --stat`: **64 files changed, 67 insertions(+), 4 deletions(-)** (net +63 lines).
- `uv run dbt ls --resource-type model --select tag:gas_fees --project-dir dbt_subprojects/hourly_spellbook/ --profiles-dir dbt_subprojects/hourly_spellbook/`: returns **exactly 64** models, all matching `gas_<chain>_fees`.
- `uv run dbt compile --select gas_rise_fees gas_aptos_fees gas_xrpl_fees gas_viction_fees ...`: exit 0 on all 4 style-diverse cases (Style A op_stack, Style B comma-missing, Style B trailing-comma + `block_date`, Style A extend-in-place).

## Baseline family footprint (from CUR2-2765, Andre's Comment 2, 2026-06-11 spellbook-hourly)

- Family: 102.7 CPU-hrs/day, 24.3 wall-hrs/day, 14,568 runs/day, ~2.1 TB/day IO.
- Rep row-writes/run: `gas_rise_fees` 136.7M, `gas_bnb_fees` 122.7M. Peak memory 44 GB. Writer skew ~30,000× on rise. ~140× write amplification.
- Live rows/30d (confirmed at decision time): rise 490.99M, bnb 467.37M, tron 380.68M, base 261.88M, polygon 213.27M, monad 89.45M, opbnb 86.46M, avalanche_c 84.50M, ethereum 65.47M.

## Refs

- Linear: [CUR2-2765](https://linear.app/dune/issue/CUR2-2765/) (M5, Curated Data).
- Related: CUR2-2678 (raw-source late-arrival profile), CUR2-2715, CUR2-2784.
- Similar pattern: `nft_polygon_transfers` (~11 CPU-h/d), `nft_mints` family (Andre's Comment 1).

## Next owners

- **Ops** — configure the `tag:gas_fees` selector on dbt Cloud for the /4 cadence flip once downstream freshness SLO is confirmed.
