### PR TITLE
fix(macros): use valid dbt type names in macro argument docs

### DIFF
--- a/dbt_macros/dune/macros_schema.yml
+++ b/dbt_macros/dune/macros_schema.yml
@@ -5,20 +5,20 @@ macros:
     description: "This overrides the dbt-core function for setting schemas. For PR tests, the schema is set to test_schema"
     arguments:
       - name: custom_schema_name
-        type: column name or expression
+        type: optional[string]
         description: "Custom schema name"
       - name: node
-        type: column name or expression
+        type: any
         description: "Node"
 
   - name: generate_alias_name
     description: "This overrides the dbt-core function for setting aliases. For PR test, the alias is set to the user schema and file name. "
     arguments:
       - name: custom_alias_name
-        type: column name or expression
+        type: optional[string]
         description: "Custom alias name"
       - name: node
-        type: column name or expression
+        type: any
         description: "Node"
 
   - name: is_incremental
@@ -41,7 +41,7 @@ macros:
       that is the only way to withdraw a hint already published on a view.
     arguments:
       - name: properties
-        type: dict
+        type: dict[string, any]
         description: "Property map to update in place"
 
   - name: deprecate_spells


### PR DESCRIPTION
dbt-core 1.12 turns the `validate_macro_args` behavior flag on by default, which checks every documented macro argument `type:` against a closed vocabulary (`str`, `bool`, `int`, `float`, `any`, `relation`, `column`, `list[T]`, `optional[T]`, `dict[K,V]`). Five of ours are not in it, so every parse under 1.12 emits `InvalidMacroAnnotation` warnings — visible today in the dbtco job logs, which already run 1.12.

`type:` is documentation metadata only (it lands in `manifest.json`), so no model output changes. It matters because `dbt_run.yml` compiles with `--warn-error`: once spellbook moves off 1.10 these warnings become hard CI failures on all five subprojects.

The `column name or expression` values look copy-pasted from dbt's column docs convention, where the field is free text. `node` becomes `any` because a dbt node object has no matching type name.

Verified with `dbt parse` on the tokens subproject: five warnings before, zero after under 1.12.0, and `--warn-error parse` clean on both 1.10.20 and 1.12.0.