### PR TITLE
fix(solana): dedupe Jupiter swap instructions

### DIFF
--- a/dbt_subprojects/solana/models/jupiter/jupiter_v6_solana_swapsevent_aggregator_swaps.sql
+++ b/dbt_subprojects/solana/models/jupiter/jupiter_v6_solana_swapsevent_aggregator_swaps.sql
@@ -90,18 +90,15 @@ WITH amms AS (
         amm
 )
 
-, amms_involved AS (
-    SELECT
+, amm_instructions AS (
+    SELECT DISTINCT
           a.block_date
         , a.block_slot
         , a.tx_index
+        , a.tx_id
         , a.executing_account AS amm
         , a.outer_instruction_index
         , a.inner_instruction_index
-        , ROW_NUMBER() OVER (
-            PARTITION BY a.block_date, a.tx_id, a.outer_instruction_index
-            ORDER BY a.inner_instruction_index ASC
-          ) AS rnk
     FROM {{ source('solana', 'instruction_calls') }} a
     INNER JOIN route_calls b
         ON  a.block_date = b.call_block_date
@@ -117,6 +114,21 @@ WITH amms AS (
       {% else %}
       AND a.block_date >= DATE '{{ project_start_date }}'
       {% endif %}
+)
+
+, amms_involved AS (
+    SELECT
+          a.block_date
+        , a.block_slot
+        , a.tx_index
+        , a.amm
+        , a.outer_instruction_index
+        , a.inner_instruction_index
+        , ROW_NUMBER() OVER (
+            PARTITION BY a.block_date, a.tx_id, a.outer_instruction_index
+            ORDER BY a.inner_instruction_index ASC
+          ) AS rnk
+    FROM amm_instructions a
 )
 
 , swap_amounts AS (

--- a/dbt_subprojects/solana/models/jupiter/jupiter_v6_solana_swapsevent_aggregator_swaps.sql
+++ b/dbt_subprojects/solana/models/jupiter/jupiter_v6_solana_swapsevent_aggregator_swaps.sql
@@ -140,9 +140,13 @@ WITH amms AS (
         , evt_tx_id AS tx_id
         , evt_tx_signer AS tx_signer
         , evt_outer_instruction_index AS outer_instruction_index
+        -- a single outer instruction can carry multiple SwapsEvent emissions when
+        -- jupiter routes are nested, and `ord` restarts at 1 for each of them.
+        -- order by the emitting instruction first so the sort is total, otherwise
+        -- tied `ord` values pair swaps with the wrong amm non-deterministically.
         , ROW_NUMBER() OVER (
             PARTITION BY evt_block_slot, evt_tx_index, evt_outer_instruction_index
-            ORDER BY ord ASC
+            ORDER BY evt_inner_instruction_index ASC, ord ASC
           ) AS swap_order
         , REPLACE(REPLACE(json_extract_scalar(CAST(evt AS VARCHAR), '$.SwapEventV2.input_mint'), 'PublicKey(', ''), ')', '') AS input_mint
         , CAST(json_extract_scalar(CAST(evt AS VARCHAR), '$.SwapEventV2.input_amount') AS UINT256) AS input_amount


### PR DESCRIPTION
## What & why
Deduplicate AMM instruction candidates before assigning SwapEvent order.
Nested Jupiter route calls currently fan out the same instruction and fail the Solana production merge.
This restores one merge key per swap and allows incremental refreshes to complete.
- No visual surface (dbt model logic only)

## Architecture
- `dbt_subprojects/solana/models/jupiter/jupiter_v6_solana_swapsevent_aggregator_swaps.sql` - data-critical model; deduplicates physical AMM instructions before `ROW_NUMBER()` assigns swap order.
- Tested: selected model compiles; bounded DuneSQL over the last three days returns zero duplicate source keys; both failing transactions map three swaps to three distinct instructions.
- Needs human eyes: run a one-time full refresh after deploy to remove the two duplicate keys already stored in the August 1 production partition.
- Cross-system blast radius: `jupiter_v6_solana.swapsevent_aggregator_swaps` and downstream Jupiter aggregator swaps consumers; no schema change.

<details><summary>Agent context</summary>

- Reproduced from dbt Cloud run https://nd058.us1.dbt.com/deploy/58579/projects/372518/runs/70471891091654/ and Trino query `20260802_130440_00420_i9vf2`.
- Compile: `uv run dbt compile --select jupiter_v6_solana_swapsevent_aggregator_swaps --project-dir dbt_subprojects/solana/`.
- Regression: Dune CLI query over a three-day partition-bounded window returned `duplicate_key_groups = 0`.
- Failing transaction mappings changed from duplicate instructions to `[13, 20, 23]` and `[13, 22, 27]`, with three distinct merge keys each.
</details>