### PR TITLE
feat(squeeze): launchpad deployments, trades, labels (Base, Robinhood, Solana)

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/_sector/labels/addresses/__single_category_labels__/squeeze/labels_squeeze.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/labels/addresses/__single_category_labels__/squeeze/labels_squeeze.sql
@@ -1,0 +1,48 @@
+{{ config(
+    alias = 'squeeze'
+    , post_hook = '{{ hide_spells() }}'
+) }}
+
+-- Static identifier labels for Squeeze launchpad contracts / wallets.
+-- Source of truth: Squeeze utils/squeezeIntegration.js
+-- Note: Airlock contracts are shared across Doppler integrators — labels mark
+-- the contracts Squeeze uses; launch attribution still requires integrator filter.
+
+SELECT blockchain, address, name, category, contributor, source, created_at, updated_at, model_name, label_type
+FROM (
+    VALUES
+        ('base', 0x6C61feE73584670AbEd65101946734006DAB12d6, 'Squeeze: Integrator / Platform Fee Wallet', 'infrastructure', 'flockain', 'static', TIMESTAMP '2026-07-25', now(), 'labels_squeeze', 'identifier')
+        , ('robinhood', 0x6C61feE73584670AbEd65101946734006DAB12d6, 'Squeeze: Integrator / Platform Fee Wallet', 'infrastructure', 'flockain', 'static', TIMESTAMP '2026-07-25', now(), 'labels_squeeze', 'identifier')
+        , ('base', 0x660eAaEdEBc968f8f3694354FA8EC0b4c5Ba8D12, 'Doppler Airlock (Base; Squeeze uses integrator filter)', 'infrastructure', 'flockain', 'static', TIMESTAMP '2026-07-25', now(), 'labels_squeeze', 'identifier')
+        , ('robinhood', 0xeb7c034704ef8dcd2d32324c1545f62fb4ad0862, 'Doppler Airlock (Robinhood; Squeeze uses integrator filter)', 'infrastructure', 'flockain', 'static', TIMESTAMP '2026-07-25', now(), 'labels_squeeze', 'identifier')
+        , ('base', 0x65de470da664a5be139a5d812be5fda0d76cc951, 'Squeeze fee source: Base Multicurve Initializer', 'infrastructure', 'flockain', 'static', TIMESTAMP '2026-07-25', now(), 'labels_squeeze', 'identifier')
+        , ('robinhood', 0x4e3468951d49f2eea976ed0d6e75ffcb44a9a544, 'Squeeze fee source: Robinhood Hook Initializer', 'infrastructure', 'flockain', 'static', TIMESTAMP '2026-07-25', now(), 'labels_squeeze', 'identifier')
+) AS t (blockchain, address, name, category, contributor, source, created_at, updated_at, model_name, label_type)
+
+UNION ALL
+
+SELECT
+    'solana' AS blockchain
+    , from_base58('FpKUW9vDSRPTByNu4MerR2SU4YPkJU9pLWQTnChGAW3h') AS address
+    , 'Squeeze: LaunchLab PlatformConfig PDA' AS name
+    , 'infrastructure' AS category
+    , 'flockain' AS contributor
+    , 'static' AS source
+    , TIMESTAMP '2026-07-25' AS created_at
+    , now() AS updated_at
+    , 'labels_squeeze' AS model_name
+    , 'identifier' AS label_type
+
+UNION ALL
+
+SELECT
+    'solana' AS blockchain
+    , from_base58('2qUg6a3yCSATL7stUyJHDBgFJwLW8DXzemZQDePxscws') AS address
+    , 'Squeeze: LaunchLab Claim / Platform Admin Wallet' AS name
+    , 'infrastructure' AS category
+    , 'flockain' AS contributor
+    , 'static' AS source
+    , TIMESTAMP '2026-07-25' AS created_at
+    , now() AS updated_at
+    , 'labels_squeeze' AS model_name
+    , 'identifier' AS label_type

--- a/dbt_subprojects/daily_spellbook/models/_sector/labels/addresses/__single_category_labels__/squeeze/labels_squeeze_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/_sector/labels/addresses/__single_category_labels__/squeeze/labels_squeeze_schema.yml
@@ -1,0 +1,33 @@
+version: 2
+
+models:
+  - name: labels_squeeze
+    meta:
+      blockchain: base, robinhood, solana
+      sector: labels
+      project: squeeze
+      contributors: flockain
+    config:
+      tags: ['labels', 'squeeze', 'launchpad']
+    description: "Squeeze launchpad identifier labels (integrator, Airlocks, LaunchLab PDAs)"
+    columns:
+      - name: blockchain
+        description: "Blockchain"
+      - name: address
+        description: "Address (EVM) or Solana pubkey"
+      - name: name
+        description: "Label name"
+      - name: category
+        description: "Label category"
+      - name: contributor
+        description: "Contributor"
+      - name: source
+        description: "static | query"
+      - name: created_at
+        description: "Created at"
+      - name: updated_at
+        description: "Updated at"
+      - name: model_name
+        description: "Model name"
+      - name: label_type
+        description: "identifier | usage | persona"

--- a/dbt_subprojects/daily_spellbook/models/_sector/labels/labels_addresses.sql
+++ b/dbt_subprojects/daily_spellbook/models/_sector/labels/labels_addresses.sql
@@ -20,6 +20,7 @@
     , ref('labels_ofac_sanctionned_ethereum')
     , ref('labels_project_wallets')
     , ref('labels_safe_ethereum')
+    , ref('labels_squeeze')
     , ref('labels_tornado_cash')
     , ref('labels_quest_participants')
     , ref('labels_cex_users')

--- a/dbt_subprojects/daily_spellbook/models/squeeze/_sources.yml
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/_sources.yml
@@ -1,0 +1,20 @@
+# sources placeholder — update namespaces after Airlock ABI decode on Dune
+
+version: 2
+
+sources:
+  - name: doppler_base
+    description: >
+      Decoded Doppler Airlock on Base. Confirm schema/table names in Dune after
+      submitting ABI for 0x660eAaEdEBc968f8f3694354FA8EC0b4c5Ba8D12.
+    tables:
+      - name: Airlock_call_create
+        description: Decoded Airlock.create calls including integrator field
+
+  - name: doppler_robinhood
+    description: >
+      Decoded Doppler Airlock on Robinhood (4663). Confirm after ABI submit for
+      0xeb7c034704ef8dcd2d32324c1545f62fb4ad0862.
+    tables:
+      - name: Airlock_call_create
+        description: Decoded Airlock.create calls including integrator field

--- a/dbt_subprojects/daily_spellbook/models/squeeze/base/squeeze_base_deployments.sql
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/base/squeeze_base_deployments.sql
@@ -1,0 +1,39 @@
+{{ config(
+    alias = 'deployments',
+    schema = 'squeeze_base',
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key = 'token'
+) }}
+
+{% set project_start_date = '2025-01-01' %}
+{% set blockchain = 'base' %}
+{% set airlock = '0x660eAaEdEBc968f8f3694354FA8EC0b4c5Ba8D12' %}
+{% set integrator = '0x6C61feE73584670AbEd65101946734006DAB12d6' %}
+
+-- Prerequisite: Doppler Airlock ABI decoded on Dune.
+-- Confirm actual source schema/table names after submit, then update source().
+-- Integrator is on the create() call, NOT on Create event args.
+
+SELECT
+    c.call_block_time AS block_time
+    , date_trunc('day', c.call_block_time) AS block_date
+    , date_trunc('month', c.call_block_time) AS block_month
+    , '{{ blockchain }}' AS blockchain
+    , 'squeeze' AS project
+    , c.output_asset AS token
+    , c.output_pool AS pool
+    , c.integrator AS integrator
+    , c.call_tx_from AS deployer
+    , c.call_tx_hash AS tx_hash
+FROM {{ source('doppler_base', 'Airlock_call_create') }} c
+WHERE c.call_success = true
+  AND c.contract_address = {{ airlock }}
+  AND c.integrator = {{ integrator }}
+  {% if is_incremental() %}
+  AND {{ incremental_predicate('c.call_block_time') }}
+  {% else %}
+  AND c.call_block_time >= TIMESTAMP '{{ project_start_date }}'
+  {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/squeeze/base/squeeze_base_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/base/squeeze_base_schema.yml
@@ -1,0 +1,45 @@
+version: 2
+
+models:
+  - name: squeeze_base_deployments
+    meta:
+      blockchain: base
+      project: squeeze
+      contributors: flockain
+    config:
+      tags: ['base', 'squeeze', 'launchpad', 'doppler']
+    description: >
+      Tokens launched through Squeeze on Base via Doppler Airlock where
+      integrator = 0x6C61feE73584670AbEd65101946734006DAB12d6.
+      Requires decoded Airlock_call_create (ABI submit).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: ['token']
+    columns:
+      - name: token
+        description: ERC-20 asset address from Airlock create
+        data_tests:
+          - not_null
+      - name: integrator
+        description: Doppler integrator (Squeeze identity)
+      - name: tx_hash
+        description: Launch transaction
+
+  - name: squeeze_base_trades
+    meta:
+      blockchain: base
+      project: squeeze
+      contributors: flockain
+    config:
+      tags: ['base', 'squeeze', 'launchpad', 'dex']
+    description: >
+      dex.trades rows touching Squeeze-launched Base tokens (attribution; overlaps Uniswap volume).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - blockchain
+              - tx_hash
+              - evt_index

--- a/dbt_subprojects/daily_spellbook/models/squeeze/base/squeeze_base_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/base/squeeze_base_trades.sql
@@ -1,0 +1,52 @@
+{{ config(
+    alias = 'trades',
+    schema = 'squeeze_base',
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key = ['block_month', 'blockchain', 'tx_hash', 'evt_index']
+) }}
+
+{% set project_start_date = '2025-01-01' %}
+{% set blockchain = 'base' %}
+
+-- Attribution table: Uniswap (etc.) volume on Squeeze-launched tokens.
+-- Double-counted vs dex.trades project volume — intentional launchpad lens.
+
+WITH deployments AS (
+    SELECT * FROM {{ ref('squeeze_base_deployments') }}
+)
+
+SELECT
+    t.block_time
+    , date_trunc('day', t.block_time) AS block_date
+    , date_trunc('month', t.block_time) AS block_month
+    , t.blockchain
+    , 'squeeze' AS project
+    , t.project AS dex_project
+    , t.version AS dex_version
+    , t.token_bought_amount
+    , t.token_sold_amount
+    , t.token_bought_symbol
+    , t.token_sold_symbol
+    , t.token_bought_address
+    , t.token_sold_address
+    , t.amount_usd
+    , t.taker AS user
+    , t.tx_hash
+    , t.evt_index
+FROM {{ source('dex', 'trades') }} t
+INNER JOIN deployments d
+    ON t.blockchain = d.blockchain
+   AND (
+        t.token_bought_address = d.token
+        OR t.token_sold_address = d.token
+   )
+WHERE t.blockchain = '{{ blockchain }}'
+  {% if is_incremental() %}
+  AND {{ incremental_predicate('t.block_time') }}
+  {% else %}
+  AND t.block_time >= TIMESTAMP '{{ project_start_date }}'
+  {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/squeeze/robinhood/squeeze_robinhood_deployments.sql
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/robinhood/squeeze_robinhood_deployments.sql
@@ -1,0 +1,38 @@
+{{ config(
+    alias = 'deployments',
+    schema = 'squeeze_robinhood',
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key = 'token'
+) }}
+
+{% set project_start_date = '2026-01-01' %}
+{% set blockchain = 'robinhood' %}
+{% set airlock = '0xeb7c034704ef8dcd2d32324c1545f62fb4ad0862' %}
+{% set integrator = '0x6C61feE73584670AbEd65101946734006DAB12d6' %}
+
+-- Robinhood (4663) is a supported Dune chain (`robinhood.*` raw + dex scaffolding).
+-- Decoded Airlock_call_create still requires ABI submit on this chain.
+
+SELECT
+    c.call_block_time AS block_time
+    , date_trunc('day', c.call_block_time) AS block_date
+    , date_trunc('month', c.call_block_time) AS block_month
+    , '{{ blockchain }}' AS blockchain
+    , 'squeeze' AS project
+    , c.output_asset AS token
+    , c.output_pool AS pool
+    , c.integrator AS integrator
+    , c.call_tx_from AS deployer
+    , c.call_tx_hash AS tx_hash
+FROM {{ source('doppler_robinhood', 'Airlock_call_create') }} c
+WHERE c.call_success = true
+  AND c.contract_address = {{ airlock }}
+  AND c.integrator = {{ integrator }}
+  {% if is_incremental() %}
+  AND {{ incremental_predicate('c.call_block_time') }}
+  {% else %}
+  AND c.call_block_time >= TIMESTAMP '{{ project_start_date }}'
+  {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/squeeze/robinhood/squeeze_robinhood_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/robinhood/squeeze_robinhood_schema.yml
@@ -1,0 +1,41 @@
+version: 2
+
+models:
+  - name: squeeze_robinhood_deployments
+    meta:
+      blockchain: robinhood
+      project: squeeze
+      contributors: flockain
+    config:
+      tags: ['robinhood', 'squeeze', 'launchpad', 'doppler']
+    description: >
+      Tokens launched through Squeeze on Robinhood Chain (4663) via Doppler Airlock
+      where integrator = 0x6C61feE73584670AbEd65101946734006DAB12d6.
+      Chain raw data is supported on Dune; decoded Airlock call table requires ABI submit.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: ['token']
+    columns:
+      - name: token
+        description: ERC-20 asset address from Airlock create
+        data_tests:
+          - not_null
+
+  - name: squeeze_robinhood_trades
+    meta:
+      blockchain: robinhood
+      project: squeeze
+      contributors: flockain
+    config:
+      tags: ['robinhood', 'squeeze', 'launchpad', 'dex']
+    description: >
+      dex.trades rows touching Squeeze-launched Robinhood tokens (attribution).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - blockchain
+              - tx_hash
+              - evt_index

--- a/dbt_subprojects/daily_spellbook/models/squeeze/robinhood/squeeze_robinhood_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/robinhood/squeeze_robinhood_trades.sql
@@ -1,0 +1,49 @@
+{{ config(
+    alias = 'trades',
+    schema = 'squeeze_robinhood',
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key = ['block_month', 'blockchain', 'tx_hash', 'evt_index']
+) }}
+
+{% set project_start_date = '2026-01-01' %}
+{% set blockchain = 'robinhood' %}
+
+WITH deployments AS (
+    SELECT * FROM {{ ref('squeeze_robinhood_deployments') }}
+)
+
+SELECT
+    t.block_time
+    , date_trunc('day', t.block_time) AS block_date
+    , date_trunc('month', t.block_time) AS block_month
+    , t.blockchain
+    , 'squeeze' AS project
+    , t.project AS dex_project
+    , t.version AS dex_version
+    , t.token_bought_amount
+    , t.token_sold_amount
+    , t.token_bought_symbol
+    , t.token_sold_symbol
+    , t.token_bought_address
+    , t.token_sold_address
+    , t.amount_usd
+    , t.taker AS user
+    , t.tx_hash
+    , t.evt_index
+FROM {{ source('dex', 'trades') }} t
+INNER JOIN deployments d
+    ON t.blockchain = d.blockchain
+   AND (
+        t.token_bought_address = d.token
+        OR t.token_sold_address = d.token
+   )
+WHERE t.blockchain = '{{ blockchain }}'
+  {% if is_incremental() %}
+  AND {{ incremental_predicate('t.block_time') }}
+  {% else %}
+  AND t.block_time >= TIMESTAMP '{{ project_start_date }}'
+  {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/squeeze/solana/squeeze_solana_launches.sql
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/solana/squeeze_solana_launches.sql
@@ -1,0 +1,35 @@
+{{ config(
+    alias = 'launches',
+    schema = 'squeeze_solana',
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key = 'pool_id'
+) }}
+
+{% set project_start_date = '2025-04-15' %}
+{% set platform_id = 'FpKUW9vDSRPTByNu4MerR2SU4YPkJU9pLWQTnChGAW3h' %}
+
+-- Squeeze is a Raydium LaunchLab platform (platformId), not a separate program.
+-- Filter existing LaunchLab spells by platform_config.
+
+SELECT
+    MIN(b.block_time) AS block_time
+    , date_trunc('day', MIN(b.block_time)) AS block_date
+    , date_trunc('month', MIN(b.block_time)) AS block_month
+    , 'solana' AS blockchain
+    , 'squeeze' AS project
+    , b.pool_id
+    , b.base_token_mint AS mint
+    , b.quote_token_mint AS quote_mint
+    , b.platform_config AS platform_id
+    , MAX(b.platform_name) AS platform_name
+FROM {{ ref('raydium_launchlab_v1_base_trades') }} b
+WHERE b.platform_config = '{{ platform_id }}'
+  {% if is_incremental() %}
+  AND {{ incremental_predicate('b.block_time') }}
+  {% else %}
+  AND b.block_time >= TIMESTAMP '{{ project_start_date }}'
+  {% endif %}
+GROUP BY b.pool_id, b.base_token_mint, b.quote_token_mint, b.platform_config

--- a/dbt_subprojects/daily_spellbook/models/squeeze/solana/squeeze_solana_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/solana/squeeze_solana_schema.yml
@@ -1,0 +1,35 @@
+version: 2
+
+models:
+  - name: squeeze_solana_launches
+    meta:
+      blockchain: solana
+      project: squeeze
+      contributors: flockain
+    config:
+      tags: ['solana', 'squeeze', 'launchpad', 'raydium_launchlab']
+    description: >
+      Distinct Raydium LaunchLab pools for Squeeze platformId
+      FpKUW9vDSRPTByNu4MerR2SU4YPkJU9pLWQTnChGAW3h.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: ['pool_id']
+
+  - name: squeeze_solana_trades
+    meta:
+      blockchain: solana
+      project: squeeze
+      contributors: flockain
+    config:
+      tags: ['solana', 'squeeze', 'launchpad', 'raydium_launchlab']
+    description: >
+      LaunchLab base trades filtered to Squeeze platform_config (attribution vs full raydium_launchlab).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_id
+              - outer_instruction_index
+              - inner_instruction_index

--- a/dbt_subprojects/daily_spellbook/models/squeeze/solana/squeeze_solana_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/solana/squeeze_solana_trades.sql
@@ -1,0 +1,40 @@
+{{ config(
+    alias = 'trades',
+    schema = 'squeeze_solana',
+    partition_by = ['block_month'],
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key = ['block_month', 'tx_id', 'outer_instruction_index', 'inner_instruction_index']
+) }}
+
+{% set project_start_date = '2025-04-15' %}
+{% set platform_id = 'FpKUW9vDSRPTByNu4MerR2SU4YPkJU9pLWQTnChGAW3h' %}
+
+SELECT
+    b.block_time
+    , date_trunc('day', b.block_time) AS block_date
+    , date_trunc('month', b.block_time) AS block_month
+    , 'solana' AS blockchain
+    , 'squeeze' AS project
+    , 'raydium_launchlab' AS dex_project
+    , b.pool_id
+    , b.base_token_mint
+    , b.quote_token_mint
+    , b.is_buy
+    , b.platform_config AS platform_id
+    , b.platform_name
+    , b.tx_id
+    , b.tx_signer AS trader_id
+    , b.outer_instruction_index
+    , b.inner_instruction_index
+    , b.tx_index
+    , b.block_slot
+FROM {{ ref('raydium_launchlab_v1_base_trades') }} b
+WHERE b.platform_config = '{{ platform_id }}'
+  {% if is_incremental() %}
+  AND {{ incremental_predicate('b.block_time') }}
+  {% else %}
+  AND b.block_time >= TIMESTAMP '{{ project_start_date }}'
+  {% endif %}

--- a/dbt_subprojects/daily_spellbook/models/squeeze/squeeze_deployments.sql
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/squeeze_deployments.sql
@@ -1,0 +1,9 @@
+{{ config(
+    alias = 'deployments',
+    schema = 'squeeze',
+    materialized = 'view'
+) }}
+
+SELECT * FROM {{ ref('squeeze_base_deployments') }}
+UNION ALL
+SELECT * FROM {{ ref('squeeze_robinhood_deployments') }}

--- a/dbt_subprojects/daily_spellbook/models/squeeze/squeeze_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/squeeze_schema.yml
@@ -1,0 +1,22 @@
+version: 2
+
+models:
+  - name: squeeze_deployments
+    meta:
+      blockchain: base, robinhood
+      project: squeeze
+      contributors: flockain
+    config:
+      tags: ['squeeze', 'launchpad']
+    description: >
+      Union of Squeeze Doppler Airlock deployments on Base and Robinhood.
+
+  - name: squeeze_trades
+    meta:
+      blockchain: base, robinhood
+      project: squeeze
+      contributors: flockain
+    config:
+      tags: ['squeeze', 'launchpad', 'dex']
+    description: >
+      Union of EVM dex.trades attribution for Squeeze-launched tokens.

--- a/dbt_subprojects/daily_spellbook/models/squeeze/squeeze_trades.sql
+++ b/dbt_subprojects/daily_spellbook/models/squeeze/squeeze_trades.sql
@@ -1,0 +1,49 @@
+{{ config(
+    alias = 'trades',
+    schema = 'squeeze',
+    materialized = 'view'
+) }}
+
+-- EVM attribution trades only (aligned columns). Solana stays in squeeze_solana.trades.
+
+SELECT
+    block_time
+    , block_date
+    , block_month
+    , blockchain
+    , project
+    , dex_project
+    , dex_version
+    , token_bought_amount
+    , token_sold_amount
+    , token_bought_symbol
+    , token_sold_symbol
+    , token_bought_address
+    , token_sold_address
+    , amount_usd
+    , user
+    , tx_hash
+    , evt_index
+FROM {{ ref('squeeze_base_trades') }}
+
+UNION ALL
+
+SELECT
+    block_time
+    , block_date
+    , block_month
+    , blockchain
+    , project
+    , dex_project
+    , dex_version
+    , token_bought_amount
+    , token_sold_amount
+    , token_bought_symbol
+    , token_sold_symbol
+    , token_bought_address
+    , token_sold_address
+    , amount_usd
+    , user
+    , tx_hash
+    , evt_index
+FROM {{ ref('squeeze_robinhood_trades') }}


### PR DESCRIPTION
## Summary
Adds Squeeze launchpad abstractions (deployments + trades + address labels).

- Website: https://squeeze.run
- Docs: https://squeeze.run/docs#dune
- Addresses: https://squeeze.run/api/defillama
- Related issue: https://github.com/duneanalytics/spellbook/issues/9903

## Methodology
- **EVM:** Airlock `create` filtered by integrator `0x6C61feE73584670AbEd65101946734006DAB12d6`; assets from decoded `create` outputs
- **Solana:** `raydium_launchlab` filtered by `platform_config = FpKUW9…AW3h`
- Trades: join Squeeze assets to `dex.trades` / LaunchLab trades (attribution table; may double-count vs Uniswap/Raydium)

## Notes for reviewers
- EVM models depend on Doppler Airlock ABI decode on Base + Robinhood (`source('doppler_*', 'Airlock_call_create')`). Namespaces/column names will be updated once decode lands (`create` takes a `createData` struct containing `integrator`).
- Issue #9903 was opened for prior approval; opening this PR in parallel so maintainers can review drafts.

## Test plan
- [ ] CI `dbt slim ci` green (may need decoded Airlock sources first)
- [ ] Spot-check Base Create txs against known Squeeze launches
- [ ] Spot-check Solana LaunchLab pools with Squeeze platformId
- [ ] Confirm Robinhood chain tables resolve (`blockchain = 'robinhood'`)
- [ ] Confirm `labels_squeeze` appears in `labels.addresses` union


Made with [Cursor](https://cursor.com)