### PR TITLE
Expose gas_xrpl.fees in Explorer

### DIFF
--- a/dbt_subprojects/hourly_spellbook/dbt_project.yml
+++ b/dbt_subprojects/hourly_spellbook/dbt_project.yml
@@ -72,6 +72,13 @@ models:
     +schema: no_schema    # this should be overriden in model specific configs
     +view_security: invoker
 
+    _sector:
+      gas:
+        fees:
+          xrpl:
+            gas_xrpl_fees:
+              +post-hook: "{{ expose_spells('[\"xrpl\"]', \"sector\", \"gas\", '[\"krishhh\", \"tomfutago\"]') }}"
+
     _project:
       safe:
         +schema: safe

--- a/dbt_subprojects/hourly_spellbook/dbt_project.yml
+++ b/dbt_subprojects/hourly_spellbook/dbt_project.yml
@@ -72,13 +72,6 @@ models:
     +schema: no_schema    # this should be overriden in model specific configs
     +view_security: invoker
 
-    _sector:
-      gas:
-        fees:
-          xrpl:
-            gas_xrpl_fees:
-              +post-hook: "{{ expose_spells('[\"xrpl\"]', \"sector\", \"gas\", '[\"krishhh\", \"tomfutago\"]') }}"
-
     _project:
       safe:
         +schema: safe

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/aptos/gas_aptos_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/aptos/gas_aptos_fees.sql
@@ -9,7 +9,11 @@
     file_format = 'delta',
     incremental_strategy = 'merge',
     unique_key = ['block_month', 'tx_hash'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    post_hook = '{{ expose_spells(\'["aptos"]\',
+                                    "sector",
+                                    "gas",
+                                    \'["tomfutago"]\') }}'
   )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/xrpl/gas_xrpl_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/xrpl/gas_xrpl_fees.sql
@@ -8,6 +8,10 @@
     incremental_strategy = 'merge',
     unique_key = ['block_month', 'tx_hash'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')],
+    post_hook = '{{ expose_spells(\'["xrpl"]\',
+                                    "sector",
+                                    "gas",
+                                    \'["krishhh", "tomfutago"]\') }}',
   )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/xrpl/gas_xrpl_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/xrpl/gas_xrpl_fees.sql
@@ -8,7 +8,6 @@
     incremental_strategy = 'merge',
     unique_key = ['block_month', 'tx_hash'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')],
-    post_hook = '{{ expose_spells(\'["xrpl"]\', "sector", "gas", \'["krishhh", "tomfutago"]\') }}',
   )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/xrpl/gas_xrpl_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/xrpl/gas_xrpl_fees.sql
@@ -8,6 +8,7 @@
     incremental_strategy = 'merge',
     unique_key = ['block_month', 'tx_hash'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')],
+    post_hook = '{{ expose_spells(\'["xrpl"]\', "sector", "gas", \'["krishhh", "tomfutago"]\') }}',
   )
 }}
 


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Description:

Adds the `expose_spells` post-hook to `gas_xrpl.fees` so the spell is visible in Explorer. The hook follows the gas sector precedent with blockchain `xrpl`, spell type `sector`, spell name `gas`, and the model contributors `krishhh` and `tomfutago`.

Context: [duneanalytics/core#6786](https://github.com/duneanalytics/core/pull/6786) moves `gas_xrpl.fees` into the Gas & Fees Explorer category.

No CI stamp was added because Spellbook intentionally skips CI selection for exposure-only post-hook changes.

### Validation:

- `uv run dbt ls --select gas_xrpl_fees`
- `uv run dbt compile --select gas_xrpl_fees`
- `uv run pre-commit run --hook-stage manual forbid-crlf --files dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/xrpl/gas_xrpl_fees.sql`
- `git diff --check`

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)