### PR TITLE
Add explicit EVM compatibility views for DEX trades and gas fees

### DIFF
--- a/dbt_subprojects/dex/models/trades/_schema.yml
+++ b/dbt_subprojects/dex/models/trades/_schema.yml
@@ -84,5 +84,43 @@ models:
       - &evt_index
         name: evt_index
         description: "Index of the event in the transaction. Can be used to uniquely identify the order of trades within in a transaction"
-      - name: _updated_at
+      - &_updated_at
+        name: _updated_at
         description: "Timestamp when this row was last written or updated by the pipeline"
+
+  - name: dex_evm_trades
+    meta:
+      sector: dex_evm
+      short_description: "DEX trades across EVM-compatible chains, exposed under the explicit dex_evm namespace."
+      contributors: 0xRob, hosuke, jeff-dude, tomfutago, viniabussafi
+    config:
+      tags: ['dex', 'trades', 'evm']
+    description: >
+      Compatibility view over dex.trades. It exposes the same column contract and chain coverage
+      under dex_evm.trades for consumers that need an explicitly EVM-scoped namespace.
+    columns:
+      - <<: *blockchain
+      - <<: *project
+      - <<: *version
+      - <<: *block_month
+      - <<: *block_date
+      - <<: *block_time
+      - <<: *block_number
+      - <<: *token_bought_symbol
+      - <<: *token_sold_symbol
+      - <<: *token_pair
+      - <<: *token_bought_amount
+      - <<: *token_sold_amount
+      - <<: *token_bought_amount_raw
+      - <<: *token_sold_amount_raw
+      - <<: *amount_usd
+      - <<: *token_bought_address
+      - <<: *token_sold_address
+      - <<: *taker
+      - <<: *maker
+      - <<: *project_contract_address
+      - <<: *tx_hash
+      - <<: *tx_from
+      - <<: *tx_to
+      - <<: *evt_index
+      - <<: *_updated_at

--- a/dbt_subprojects/dex/models/trades/dex_evm_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_evm_trades.sql
@@ -1,0 +1,96 @@
+{% set chains = [
+	'abstract'
+	, 'apechain'
+	, 'arbitrum'
+	, 'avalanche_c'
+	, 'base'
+	, 'berachain'
+	, 'blast'
+	, 'bnb'
+	, 'boba'
+	, 'celo'
+	, 'corn'
+	, 'cronos'
+	, 'ethereum'
+	, 'fantom'
+	, 'flare'
+	, 'flow'
+	, 'gnosis'
+	, 'hemi'
+	, 'hyperevm'
+	, 'ink'
+	, 'kaia'
+	, 'katana'
+	, 'linea'
+	, 'mantle'
+	, 'megaeth'
+	, 'mezo'
+	, 'monad'
+	, 'morph'
+	, 'nova'
+	, 'opbnb'
+	, 'optimism'
+	, 'peaq'
+	, 'plasma'
+	, 'plume'
+	, 'polygon'
+	, 'robinhood'
+	, 'ronin'
+	, 'scroll'
+	, 'sei'
+	, 'shape'
+	, 'somnia'
+	, 'sonic'
+	, 'sophon'
+	, 'story'
+	, 'superseed'
+	, 'tac'
+	, 'taiko'
+	, 'tempo'
+	, 'tezos_evm'
+	, 'unichain'
+	, 'worldchain'
+	, 'xlayer'
+	, 'zkevm'
+	, 'zksync'
+	, 'zora'
+] %}
+
+{{ config(
+	schema = 'dex_evm'
+	, alias = 'trades'
+	, materialized = 'view'
+	, post_hook = '{{ expose_spells(blockchains = \'["' + chains | join('","') + '"]\',
+									spell_type = "sector",
+									spell_name = "dex_evm",
+									contributors = \'["hosuke", "0xrob", "jeff-dude", "tomfutago", "viniabussafi", "krishhh", "kryptaki"]\') }}'
+	)
+}}
+
+select
+	blockchain
+	, project
+	, version
+	, block_month
+	, block_date
+	, block_time
+	, block_number
+	, token_bought_symbol
+	, token_sold_symbol
+	, token_pair
+	, token_bought_amount
+	, token_sold_amount
+	, token_bought_amount_raw
+	, token_sold_amount_raw
+	, amount_usd
+	, token_bought_address
+	, token_sold_address
+	, taker
+	, maker
+	, project_contract_address
+	, tx_hash
+	, tx_from
+	, tx_to
+	, evt_index
+	, _updated_at
+from {{ ref('dex_trades') }}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/_schema.yml
@@ -79,3 +79,59 @@ models:
       - &type
         name: type
         description: "Transaction type"
+
+  - name: gas_evm_fees
+    meta:
+      sector: gas_evm
+      short_description: "Transaction gas fees across EVM-compatible chains under the explicit gas_evm namespace."
+      contributors: soispoke, ilemi, 0xRob, jeff-dude, hosuke, tomfutago
+    config:
+      tags: ['gas', 'fees', 'evm']
+    description: >
+      Compatibility view over gas.fees that excludes the non-EVM Tron rows and exposes the
+      aggregate's EVM-compatible chain coverage under gas_evm.fees.
+    columns:
+      - name: blockchain
+        description: "Blockchain on which the transaction occurred"
+      - name: block_month
+        description: "UTC month of the transaction block"
+      - name: block_date
+        description: "UTC date of the transaction block"
+      - name: block_time
+        description: "UTC timestamp of the transaction block"
+      - name: block_number
+        description: "Number of the block containing the transaction"
+      - name: tx_hash
+        description: "Hash of the transaction"
+      - name: tx_index
+        description: "Index position of the transaction within its block"
+      - name: tx_from
+        description: "Address that initiated the transaction"
+      - name: tx_to
+        description: "Address called by the transaction"
+      - name: gas_price
+        description: "Gas price paid per unit of gas"
+      - name: gas_used
+        description: "Amount of gas consumed by the transaction"
+      - name: currency_symbol
+        description: "Symbol of the blockchain's native fee currency"
+      - name: tx_fee
+        description: "Total transaction fee denominated in the native fee currency"
+      - name: tx_fee_usd
+        description: "Total transaction fee denominated in USD"
+      - name: tx_fee_raw
+        description: "Total transaction fee in the native currency's base unit"
+      - name: tx_fee_breakdown
+        description: "Transaction fee components denominated in the native fee currency"
+      - name: tx_fee_breakdown_usd
+        description: "Transaction fee components denominated in USD"
+      - name: tx_fee_breakdown_raw
+        description: "Transaction fee components in the native currency's base unit"
+      - name: tx_fee_currency
+        description: "Token address or identifier of the currency used to pay transaction fees"
+      - name: block_proposer
+        description: "Address of the validator or proposer for the transaction's block"
+      - name: gas_limit
+        description: "Maximum amount of gas available to the transaction"
+      - name: gas_limit_usage
+        description: "Share of the transaction gas limit that was consumed"

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/gas_evm_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/gas_evm_fees.sql
@@ -1,0 +1,99 @@
+{% set chains = [
+	'abstract'
+	, 'apechain'
+	, 'arbitrum'
+	, 'avalanche_c'
+	, 'b3'
+	, 'base'
+	, 'berachain'
+	, 'blast'
+	, 'bnb'
+	, 'bob'
+	, 'boba'
+	, 'celo'
+	, 'corn'
+	, 'cronos'
+	, 'degen'
+	, 'ethereum'
+	, 'fantom'
+	, 'flare'
+	, 'gnosis'
+	, 'hemi'
+	, 'henesys'
+	, 'hyperevm'
+	, 'ink'
+	, 'kaia'
+	, 'katana'
+	, 'lens'
+	, 'linea'
+	, 'mantle'
+	, 'megaeth'
+	, 'mezo'
+	, 'monad'
+	, 'morph'
+	, 'nova'
+	, 'opbnb'
+	, 'optimism'
+	, 'peaq'
+	, 'plasma'
+	, 'plume'
+	, 'polygon'
+	, 'robinhood'
+	, 'ronin'
+	, 'rise'
+	, 'scroll'
+	, 'sei'
+	, 'shape'
+	, 'somnia'
+	, 'sonic'
+	, 'sophon'
+	, 'story'
+	, 'superseed'
+	, 'tac'
+	, 'taiko'
+	, 'tempo'
+	, 'tezos_evm'
+	, 'unichain'
+	, 'worldchain'
+	, 'xlayer'
+	, 'zkevm'
+	, 'zksync'
+	, 'zora'
+] %}
+
+{{ config(
+	schema = 'gas_evm'
+	, alias = 'fees'
+	, materialized = 'view'
+	, post_hook = '{{ expose_spells(blockchains = \'["' + chains | join('","') + '"]\',
+									spell_type = "sector",
+									spell_name = "gas_evm",
+									contributors = \'["soispoke", "ilemi", "0xRob", "jeff-dude", "krishhh", "tomfutago"]\') }}'
+	)
+}}
+
+select
+	blockchain
+	, block_month
+	, block_date
+	, block_time
+	, block_number
+	, tx_hash
+	, tx_index
+	, tx_from
+	, tx_to
+	, gas_price
+	, gas_used
+	, currency_symbol
+	, tx_fee
+	, tx_fee_usd
+	, tx_fee_raw
+	, tx_fee_breakdown
+	, tx_fee_breakdown_usd
+	, tx_fee_breakdown_raw
+	, tx_fee_currency
+	, block_proposer
+	, gas_limit
+	, gas_limit_usage
+from {{ ref('gas_fees') }}
+where blockchain != 'tron'


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:

Adds public compatibility views for consumers that need explicitly EVM-scoped namespaces:

- `dex_evm.trades` is a thin view over `dex.trades` with identical chain coverage and column contract.
- `gas_evm.fees` is a thin view over `gas.fees` that excludes Tron, preserving the aggregate's EVM-compatible chains.
- Both models are documented in their adjacent schema YAML files and exposed as public sector spells.

The views enumerate columns explicitly rather than using `select *`. This keeps their public contracts intentional and reviewable while still compiling directly to the existing aggregate relations.

Validation:
- `uv run --frozen dbt ls -s dex_evm_trades`
- `uv run --frozen dbt compile -s dex_evm_trades`
- `uv run --frozen dbt ls -s gas_evm_fees`
- `uv run --frozen dbt compile -s gas_evm_fees`
- `git diff --check`

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

Made with [Cursor](https://cursor.com)