### PR TITLE
Enable Delta Change Data Feed globally for all spellbook tables

### DIFF
--- a/dbt_macros/dune/adapters.sql
+++ b/dbt_macros/dune/adapters.sql
@@ -52,6 +52,7 @@
     {%- set location= 's3a://%s/%s/%s' % (s3_bucket(), relation.schema, unique_location) -%}
     {%- do _properties.update({'location': "'" + location + "'"}) -%}
   {%- endif -%}
+  {%- do _properties.update({'delta.enableChangeDataFeed': 'true'}) -%}
   {%- if target.name == 'ci' -%}
     {%- do _properties.update({'extra_properties': "map_from_entries(ARRAY[ROW('dune.public', 'true')])"}) -%}
   {%- endif -%}


### PR DESCRIPTION
Add delta.enableChangeDataFeed = true to the create_table_properties macro to enable CDC for all Delta tables created by dbt, both in production and CI.

This applies globally at CREATE TABLE time via the WITH clause for all models using file_format = 'delta' (100+ models across all sub-projects).

Property is rendered via dune_properties() macro into valid Trino SQL and applies to prod, dev, and CI equally. CDC is required for downstream datashare replication pipelines.