### PR TITLE
fix: add receipt_id and log_index to near_bridge_omni unique key

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_blockchains/near/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_blockchains/near/_schema.yml
@@ -18,12 +18,17 @@ models:
       
       Inbound transfers are identified by FinTransferEvent logs and mint method calls.
       Outbound transfers are identified by InitTransferEvent logs and burn method calls.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - bridge_omni_id
     columns:
       - name: bridge_omni_id
         description: "Unique identifier for each bridge transaction (surrogate key)"
         tests:
           - not_null
-          - unique
       - name: block_height
         description: "Height of the block containing the transaction"
         tests:

--- a/dbt_subprojects/daily_spellbook/models/_blockchains/near/near_bridge_omni.sql
+++ b/dbt_subprojects/daily_spellbook/models/_blockchains/near/near_bridge_omni.sql
@@ -4,7 +4,7 @@
     materialized = 'incremental',
     file_format = 'delta',
     incremental_strategy = 'merge',
-    unique_key = ['bridge_omni_id'],
+    unique_key = ['block_date', 'bridge_omni_id'],
     partition_by = ['block_date'],
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     post_hook='{{ expose_spells(\'["near"]\',

--- a/dbt_subprojects/daily_spellbook/models/_blockchains/near/near_bridge_omni.sql
+++ b/dbt_subprojects/daily_spellbook/models/_blockchains/near/near_bridge_omni.sql
@@ -310,7 +310,7 @@ SELECT
     has_burn,
     'omni' AS platform,
     {{ dbt_utils.generate_surrogate_key(
-        ['tx_hash', 'source_chain_id', 'destination_address', 'token_address', 'amount_raw']
+        ['tx_hash', 'source_chain_id', 'destination_address', 'token_address', 'amount_raw', 'receipt_id', 'log_index']
     ) }} AS bridge_omni_id,
     _partition_by_block_number
 FROM 


### PR DESCRIPTION
### Description:

## What & why
Prod merges of `near.bridge_omni` fail with `MERGE_TARGET_ROW_MULTIPLE_MATCHES`: two distinct omni bridge transfers in one NEAR tx with identical token, amount, and recipient collide on the surrogate key.
The first run inserted the collided rows as duplicates; every subsequent run in the incremental window now errors.
Adding `receipt_id` and `log_index` to `bridge_omni_id` makes the key unique at the event grain.

## Architecture
- `dbt_subprojects/daily_spellbook/models/_blockchains/near/near_bridge_omni.sql` - surrogate key expanded from 5 to 7 columns; existing `bridge_omni_id` values all change, so this requires a **full refresh** of the table (prod currently holds 2 duplicated keys / 4 rows).
- Tested: expanded key validated on Dune over a 30-day source window (200,907 rows): 0 duplicate keys, 0 nulls in `receipt_id`/`log_index`.
- Needs human eyes: confirm full-refresh deployment path and that prod dupe count drops to 0 after rebuild.
- Blast radius: `near.bridge_omni` consumers see new `bridge_omni_id` values; all other columns unchanged.

<details><summary>Agent context</summary>

- Failure: `TrinoUserError MERGE_TARGET_ROW_MULTIPLE_MATCHES`, query_id `20260722_034109_07333_ck2p3`, prod run 2026-07-22.
- Colliding txs: `FXDiH8CMcu7PYQHTzhTt7qkq7GoxaMXCrSqhjVgoFpBw`, `AmNJaDE7amu8bxNC2qGsWpfSDHtu353XQVY4w9cJMfR7` - each has two `InitTransferEvent`s (consecutive `origin_nonce`, distinct `receipt_id`) from `intents.near` with same token/amount/recipient.
- Repro: group the model's source query by the old 5 key columns over the 3-day incremental window; 2 keys return count > 1.
- No agent review yet.
</details>