### PR TITLE
feat(macros): add optional filtering_columns model config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,8 @@ Additional materialization requirements:
 - Use `incremental_predicate()` for `incremental_predicates`; do not hardcode equivalent predicates.
 - Use `incremental_predicate()` only for time-series data. Omit it when full-history lookups are required, such as pool creation events.
 
+Set `filtering_columns` on Data Explorer-visible views and unpartitioned tables, whatever the materialization. The catalog service defaults a spell's filtering columns to its partition columns, so partitioned tables need nothing, while views and unpartitioned tables get no filtering hint unless the config declares one. List only columns that reduce data scanned, most discriminating first, for example `filtering_columns=['block_month', 'blockchain']`.
+
 Config-only changes that affect physical tables may not trigger CI because CI selects with `state:modified.body` and `state:modified.macros`. If the SQL body otherwise does not change, add or bump a body stamp comment for changes to `materialized`, `partition_by`, `incremental_strategy`, `file_format`, `schema`, or `alias`:
 
 ```sql

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Additional materialization requirements:
 - Use `incremental_predicate()` for `incremental_predicates`; do not hardcode equivalent predicates.
 - Use `incremental_predicate()` only for time-series data. Omit it when full-history lookups are required, such as pool creation events.
 
-Set `filtering_columns` on Data Explorer-visible views and unpartitioned tables, whatever the materialization. The catalog service defaults a spell's filtering columns to its partition columns, so partitioned tables need nothing, while views and unpartitioned tables get no filtering hint unless the config declares one. List only columns that reduce data scanned, most discriminating first, for example `filtering_columns=['block_month', 'blockchain']`.
+Set `filtering_columns` on Data Explorer-visible views and unpartitioned tables, whatever the materialization. The catalog service defaults a spell's filtering columns to its partition columns, so partitioned tables need nothing, while views and unpartitioned tables get no filtering hint unless the config declares one. List only columns that reduce data scanned, most discriminating first, for example `filtering_columns=['block_month', 'blockchain']`. To withdraw a published hint set `filtering_columns=[]`; deleting the config line leaves the last published value in place on views.
 
 Config-only changes that affect physical tables may not trigger CI because CI selects with `state:modified.body` and `state:modified.macros`. If the SQL body otherwise does not change, add or bump a body stamp comment for changes to `materialized`, `partition_by`, `incremental_strategy`, `file_format`, `schema`, or `alias`:
 

--- a/dbt_macros/dune/config_trino_properties.sql
+++ b/dbt_macros/dune/config_trino_properties.sql
@@ -7,6 +7,22 @@
   ])
 {%- endmacro -%}
 
+{#
+  The catalog service only derives filtering columns from a table's partition columns, so views
+  and unpartitioned tables get no Data Explorer filtering hint unless the spell sets one. Every
+  macro that emits properties has to apply this: on the table path, ALTER TABLE SET PROPERTIES
+  replaces the whole data explorer metadata struct, so the last statement of a run must carry it.
+#}
+{%- macro apply_filtering_columns(properties) -%}
+  {%- set columns = model.config.get('filtering_columns', none) -%}
+  {%- if columns -%}
+    {%- if columns is not sequence or columns is mapping or columns is string or columns | reject('string') | list | length > 0 -%}
+      {%- do exceptions.raise_compiler_error("Invalid filtering_columns '%s'. Must be a list of column names." % columns) -%}
+    {%- endif -%}
+    {%- do properties.update({'dune.data_explorer.filtering_columns': tojson(columns)}) -%}
+  {%- endif -%}
+{%- endmacro -%}
+
 {% macro expose_spells(blockchains, spell_type, spell_name, contributors) %}
   {%- set validated_contributors = tojson(fromjson(contributors | as_text)) -%}
   {%- if ("%s" % validated_contributors) == "null" -%}
@@ -25,6 +41,7 @@
             'dune.data_explorer.freshness': var('freshness'),
             'dune.vacuum': '{"enabled":true}'
           } -%}
+    {%- do apply_filtering_columns(properties) -%}
     {%- if model.config.materialized == "view" -%}
       CALL {{ model.database }}._internal.alter_view_properties('{{ model.schema }}', '{{ model.alias }}',
         {{ trino_properties(properties) }}
@@ -45,6 +62,7 @@
             'dune.data_explorer.category': 'abstraction',
             'dune.vacuum': '{"enabled":true}'
           } -%}
+    {%- do apply_filtering_columns(properties) -%}
     {%- if model.config.materialized == "view" -%}
       CALL {{ model.database }}._internal.alter_view_properties('{{ model.schema }}', '{{ model.alias }}',
         {{ trino_properties(properties) }}

--- a/dbt_macros/dune/config_trino_properties.sql
+++ b/dbt_macros/dune/config_trino_properties.sql
@@ -12,12 +12,15 @@
   and unpartitioned tables get no Data Explorer filtering hint unless the spell sets one. Every
   macro that emits properties has to apply this: on the table path, ALTER TABLE SET PROPERTIES
   replaces the whole data explorer metadata struct, so the last statement of a run must carry it.
+
+  An explicit empty list is emitted rather than skipped. View property updates only upsert the
+  keys they send, so `[]` is the only way to withdraw a hint that is already published.
 #}
 {%- macro apply_filtering_columns(properties) -%}
   {%- set columns = model.config.get('filtering_columns', none) -%}
-  {%- if columns -%}
+  {%- if columns is not none -%}
     {%- if columns is not sequence or columns is mapping or columns is string or columns | reject('string') | list | length > 0 -%}
-      {%- do exceptions.raise_compiler_error("Invalid filtering_columns '%s'. Must be a list of column names." % columns) -%}
+      {%- do exceptions.raise_compiler_error("Invalid filtering_columns '" ~ columns ~ "'. Must be a list of column names.") -%}
     {%- endif -%}
     {%- do properties.update({'dune.data_explorer.filtering_columns': tojson(columns)}) -%}
   {%- endif -%}

--- a/dbt_macros/dune/deprecate_spells.sql
+++ b/dbt_macros/dune/deprecate_spells.sql
@@ -7,6 +7,7 @@
             'dune.data_explorer.category': 'abstraction',
             'dune.vacuum': '{"enabled":true}'
           } -%}
+    {%- do apply_filtering_columns(properties) -%}
     {%- if model.config.materialized == "view" -%}
       CALL {{ model.database }}._internal.alter_view_properties('{{ model.schema }}', '{{ model.alias }}',
         {{ trino_properties(properties) }}

--- a/dbt_macros/dune/expose_dataset.sql
+++ b/dbt_macros/dune/expose_dataset.sql
@@ -8,6 +8,7 @@
             'dune.data_explorer.category': 'third_party_data',
             'dune.data_explorer.contributors': contributors | as_text,
           } -%}
+    {%- do apply_filtering_columns(properties) -%}
     {%- if model.config.materialized == "view" -%}
       CALL {{ model.database }}._internal.alter_view_properties('{{ model.schema }}', '{{ model.alias }}',
         {{ trino_properties(properties) }}

--- a/dbt_macros/dune/macros_schema.yml
+++ b/dbt_macros/dune/macros_schema.yml
@@ -37,7 +37,8 @@ macros:
       dune.data_explorer.filtering_columns. Applied by every macro that emits table properties,
       because the table path replaces the whole data explorer metadata struct on each ALTER.
       The catalog service falls back to the partition columns when the property is absent, so only
-      views and unpartitioned tables need it.
+      views and unpartitioned tables need it. An empty list is emitted rather than skipped, since
+      that is the only way to withdraw a hint already published on a view.
     arguments:
       - name: properties
         type: dict

--- a/dbt_macros/dune/macros_schema.yml
+++ b/dbt_macros/dune/macros_schema.yml
@@ -31,6 +31,18 @@ macros:
     description: >
       Catch all macro to mark all models as spells even if they are not exposed in the data explorer
 
+  - name: apply_filtering_columns
+    description: >
+      Adds the optional filtering_columns model config to a property map as
+      dune.data_explorer.filtering_columns. Applied by every macro that emits table properties,
+      because the table path replaces the whole data explorer metadata struct on each ALTER.
+      The catalog service falls back to the partition columns when the property is absent, so only
+      views and unpartitioned tables need it.
+    arguments:
+      - name: properties
+        type: dict
+        description: "Property map to update in place"
+
   - name: deprecate_spells
     description: >
       Prod post-hook: set dune.public false and dune.visible false. For deprecated relations that should

--- a/dbt_macros/dune/mark_as_spell.sql
+++ b/dbt_macros/dune/mark_as_spell.sql
@@ -20,6 +20,7 @@
     {%- if deprecated_at -%}
       {%- do properties.update({'dune.data_explorer.deprecated_at': deprecated_at}) -%}
     {%- endif -%}
+    {%- do apply_filtering_columns(properties) -%}
     {%- if model.config.materialized == "view" -%}
       CALL {{ model.database }}._internal.alter_view_properties('{{ model.schema }}', '{{ model.alias }}',
         {{ trino_properties(properties) }}

--- a/dbt_macros/dune/private_data_explorer.sql
+++ b/dbt_macros/dune/private_data_explorer.sql
@@ -11,6 +11,7 @@
             'dune.data_explorer.freshness': var('freshness'),
             'dune.vacuum': '{"enabled":true}'
           } -%}
+    {%- do apply_filtering_columns(properties) -%}
     {%- if model.config.materialized == "view" -%}
       CALL {{ model.database }}._internal.alter_view_properties('{{ model.schema }}', '{{ model.alias }}',
         {{ trino_properties(properties) }}

--- a/dbt_macros/tests/test_property_macros.py
+++ b/dbt_macros/tests/test_property_macros.py
@@ -1,0 +1,144 @@
+"""Render checks for the Dune table property post-hook macros.
+
+These macros only emit SQL when `target.name == 'prod'`, so dbt CI (which runs against a `ci`
+target) never renders them and a mistake would only surface during a production run. The tests
+render the macros directly against a stubbed dbt context and assert on the properties they emit.
+"""
+
+import json
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from jinja2 import DictLoader, Environment
+from jinja2.ext import do
+
+MACRO_DIR = Path(__file__).resolve().parent.parent / "dune"
+MACRO_FILES = (
+    "config_trino_properties.sql",
+    "mark_as_spell.sql",
+    "private_data_explorer.sql",
+    "expose_dataset.sql",
+    "deprecate_spells.sql",
+)
+FILTERING_COLUMNS = "dune.data_explorer.filtering_columns"
+
+# Every macro that emits Dune table properties, with representative arguments.
+PROPERTY_MACROS = {
+    "mark_as_spell": ("hive.tokens_evm.transfers", "view"),
+    "expose_spells": ('["ethereum"]', "sector", "tokens", '["jeff-dude"]'),
+    "hide_spells": (),
+    "private_data_explorer": ('["ethereum"]', "sector", "tokens"),
+    "expose_dataset": ('["ethereum"]', '["jeff-dude"]'),
+    "deprecate_spells": (),
+}
+
+PROPERTY_PATTERN = re.compile(r"ROW\('([^']+)', '(.*?)'\)")
+
+
+class CompilerError(Exception):
+    """Stands in for dbt's compilation error, which is raised out of the macro context."""
+
+
+def render(macro, materialized="view", config=None, target="prod"):
+    source = "\n".join((MACRO_DIR / name).read_text() for name in MACRO_FILES)
+    env = Environment(loader=DictLoader({"macros": source}), extensions=[do])
+    model_config = {"materialized": materialized, **(config or {})}
+
+    env.filters["as_text"] = lambda value: value
+    env.globals.update(
+        tojson=json.dumps,
+        fromjson=json.loads,
+        var=lambda name, default=None: "1h",
+        exceptions=SimpleNamespace(
+            raise_compiler_error=lambda message, node=None: (_ for _ in ()).throw(
+                CompilerError(message)
+            )
+        ),
+        target=SimpleNamespace(name=target),
+        this="hive_catalog_svc.tokens_evm.transfers",
+        model=SimpleNamespace(
+            database="hive_catalog_svc",
+            schema="tokens_evm",
+            alias="transfers",
+            config=SimpleNamespace(materialized=materialized, get=model_config.get),
+        ),
+    )
+    template = env.get_template("macros")
+    return getattr(template.module, macro)(*PROPERTY_MACROS[macro])
+
+
+def emitted_properties(sql):
+    return dict(PROPERTY_PATTERN.findall(sql))
+
+
+@pytest.mark.parametrize("macro", PROPERTY_MACROS)
+@pytest.mark.parametrize("materialized", ["view", "table", "incremental"])
+def test_filtering_columns_emitted_by_every_property_macro(macro, materialized):
+    sql = render(
+        macro, materialized, {"filtering_columns": ["block_month", "blockchain"]}
+    )
+    assert json.loads(emitted_properties(sql)[FILTERING_COLUMNS]) == [
+        "block_month",
+        "blockchain",
+    ]
+
+
+@pytest.mark.parametrize("macro", PROPERTY_MACROS)
+def test_filtering_columns_omitted_when_not_configured(macro):
+    assert FILTERING_COLUMNS not in emitted_properties(render(macro))
+
+
+@pytest.mark.parametrize("macro", PROPERTY_MACROS)
+def test_empty_list_is_emitted_so_a_published_hint_can_be_cleared(macro):
+    # Views only upsert the keys they are sent, so omitting the property would strand the old value.
+    sql = render(macro, config={"filtering_columns": []})
+    assert json.loads(emitted_properties(sql)[FILTERING_COLUMNS]) == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "block_month",  # bare string
+        ["block_month", 3],  # non-string member
+        (
+            "block_month",
+            3,
+        ),  # same, as a tuple: %-formatting the error message would raise
+        {
+            "block_month": True
+        },  # mapping: iterates as its keys, would serialize as an object
+        5,
+        True,
+    ],
+)
+def test_invalid_filtering_columns_are_rejected(value):
+    with pytest.raises(CompilerError, match="Invalid filtering_columns"):
+        render("expose_spells", config={"filtering_columns": value})
+
+
+@pytest.mark.parametrize("macro", PROPERTY_MACROS)
+def test_nothing_is_emitted_outside_prod(macro):
+    sql = render(macro, config={"filtering_columns": ["block_month"]}, target="ci")
+    assert sql.strip() == ""
+
+
+def test_views_and_tables_use_their_own_property_statement():
+    assert "alter_view_properties" in render("expose_spells", "view")
+    assert "ALTER TABLE" in render("expose_spells", "incremental")
+
+
+def test_filtering_columns_does_not_displace_the_other_properties():
+    sql = render("expose_spells", "incremental", {"filtering_columns": ["block_month"]})
+    properties = emitted_properties(sql)
+    # The table path rebuilds the whole metadata struct per statement, so a partial map drops fields.
+    assert {
+        "dune.created_by",
+        "dune.public",
+        "dune.visible",
+        "dune.data_explorer.category",
+        "dune.data_explorer.contributors",
+        "dune.vacuum",
+        FILTERING_COLUMNS,
+    } <= set(properties)

--- a/docs/models/model_config_block.md
+++ b/docs/models/model_config_block.md
@@ -75,3 +75,9 @@ Each model within Spellbook contains a config block with various properties. Dep
    - Overrides existing behavior for how a table is rebuilt on full refresh.
    - **Example**: `drop` to overcome dbt-trino bugs when changing a spell from view to table.
    - **Note**: This property is rare and usually applied by the Dune team.
+
+4. **filtering_columns**
+   - List of columns the Data Explorer suggests filtering on, ordered from most to least discriminating. Emitted as the `dune.data_explorer.filtering_columns` table property by the post-hook macros on prod runs.
+   - Only set columns that actually reduce the data scanned: partition columns of the underlying tables, or a column that is constant per file (such as `blockchain` in a cross-chain union).
+   - Partitioned tables do not need it — the catalog service defaults filtering columns to the partition columns when the property is absent. Set it for views and unpartitioned tables, which otherwise get no hint at all.
+   - **Example**: `filtering_columns=['block_month', 'blockchain']` on a cross-chain view whose upstream tables are partitioned by `block_month`.

--- a/docs/models/model_config_block.md
+++ b/docs/models/model_config_block.md
@@ -81,3 +81,4 @@ Each model within Spellbook contains a config block with various properties. Dep
    - Only set columns that actually reduce the data scanned: partition columns of the underlying tables, or a column that is constant per file (such as `blockchain` in a cross-chain union).
    - Partitioned tables do not need it — the catalog service defaults filtering columns to the partition columns when the property is absent. Set it for views and unpartitioned tables, which otherwise get no hint at all.
    - **Example**: `filtering_columns=['block_month', 'blockchain']` on a cross-chain view whose upstream tables are partitioned by `block_month`.
+   - Set `filtering_columns=[]` to withdraw a hint that has already been published. Deleting the config line is not enough: view property updates only upsert the keys they send, so the last published value stays in place. On a table an empty list falls back to the partition-derived default.


### PR DESCRIPTION
Spells get their Data Explorer filtering hint from the catalog service, which derives it from the table's partition columns. Views and unpartitioned tables have no partition columns, so they show no hint at all -- `tokens_evm.transfers`, `nft.trades`, `gas.fees` and every other cross-chain sector view included. Models can now declare `filtering_columns=['block_month', 'blockchain']` and the post-hook macros emit `dune.data_explorer.filtering_columns`.

Every property-emitting macro applies it, not just `expose_spells`. On the table path, `ALTER TABLE SET PROPERTIES` flows through `replaceTable()` -> `CreateTable`, which rebuilds the whole data explorer metadata struct from the properties in that single statement, so whichever macro emits last has to carry the key or it gets dropped and silently refilled from the partition columns. Views go through `alter_view_properties`, which upserts.

`none` and `[]` mean different things. An absent config omits the property; an explicit empty list emits `[]`, which is the only way to withdraw a hint already published on a view, since view updates upsert only the keys they send. On a table `[]` is not a true clear -- it falls back to the partition-derived default, because the catalog refills empty filtering columns from the partition columns. Both paths are documented.

The value has to reach the catalog as a JSON array, so a malformed config is a prod-only failure inside a post-hook. The guard rejects anything that isn't a list of strings, using the same `is sequence` / `is not mapping` / `is not string` combination as `trino__get_merge_sql` in `incremental.sql` -- a dict is a sequence to Jinja and would otherwise serialize as a JSON object.

The post-hooks only render when `target.name == 'prod'`, so no dbt CI job ever executes them. `dbt_macros/tests/test_property_macros.py` renders all six macros against a stubbed dbt context and asserts the emitted property map: present/absent/explicitly-empty, view and table statements, the other properties surviving alongside, nothing emitted off-prod, and the guard against a bare string, a non-string member, a tuple, a dict, an int and a bool. 44 assertions, no Trino needed. #9911 wires it into the pytest workflow and explains why that has to be a separate PR.

No model sets the config yet, so this is inert on its own; the models are in #9910.