### PR TITLE
chore(cow_protocol): tag failing ethereum tx_hash_labels models prod_exclude

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/offramp/ethereum/cow_protocol_tx_hash_labels_offramp_ethereum.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/offramp/ethereum/cow_protocol_tx_hash_labels_offramp_ethereum.sql
@@ -1,7 +1,7 @@
 {{
     config(
         alias = 'tx_hash_labels_offramp_ethereum',
-
+        tags = ['prod_exclude'],
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/onramp/ethereum/cow_protocol_tx_hash_labels_onramp_ethereum.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/onramp/ethereum/cow_protocol_tx_hash_labels_onramp_ethereum.sql
@@ -1,7 +1,7 @@
 {{
     config(
         alias = 'tx_hash_labels_onramp_ethereum',
-
+        tags = ['prod_exclude'],
     )
 }}
 

--- a/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/stable_to_stable/ethereum/cow_protocol_tx_hash_labels_stable_to_stable_ethereum.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_project/cow_protocol/tx_hash_labels/stable_to_stable/ethereum/cow_protocol_tx_hash_labels_stable_to_stable_ethereum.sql
@@ -1,7 +1,7 @@
 {{
     config(
         alias = 'tx_hash_labels_stable_to_stable_ethereum',
-
+        tags = ['prod_exclude'],
     )
 }}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:

Adds `tags = ['prod_exclude']` to the three `cow_protocol` tx_hash_labels ethereum models that are breaking the hourly prod view deploy:

- `cow_protocol_tx_hash_labels_offramp_ethereum`
- `cow_protocol_tx_hash_labels_onramp_ethereum`
- `cow_protocol_tx_hash_labels_stable_to_stable_ethereum`

**Why:** dbt Cloud run [#70471891296666](https://nd058.us1.dbt.com/deploy/58579/projects/259299/runs/70471891296666/) (`[prod] deploy modified models`, step `dbt run -s config.materialized:view --exclude tag:prod_exclude`) failed on all three with:

```
TrinoUserError(type=USER_ERROR, name=TABLE_NOT_FOUND,
message="line 17:67: Table 'delta_prod.tokens_ethereum.stablecoins' does not exist")
```

All three reference `source('tokens_ethereum', 'stablecoins')`, which no longer resolves in `delta_prod`. The culprit is the upstream source, not these models, so this is an unblock-the-deploy change rather than a fix.

**Scope notes:**

- This is a stopgap. The real follow-up is determining whether `tokens_ethereum.stablecoins` was renamed, migrated, or made private, and then either restoring visibility or repointing these models at the current stablecoins spell. Suggest keeping this PR open/tracked until that is resolved so the models get un-tagged rather than silently left out of prod.
- The parent union model `cow_protocol_tx_hash_labels_all` is already tagged `prod_exclude`, so this matches existing handling in the same lineage.
- The cross-chain view `cow_protocol_tx_hash_labels_offramp` (and its onramp/stable_to_stable siblings) is deliberately left untagged; it only references the ethereum view by name and should continue to deploy.

**Validation:** `dbt ls --select tag:prod_exclude,path:models/_project/cow_protocol` in `hourly_spellbook` now returns all three models plus the already-tagged `cow_protocol_tx_hash_labels_all`.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duneanalytics.slack.com/archives/C04E0CV1SG3/p1785802817481109?thread_ts=1785802817.481109&cid=C04E0CV1SG3)

<div><a href="https://cursor.com/agents/bc-62cb18f4-a370-57d2-adda-87218165dcc4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62cb18f4-a370-57d2-adda-87218165dcc4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

