### PR TITLE
ci: run commit-manifest matrix jobs in parallel

### DIFF
--- a/.github/workflows/commit_manifest.yml
+++ b/.github/workflows/commit_manifest.yml
@@ -19,7 +19,10 @@ jobs:
     strategy:
       matrix:
         project: [ 'tokens', 'daily_spellbook', 'dex', 'solana', 'hourly_spellbook']
-      max-parallel: 1
+      # Projects are fully independent (own runner VM, own S3 prefix, own
+      # cache key) and dbt parse never touches the cluster, so run them in
+      # parallel. One project failing must not cancel the others' uploads.
+      fail-fast: false
 
     steps:
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/commit_manifest.yml
+++ b/.github/workflows/commit_manifest.yml
@@ -19,9 +19,6 @@ jobs:
     strategy:
       matrix:
         project: [ 'tokens', 'daily_spellbook', 'dex', 'solana', 'hourly_spellbook']
-      # Projects are fully independent (own runner VM, own S3 prefix, own
-      # cache key) and dbt parse never touches the cluster, so run them in
-      # parallel. One project failing must not cancel the others' uploads.
       fail-fast: false
 
     steps:


### PR DESCRIPTION
## Why

`max-parallel: 1` on the commit-manifest matrix dates back to the 2023 DuneSQL migration (e5fc627fb), when the matrix was `engine: [dunesql, spark]` running on a single self-hosted runner (`spellbook-trino`) with a shared working directory, and both legs ran `dbt compile` against the cluster. Serializing was necessary then, and the setting was carried forward through the subproject split and the migration to GitHub-hosted runners without being revisited.

None of those constraints exist anymore:

- Each matrix job gets its own `ubuntu-latest` VM (#9692) — no shared runner or workdir.
- The job runs `dbt parse` (#9629), which never connects to the warehouse — no cluster load.
- S3 prefixes are per-project (`s3://manifest-spellbook-dunesql/<project>`) — no write overlap.
- Partial-parse cache keys are per-project (`partial-parse-<project>-<sha>`) — no collision. The shared setup-uv cache can race on save, which GitHub handles benignly (first save wins, others log a warning).

## What

- Remove `max-parallel: 1` so the 5 project jobs fan out (matrix default).
- Add `fail-fast: false` so one project's parse failure doesn't cancel the other four manifests' uploads — previously a failure also blocked later projects, since they simply never started.

Wall time drops roughly 5x, which also shrinks the window in which a just-merged PR's CI can pick up a stale manifest. The workflow-level `concurrency` group (cancel-in-progress on new pushes to main) is unchanged.