### PR TITLE
feat(spells): declare filtering_columns on cross-chain sector views

### DIFF
--- a/dbt_subprojects/dex/models/_projects/bitget_dex_aggregator/bitget_dex_aggregator_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/bitget_dex_aggregator/bitget_dex_aggregator_trades.sql
@@ -2,6 +2,7 @@
     schema = 'bitget_dex_aggregator',
     alias = 'trades',
     materialized = 'view',
+    filtering_columns = ['block_month', 'blockchain'],
     post_hook='{{ expose_spells(
         blockchains = \'["bnb", "ethereum", "arbitrum", "polygon", "base"]\',
         spell_type = "project",

--- a/dbt_subprojects/dex/models/trades/dex_evm_trades.sql
+++ b/dbt_subprojects/dex/models/trades/dex_evm_trades.sql
@@ -4,6 +4,7 @@
 	schema = 'dex_evm'
 	, alias = 'trades'
 	, materialized = 'view'
+	, filtering_columns = ['block_month', 'blockchain', 'project']
 	, post_hook = '{{ expose_spells(blockchains = \'["' + chains | join('","') + '"]\',
 									spell_type = "sector",
 									spell_name = "dex_evm",

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/gas_evm_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/gas_evm_fees.sql
@@ -4,6 +4,7 @@
 	schema = 'gas_evm'
 	, alias = 'fees'
 	, materialized = 'view'
+	, filtering_columns = ['block_month', 'blockchain']
 	, post_hook = '{{ expose_spells(blockchains = \'["' + chains | join('","') + '"]\',
 									spell_type = "sector",
 									spell_name = "gas_evm",

--- a/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/gas_fees.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/gas/fees/gas_fees.sql
@@ -3,6 +3,7 @@
 {{ config(
     schema = 'gas',
     alias = 'fees',
+    filtering_columns = ['block_month', 'blockchain'],
     post_hook='{{ expose_spells(blockchains = \'["' + chains | join('","') + '"]\',
                                 spell_type = "sector",
                                 spell_name = "gas",

--- a/dbt_subprojects/hourly_spellbook/models/_sector/nft/trades/nft_trades.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/nft/trades/nft_trades.sql
@@ -2,6 +2,7 @@
     schema = 'nft',
     alias = 'trades',
     materialized = 'view',
+    filtering_columns = ['block_month', 'blockchain', 'project'],
     post_hook='{{ expose_spells(\'["ethereum","solana","bnb","optimism","arbitrum","polygon","zksync", "blast", "ronin", "nova", "abstract", "apechain"]\',
                     "sector",
                     "nft",

--- a/dbt_subprojects/hourly_spellbook/models/_sector/nft/trades/nft_trades.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/nft/trades/nft_trades.sql
@@ -2,7 +2,7 @@
     schema = 'nft',
     alias = 'trades',
     materialized = 'view',
-    filtering_columns = ['block_month', 'blockchain', 'project'],
+    filtering_columns = ['blockchain', 'project', 'block_month'],
     post_hook='{{ expose_spells(\'["ethereum","solana","bnb","optimism","arbitrum","polygon","zksync", "blast", "ronin", "nova", "abstract", "apechain"]\',
                     "sector",
                     "nft",

--- a/dbt_subprojects/hourly_spellbook/models/_sector/nft/transfers/nft_transfers.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/nft/transfers/nft_transfers.sql
@@ -25,6 +25,7 @@
 	schema='nft',
 	alias='transfers',
 	materialized='view',
+	filtering_columns=['block_month', 'blockchain'],
 	post_hook='{{ expose_spells(blockchains = \'["' ~ chains | join('","') ~ '"]\',
 		spell_type = "sector",
 		spell_name = "nft",

--- a/dbt_subprojects/hourly_spellbook/models/_sector/nft/wash_trades/nft_wash_trades.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/nft/wash_trades/nft_wash_trades.sql
@@ -1,7 +1,7 @@
 {{ config(
         alias = 'wash_trades',
         schema = 'nft',
-        filtering_columns = ['blockchain', 'block_date'],
+        filtering_columns = ['blockchain'],
         
         post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "bnb", "ethereum", "gnosis", "optimism", "polygon", "celo", "zksync", "base", "scroll", "zora", "blast", "fantom", "ronin", "nova", "linea", "abstract"]\',
                                     "sector",

--- a/dbt_subprojects/hourly_spellbook/models/_sector/nft/wash_trades/nft_wash_trades.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/nft/wash_trades/nft_wash_trades.sql
@@ -1,6 +1,7 @@
 {{ config(
         alias = 'wash_trades',
         schema = 'nft',
+        filtering_columns = ['blockchain', 'block_date'],
         
         post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "bnb", "ethereum", "gnosis", "optimism", "polygon", "celo", "zksync", "base", "scroll", "zora", "blast", "fantom", "ronin", "nova", "linea", "abstract"]\',
                                     "sector",

--- a/dbt_subprojects/solana/models/_sector/gas/gas_solana_fees.sql
+++ b/dbt_subprojects/solana/models/_sector/gas/gas_solana_fees.sql
@@ -2,6 +2,7 @@
     schema = 'gas_solana',
     alias = 'fees',
     materialized = 'view',
+    filtering_columns = ['block_date'],
     post_hook='{{ expose_spells(\'["solana"]\',
                                     "sector",
                                     "gas",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/tokens_evm_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/tokens_evm_transfers.sql
@@ -65,6 +65,7 @@
         schema = 'tokens_evm'
         , alias = 'transfers'
         , materialized = 'view'
+        , filtering_columns = ['block_month', 'blockchain']
         , post_hook='{{ expose_spells(blockchains = \'["' + chains | join('","') + '"]\',
                                         spell_type = "sector",
                                         spell_name = "tokens_evm",

--- a/dbt_subprojects/tokens/models/transfers_and_balances/tokens_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/tokens_transfers.sql
@@ -66,6 +66,7 @@
 {{ config(
         schema = 'tokens'
         , alias = 'transfers'
+        , filtering_columns = ['block_month', 'blockchain']
         , post_hook='{{ expose_spells(blockchains = \'["' + chains | join('","') + '"]\',
                                         spell_type = "sector",
                                         spell_name = "tokens",


### PR DESCRIPTION
Needs #9909 to land for the property to actually be emitted; the config is inert without it, so merge order doesn't matter.

The Data Explorer filtering hint comes from the catalog service, which derives it from a table's partition columns. Views have none, so every cross-chain sector view currently shows no hint at all — including `tokens.transfers`, the second most queried spell after `dex.trades` (which does have hints, via its partitioning). Each value mirrors the parent's partition order, plus `blockchain` where the view unions per-chain tables: `blockchain` is constant within each upstream table, so it still skips files via Delta statistics.

| spell | value |
| --- | --- |
| `tokens.transfers`, `tokens_evm.transfers` | `['block_month', 'blockchain']` |
| `nft.trades` | `['blockchain', 'project', 'block_month']` |
| `nft.transfers` | `['block_month', 'blockchain']` |
| `nft.wash_trades` | `['blockchain']` |
| `gas.fees`, `gas_evm.fees` | `['block_month', 'blockchain']` |
| `gas_solana.fees` | `['block_date']` |
| `dex_evm.trades` | `['block_month', 'blockchain', 'project']` |
| `bitget_dex_aggregator.trades` | `['block_month', 'blockchain']` |

Two are not the obvious value. `gas_solana.fees` uses `block_date` because its quarterly backfill tables are partitioned by `block_date`, not `block_month`. `nft.wash_trades` gets `blockchain` alone because the view never selects `block_month` even though its upstream tables are partitioned by it — exposing `block_month` there would be an additive schema change, worth doing separately.

`dex_evm.trades` and `gas_evm.fees` come from @jeff-dude (ed6b9a3), who also aligned `nft.trades` with its parent partition order and trimmed `nft.wash_trades`. Both are in core's curated overrides (`core-go/syncsense2/models/table_overrides.go`) and were missing from my initial pass.

Partitioned spells need nothing here — the catalog already defaults them to their partition columns, and an explicit value only wins when set. Of the 190 relations in the curated override list, 43 still have no hint: 7 `utils.*` date spines where filtering is meaningless, 30 unpartitioned TON/thorchain incrementals owned by outside contributors, `dex_aggregator.trades` (which wants partitioning rather than a hint), and a handful of small views. Details in the thread.

Verified by parsing all five subprojects and asserting each model's `filtering_columns` in the manifest, and by checking every named column against both the view's SELECT output and the upstream `partition_by`. CI can't verify emission: the post-hooks are gated on `target.name == 'prod'`.
