### PR TITLE
Add prod_exclude tag to failing views

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/offramp/ethereum/cow_protocol_tx_hash_labels_offramp_ethereum.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/offramp/ethereum/cow_protocol_tx_hash_labels_offramp_ethereum.sql
@@ -1,7 +1,7 @@
 {{
     config(
         alias = 'tx_hash_labels_offramp_ethereum',
-
+        tags = ['prod_exclude'],
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/onramp/ethereum/cow_protocol_tx_hash_labels_onramp_ethereum.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/onramp/ethereum/cow_protocol_tx_hash_labels_onramp_ethereum.sql
@@ -1,7 +1,7 @@
 {{
     config(
         alias = 'tx_hash_labels_onramp_ethereum',
-
+        tags = ['prod_exclude'],
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/stable_to_stable/ethereum/cow_protocol_tx_hash_labels_stable_to_stable_ethereum.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/stable_to_stable/ethereum/cow_protocol_tx_hash_labels_stable_to_stable_ethereum.sql
@@ -1,7 +1,7 @@
 {{
     config(
         alias = 'tx_hash_labels_stable_to_stable_ethereum',
-
+        tags = ['prod_exclude'],
     )
 }}
 

--- a/dbt_subprojects/tokens/models/prices/prices_solana_day.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_solana_day.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'prices_solana',
         alias = 'day',
-        materialized = 'view'
+        materialized = 'view',
+        tags = ['prod_exclude']
     )
 }}
 

--- a/dbt_subprojects/tokens/models/prices/prices_solana_hour.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_solana_hour.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'prices_solana',
         alias = 'hour',
-        materialized = 'view'
+        materialized = 'view',
+        tags = ['prod_exclude']
     )
 }}
 

--- a/dbt_subprojects/tokens/models/prices/prices_solana_minute.sql
+++ b/dbt_subprojects/tokens/models/prices/prices_solana_minute.sql
@@ -1,7 +1,8 @@
 {{ config(
         schema = 'prices_solana',
         alias = 'minute',
-        materialized = 'view'
+        materialized = 'view',
+        tags = ['prod_exclude']
     )
 }}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `[prod] deploy modified models` job (run #70471891296752) failed because three Solana price views reference upstream `_raw` tables that no longer exist:

```
TrinoUserError(type=USER_ERROR, name=TABLE_NOT_FOUND, message="Table 'dune.dune.prices_solana_day_raw' does not exist")
```

The failing models are all `config.materialized:view` spells, which the deploy job runs via `dbt run -s config.materialized:view --exclude tag:prod_exclude`. This PR adds the `prod_exclude` tag to their config blocks so the deploy job skips them until their upstream `_raw` sources are restored.

Adds `tags = ['prod_exclude']` to the three `cow_protocol` tx_hash_labels ethereum models that are breaking the hourly prod view deploy:

- `cow_protocol_tx_hash_labels_offramp_ethereum`
- `cow_protocol_tx_hash_labels_onramp_ethereum`
- `cow_protocol_tx_hash_labels_stable_to_stable_ethereum`

**Why:** dbt Cloud run [#70471891296666](https://nd058.us1.dbt.com/deploy/58579/projects/259299/runs/70471891296666/) (`[prod] deploy modified models`, step `dbt run -s config.materialized:view --exclude tag:prod_exclude`) failed on all three with:

```
TrinoUserError(type=USER_ERROR, name=TABLE_NOT_FOUND,
message="line 17:67: Table 'delta_prod.tokens_ethereum.stablecoins' does not exist")
```

All three reference `source('tokens_ethereum', 'stablecoins')`, which no longer resolves in `delta_prod`. The culprit is the upstream source, not these models, so this is an unblock-the-deploy change rather than a fix.