### PR TITLE
chore(tokens): hide and make private all spells built on tokens_<chain>.balances

### DIFF
--- a/dbt_macros/dune/config_trino_properties.sql
+++ b/dbt_macros/dune/config_trino_properties.sql
@@ -55,23 +55,3 @@
     {%- endif -%}
   {%- endif -%}
 {%- endmacro -%}
-
-{% macro deprecate_spells() %}
-  {%- if target.name == 'prod' -%}
-    {%- set properties = {
-            'dune.created_by': 'dbt_spellbook',
-            'dune.public': 'false',
-            'dune.visible': 'false',
-            'dune.data_explorer.category': 'abstraction',
-            'dune.vacuum': '{"enabled":true}'
-          } -%}
-    {%- if model.config.materialized == "view" -%}
-      CALL {{ model.database }}._internal.alter_view_properties('{{ model.schema }}', '{{ model.alias }}',
-        {{ trino_properties(properties) }}
-      )
-    {%- else -%}
-      ALTER TABLE {{ this }}
-        SET PROPERTIES extra_properties = {{ trino_properties(properties) }}
-    {%- endif -%}
-  {%- endif -%}
-{%- endmacro -%}

--- a/dbt_macros/dune/config_trino_properties.sql
+++ b/dbt_macros/dune/config_trino_properties.sql
@@ -55,3 +55,23 @@
     {%- endif -%}
   {%- endif -%}
 {%- endmacro -%}
+
+{% macro deprecate_spells() %}
+  {%- if target.name == 'prod' -%}
+    {%- set properties = {
+            'dune.created_by': 'dbt_spellbook',
+            'dune.public': 'false',
+            'dune.visible': 'false',
+            'dune.data_explorer.category': 'abstraction',
+            'dune.vacuum': '{"enabled":true}'
+          } -%}
+    {%- if model.config.materialized == "view" -%}
+      CALL {{ model.database }}._internal.alter_view_properties('{{ model.schema }}', '{{ model.alias }}',
+        {{ trino_properties(properties) }}
+      )
+    {%- else -%}
+      ALTER TABLE {{ this }}
+        SET PROPERTIES extra_properties = {{ trino_properties(properties) }}
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro -%}

--- a/dbt_macros/dune/deprecate_spells.sql
+++ b/dbt_macros/dune/deprecate_spells.sql
@@ -1,0 +1,19 @@
+{% macro deprecate_spells() %}
+  {%- if target.name == 'prod' -%}
+    {%- set properties = {
+            'dune.created_by': 'dbt_spellbook',
+            'dune.public': 'false',
+            'dune.visible': 'false',
+            'dune.data_explorer.category': 'abstraction',
+            'dune.vacuum': '{"enabled":true}'
+          } -%}
+    {%- if model.config.materialized == "view" -%}
+      CALL {{ model.database }}._internal.alter_view_properties('{{ model.schema }}', '{{ model.alias }}',
+        {{ trino_properties(properties) }}
+      )
+    {%- else -%}
+      ALTER TABLE {{ this }}
+        SET PROPERTIES extra_properties = {{ trino_properties(properties) }}
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro -%}

--- a/dbt_macros/dune/macros_schema.yml
+++ b/dbt_macros/dune/macros_schema.yml
@@ -31,6 +31,12 @@ macros:
     description: >
       Catch all macro to mark all models as spells even if they are not exposed in the data explorer
 
+  - name: deprecate_spells
+    description: >
+      Prod post-hook: set dune.public false and dune.visible false. For deprecated relations that should
+      be removed from the data explorer and made unqueryable ahead of being deleted from the repo.
+      Stronger than hide_spells, which leaves dune.public true so the relation stays queryable.
+
   - name: private_data_explorer
     description: >
       Prod post-hook: set dune.public false and dune.visible true with data explorer abstraction metadata

--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_arbitrum',
         alias = 'balances',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_daily.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_arbitrum',
         alias = 'balances_daily',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_daily_agg.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'tokens_arbitrum',
         alias = 'balances_daily_agg',
-        materialized = 'view'
+        materialized = 'view',
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/arbitrum/tokens_arbitrum_balances_daily_agg_base.sql
@@ -7,6 +7,7 @@
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['day', 'unique_key'],
         partition_by = ['day'],
+        post_hook = '{{ deprecate_spells() }}',
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_avalanche_c',
         alias = 'balances',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_daily.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_avalanche_c',
         alias = 'balances_daily',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_daily_agg.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'tokens_avalanche_c',
         alias = 'balances_daily_agg',
-        materialized = 'view'
+        materialized = 'view',
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/avalanche_c/tokens_avalanche_c_balances_daily_agg_base.sql
@@ -7,6 +7,7 @@
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['day', 'unique_key'],
         partition_by = ['day'],
+        post_hook = '{{ deprecate_spells() }}',
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances.sql
@@ -2,7 +2,7 @@
     schema = 'tokens_base',
     alias = 'balances',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ deprecate_spells() }}'
     )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_daily.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_base',
         alias = 'balances_daily',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_daily_agg.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'tokens_base',
         alias = 'balances_daily_agg',
-        materialized = 'view'
+        materialized = 'view',
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/base/tokens_base_balances_daily_agg_base.sql
@@ -7,6 +7,7 @@
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['day', 'unique_key'],
         partition_by = ['day'],
+        post_hook = '{{ deprecate_spells() }}',
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_bnb',
         alias = 'balances',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances_daily.sql
@@ -2,7 +2,7 @@
     schema = 'tokens_bnb',
     alias = 'balances_daily',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ deprecate_spells() }}'
 ) }}
 
 {{

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances_daily_agg.sql
@@ -1,7 +1,8 @@
 {{ config(
     schema = 'tokens_bnb',
     alias = 'balances_daily_agg',
-    materialized = 'view'
+    materialized = 'view',
+    post_hook = '{{ deprecate_spells() }}'
 ) }}
 
 {{

--- a/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/bnb/tokens_bnb_balances_daily_agg_base.sql
@@ -7,6 +7,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     unique_key = ['day', 'unique_key'],
     partition_by = ['day'],
+    post_hook = '{{ deprecate_spells() }}',
 ) }}
 
 with balances_raw as (

--- a/dbt_subprojects/tokens/models/transfers_and_balances/celo/tokens_celo_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/celo/tokens_celo_balances_daily_agg_base.sql
@@ -8,6 +8,7 @@
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['day', 'unique_key'],
         partition_by = ['day'],
+        post_hook = '{{ deprecate_spells() }}',
     )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_ethereum',
         alias = 'balances',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_daily.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_ethereum',
         alias = 'balances_daily',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_daily_agg.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'tokens_ethereum',
         alias = 'balances_daily_agg',
-        materialized = 'view'
+        materialized = 'view',
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_daily_agg_base.sql
@@ -6,6 +6,7 @@
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['unique_key'],
+        post_hook = '{{ deprecate_spells() }}',
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_daily_agg_base_erc20_native.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/ethereum/tokens_ethereum_balances_daily_agg_base_erc20_native.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'tokens_ethereum',
         alias = 'balances_daily_agg_base_erc20_native',
-        materialized='view'        
+        materialized='view',
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_balances.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_balances.sql
@@ -2,7 +2,7 @@
     schema = 'tokens_kaia',
     alias = 'balances',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ deprecate_spells() }}'
     )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_balances_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_balances_daily.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_kaia',
         alias = 'balances_daily',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_balances_daily_agg.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'tokens_kaia',
         alias = 'balances_daily_agg',
-        materialized = 'view'
+        materialized = 'view',
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/kaia/tokens_kaia_balances_daily_agg_base.sql
@@ -6,7 +6,8 @@
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['day', 'unique_key'],
-        partition_by = ['day']
+        partition_by = ['day'],
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_linea',
         alias = 'balances',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_daily.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_linea',
         alias = 'balances_daily',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_daily_agg.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'tokens_linea',
         alias = 'balances_daily_agg',
-        materialized = 'view'
+        materialized = 'view',
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/linea/tokens_linea_balances_daily_agg_base.sql
@@ -7,6 +7,7 @@
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['day', 'unique_key'],
         partition_by = ['day'],
+        post_hook = '{{ deprecate_spells() }}',
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_optimism',
         alias = 'balances',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_daily.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_optimism',
         alias = 'balances_daily',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_daily_agg.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'tokens_optimism',
         alias = 'balances_daily_agg',
-        materialized = 'view'
+        materialized = 'view',
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/optimism/tokens_optimism_balances_daily_agg_base.sql
@@ -7,6 +7,7 @@
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['day', 'unique_key'],
         partition_by = ['day'],
+        post_hook = '{{ deprecate_spells() }}',
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_polygon',
         alias = 'balances',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_daily.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_polygon',
         alias = 'balances_daily',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_daily_agg.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'tokens_polygon',
         alias = 'balances_daily_agg',
-        materialized = 'view'
+        materialized = 'view',
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/polygon/tokens_polygon_balances_daily_agg_base.sql
@@ -7,6 +7,7 @@
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['day', 'unique_key'],
         partition_by = ['day'],
+        post_hook = '{{ deprecate_spells() }}',
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_scroll',
         alias = 'balances',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances_daily.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_scroll',
         alias = 'balances_daily',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances_daily_agg.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'tokens_scroll',
         alias = 'balances_daily_agg',
-        materialized = 'view'
+        materialized = 'view',
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/scroll/tokens_scroll_balances_daily_agg_base.sql
@@ -6,6 +6,7 @@
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['unique_key'],
+        post_hook = '{{ deprecate_spells() }}',
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/unichain/tokens_unichain_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/unichain/tokens_unichain_balances_daily_agg_base.sql
@@ -8,6 +8,7 @@
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['day', 'unique_key'],
         partition_by = ['day'],
+        post_hook = '{{ deprecate_spells() }}',
     )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_balances.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_balances.sql
@@ -2,7 +2,7 @@
     schema = 'tokens_worldchain',
     alias = 'balances',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ deprecate_spells() }}'
     )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_balances_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_balances_daily.sql
@@ -2,7 +2,7 @@
         schema = 'tokens_worldchain',
         alias = 'balances_daily',
         materialized = 'view',
-        post_hook = '{{ hide_spells() }}'
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_balances_daily_agg.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'tokens_worldchain',
         alias = 'balances_daily_agg',
-        materialized = 'view'
+        materialized = 'view',
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/worldchain/tokens_worldchain_balances_daily_agg_base.sql
@@ -6,7 +6,8 @@
         incremental_strategy='merge',
         incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         unique_key = ['day', 'unique_key'],
-        partition_by = ['day']
+        partition_by = ['day'],
+        post_hook = '{{ deprecate_spells() }}'
         )
 }}
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/zksync/tokens_zksync_balances.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/zksync/tokens_zksync_balances.sql
@@ -2,7 +2,7 @@
     schema = 'tokens_zksync',
     alias = 'balances',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ deprecate_spells() }}'
 ) }}
 
 with balances_raw as (

--- a/dbt_subprojects/tokens/models/transfers_and_balances/zksync/tokens_zksync_balances_daily.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/zksync/tokens_zksync_balances_daily.sql
@@ -2,7 +2,7 @@
     schema = 'tokens_zksync',
     alias = 'balances_daily',
     materialized = 'view',
-    post_hook = '{{ hide_spells() }}'
+    post_hook = '{{ deprecate_spells() }}'
 ) }}
 
 {{

--- a/dbt_subprojects/tokens/models/transfers_and_balances/zksync/tokens_zksync_balances_daily_agg.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/zksync/tokens_zksync_balances_daily_agg.sql
@@ -1,7 +1,8 @@
 {{ config(
     schema = 'tokens_zksync',
     alias = 'balances_daily_agg',
-    materialized = 'view'
+    materialized = 'view',
+    post_hook = '{{ deprecate_spells() }}'
 ) }}
 
 {{

--- a/dbt_subprojects/tokens/models/transfers_and_balances/zksync/tokens_zksync_balances_daily_agg_base.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/zksync/tokens_zksync_balances_daily_agg_base.sql
@@ -7,6 +7,7 @@
     incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
     unique_key = ['day', 'unique_key'],
     partition_by = ['day'],
+    post_hook = '{{ deprecate_spells() }}',
 ) }}
 
 with balances_raw as (


### PR DESCRIPTION
Step 1 of 2 in retiring the `tokens_<chain>.balances` raw tables. This PR stops exposing everything built on top of them. A follow-up PR deletes the models outright.

## New macro: `deprecate_spells()`

The existing `hide_spells()` sets `dune.visible = false` but leaves `dune.public = true` — the relation disappears from the Data Explorer but is still queryable. That is not enough for something we are about to delete.

`deprecate_spells()` sets **both** `dune.public` and `dune.visible` to `false`. It is otherwise a byte-for-byte copy of `hide_spells()`; the only difference is that one property value:

```diff
-            'dune.public': 'true',
+            'dune.public': 'false',
```

It sits alongside the existing `hide_spells()` / `private_data_explorer()` pair, filling the one gap in that matrix:

| macro | `dune.public` | `dune.visible` | use |
|---|---|---|---|
| `expose_spells()` | true | true | normal curated spell |
| `private_data_explorer()` | false | true | team-private, still listed |
| `hide_spells()` | true | false | de-listed, still queryable |
| **`deprecate_spells()`** | **false** | **false** | **on its way out** |

Kept as a separate macro rather than a flag on `hide_spells()` so the intent is readable at the call site, the 19 existing `hide_spells()` callers are untouched, and the follow-up removal PR has a single greppable marker.

## Scope

All **51** models sourced from the `tokens_<chain>.balances_<chain>` raw tables:

| layer | count | materialization | previous state |
|---|---|---|---|
| `tokens_<chain>.balances` | 12 | view | `hide_spells()` |
| `tokens_<chain>.balances_daily` | 12 | view | `hide_spells()` |
| `tokens_<chain>.balances_daily_agg` | 12 | view | no post_hook |
| `tokens_<chain>.balances_daily_agg_base` | 14 | incremental | no post_hook |
| `tokens_ethereum.balances_daily_agg_base_erc20_native` | 1 | view | no post_hook |

Chains: ethereum, arbitrum, base, bnb, optimism, polygon, avalanche_c, kaia, linea, scroll, worldchain, zksync — plus celo and unichain, which only have a `balances_daily_agg_base`.

`balances` and `balances_daily` were already hidden in #8586 (CUR2-66). This completes that work by making them private, and extends the same treatment to the `daily_agg` layer, which was never hidden at all.

## Not in scope

`balances_bitcoin.satoshi_day` and `balances_bitcoin.satoshi_latest_day` were hidden in the same original commit, but they read bitcoin UTXO data rather than the `tokens_<chain>.balances` raw tables, so they are left alone.

## Blast radius

No spell in any sub-project reads these models — the only `ref()`s are internal to the balances lineage itself. Nothing else needed to change. There are no seeds or tests attached to this family.

Only the table properties change; no model SQL logic is touched, so the data itself is unaffected. The properties are applied by a prod post-hook, so they take effect on the next scheduled prod run.

## Verification

- `dbt parse` clean on the tokens sub-project
- `dbt compile` clean across all 51 models (exit 0)
- Verified in `manifest.json` that all 51 nodes carry the `deprecate_spells()` post-hook and that the macro is registered

## CI status

CI fails on `CLUSTER_OUT_OF_MEMORY` building `tokens_ethereum_balances_daily_agg_base`. CI does a full-history rebuild of these incrementals from scratch, which prod does not; the failure is a CI-capacity artifact, not a defect in the change. No model SQL logic is modified here.

A first attempt also revealed an unintended CI fan-out, fixed in 87e6ccc27. `hide_spells()` was the last macro in `config_trino_properties.sql`, so the `macro_sql` dbt records for it ran to EOF. Appending `deprecate_spells()` after it pulled the `\n\n` separator into that text — 710 to 712 bytes, semantically identical — which made dbt flag `hide_spells` as modified and select every model that calls it.

Verified against the prod state manifest (2026-07-27):

| | before | after |
|---|--:|--:|
| `state:modified.body` | 51 | 51 |
| `state:modified.macros` | 150 | 51 |

The new macro now lives in its own `dbt_macros/dune/deprecate_spells.sql`, leaving `config_trino_properties.sql` byte-for-byte unchanged.
