### PR TITLE
refactor(dex): split 1inch LOP dedup models per chain to isolate blast radius

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lop_own_trades_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lop_own_trades_macro.sql
@@ -1,0 +1,70 @@
+{% macro oneinch_lop_own_trades_macro(
+    blockchain
+) %}
+
+{%- set src_symbol = "coalesce(src_executed_symbol, '')" -%}
+{%- set dst_symbol = "coalesce(dst_executed_symbol, '')" -%}
+{%- set placeholder_tokens = oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') -%}
+{%- set maturity_delay = "interval '6' hour" -%}
+
+with fills as (
+    -- evt_index is numbered over ALL limits fills, before the venue-settled exclusion:
+    -- kept rows must retain their historical evt_index because dex_{{ blockchain.name }}_trades
+    -- merges can only upsert, never delete
+    select *
+        , {{ oneinch_lop_evt_index() }} as evt_index
+    from {{ ref('oneinch_swaps') }}
+    where true
+        and blockchain = '{{ blockchain.name }}'
+        and mode = 'limits'
+        and tx_success
+        and call_success
+        -- exclude Fusion+ cross-chain fills: the ERC20True placeholder leg makes these degenerate single-chain rows
+        and (src_token_address is null or src_token_address not in ({{ placeholder_tokens }}))
+        and (dst_token_address is null or dst_token_address not in ({{ placeholder_tokens }}))
+)
+
+select
+    blockchain
+    , '1inch-LOP' as project
+    , cast(protocol_version as varchar) as version
+    , block_date
+    , block_month
+    , block_time
+    , block_number
+    , {{ src_symbol }} as token_bought_symbol
+    , {{ dst_symbol }} as token_sold_symbol
+    , case
+        when lower({{ src_symbol }}) > lower({{ dst_symbol }}) then concat({{ dst_symbol }}, '-', {{ src_symbol }})
+        else concat({{ src_symbol }}, '-', {{ dst_symbol }})
+    end as token_pair
+    , cast(src_executed_amount as double) / pow(10, cast(element_at(complement, 'src_decimals') as bigint)) as token_bought_amount
+    , cast(dst_executed_amount as double) / pow(10, cast(element_at(complement, 'dst_decimals') as bigint)) as token_sold_amount
+    , src_executed_amount as token_bought_amount_raw
+    , dst_executed_amount as token_sold_amount_raw
+    , amount_usd
+    , src_token_address as token_bought_address
+    , dst_token_address as token_sold_address
+    , call_from as taker
+    , user as maker
+    , call_to as project_contract_address
+    , tx_hash
+    , tx_from
+    , tx_to
+    , evt_index
+from fills as f
+where true
+    and not exists ( -- venue-settled fills are reclassified into dex_aggregator.trades (see oneinch_lop_aggregator_trades)
+        select 1
+        from {{ ref('oneinch_' + blockchain.name + '_lop_venue_settled_fills') }} as v
+        where true
+            and v.block_month = f.block_month
+            and v.execution_id = f.execution_id
+    )
+    -- maturity delay: the 1inch lineage builds from raw traces while venue base trades
+    -- build from decoded events; a fill merged into dex_{{ blockchain.name }}_trades before its
+    -- venue's event decodes would never be removed (merge can't delete), so fills only
+    -- pass through once old enough for the venue side to have landed
+    and f.block_time <= now() - {{ maturity_delay }}
+
+{% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lop_venue_settled_fills_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lop_venue_settled_fills_macro.sql
@@ -1,19 +1,9 @@
-{%- set stream = oneinch_lo_cfg_macro() -%}
-{%- set placeholder_tokens = oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') -%}
+{% macro oneinch_lop_venue_settled_fills_macro(
+    blockchain
+    , stream
+) %}
 
-{{
-    config(
-        schema = 'oneinch',
-        alias = 'lop_venue_settled_fills',
-        materialized = 'incremental',
-        file_format = 'delta',
-        incremental_strategy = 'merge',
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
-        partition_by = ['blockchain', 'block_month'],
-        unique_key = ['blockchain', 'block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
-    )
-}}
+{%- set placeholder_tokens = oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') -%}
 
 {% set window_guard %}
         {% if var('dev_dates', false) -%} and block_date > current_date - interval '3' day
@@ -21,7 +11,7 @@
 {% endset %}
 
 -- LOP fills that a resolver settled on an underlying DEX in the same tx: the venue's
--- own row is already in dex_<blockchain>_base_trades, so keeping the '1inch-LOP' row
+-- own row is already in dex_{{ blockchain.name }}_base_trades, so keeping the '1inch-LOP' row
 -- in dex.trades double-counts the same fill. Fills settled via private liquidity
 -- (no co-occurring venue row) stay in dex.trades; fills listed here are reclassified
 -- into dex_aggregator.trades (see oneinch_lop_aggregator_trades).
@@ -33,9 +23,6 @@
 --   * direct fills (flags['direct']): their synthesized second-side row already
 --     feeds dex_aggregator.trades as '1inch', so reclassifying them would duplicate
 --     within that table; they remain in dex.trades unconditionally
---
--- Cross-chain identical (tx_hash, call_trace_address) replays are an accepted
--- ~0-probability residual (the evt_index window is tx_hash-only).
 
 with
 
@@ -52,10 +39,11 @@ fills as (
         , {{ oneinch_lop_evt_index() }} as evt_index -- numbered before the exclusions below
     from {{ ref('oneinch_swaps') }}
     where true
+        and blockchain = '{{ blockchain.name }}'
         and mode = 'limits'
         and tx_success
         and call_success
-        -- same pre-numbering predicates as oneinch_lop_own_trades (evt_index parity!):
+        -- same pre-numbering predicates as oneinch_{{ blockchain.name }}_lop_own_trades (evt_index parity!):
         -- Fusion+ cross-chain placeholder fills are excluded from both trade views (CUR2-2665)
         and (src_token_address is null or src_token_address not in ({{ placeholder_tokens }}))
         and (dst_token_address is null or dst_token_address not in ({{ placeholder_tokens }}))
@@ -64,11 +52,11 @@ fills as (
 
 , parent_calls as (
     select
-        blockchain
-        , tx_hash
+        tx_hash
         , call_trace_address
     from {{ ref('oneinch_swaps') }}
     where true
+        and blockchain = '{{ blockchain.name }}'
         and mode in ('classic', 'fusion', 'cross-chain')
         and tx_success
         and call_success
@@ -78,35 +66,28 @@ fills as (
 
 , lop_tx_keys as (
     select distinct
-        blockchain
-        , block_month
+        block_month
         , tx_hash
     from fills
 )
 
--- joined to the small LOP tx set (instead of EXISTS with the union as the build side)
--- so the base trades scans get dynamically filtered on tx_hash
+-- joined to the small LOP tx set (instead of EXISTS with the base trades as the build side)
+-- so the base trades scan gets dynamically filtered on tx_hash
 , venue_txs as (
     select distinct
-        k.blockchain
-        , k.block_month
+        k.block_month
         , k.tx_hash
     from (
-        {%- for blockchain in oneinch_blockchains_cfg_macro() if blockchain.exposed and stream.name in blockchain.exposed %}
         select
-            '{{ blockchain.name }}' as blockchain
-            , block_month
+            block_month
             , tx_hash
         from {{ ref('dex_' + blockchain.name + '_base_trades') }}
         where true
             and block_time >= timestamp '{{ stream.start }}' -- LOP stream start; prunes pre-LOP history on full builds
             {{ window_guard }}
-        {% if not loop.last %} union all {% endif %}
-        {%- endfor %}
     ) as b
     join lop_tx_keys as k
-        on k.blockchain = b.blockchain
-        and k.block_month = b.block_month
+        on k.block_month = b.block_month
         and k.tx_hash = b.tx_hash
 )
 
@@ -128,7 +109,6 @@ where true
         select 1
         from parent_calls as p
         where true
-            and p.blockchain = f.blockchain
             and p.tx_hash = f.tx_hash
             and cardinality(f.call_trace_address) > cardinality(p.call_trace_address) -- strict: a direct fill's second-side row shares its call_trace_address
             and slice(f.call_trace_address, 1, cardinality(p.call_trace_address)) = p.call_trace_address
@@ -137,7 +117,8 @@ where true
         select 1
         from venue_txs as v
         where true
-            and v.blockchain = f.blockchain
             and v.block_month = f.block_month
             and v.tx_hash = f.tx_hash
     )
+
+{% endmacro %}

--- a/dbt_subprojects/dex/macros/models/oneinch_lop_dex_trades_passthrough.sql
+++ b/dbt_subprojects/dex/macros/models/oneinch_lop_dex_trades_passthrough.sql
@@ -34,7 +34,7 @@ SELECT
 	, o.tx_from
 	, o.tx_to
 	, o.evt_index
-FROM {{ ref('oneinch_lop_own_trades') }} AS o
+FROM {{ ref('oneinch_' + blockchain + '_lop_own_trades') }} AS o
 LEFT JOIN {{ source('tokens', 'erc20') }} AS tb
 	ON tb.blockchain = '{{ blockchain }}'
 	AND tb.contract_address = o.token_bought_address

--- a/dbt_subprojects/dex/models/_projects/oneinch/LINEAGE.md
+++ b/dbt_subprojects/dex/models/_projects/oneinch/LINEAGE.md
@@ -26,6 +26,12 @@
     - `oneinch.cc_executions` - _materialized view_ - unioned view of all exposed blockchains with a matched sources and destinations
 5. **swaps** - aggregate `executions` - _materialized view_ - a top-level data mart containing aggregated data on user exchanges
   accessing: `oneinch.swaps` - _materialized view_ - combining and allocating modes & limits second side
+6. **lop trades split** - LOP fills routed into dex.trades vs dex_aggregator.trades; kept per-chain so one chain's base-trades changes don't fan out to every chain's trades lineage
+  accessing:
+    - `oneinch_{blockchain}.lop_venue_settled_fills` - _materialized viewes_ - fills a resolver settled on an underlying DEX in the same tx (venue row co-occurs in `dex_{blockchain}_base_trades`)
+    - `oneinch_{blockchain}.lop_own_trades` - _viewes_ - LOP fills for `dex_{blockchain}_trades` (venue-settled fills excluded); consumed per-chain via `oneinch_lop_dex_trades_passthrough`
+    - `oneinch.lop_own_trades` - _view_ - unioned view of all exposed blockchains
+    - `oneinch.lop_aggregator_trades` - _view_ - venue-settled fills served to `dex_aggregator.trades`
 
 ## Configs:
 - **meta_cfg** - a config that aggregated meta data and settings of streams, blockchains etc.

--- a/dbt_subprojects/dex/models/_projects/oneinch/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/oneinch/_schema.yml
@@ -412,24 +412,24 @@ models:
         data_tests:
           - not_null
 
-  - name: oneinch_lop_venue_settled_fills
+  - name: oneinch_ethereum_lop_venue_settled_fills
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum']
       sector: oneinch
       contributors: ['thevaizman']
     config:
       tags: ['oneinch', 'lo']
     description: >
-        1inch limit order protocol fills that a resolver settled on an underlying DEX in
-        the same tx (the venue's own row co-occurs in dex_<blockchain>_base_trades).
-        These fills are excluded from oneinch_lop_own_trades (dex.trades) and emitted
-        into dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        1inch limit order protocol fills on ethereum that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_ethereum_base_trades). These fills are excluded from
+        oneinch_ethereum_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
         a classic/fusion/cross-chain execution and direct fills are kept out of this set.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - blockchain
               - block_month
               - block_date
               - execution_id
@@ -456,6 +456,741 @@ models:
       - name: evt_index
         data_tests:
           - not_null
+
+  - name: oneinch_ethereum_lop_own_trades
+    meta:
+      blockchain: ['ethereum']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on ethereum - per-chain input for
+        dex_ethereum_trades. Venue-settled fills are excluded here (see
+        oneinch_ethereum_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_ethereum_trades merges them.
+
+  - name: oneinch_bnb_lop_venue_settled_fills
+    meta:
+      blockchain: ['bnb']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on bnb that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_bnb_base_trades). These fills are excluded from
+        oneinch_bnb_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_bnb_lop_own_trades
+    meta:
+      blockchain: ['bnb']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on bnb - per-chain input for
+        dex_bnb_trades. Venue-settled fills are excluded here (see
+        oneinch_bnb_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_bnb_trades merges them.
+
+  - name: oneinch_polygon_lop_venue_settled_fills
+    meta:
+      blockchain: ['polygon']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on polygon that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_polygon_base_trades). These fills are excluded from
+        oneinch_polygon_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_polygon_lop_own_trades
+    meta:
+      blockchain: ['polygon']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on polygon - per-chain input for
+        dex_polygon_trades. Venue-settled fills are excluded here (see
+        oneinch_polygon_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_polygon_trades merges them.
+
+  - name: oneinch_arbitrum_lop_venue_settled_fills
+    meta:
+      blockchain: ['arbitrum']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on arbitrum that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_arbitrum_base_trades). These fills are excluded from
+        oneinch_arbitrum_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_arbitrum_lop_own_trades
+    meta:
+      blockchain: ['arbitrum']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on arbitrum - per-chain input for
+        dex_arbitrum_trades. Venue-settled fills are excluded here (see
+        oneinch_arbitrum_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_arbitrum_trades merges them.
+
+  - name: oneinch_optimism_lop_venue_settled_fills
+    meta:
+      blockchain: ['optimism']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on optimism that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_optimism_base_trades). These fills are excluded from
+        oneinch_optimism_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_optimism_lop_own_trades
+    meta:
+      blockchain: ['optimism']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on optimism - per-chain input for
+        dex_optimism_trades. Venue-settled fills are excluded here (see
+        oneinch_optimism_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_optimism_trades merges them.
+
+  - name: oneinch_avalanche_c_lop_venue_settled_fills
+    meta:
+      blockchain: ['avalanche_c']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on avalanche_c that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_avalanche_c_base_trades). These fills are excluded from
+        oneinch_avalanche_c_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_avalanche_c_lop_own_trades
+    meta:
+      blockchain: ['avalanche_c']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on avalanche_c - per-chain input for
+        dex_avalanche_c_trades. Venue-settled fills are excluded here (see
+        oneinch_avalanche_c_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_avalanche_c_trades merges them.
+
+  - name: oneinch_gnosis_lop_venue_settled_fills
+    meta:
+      blockchain: ['gnosis']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on gnosis that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_gnosis_base_trades). These fills are excluded from
+        oneinch_gnosis_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_gnosis_lop_own_trades
+    meta:
+      blockchain: ['gnosis']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on gnosis - per-chain input for
+        dex_gnosis_trades. Venue-settled fills are excluded here (see
+        oneinch_gnosis_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_gnosis_trades merges them.
+
+  - name: oneinch_base_lop_venue_settled_fills
+    meta:
+      blockchain: ['base']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on base that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_base_base_trades). These fills are excluded from
+        oneinch_base_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_base_lop_own_trades
+    meta:
+      blockchain: ['base']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on base - per-chain input for
+        dex_base_trades. Venue-settled fills are excluded here (see
+        oneinch_base_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_base_trades merges them.
+
+  - name: oneinch_fantom_lop_venue_settled_fills
+    meta:
+      blockchain: ['fantom']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on fantom that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_fantom_base_trades). These fills are excluded from
+        oneinch_fantom_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_fantom_lop_own_trades
+    meta:
+      blockchain: ['fantom']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on fantom - per-chain input for
+        dex_fantom_trades. Venue-settled fills are excluded here (see
+        oneinch_fantom_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_fantom_trades merges them.
+
+  - name: oneinch_zksync_lop_venue_settled_fills
+    meta:
+      blockchain: ['zksync']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on zksync that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_zksync_base_trades). These fills are excluded from
+        oneinch_zksync_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_zksync_lop_own_trades
+    meta:
+      blockchain: ['zksync']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on zksync - per-chain input for
+        dex_zksync_trades. Venue-settled fills are excluded here (see
+        oneinch_zksync_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_zksync_trades merges them.
+
+  - name: oneinch_linea_lop_venue_settled_fills
+    meta:
+      blockchain: ['linea']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on linea that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_linea_base_trades). These fills are excluded from
+        oneinch_linea_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_linea_lop_own_trades
+    meta:
+      blockchain: ['linea']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on linea - per-chain input for
+        dex_linea_trades. Venue-settled fills are excluded here (see
+        oneinch_linea_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_linea_trades merges them.
+
+  - name: oneinch_sonic_lop_venue_settled_fills
+    meta:
+      blockchain: ['sonic']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on sonic that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_sonic_base_trades). These fills are excluded from
+        oneinch_sonic_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_sonic_lop_own_trades
+    meta:
+      blockchain: ['sonic']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on sonic - per-chain input for
+        dex_sonic_trades. Venue-settled fills are excluded here (see
+        oneinch_sonic_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_sonic_trades merges them.
+
+  - name: oneinch_unichain_lop_venue_settled_fills
+    meta:
+      blockchain: ['unichain']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on unichain that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_unichain_base_trades). These fills are excluded from
+        oneinch_unichain_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_unichain_lop_own_trades
+    meta:
+      blockchain: ['unichain']
+      sector: oneinch
+      contributors: ['thevaizman']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on unichain - per-chain input for
+        dex_unichain_trades. Venue-settled fills are excluded here (see
+        oneinch_unichain_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_unichain_trades merges them.
 
   - name: oneinch_lop_aggregator_trades
     meta:

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/arbitrum/oneinch_arbitrum_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/arbitrum/oneinch_arbitrum_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/arbitrum/oneinch_arbitrum_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/arbitrum/oneinch_arbitrum_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_arbitrum_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/arbitrum/oneinch_arbitrum_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/arbitrum/oneinch_arbitrum_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_arbitrum_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/arbitrum/oneinch_arbitrum_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/arbitrum/oneinch_arbitrum_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/avalanche_c/oneinch_avalanche_c_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/avalanche_c/oneinch_avalanche_c_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/avalanche_c/oneinch_avalanche_c_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/avalanche_c/oneinch_avalanche_c_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_avalanche_c_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/avalanche_c/oneinch_avalanche_c_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/avalanche_c/oneinch_avalanche_c_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_avalanche_c_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/avalanche_c/oneinch_avalanche_c_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/avalanche_c/oneinch_avalanche_c_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/base/oneinch_base_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/base/oneinch_base_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_base_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/base/oneinch_base_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/base/oneinch_base_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/base/oneinch_base_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/base/oneinch_base_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_base_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/base/oneinch_base_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/base/oneinch_base_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/bnb/oneinch_bnb_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/bnb/oneinch_bnb_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_bnb_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/bnb/oneinch_bnb_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/bnb/oneinch_bnb_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/bnb/oneinch_bnb_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/bnb/oneinch_bnb_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_bnb_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/bnb/oneinch_bnb_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/bnb/oneinch_bnb_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/ethereum/oneinch_ethereum_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/ethereum/oneinch_ethereum_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/ethereum/oneinch_ethereum_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/ethereum/oneinch_ethereum_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_ethereum_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/ethereum/oneinch_ethereum_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/ethereum/oneinch_ethereum_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_ethereum_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/ethereum/oneinch_ethereum_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/ethereum/oneinch_ethereum_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/fantom/oneinch_fantom_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/fantom/oneinch_fantom_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/fantom/oneinch_fantom_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/fantom/oneinch_fantom_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_fantom_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/fantom/oneinch_fantom_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/fantom/oneinch_fantom_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_fantom_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/fantom/oneinch_fantom_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/fantom/oneinch_fantom_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/gnosis/oneinch_gnosis_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/gnosis/oneinch_gnosis_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_gnosis_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/gnosis/oneinch_gnosis_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/gnosis/oneinch_gnosis_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/gnosis/oneinch_gnosis_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/gnosis/oneinch_gnosis_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_gnosis_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/gnosis/oneinch_gnosis_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/gnosis/oneinch_gnosis_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/linea/oneinch_linea_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/linea/oneinch_linea_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_linea_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/linea/oneinch_linea_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/linea/oneinch_linea_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/linea/oneinch_linea_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/linea/oneinch_linea_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_linea_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/linea/oneinch_linea_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/linea/oneinch_linea_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/optimism/oneinch_optimism_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/optimism/oneinch_optimism_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_optimism_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/optimism/oneinch_optimism_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/optimism/oneinch_optimism_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/optimism/oneinch_optimism_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/optimism/oneinch_optimism_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_optimism_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/optimism/oneinch_optimism_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/optimism/oneinch_optimism_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/polygon/oneinch_polygon_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/polygon/oneinch_polygon_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_polygon_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/polygon/oneinch_polygon_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/polygon/oneinch_polygon_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/polygon/oneinch_polygon_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/polygon/oneinch_polygon_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_polygon_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/polygon/oneinch_polygon_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/polygon/oneinch_polygon_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/sonic/oneinch_sonic_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/sonic/oneinch_sonic_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/sonic/oneinch_sonic_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/sonic/oneinch_sonic_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_sonic_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/sonic/oneinch_sonic_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/sonic/oneinch_sonic_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/sonic/oneinch_sonic_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/sonic/oneinch_sonic_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_sonic_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/unichain/oneinch_unichain_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/unichain/oneinch_unichain_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_unichain_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/unichain/oneinch_unichain_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/unichain/oneinch_unichain_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/unichain/oneinch_unichain_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/unichain/oneinch_unichain_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_unichain_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/unichain/oneinch_unichain_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/unichain/oneinch_unichain_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/zksync/oneinch_zksync_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/zksync/oneinch_zksync_lop_own_trades.sql
@@ -5,7 +5,6 @@
         schema = 'oneinch_' + blockchain.name,
         alias = 'lop_own_trades',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/zksync/oneinch_zksync_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/zksync/oneinch_zksync_lop_own_trades.sql
@@ -1,0 +1,16 @@
+{%- set blockchain = oneinch_zksync_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/zksync/oneinch_zksync_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/zksync/oneinch_zksync_lop_venue_settled_fills.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_zksync_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+        post_hook = '{{ hide_spells() }}'
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/zksync/oneinch_zksync_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/zksync/oneinch_zksync_lop_venue_settled_fills.sql
@@ -11,7 +11,6 @@
         incremental_strategy = 'merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['block_month', 'block_date', 'execution_id'],
-        post_hook = '{{ hide_spells() }}'
     )
 -}}
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_lop_aggregator_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_lop_aggregator_trades.sql
@@ -9,14 +9,24 @@
 
 {% set src_symbol = "coalesce(src_executed_symbol, '')" %}
 {% set dst_symbol = "coalesce(dst_executed_symbol, '')" %}
+{% set stream = oneinch_lo_cfg_macro() %}
 
 
 
 -- venue-settled LOP fills: the underlying venue's own row stays in dex.trades, so the
 -- intent-layer fill is recorded here instead (user perspective, like oneinch_ar_trades).
--- evt_index comes persisted from oneinch_lop_venue_settled_fills (same numbering as
--- oneinch_lop_own_trades via oneinch_lop_evt_index()); keeping this view window-free
--- lets consumers' block_time predicates push down into the oneinch_swaps scan
+-- evt_index comes persisted from the per-chain lop_venue_settled_fills models (same
+-- numbering as the per-chain lop_own_trades views via oneinch_lop_evt_index()); keeping
+-- this view window-free lets consumers' block_time predicates push down into the
+-- oneinch_swaps scan
+with venue_settled_fills as (
+    {% for blockchain in oneinch_blockchains_cfg_macro() if blockchain.exposed and stream.name in blockchain.exposed %}
+    select *
+    from {{ ref('oneinch_' + blockchain.name + '_lop_venue_settled_fills') }}
+    {% if not loop.last %}union all{% endif %}
+    {% endfor %}
+)
+
 select
     f.blockchain
     , '1inch-LOP' as project
@@ -46,7 +56,7 @@ select
     , f.call_trace_address as trace_address
     , v.evt_index
 from {{ ref('oneinch_swaps') }} as f
-join {{ ref('oneinch_lop_venue_settled_fills') }} as v
+join venue_settled_fills as v
     on v.blockchain = f.blockchain
     and v.block_month = f.block_month
     and v.execution_id = f.execution_id

--- a/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/outside/oneinch_lop_own_trades.sql
@@ -7,69 +7,14 @@
     )
 }}
 
-{% set src_symbol = "coalesce(src_executed_symbol, '')" %}
-{% set dst_symbol = "coalesce(dst_executed_symbol, '')" %}
-{% set placeholder_tokens = oneinch_cross_chain_placeholder_tokens_cfg_macro() | join(', ') %}
-{% set maturity_delay = "interval '6' hour" %}
+{%- set stream = oneinch_lo_cfg_macro() -%}
 
+-- cross-chain union of the per-chain LOP own-trades views; dex_<blockchain>_trades
+-- consume the per-chain models directly (oneinch_lop_dex_trades_passthrough) so that
+-- one chain's base-trades changes don't fan out to every chain's trades lineage
 
-
-with fills as (
-    -- evt_index is numbered over ALL limits fills, before the venue-settled exclusion:
-    -- kept rows must retain their historical evt_index because dex_<blockchain>_trades
-    -- merges can only upsert, never delete
-    select *
-        , {{ oneinch_lop_evt_index() }} as evt_index
-    from {{ ref('oneinch_swaps') }}
-    where true
-        and mode = 'limits'
-        and tx_success
-        and call_success
-        -- exclude Fusion+ cross-chain fills: the ERC20True placeholder leg makes these degenerate single-chain rows
-        and (src_token_address is null or src_token_address not in ({{ placeholder_tokens }}))
-        and (dst_token_address is null or dst_token_address not in ({{ placeholder_tokens }}))
-)
-
-select
-    blockchain
-    , '1inch-LOP' as project
-    , cast(protocol_version as varchar) as version
-    , block_date
-    , block_month
-    , block_time
-    , block_number
-    , {{ src_symbol }} as token_bought_symbol
-    , {{ dst_symbol }} as token_sold_symbol
-    , case
-        when lower({{ src_symbol }}) > lower({{ dst_symbol }}) then concat({{ dst_symbol }}, '-', {{ src_symbol }})
-        else concat({{ src_symbol }}, '-', {{ dst_symbol }})
-    end as token_pair
-    , cast(src_executed_amount as double) / pow(10, cast(element_at(complement, 'src_decimals') as bigint)) as token_bought_amount
-    , cast(dst_executed_amount as double) / pow(10, cast(element_at(complement, 'dst_decimals') as bigint)) as token_sold_amount
-    , src_executed_amount as token_bought_amount_raw
-    , dst_executed_amount as token_sold_amount_raw
-    , amount_usd
-    , src_token_address as token_bought_address
-    , dst_token_address as token_sold_address
-    , call_from as taker
-    , user as maker
-    , call_to as project_contract_address
-    , tx_hash
-    , tx_from
-    , tx_to
-    , evt_index
-from fills as f
-where true
-    and not exists ( -- venue-settled fills are reclassified into dex_aggregator.trades (see oneinch_lop_aggregator_trades)
-        select 1
-        from {{ ref('oneinch_lop_venue_settled_fills') }} as v
-        where true
-            and v.blockchain = f.blockchain
-            and v.block_month = f.block_month
-            and v.execution_id = f.execution_id
-    )
-    -- maturity delay: the 1inch lineage builds from raw traces while venue base trades
-    -- build from decoded events; a fill merged into dex_<blockchain>_trades before its
-    -- venue's event decodes would never be removed (merge can't delete), so fills only
-    -- pass through once old enough for the venue side to have landed
-    and f.block_time <= now() - {{ maturity_delay }}
+{% for blockchain in oneinch_blockchains_cfg_macro() if blockchain.exposed and stream.name in blockchain.exposed %}
+select *
+from {{ ref('oneinch_' + blockchain.name + '_lop_own_trades') }}
+{% if not loop.last %}union all{% endif %}
+{% endfor %}


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:

## What & why
The 1inch LOP venue-settled dedup was one cross-chain model reading every chain's `dex_<chain>_base_trades` and feeding back into every chain's `dex_<chain>_trades`, so touching one chain's base trades rebuilt all EVM chains' dex + dex_aggregator lineage. The dedup join is strictly per-chain, so the logic now lives in per-chain models and each `dex_<chain>_trades` refs only its own chain's model. Adding a DEX to one chain now rebuilds only that chain's stack plus the cross-chain final unions. Output data is unchanged; `oneinch.lop_own_trades` stays as a cross-chain union view.

## Architecture
- `macros/models/oneinch_lop_dex_trades_passthrough.sql` - the decoupling edge: refs `oneinch_<chain>_lop_own_trades` instead of the cross-chain view; macro change triggers a one-time rebuild of all `dex_<chain>_trades` on this PR
- `macros/.../LO/oneinch_lop_venue_settled_fills_macro.sql`, `oneinch_lop_own_trades_macro.sql` - former model bodies parameterized by chain; venue co-occurrence now scans only that chain's base trades
- `outside/oneinch_lop_own_trades.sql` - now a union view of the 13 per-chain views (user-facing name, tests, and seed check preserved)
- `outside/oneinch_lop_aggregator_trades.sql` - unions the per-chain fills inline; feeds `dex_aggregator.trades` as before
- `outside/oneinch_lop_venue_settled_fills.sql` - deleted; prod table `oneinch.lop_venue_settled_fills` needs a manual drop after merge
- +29 files: 26 generated per-chain models (13 chains × fills incremental + own-trades view), schema entries, LINEAGE.md
- Tested: full compile of all new/changed models; `dbt ls dex_ethereum_base_trades+` confirms no other chain's trades/MEV models remain downstream. Not tested: prod data parity (views are definitionally equivalent; fills tables rebuild from full history on first run)
- Needs human eyes: first prod build of the 13 fills tables is full-history (heavy, per-chain parallel); evt_index numbering is now per-chain, which removes the documented ~0-probability cross-chain tx_hash collision quirk but would shift merge keys for any such historical row
- Blast radius: `dex.trades` / `dex_aggregator.trades` consumers see identical data; CI/deploy selection scope shrinks for future per-chain DEX additions (checked via dbt lineage)

<details><summary>Agent context</summary>

- No agent review yet
- Repro fan-out check: `uv run dbt ls --select dex_ethereum_base_trades+ --project-dir dbt_subprojects/dex/ --resource-type model` — no `dex_<other_chain>_trades` in output
- Prod materiality baseline: `oneinch.lop_venue_settled_fills` = ~4.0M rows / 13 chains (2021-06-11 → 2026-07-27), ~270k rows in last 90d; `dex.trades` holds ~7.0M `1inch-LOP` rows
- Chains split: ethereum, bnb, polygon, arbitrum, optimism, avalanche_c, gnosis, base, fantom, zksync, linea, sonic, unichain (all with `lo` in `exposed`; solana excluded as before)
</details>

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)