### PR TITLE
feat: add production dbt profiles for the five subprojects

### DIFF
--- a/dbt_subprojects/daily_spellbook/profiles.yml
+++ b/dbt_subprojects/daily_spellbook/profiles.yml
@@ -10,3 +10,29 @@ spellbook-local:
       database: hive
       schema: wizard
       threads: 1
+
+# Production profile, selected explicitly by the orchestrator; local dev keeps spellbook-local
+# above. The profile and target names are load-bearing in dbt_macros/dune/ — do not rename.
+spellbook_daily:
+  target: prod
+  outputs:
+    prod:
+      type: trino
+      user: "{{ env_var('TRINO_USER', 'spellbook') }}"
+      password: "{{ env_var('TRINO_PASSWORD', '') }}"
+      host: "{{ env_var('TRINO_HOST') }}"
+      port: 443
+      method: ldap
+      database: hive
+      schema: prod
+      threads: 16
+      http_scheme: https
+      cert: true
+      http_headers:
+        X-Trino-Routing-Group: "{{ env_var('TRINO_ROUTING_GROUP') }}"
+        X-Forwarded-Proto: https
+        X-Trino-Extra-Credential: "dune={{ env_var('TRINO_DUNE_CREDENTIALS') }}"
+      session_properties:
+        delta_prod.dynamic_filtering_wait_timeout: 30s
+        hive.dynamic_filtering_wait_timeout: 30s
+      timezone: UTC

--- a/dbt_subprojects/dex/profiles.yml
+++ b/dbt_subprojects/dex/profiles.yml
@@ -10,3 +10,30 @@ spellbook-local:
       database: hive
       schema: wizard
       threads: 1
+
+# Production profile, selected explicitly by the orchestrator; local dev keeps spellbook-local
+# above. The profile and target names are load-bearing in dbt_macros/dune/ — do not rename.
+spellbook_dex:
+  target: prod
+  outputs:
+    prod:
+      type: trino
+      user: "{{ env_var('TRINO_USER', 'spellbook') }}"
+      password: "{{ env_var('TRINO_PASSWORD', '') }}"
+      host: "{{ env_var('TRINO_HOST') }}"
+      port: 443
+      method: ldap
+      database: hive
+      schema: prod
+      threads: 24
+      http_scheme: https
+      cert: true
+      http_headers:
+        X-Trino-Routing-Group: "{{ env_var('TRINO_ROUTING_GROUP') }}"
+        X-Trino-Client-Tags: "{{ env_var('TRINO_CLIENT_TAGS', 'dbt-dex') }}"
+        X-Forwarded-Proto: https
+        X-Trino-Extra-Credential: "dune={{ env_var('TRINO_DUNE_CREDENTIALS') }}"
+      session_properties:
+        delta_prod.dynamic_filtering_wait_timeout: 30s
+        hive.dynamic_filtering_wait_timeout: 30s
+      timezone: UTC

--- a/dbt_subprojects/hourly_spellbook/profiles.yml
+++ b/dbt_subprojects/hourly_spellbook/profiles.yml
@@ -10,3 +10,30 @@ spellbook-local:
       database: hive
       schema: wizard
       threads: 1
+
+# Production profile, selected explicitly by the orchestrator; local dev keeps spellbook-local
+# above. The profile and target names are load-bearing in dbt_macros/dune/ — do not rename.
+spellbook_hourly:
+  target: prod
+  outputs:
+    prod:
+      type: trino
+      user: "{{ env_var('TRINO_USER', 'spellbook') }}"
+      password: "{{ env_var('TRINO_PASSWORD', '') }}"
+      host: "{{ env_var('TRINO_HOST') }}"
+      port: 443
+      method: ldap
+      database: hive
+      schema: prod
+      threads: 12
+      http_scheme: https
+      cert: true
+      http_headers:
+        X-Trino-Routing-Group: "{{ env_var('TRINO_ROUTING_GROUP') }}"
+        X-Trino-Client-Tags: "{{ env_var('TRINO_CLIENT_TAGS', 'dbt-hourly') }}"
+        X-Forwarded-Proto: https
+        X-Trino-Extra-Credential: "dune={{ env_var('TRINO_DUNE_CREDENTIALS') }}"
+      session_properties:
+        delta_prod.dynamic_filtering_wait_timeout: 30s
+        hive.dynamic_filtering_wait_timeout: 30s
+      timezone: UTC

--- a/dbt_subprojects/solana/profiles.yml
+++ b/dbt_subprojects/solana/profiles.yml
@@ -10,3 +10,30 @@ spellbook-local:
       database: hive
       schema: wizard
       threads: 1
+
+# Production profile, selected explicitly by the orchestrator; local dev keeps spellbook-local
+# above. The profile and target names are load-bearing in dbt_macros/dune/ — do not rename.
+spellbook_solana:
+  target: prod
+  outputs:
+    prod:
+      type: trino
+      user: "{{ env_var('TRINO_USER', 'spellbook') }}"
+      password: "{{ env_var('TRINO_PASSWORD', '') }}"
+      host: "{{ env_var('TRINO_HOST') }}"
+      port: 443
+      method: ldap
+      database: hive
+      schema: prod
+      threads: 12
+      http_scheme: https
+      cert: true
+      http_headers:
+        X-Trino-Routing-Group: "{{ env_var('TRINO_ROUTING_GROUP') }}"
+        X-Trino-Client-Tags: "{{ env_var('TRINO_CLIENT_TAGS', 'dbt-solana') }}"
+        X-Forwarded-Proto: https
+        X-Trino-Extra-Credential: "dune={{ env_var('TRINO_DUNE_CREDENTIALS') }}"
+      session_properties:
+        delta_prod.dynamic_filtering_wait_timeout: 30s
+        hive.dynamic_filtering_wait_timeout: 30s
+      timezone: UTC

--- a/dbt_subprojects/tokens/profiles.yml
+++ b/dbt_subprojects/tokens/profiles.yml
@@ -10,3 +10,30 @@ spellbook-local:
       database: hive
       schema: wizard
       threads: 1
+
+# Production profile, selected explicitly by the orchestrator; local dev keeps spellbook-local
+# above. The profile and target names are load-bearing in dbt_macros/dune/ — do not rename.
+spellbook_tokens:
+  target: prod
+  outputs:
+    prod:
+      type: trino
+      user: "{{ env_var('TRINO_USER', 'spellbook') }}"
+      password: "{{ env_var('TRINO_PASSWORD', '') }}"
+      host: "{{ env_var('TRINO_HOST') }}"
+      port: 443
+      method: ldap
+      database: hive
+      schema: prod
+      threads: 16
+      http_scheme: https
+      cert: true
+      http_headers:
+        X-Trino-Routing-Group: "{{ env_var('TRINO_ROUTING_GROUP') }}"
+        X-Trino-Client-Tags: "{{ env_var('TRINO_CLIENT_TAGS', 'dbt-tokens') }}"
+        X-Forwarded-Proto: https
+        X-Trino-Extra-Credential: "dune={{ env_var('TRINO_DUNE_CREDENTIALS') }}"
+      session_properties:
+        delta_prod.dynamic_filtering_wait_timeout: 30s
+        hive.dynamic_filtering_wait_timeout: 30s
+      timezone: UTC


### PR DESCRIPTION
Adds a production dbt profile to each of the five subprojects, alongside the existing `spellbook-local` default. Each holds a single `prod` output whose credentials, host and routing details all come from environment variables injected at run time — nothing is hardcoded here.

Two names are load-bearing, in opposite directions. The profile must **not** be called `spellbook-local`, because that name short-circuits `get_catalog`, `list_schemas` and `list_relations_without_caching` to `[]` in `dbt_macros/dune/no-relation-listing.sql` — a deliberate local-dev speedup that in production would empty the relation cache and make incremental models rebuild instead of merge. The target must be exactly `prod`, since `generate_schema_name`, `config_trino_properties`, `s3_bucket()` and `private_data_explorer` all branch on `target.name == 'prod'`.

Inert until the scheduler selects it. dbt renders only the selected profile, verified by parsing on `spellbook-local` with the prod profile's environment variables unset, so local dev is unaffected. CI is unaffected too — it decodes its own profiles into `$HOME/.dbt` and passes `--profiles-dir`.

Merge this before the corresponding orchestrator change, which registers the jobs that select these profiles.
