### PR TITLE
ci: run pytest for dbt_macros changes

### DIFF
--- a/.github/workflows/pytest_automations.yml
+++ b/.github/workflows/pytest_automations.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
     paths:
       - 'scripts/**'
+      - 'dbt_macros/**'
 
 permissions:
   contents: read
@@ -27,4 +28,4 @@ jobs:
       run: uv sync --locked
 
     - name: Run pytest
-      run: uv run pytest scripts/test_token_checker.py
+      run: uv run pytest scripts/test_token_checker.py dbt_macros/tests


### PR DESCRIPTION
Merge after #9909 -- it adds `dbt_macros/tests/`, which this workflow points at.

The Dune property post-hook macros only render when `target.name == 'prod'`, so the dbt CI jobs never execute them, and `dbt_macros/dune/` is not in the path filter that `dbt_full_run.yml` uses to select subprojects. A macro edit therefore lands with no CI coverage at all today, which is how #9909 got a green board while running nothing.

This points the existing pytest workflow at the macro render tests and triggers it on `dbt_macros/**`.

Kept separate from #9909 on purpose. `.github/workflows/**` and `scripts/**` both match the shared-code branch of the project detection in `dbt_full_run.yml`, which marks every subproject as modified. Combined with a macro change in the same PR, `state:modified.macros` then matches every model that depends on `mark_as_spell` -- all of them, roughly 7400 across the five subprojects -- and CI would try to rebuild the repo. Landing the workflow change on its own means the subprojects are selected but have nothing to build.

For the same reason the tests live in `dbt_macros/tests/` rather than next to `scripts/test_token_checker.py`.