### PR TITLE
fix config keys dbt silently discards (columns, tag)

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/ajna/ajna_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/ajna/ajna_schema.yml
@@ -7,7 +7,7 @@ models:
       project: ajna
       contributors: [gunboats]
     config:
-      tag: ['ajna', 'cross-chain', 'borrowing', 'lending']
+      tags: ['ajna', 'cross-chain', 'borrowing', 'lending']
       description: 'All deployed ERC-20 pools across all chains on Ajna'
     data_tests:
       - dbt_utils.unique_combination_of_columns:

--- a/dbt_subprojects/daily_spellbook/models/chainswap/chain_swap_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/chainswap/chain_swap_schema.yml
@@ -10,79 +10,79 @@ models:
       tags: ["ethereum", "dex", "bot", "trades"]
       description: >
         Trades by trading bots on Ethereum
-      columns:
-        - &blockchain
-          name: blockchain
-          description: "Blockchain which the DEX is deployed"
-        - &block_time
-          name: block_time
-          description: "UTC event block time of each DEX trade"
-        - &block_date
-          name: block_date
-          description: "UTC event block date of each DEX trade"
-        - &block_month
-          name: block_month
-          description: "UTC event block month of each DEX trade"
-        - &amount_usd
-          name: amount_usd
-          description: "USD value of the trade at time of execution"
-        - &type
-          name: type
-          description: "Wether the trade is a buy or sell"
-        - &token_bought_amount
-          name: token_bought_amount
-          description: "Value of the token bought at time of execution in the original currency"
-        - &token_bought_symbol
-          name: token_bought_symbol
-          description: "Token symbol for token bought in the trade"
-        - &token_bought_address
-          name: token_bought_address
-          description: "Contract address of the token bought"
-        - &token_sold_amount
-          name: token_sold_amount
-          description: "Value of the token sold at time of execution in the original currency"
-        - &token_sold_symbol
-          name: token_sold_symbol
-          description: "Token symbol for token sold in the trade"
-        - &token_sold_address
-          name: token_sold_address
-          description: "Contract address of the token sold"
-        - &fee_usd
-          name: fee_usd
-          description: "USD value of the fee at time of execution"
-        - &fee_token_amount
-          name: fee_token_amount
-          description: "Value of the fee paid at time of execution in the original currency"
-        - &fee_token_symbol
-          name: fee_token_symbol
-          description: "Token symbol for fee token"
-        - &fee_token_address
-          name: fee_token_address
-          description: "Contract address of the fee token"
-        - &project
-          name: project
-          description: "Project name of the DEX"
-        - &version
-          name: version
-          description: "Version of the contract built and deployed by the DEX project"
-        - &token_pair
-          name: token_pair
-          description: "Token symbol pair for each token involved in the trade"
-        - &project_contract_address
-          name: project_contract_address
-          description: "Project contract address which executed the trade on the blockchain"
-        - &user
-          name: user
-          description: "Address which initiated the trade"
-        - &tx_hash
-          name: tx_hash
-          description: "Unique transaction hash value tied to each transaction on the DEX"
-        - &evt_index
-          name: evt_index
-          description: "Index of the corresponding trade event"
-        - &is_last_trade_in_transaction
-          name: is_last_trade_in_transaction
-          description: "Wether the trade is the last hop of the trade transaction, in case of a multi-hop trade"
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain which the DEX is deployed"
+      - &block_time
+        name: block_time
+        description: "UTC event block time of each DEX trade"
+      - &block_date
+        name: block_date
+        description: "UTC event block date of each DEX trade"
+      - &block_month
+        name: block_month
+        description: "UTC event block month of each DEX trade"
+      - &amount_usd
+        name: amount_usd
+        description: "USD value of the trade at time of execution"
+      - &type
+        name: type
+        description: "Wether the trade is a buy or sell"
+      - &token_bought_amount
+        name: token_bought_amount
+        description: "Value of the token bought at time of execution in the original currency"
+      - &token_bought_symbol
+        name: token_bought_symbol
+        description: "Token symbol for token bought in the trade"
+      - &token_bought_address
+        name: token_bought_address
+        description: "Contract address of the token bought"
+      - &token_sold_amount
+        name: token_sold_amount
+        description: "Value of the token sold at time of execution in the original currency"
+      - &token_sold_symbol
+        name: token_sold_symbol
+        description: "Token symbol for token sold in the trade"
+      - &token_sold_address
+        name: token_sold_address
+        description: "Contract address of the token sold"
+      - &fee_usd
+        name: fee_usd
+        description: "USD value of the fee at time of execution"
+      - &fee_token_amount
+        name: fee_token_amount
+        description: "Value of the fee paid at time of execution in the original currency"
+      - &fee_token_symbol
+        name: fee_token_symbol
+        description: "Token symbol for fee token"
+      - &fee_token_address
+        name: fee_token_address
+        description: "Contract address of the fee token"
+      - &project
+        name: project
+        description: "Project name of the DEX"
+      - &version
+        name: version
+        description: "Version of the contract built and deployed by the DEX project"
+      - &token_pair
+        name: token_pair
+        description: "Token symbol pair for each token involved in the trade"
+      - &project_contract_address
+        name: project_contract_address
+        description: "Project contract address which executed the trade on the blockchain"
+      - &user
+        name: user
+        description: "Address which initiated the trade"
+      - &tx_hash
+        name: tx_hash
+        description: "Unique transaction hash value tied to each transaction on the DEX"
+      - &evt_index
+        name: evt_index
+        description: "Index of the corresponding trade event"
+      - &is_last_trade_in_transaction
+        name: is_last_trade_in_transaction
+        description: "Wether the trade is the last hop of the trade transaction, in case of a multi-hop trade"
 
   - name: chain_swap_ethereum_trades
     meta:

--- a/dbt_subprojects/dex/models/bot_trades/_schema.yml
+++ b/dbt_subprojects/dex/models/bot_trades/_schema.yml
@@ -10,88 +10,88 @@ models:
       tags: ["evm", "dex", "bot", "trades"]
       description: >
         Trades by trading bots on EVM chains
-      columns:
-        - &blockchain
-          name: blockchain
-          description: "Blockchain which the DEX is deployed"
-        - &block_number
-          name: block_number
-          description: "Block number that includes the DEX trade"
-        - &block_time
-          name: block_time
-          description: "UTC event block time of each DEX trade"
-        - &block_date
-          name: block_date
-          description: "UTC event block date of each DEX trade"
-        - &block_month
-          name: block_month
-          description: "UTC event block month of each DEX trade"
-        - &bot
-          name: bot
-          description: "Trading bot which executed the trade"
-        - &amount_usd
-          name: amount_usd
-          description: "USD value of the trade at time of execution"
-        - &type
-          name: type
-          description: "Wether the trade is a buy or sell"
-        - &token_bought_amount
-          name: token_bought_amount
-          description: "Value of the token bought at time of execution in the original currency"
-        - &token_bought_symbol
-          name: token_bought_symbol
-          description: "Token symbol for token bought in the trade"
-        - &token_bought_address
-          name: token_bought_address
-          description: "Contract address of the token bought"
-        - &token_sold_amount
-          name: token_sold_amount
-          description: "Value of the token sold at time of execution in the original currency"
-        - &token_sold_symbol
-          name: token_sold_symbol
-          description: "Token symbol for token sold in the trade"
-        - &token_sold_address
-          name: token_sold_address
-          description: "Contract address of the token sold"
-        - &fee_percentage_fraction
-          name: fee_percentage_fraction
-          description: "The trading fee in percent, as a fraction of 100"
-        - &fee_usd
-          name: fee_usd
-          description: "USD value of the fee at time of execution"
-        - &fee_token_amount
-          name: fee_token_amount
-          description: "Value of the fee paid at time of execution in the original currency"
-        - &fee_token_symbol
-          name: fee_token_symbol
-          description: "Token symbol for fee token"
-        - &fee_token_address
-          name: fee_token_address
-          description: "Contract address of the fee token"
-        - &project
-          name: project
-          description: "Project name of the DEX"
-        - &version
-          name: version
-          description: "Version of the contract built and deployed by the DEX project"
-        - &token_pair
-          name: token_pair
-          description: "Token symbol pair for each token involved in the trade"
-        - &project_contract_address
-          name: project_contract_address
-          description: "Project contract address which executed the trade on the blockchain"
-        - &user
-          name: user
-          description: "Address which initiated the trade"
-        - &tx_hash
-          name: tx_hash
-          description: "Unique transaction hash value tied to each transaction on the DEX"
-        - &evt_index
-          name: evt_index
-          description: "Index of the corresponding trade event"
-        - &is_last_trade_in_transaction
-          name: is_last_trade_in_transaction
-          description: "Wether the trade is the last hop of the trade transaction, in case of a multi-hop trade"
+    columns:
+      - &blockchain
+        name: blockchain
+        description: "Blockchain which the DEX is deployed"
+      - &block_number
+        name: block_number
+        description: "Block number that includes the DEX trade"
+      - &block_time
+        name: block_time
+        description: "UTC event block time of each DEX trade"
+      - &block_date
+        name: block_date
+        description: "UTC event block date of each DEX trade"
+      - &block_month
+        name: block_month
+        description: "UTC event block month of each DEX trade"
+      - &bot
+        name: bot
+        description: "Trading bot which executed the trade"
+      - &amount_usd
+        name: amount_usd
+        description: "USD value of the trade at time of execution"
+      - &type
+        name: type
+        description: "Wether the trade is a buy or sell"
+      - &token_bought_amount
+        name: token_bought_amount
+        description: "Value of the token bought at time of execution in the original currency"
+      - &token_bought_symbol
+        name: token_bought_symbol
+        description: "Token symbol for token bought in the trade"
+      - &token_bought_address
+        name: token_bought_address
+        description: "Contract address of the token bought"
+      - &token_sold_amount
+        name: token_sold_amount
+        description: "Value of the token sold at time of execution in the original currency"
+      - &token_sold_symbol
+        name: token_sold_symbol
+        description: "Token symbol for token sold in the trade"
+      - &token_sold_address
+        name: token_sold_address
+        description: "Contract address of the token sold"
+      - &fee_percentage_fraction
+        name: fee_percentage_fraction
+        description: "The trading fee in percent, as a fraction of 100"
+      - &fee_usd
+        name: fee_usd
+        description: "USD value of the fee at time of execution"
+      - &fee_token_amount
+        name: fee_token_amount
+        description: "Value of the fee paid at time of execution in the original currency"
+      - &fee_token_symbol
+        name: fee_token_symbol
+        description: "Token symbol for fee token"
+      - &fee_token_address
+        name: fee_token_address
+        description: "Contract address of the fee token"
+      - &project
+        name: project
+        description: "Project name of the DEX"
+      - &version
+        name: version
+        description: "Version of the contract built and deployed by the DEX project"
+      - &token_pair
+        name: token_pair
+        description: "Token symbol pair for each token involved in the trade"
+      - &project_contract_address
+        name: project_contract_address
+        description: "Project contract address which executed the trade on the blockchain"
+      - &user
+        name: user
+        description: "Address which initiated the trade"
+      - &tx_hash
+        name: tx_hash
+        description: "Unique transaction hash value tied to each transaction on the DEX"
+      - &evt_index
+        name: evt_index
+        description: "Index of the corresponding trade event"
+      - &is_last_trade_in_transaction
+        name: is_last_trade_in_transaction
+        description: "Wether the trade is the last hop of the trade transaction, in case of a multi-hop trade"
 
   - name: banana_gun_ethereum_bot_trades
     meta:

--- a/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/_schema.yml
+++ b/dbt_subprojects/solana/models/_sector/dex/bot_trades/solana/_schema.yml
@@ -10,88 +10,88 @@ models:
       tags: ["solana", "dex", "bot", "trades"]
       description: >
         Trades by trading bots on Solana
-      columns:
-        - &bot
-          name: bot
-          description: "Trading bot which executed the trade"
-        - &blockchain
-          name: blockchain
-          description: "Blockchain which the DEX is deployed"
-        - &block_time
-          name: block_time
-          description: "UTC event block time of each DEX trade"
-        - &block_date
-          name: block_date
-          description: "UTC event block date of each DEX trade"
-        - &block_month
-          name: block_month
-          description: "UTC event block month of each DEX trade"
-        - &amount_usd
-          name: amount_usd
-          description: "USD value of the trade at time of execution"
-        - &type
-          name: type
-          description: "Wether the trade is a buy or sell"
-        - &token_bought_amount
-          name: token_bought_amount
-          description: "Value of the token bought at time of execution in the original currency"
-        - &token_bought_symbol
-          name: token_bought_symbol
-          description: "Token symbol for token bought in the trade"
-        - &token_bought_address
-          name: token_bought_address
-          description: "Contract address of the token bought"
-        - &token_sold_amount
-          name: token_sold_amount
-          description: "Value of the token sold at time of execution in the original currency"
-        - &token_sold_symbol
-          name: token_sold_symbol
-          description: "Token symbol for token sold in the trade"
-        - &token_sold_address
-          name: token_sold_address
-          description: "Contract address of the token sold"
-        - &fee_usd
-          name: fee_usd
-          description: "USD value of the fee at time of execution"
-        - &fee_token_amount
-          name: fee_token_amount
-          description: "Value of the fee paid at time of execution in the original currency"
-        - &fee_token_symbol
-          name: fee_token_symbol
-          description: "Token symbol for fee token"
-        - &fee_token_address
-          name: fee_token_address
-          description: "Contract address of the fee token"
-        - &project
-          name: project
-          description: "Project name of the DEX"
-        - &version
-          name: version
-          description: "Version of the contract built and deployed by the DEX project"
-        - &token_pair
-          name: token_pair
-          description: "Token symbol pair for each token involved in the trade"
-        - &project_contract_address
-          name: project_contract_address
-          description: "Project contract address which executed the trade on the blockchain"
-        - &user
-          name: user
-          description: "Address which initiated the trade"
-        - &tx_id
-          name: tx_id
-          description: "Unique transaction hash value tied to each transaction on the DEX"
-        - &tx_index
-          name: tx_index
-          description: "Index of the corresponding trade event"
-        - &outer_instruction_index
-          name: outer_instruction_index
-          description: "Index of the outer instruction in the transaction"
-        - &inner_instruction_index
-          name: inner_instruction_index
-          description: "Index of the inner instruction in the transaction"
-        - &is_last_trade_in_transaction
-          name: is_last_trade_in_transaction
-          description: "Wether the trade is the last hop of the trade transaction, in case of a multi-hop trade"
+    columns:
+      - &bot
+        name: bot
+        description: "Trading bot which executed the trade"
+      - &blockchain
+        name: blockchain
+        description: "Blockchain which the DEX is deployed"
+      - &block_time
+        name: block_time
+        description: "UTC event block time of each DEX trade"
+      - &block_date
+        name: block_date
+        description: "UTC event block date of each DEX trade"
+      - &block_month
+        name: block_month
+        description: "UTC event block month of each DEX trade"
+      - &amount_usd
+        name: amount_usd
+        description: "USD value of the trade at time of execution"
+      - &type
+        name: type
+        description: "Wether the trade is a buy or sell"
+      - &token_bought_amount
+        name: token_bought_amount
+        description: "Value of the token bought at time of execution in the original currency"
+      - &token_bought_symbol
+        name: token_bought_symbol
+        description: "Token symbol for token bought in the trade"
+      - &token_bought_address
+        name: token_bought_address
+        description: "Contract address of the token bought"
+      - &token_sold_amount
+        name: token_sold_amount
+        description: "Value of the token sold at time of execution in the original currency"
+      - &token_sold_symbol
+        name: token_sold_symbol
+        description: "Token symbol for token sold in the trade"
+      - &token_sold_address
+        name: token_sold_address
+        description: "Contract address of the token sold"
+      - &fee_usd
+        name: fee_usd
+        description: "USD value of the fee at time of execution"
+      - &fee_token_amount
+        name: fee_token_amount
+        description: "Value of the fee paid at time of execution in the original currency"
+      - &fee_token_symbol
+        name: fee_token_symbol
+        description: "Token symbol for fee token"
+      - &fee_token_address
+        name: fee_token_address
+        description: "Contract address of the fee token"
+      - &project
+        name: project
+        description: "Project name of the DEX"
+      - &version
+        name: version
+        description: "Version of the contract built and deployed by the DEX project"
+      - &token_pair
+        name: token_pair
+        description: "Token symbol pair for each token involved in the trade"
+      - &project_contract_address
+        name: project_contract_address
+        description: "Project contract address which executed the trade on the blockchain"
+      - &user
+        name: user
+        description: "Address which initiated the trade"
+      - &tx_id
+        name: tx_id
+        description: "Unique transaction hash value tied to each transaction on the DEX"
+      - &tx_index
+        name: tx_index
+        description: "Index of the corresponding trade event"
+      - &outer_instruction_index
+        name: outer_instruction_index
+        description: "Index of the outer instruction in the transaction"
+      - &inner_instruction_index
+        name: inner_instruction_index
+        description: "Index of the inner instruction in the transaction"
+      - &is_last_trade_in_transaction
+        name: is_last_trade_in_transaction
+        description: "Wether the trade is the last hop of the trade transaction, in case of a multi-hop trade"
 
   - name: trojan_solana_bot_trades
     meta:
@@ -415,9 +415,10 @@ models:
       consortium_key users on Solana
     config:
       tags: ["solana", "dex", "bot_trades"]
-      columns:
-        - name: user
-          data_tests: unique
+    columns:
+      - name: user
+        data_tests:
+          - unique
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -434,9 +435,10 @@ models:
       soul_sniper users on Solana
     config:
       tags: ["solana", "dex", "bot_trades"]
-      columns:
-        - name: user
-          data_tests: unique
+    columns:
+      - name: user
+        data_tests:
+          - unique
 
   - name: tirador_solana_bot_trades
     meta:
@@ -544,9 +546,10 @@ models:
       alpha_dex users on Solana
     config:
       tags: ["solana", "dex", "bot_trades"]
-      columns:
-        - name: user
-          data_tests: unique
+    columns:
+      - name: user
+        data_tests:
+          - unique
 
   - name: jupbot_solana_bot_trades
     meta:
@@ -846,9 +849,10 @@ models:
       padre users on Solana
     config:
       tags: ["solana", "dex", "bot_trades"]
-      columns:
-        - name: user
-          data_tests: unique
+    columns:
+      - name: user
+        data_tests:
+          - unique
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:


### PR DESCRIPTION
dbt treats unrecognized keys under `config:` as custom keys and silently discards them (`CustomKeyInConfigDeprecation`, D026 — dbt Cloud has been warning about this on every run). A scan across all five subprojects found 8 real occurrences, and they weren't cosmetic: config dbt was throwing away.

Three spine models (`chain_swap_trades`, `dex_solana_bot_trades`, `dex_evm_bot_trades`) had their whole `columns:` block — including the YAML anchors the per-project sibling models alias — nested under `config:`, so none of those column descriptions ever made it into the manifest. The block moves to the model level; anchors still precede their aliases, so the siblings are untouched.

Four solana `*_bot_users` models buried a `user` column with an intended `unique` test inside `config:`. For `soul_sniper` and `alpha_dex` that was their only test, so the constraint has never run. The column is now live (and the scalar `data_tests: unique` shorthand corrected to a list, which is what dbt requires once the key is actually read). This PR's CI runs those four unique tests for the first time — if one fails, the data violates a constraint its author intended, which is worth knowing.

`ajna_erc20_pools` used singular `tag:`, so its four tags were never applied; renamed to `tags:`. None of them is used by any prod/CI selector (those only use `prod_exclude`, `remove`, `static`), so the only effect is a one-time `state:modified` flag.
