### PR TITLE
Hide curated spells marked for removal from Data Explorer

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_sector/addresses_stats/addresses_stats.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/addresses_stats/addresses_stats.sql
@@ -17,10 +17,7 @@
 	schema='addresses',
 	alias='stats',
 	materialized='view',
-	post_hook='{{ expose_spells(blockchains = \'["' ~ chains | join('","') ~ '"]\',
-		spell_type = "sector",
-		spell_name = "addresses",
-		contributors = \'["kryptaki"]\') }}',
+	post_hook = '{{ hide_spells() }}',
 ) }}
 
 select

--- a/dbt_subprojects/daily_spellbook/models/_sector/labels/addresses/social/identifier/ens/labels_ens.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/labels/addresses/social/identifier/ens/labels_ens.sql
@@ -3,10 +3,7 @@
         materialized = 'table',
         file_format = 'delta',
         unique_key = ['blockchain','address'],
-        post_hook='{{ expose_spells(\'["ethereum"]\',
-                                    "sector",
-                                    "labels",
-                                    \'["0xRob"]\') }}')
+        post_hook = '{{ hide_spells() }}')
 }}
 
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/safe/safe_safes_all.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/safe/safe_safes_all.sql
@@ -1,10 +1,7 @@
 {{ config(
         schema = 'safe',
         alias = 'safes_all',
-        post_hook='{{ expose_spells(\'["arbitrum","avalanche_c","base","blast","bnb","celo","ethereum","fantom","gnosis","linea","mantle","optimism","polygon","scroll","sonic","unichain","worldchain","zkevm","zksync"]\',
-                                "project",
-                                "safe",
-                                \'["tschubotz", "danielpartida", "kryptaki", "safeintern"]\') }}'
+        post_hook = '{{ hide_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_deposits.sql
@@ -6,10 +6,7 @@
     , incremental_strategy='append'
     , unique_key = ['deposit_chain','withdrawal_chain','withdrawal_chain_id','bridge_name','bridge_version','bridge_transfer_id', 'duplicate_index']
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
-    , post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "base", "blast", "bnb", "ethereum", "hyperevm", "ink", "lens", "linea", "optimism", "plasma", "polygon", "scroll", "tron", "unichain", "worldchain", "zksync", "zora", "fantom", "gnosis", "nova", "opbnb", "berachain", "corn", "flare", "sei", "boba", "abstract", "apechain", "bob", "celo", "kaia", "katana", "mantle", "plume", "ronin", "sonic", "sophon", "story", "taiko", "zkevm"]\',
-                                    "sector",
-                                    "bridges",
-                                    \'["hildobby", "tomfutago"]\') }}'
+    , post_hook = '{{ hide_spells() }}'
 )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_flows.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_flows.sql
@@ -2,10 +2,7 @@
     schema = 'bridges_evms'
     , alias = 'flows'
     , materialized = 'view'
-    , post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "base", "blast", "bnb", "ethereum", "hyperevm", "ink", "lens", "linea", "optimism", "plasma", "polygon", "scroll", "tron", "unichain", "worldchain", "zksync", "zora", "fantom", "gnosis", "nova", "opbnb", "berachain", "corn", "flare", "sei", "boba", "mantle", "abstract", "apechain", "bob", "celo", "kaia", "katana", "plume", "ronin", "sonic", "sophon", "story", "taiko", "zkevm"]\',
-                                "sector",
-                                "bridges",
-                                \'["hildobby", "tomfutago"]\') }}'
+    , post_hook = '{{ hide_spells() }}'
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_withdrawals.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/bridges/flows/evms/bridges_evms_withdrawals.sql
@@ -6,10 +6,7 @@
     , incremental_strategy='append'
     , unique_key = ['deposit_chain','deposit_chain_id','withdrawal_chain','bridge_name','bridge_version','bridge_transfer_id','duplicate_index']
     , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
-    , post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "base", "blast", "bnb", "ethereum", "hyperevm", "ink", "lens", "linea", "optimism", "plasma", "polygon", "scroll", "unichain", "worldchain", "zksync", "zora", "fantom", "gnosis", "nova", "opbnb", "berachain", "corn", "flare", "sei", "mantle"]\',
-                                "sector",
-                                "bridges",
-                                \'["hildobby"]\') }}'
+    , post_hook = '{{ hide_spells() }}'
 )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/cex/addresses/cex_addresses.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/cex/addresses/cex_addresses.sql
@@ -1,10 +1,7 @@
 {{ config(
         schema = 'cex',
         alias = 'addresses',
-        post_hook='{{ expose_spells(\'["ethereum", "bnb", "avalanche_c", "optimism", "arbitrum", "polygon", "bitcoin", "fantom", "aptos", "celo", "zora", "zksync", "zkevm", "linea", "solana", "scroll", "tron", "base", "mantle", "worldchain", "sei", "berachain", "ink", "katana", "kaia", "nova", "opbnb", "unichain", "sui"]\',
-                                    "sector",
-                                    "cex",
-                                    \'["hildobby"]\') }}')
+        post_hook = '{{ hide_spells() }}')
 }}
 
 {% set chains = [

--- a/dbt_subprojects/hourly_spellbook/models/_sector/cex/deposit_addresses/cex_deposit_addresses.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/cex/deposit_addresses/cex_deposit_addresses.sql
@@ -7,10 +7,7 @@
         incremental_strategy = 'merge',
         unique_key = ['address'],
         merge_update_columns = ['blockchain', 'cex_name', 'first_deposit_token_standard', 'first_deposit_token_address', 'deposit_first_block_time', 'consolidation_first_block_time', 'deposit_count', 'consolidation_count', 'amount_deposited', 'consolidation_unique_key', 'deposit_unique_key'],
-        post_hook='{{ expose_spells(\'["ethereum", "bnb", "avalanche_c", "gnosis", "optimism", "arbitrum", "polygon", "base", "celo", "scroll", "zora", "berachain", "ink", "katana", "nova", "opbnb", "unichain"]\',
-                                    "sector",
-                                    "cex",
-                                    \'["hildobby"]\') }}'
+        post_hook = '{{ hide_spells() }}'
 )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/cex/flows/cex_flows.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/cex/flows/cex_flows.sql
@@ -7,10 +7,7 @@
         incremental_strategy = 'merge',
         unique_key = ['blockchain', 'flow_type', 'unique_key'],
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-        post_hook='{{ expose_spells(blockchains = \'["ethereum", "bnb", "avalanche_c", "gnosis", "optimism", "arbitrum", "polygon", "base", "celo", "zora", "zksync", "scroll", "fantom", "linea", "zkevm", "berachain", "ink", "katana", "nova", "opbnb", "unichain"]\',
-                                spell_type = "sector",
-                                spell_name = "cex",
-                                contributors = \'["hildobby"]\') }}'
+        post_hook = '{{ hide_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/dune/dune_blockchains.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/dune/dune_blockchains.sql
@@ -2,10 +2,7 @@
         schema='dune',
         alias = 'blockchains',
         materialized = 'view',
-        post_hook='{{ expose_spells(\'["dune"]\',
-                                    "sector",
-                                    "dune",
-                                    \'["0xRob","tomfutago"]\') }}')
+        post_hook = '{{ hide_spells() }}')
 }}
 
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/lending/borrow/lending_borrow.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/lending/borrow/lending_borrow.sql
@@ -8,10 +8,7 @@
     incremental_strategy = 'merge',
     unique_key = ['blockchain', 'project', 'version', 'transaction_type', 'token_address', 'tx_hash', 'evt_index'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-    post_hook = '{{ expose_spells(\'["arbitrum", "avalanche_c", "base", "bnb", "celo", "ethereum", "fantom", "gnosis", "linea", "optimism", "polygon", "scroll", "sonic", "zksync","unichain"]\',
-                                "sector",
-                                "lending",
-                                \'["tomfutago", "hildobby"]\') }}'
+    post_hook = '{{ hide_spells() }}'
   )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/lending/flashloans/lending_flashloans.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/lending/flashloans/lending_flashloans.sql
@@ -8,10 +8,7 @@
     incremental_strategy = 'merge',
     unique_key = ['blockchain', 'project', 'version', 'tx_hash', 'evt_index'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-    post_hook = '{{ expose_spells(\'["arbitrum", "avalanche_c", "base", "bnb", "celo", "ethereum", "fantom", "gnosis", "linea", "optimism", "polygon", "scroll", "sonic", "zksync", "zkevm", "unichain"]\',
-                                "sector",
-                                "lending",
-                                \'["tomfutago", "hildobby"]\') }}'
+    post_hook = '{{ hide_spells() }}'
   )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/lending_supply.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/lending/supply/lending_supply.sql
@@ -8,10 +8,7 @@
     incremental_strategy = 'merge',
     unique_key = ['blockchain', 'project', 'version', 'transaction_type', 'token_address', 'tx_hash', 'evt_index'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-    post_hook = '{{ expose_spells(\'["arbitrum", "avalanche_c", "base", "bnb", "celo", "ethereum", "fantom", "gnosis", "linea", "optimism", "polygon", "scroll", "sonic", "zksync","unichain"]\',
-                                "sector",
-                                "lending",
-                                \'["tomfutago", "hildobby"]\') }}'
+    post_hook = '{{ hide_spells() }}'
   )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/nft/mints/nft_mints.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/nft/mints/nft_mints.sql
@@ -7,10 +7,7 @@
     incremental_strategy = 'merge',
     incremental_predicates = ['DBT_INTERNAL_DEST.block_time >= date_trunc(\'day\', now() - interval \'7\' day)'],
     unique_key = ['tx_hash','evt_index','token_id','number_of_items'],
-    post_hook='{{ expose_spells(\'["ethereum","bnb","optimism","arbitrum","zksync"]\',
-                    "sector",
-                    "nft",
-                    \'["soispoke","umer_h_adil","hildobby","0xRob", "chuxin", "lgingerich"]\') }}')
+    post_hook = '{{ hide_spells() }}')
 }}
 
 

--- a/dbt_subprojects/hourly_spellbook/models/_sector/rollup_economics/ethereum/rollup_economics_ethereum_l1_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/rollup_economics/ethereum/rollup_economics_ethereum_l1_fees.sql
@@ -5,10 +5,7 @@
     , file_format = 'delta'
     , incremental_strategy = 'merge'
     , unique_key = ['name', 'day']
-    , post_hook='{{ expose_spells(\'["ethereum"]\',
-                                    "project",
-                                    "rollup_economics",
-                                    \'["niftytable"]\') }}'
+    , post_hook = '{{ hide_spells() }}'
 )}}
 
 WITH l1_data AS (

--- a/dbt_subprojects/hourly_spellbook/models/_sector/rollup_economics/ethereum/rollup_economics_ethereum_l2_revenue.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/rollup_economics/ethereum/rollup_economics_ethereum_l2_revenue.sql
@@ -5,10 +5,7 @@
     , file_format = 'delta'
     , incremental_strategy = 'merge'
     , unique_key = ['day', 'name']
-    , post_hook='{{ expose_spells(\'["ethereum"]\',
-                                    "project",
-                                    "rollup_economics",
-                                    \'["niftytable", "maybeYonas", "lgingerich"]\') }}'
+    , post_hook = '{{ hide_spells() }}'
 )}}
 
 SELECT

--- a/dbt_subprojects/hourly_spellbook/models/_sector/staking/ethereum/staking_ethereum_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/staking/ethereum/staking_ethereum_deposits.sql
@@ -7,10 +7,7 @@
     incremental_strategy = 'merge',
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     unique_key = ['tx_hash', 'evt_index'],
-    post_hook='{{ expose_spells(\'["ethereum"]\',
-                                "sector",
-                                "staking",
-                                \'["hildobby"]\') }}')
+    post_hook = '{{ hide_spells() }}')
 }}
 
 WITH deposit_events AS (

--- a/dbt_subprojects/hourly_spellbook/models/_sector/staking/ethereum/staking_ethereum_entities.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/staking/ethereum/staking_ethereum_entities.sql
@@ -4,10 +4,7 @@
     schema = 'staking_ethereum',
     alias = 'entities',
     unique_key = ['depositor_address', 'tx_from', 'pubkey'],
-    post_hook='{{ expose_spells(\'["ethereum"]\',
-                                "sector",
-                                "staking",
-                                \'["hildobby", "sankinyue", "nerolation"]\') }}')
+    post_hook = '{{ hide_spells() }}')
 }}
 
 {% set entities_identifiers_models = [

--- a/dbt_subprojects/hourly_spellbook/models/_sector/staking/ethereum/staking_ethereum_flows.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/staking/ethereum/staking_ethereum_flows.sql
@@ -2,10 +2,7 @@
     
     schema = 'staking_ethereum',
     alias = 'flows',
-    post_hook='{{ expose_spells(\'["ethereum"]\',
-                                "sector",
-                                "staking",
-                                \'["hildobby", "0xBoxer"]\') }}')
+    post_hook = '{{ hide_spells() }}')
 }}
 
 WITH indexes AS (


### PR DESCRIPTION
### Description:

## What & why
Flip 19 spells from `expose_spells` to `hide_spells` per the Data Explorer cleanup, covering the categories marked "removed entirely": staking, lending, CEX flows, bridges, rollup economics, labels/identity, other, plus `nft.mints`.
These tables disappear from Data Explorer and search on each model's next scheduled prod run; the underlying tables and data are untouched and remain queryable.
Keep-list spells in this repo (dex, tokens, nft, utils, thorchain/TON/aptos/sui/near) were audited and already correctly exposed.

## Architecture
- 19 model files: post-hook swap only, no SQL body or config changes — `staking_ethereum.*`, `lending.*`, `cex.*`, `bridges_evms.*`, `rollup_economics_ethereum.*`, `labels.ens`, `safe.safes_all`, `addresses.stats`, `dune.blockchains`, `nft.mints`
- Tested: `dbt parse` clean on hourly_spellbook and daily_spellbook; post-hook-only changes won't trigger CI model builds (`state:modified.body`)
- Needs human eyes: confirm the 19-table list matches the final cleanup doc before merge
- Blast radius: Data Explorer/search visibility metadata only; queries referencing these tables keep working

<details><summary>Agent context</summary>

- Source of truth: CUR2-3341 comment (table list from core `table_overrides.go` review)
- All 107 blockchain-section keep tables (thorchain/TON/aptos/sui/near) verified as `expose_spells` — no changes
- `labels.ens` has no explicit `schema=` in config (inherits `labels`); matched by alias
- Repro: `grep -c hide_spells` on the 19 files; `uv run dbt parse --project-dir dbt_subprojects/{hourly,daily}_spellbook/`
- No agent review yet
</details>

Towards CUR2-3341

🤖 Generated with [Claude Code](https://claude.com/claude-code)