### PR TITLE
feat(prices): add PENDLE to base, bnb, and sonic token lists

### DIFF
--- a/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
@@ -244,6 +244,7 @@ FROM
     ('phnm-phenom', 'base', 'PHNM', 0x3fda9cc61b1fef8b2ffd715f0a9eef7182e48f37, 18),
     ('up-superform', 'base', 'UP', 0x5b2193fDc451C1f847bE09CA9d13A4Bf60f8c86B, 18),
     ('fun-sportfun', 'base', 'FUN', 0x16EE7ecAc70d1028E7712751E2Ee6BA808a7dd92, 18),
+    ('pendle-pendle', 'base', 'PENDLE', 0xa99f6e6785da0f5d6fb42495fe424bce029eeb3e, 18),
     --Coinpaprika RWA tokenized stocks, ETFs & FX
     ('mxne-real-mxn-1', 'base', 'MXNe', 0x269cae7dc59803e5c596c95756faeebb6030e0af, 6)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/bnb/prices_bnb_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/bnb/prices_bnb_tokens.sql
@@ -90,6 +90,7 @@ FROM
     ('one-harmony', 'bnb', 'ONE', 0x04baf95fd4c52fd09a56d840baee0ab8d7357bf0, 18),
     ('ont-ontology', 'bnb', 'ONT', 0xfd7b3a77848f1c2d67e05e54d78d174a0c850335, 18),
     ('orbs-orbs', 'bnb', 'ORBS', 0xebd49b26169e1b52c04cfd19fcf289405df55f80, 18),
+    ('pendle-pendle', 'bnb', 'PENDLE', 0xb3ed0a426155b79b898849803e3b36552f7ed507, 18),
     ('pets-micropets', 'bnb', 'PETS', 0xa77346760341460b42c230ca6d21d4c8e743fa9c, 18),
     ('pmon-polychain-monsters', 'bnb', 'PMON', 0x1796ae0b0fa4862485106a0de9b654efe301d0b2, 18),
     ('pols-polkastarter', 'bnb', 'POLS', 0x7e624fa0e1c4abfd309cc15719b7e2580887f570, 18),

--- a/dbt_subprojects/tokens/models/prices/sonic/prices_sonic_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/sonic/prices_sonic_tokens.sql
@@ -66,4 +66,5 @@ FROM
     , ('usdc-usd-coin', 'metaUSD', 0x1111111199558661Bf7Ff27b4F1623dC6b91Aa3e, 18)
     , ('equal-equalizer-on-sonic', 'EQUAL', 0xddf26b42c1d903de8962d3f79a74a501420d5f19, 18)
     , ('fly-flytrade', 'FLY', 0x6c9B3A74ae4779da5Ca999371eE8950e8DB3407f, 18)
+    , ('pendle-pendle', 'PENDLE', 0xf1ef7d2d4c0c881cd634481e0586ed5d2871a74b, 18)
 ) as temp (token_id, symbol, contract_address, decimals)


### PR DESCRIPTION
Adds the PENDLE token to the Base, BNB and Sonic prices token lists.

PENDLE trades on all three chains but had no USD price in Spellbook. The
coinpaprika id pendle-pendle already prices PENDLE on Ethereum, Arbitrum,
Mantle and Optimism, so this reuses the existing mapping to close a data
gap. No new coinpaprika id, no schema change, data rows only.

Verified each contract on-chain via eth_call (symbol() == PENDLE, decimals() == 18):
- Base:  0xa99f6e6785da0f5d6fb42495fe424bce029eeb3e  https://basescan.org/token/0xa99f6e6785da0f5d6fb42495fe424bce029eeb3e
- BNB:   0xb3ed0a426155b79b898849803e3b36552f7ed507  https://bscscan.com/token/0xb3ed0a426155b79b898849803e3b36552f7ed507
- Sonic: 0xf1ef7d2d4c0c881cd634481e0586ed5d2871a74b  https://sonicscan.org/token/0xf1ef7d2d4c0c881cd634481e0586ed5d2871a74b

CoinPaprika: https://coinpaprika.com/coin/pendle-pendle

Precedent: PENDLE was added to Optimism the same way in #6752.
