### PR TITLE
feat(dex): add Uniswap UniversalRouter V2 and V2.1.1 addresses for ethereum, base, arbitrum, optimism

### DIFF
--- a/dbt_subprojects/dex/models/addresses/arbitrum/dex_arbitrum_addresses.sql
+++ b/dbt_subprojects/dex/models/addresses/arbitrum/dex_arbitrum_addresses.sql
@@ -22,6 +22,8 @@ FROM (VALUES
      ('arbitrum', 0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae, 'LiFi', 'LiFiDiamond_v2'),
      ('arbitrum', 0xc873fecbd354f5a56e00e710b90ef4201db2448d, 'Camelot', 'CamelotRouter'),
      ('arbitrum', 0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad, 'Uniswap', 'UniversalRouter'),
+     ('arbitrum', 0xa51afafe0263b40edaef0df8781ea9aa03e381a3, 'Uniswap', 'UniversalRouterV2'),
+     ('arbitrum', 0x8b844f885672f333bc0042cb669255f93a4c1e6b, 'Uniswap', 'UniversalRouterV2_1_1'),
      ('arbitrum', 0xb4315e873dbcf96ffd0acd8ea43f689d8c20fb30, 'Trader Joe', 'LBRouter'),
      ('arbitrum', 0xbee5c10cf6e4f68f831e11c1d9e59b43560b3642, 'Trader Joe', 'V1 Router'),
      ('arbitrum', 0x7bfd7192e76d950832c77bb412aae841049d8d9b, 'Trader Joe', 'V2 Router'),

--- a/dbt_subprojects/dex/models/addresses/base/dex_base_addresses.sql
+++ b/dbt_subprojects/dex/models/addresses/base/dex_base_addresses.sql
@@ -10,6 +10,8 @@ FROM (VALUES
       ('base', 0x2626664c2603336e57b271c5c0b26f421741e481, 'Uniswap', 'SwapRouter02'),
       ('base', 0x198ef79f1f515f02dfe9e3115ed9fc07183f02fc, 'Uniswap', 'UniversalRouter'),
       ('base', 0xec8b0f7ffe3ae75d7ffab09429e3675bb63503e4, 'Uniswap', 'UniversalRouter'),
+      ('base', 0x6ff5693b99212da76ad316178a184ab56d299b43, 'Uniswap', 'UniversalRouterV2'),
+      ('base', 0xfdf682f51fe81aa4898f0ae2163d8a55c127fbc7, 'Uniswap', 'UniversalRouterV2_1_1'),
       ('base', 0xdef1c0ded9bec7f1a1670819833240f027b25eff, 'ZeroEx', 'ExchangeProxy'),
       ('base', 0x1b8eea9315be495187d873da7773a874545d9d48, 'BaseSwap', 'SwapRouter'),
       ('base', 0xcf77a3ba9a5ca399b7c97c74d54e5b1beb874e43, 'Aerodrome', 'SwapRouter'),

--- a/dbt_subprojects/dex/models/addresses/ethereum/dex_ethereum_addresses.sql
+++ b/dbt_subprojects/dex/models/addresses/ethereum/dex_ethereum_addresses.sql
@@ -49,6 +49,8 @@ FROM (VALUES
       ('ethereum', 0xf164fc0ec4e93095b804a4795bbe1e041497b92a, 'Uniswap', 'Router01'),
       ('ethereum', 0xef1c6e67703c7bd7107eed8303fbe6ec2554bf6b, 'Uniswap', 'Universal Router'),
       ('ethereum', 0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad, 'Uniswap', 'Universal Router'),
+      ('ethereum', 0x66a9893cc07d91d95644aedd05d03f95e1dba8af, 'Uniswap', 'UniversalRouterV2'),
+      ('ethereum', 0x4c82d1fbfe28c977cbb58d8c7ff8fcf9f70a2cca, 'Uniswap', 'UniversalRouterV2_1_1'),
       ('ethereum', 0x6000da47483062a0d734ba3dc7576ce6a0b645c4, 'Uniswap', 'UniswapX'),
       ('ethereum', 0x83c8f28c26bf6aaca652df1dbbe0e1b56f8baba2, 'GemSwap', 'GemSwap'),
       ('ethereum', 0xd9e1ce17f2641f24ae83637ab66a2cca9c378b9f, 'SushiSwap', 'Router02'),

--- a/dbt_subprojects/dex/models/addresses/optimism/dex_optimism_addresses.sql
+++ b/dbt_subprojects/dex/models/addresses/optimism/dex_optimism_addresses.sql
@@ -17,6 +17,8 @@ FROM (VALUES
       ('optimism', 0xe592427a0aece92de3edee1f18e0157c05861564, 'Uniswap', 'SwapRouter'),
       ('optimism', 0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45, 'Uniswap', 'SwapRouter02'),
       ('optimism', 0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad, 'Uniswap', 'UniversalRouter'),
+      ('optimism', 0x851116d9223fabed8e56c0e6b8ad0c31d98b3507, 'Uniswap', 'UniversalRouterV2'),
+      ('optimism', 0x8b844f885672f333bc0042cb669255f93a4c1e6b, 'Uniswap', 'UniversalRouterV2_1_1'),
       ('optimism', 0xdef1abe32c034e558cdd535791643c58a13acc10, 'ZeroEx', 'ExchangeProxy'),
       ('optimism', 0x5130f6ce257b8f9bf7fac0a0b519bd588120ed40, 'Clipper', 'ClipperPackedVerifiedExchange'),
       ('optimism', 0xa132dab612db5cb9fc9ac426a0cc215a3423f9c9, 'Velodrome', 'Router'),


### PR DESCRIPTION
## What

Adds the V2-era Uniswap Universal Router deployments to the `dex_<chain>.addresses` label tables for **ethereum, base, arbitrum and optimism**.

Coverage in these four files currently stops at the V1 / V1.2 routers, so swaps routed through `UniversalRouterV2` and `UniversalRouterV2_1_1` don't resolve to Uniswap when these tables are used for router labelling.

## Addresses

Every address below is taken from Uniswap's published deploy list, [`Uniswap/universal-router/deploy-addresses/<chain>.json`](https://github.com/Uniswap/universal-router/tree/main/deploy-addresses), and was checked against the current file contents to confirm it isn't already present.

| Chain | `UniversalRouterV2` | `UniversalRouterV2_1_1` |
|---|---|---|
| ethereum | `0x66a9893cc07d91d95644aedd05d03f95e1dba8af` | `0x4c82d1fbfe28c977cbb58d8c7ff8fcf9f70a2cca` |
| base | `0x6ff5693b99212da76ad316178a184ab56d299b43` | `0xfdf682f51fe81aa4898f0ae2163d8a55c127fbc7` |
| arbitrum | `0xa51afafe0263b40edaef0df8781ea9aa03e381a3` | `0x8b844f885672f333bc0042cb669255f93a4c1e6b` |
| optimism | `0x851116d9223fabed8e56c0e6b8ad0c31d98b3507` | `0x8b844f885672f333bc0042cb669255f93a4c1e6b` |

Note: arbitrum and optimism share the same `UniversalRouterV2_1_1` address. That is expected — it's a deterministic CREATE2 deployment reused across several chains (also bsc, celo, linea, blast, and others in Uniswap's list). The `unique` test on `address` is per-model, so this doesn't collide.

## Why it matters

Uniswap's own router flow through these deployments currently doesn't carry a Uniswap label at the router level. Over the 7 days to 2026-08-03, the eight addresses added here carried **$751.2M** of entry volume: $554.3M Base, $168.6M Ethereum, $27.9M Arbitrum, $0.5M Optimism. Adding these rows lets anyone querying `dex_<chain>.addresses` attribute that flow correctly.

> **Correction (2026-08-05).** This section previously read "roughly $63.8M over a trailing 7-day window ($52.2M Base, $11.4M Arbitrum, $0.2M Optimism, measured 2026-07-29)". Two things were wrong with it. The window was not what it claimed: the figure came from a table in my own pipeline that had silently stopped refreshing, so it described the week ending ~2026-07-15, not a window trailing 2026-07-29. And the scope was too narrow: it counted only the V2.1.1 rows on three chains rather than the flow through all eight addresses this PR adds. On the corrected 2026-08-03 window the old V2.1.1-only measure would read $16.7M ($6.7M Base, $9.8M Arbitrum, $0.2M Optimism); the figure above is the full set. The addresses themselves are unaffected: they come from Uniswap's published deploy list, not from this measurement.

Entry volume here means `dex.trades` collapsed to one notional per transaction per entrypoint, grouped by `tx_to`, so multi-hop routes are not leg-summed.

To be precise about scope: `dex.trades` is built from pool `Swap` events, so trades into Uniswap pools already attribute to Uniswap there. This PR fixes **router-level** labelling only.

## Notes for reviewers

- Existing rows are untouched; this is additive (+8/−0).
- `distinct_name` uses Uniswap's own deploy-list keys (`UniversalRouterV2`, `UniversalRouterV2_1_1`) so the rows are traceable back to the source of truth. The two pre-existing ethereum rows use the spaced form `Universal Router`; I left them as-is rather than widening the diff.
- Addresses are lowercased to match the dominant convention in these files.
- I did not add the missing V1/V1.2 variants that also differ from Uniswap's list on some chains (e.g. arbitrum's `UniversalRouterV1`), to keep this reviewable. Happy to follow up with a separate PR if useful.
- Separately, `UniversalRouterV2_1_1` is not decoded on Base / Arbitrum / Optimism. That's a contract-decoding submission rather than a Spellbook change, and I'm handling it through the decoding request path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

