### PR TITLE
bump dbt-utils to 1.4.1 across all subprojects

### DIFF
--- a/dbt_subprojects/daily_spellbook/package-lock.yml
+++ b/dbt_subprojects/daily_spellbook/package-lock.yml
@@ -1,4 +1,5 @@
 packages:
-  - package: dbt-labs/dbt_utils
-    version: 1.3.0
-sha1_hash: 226ae69cdfbc9367e2aa2c472b01f99dbce11de0
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.4.1
+sha1_hash: 8b27037b26f3f630c6661194d2470e720c49f6ee

--- a/dbt_subprojects/daily_spellbook/packages.yml
+++ b/dbt_subprojects/daily_spellbook/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 1.3.0
+    version: 1.4.1

--- a/dbt_subprojects/dex/package-lock.yml
+++ b/dbt_subprojects/dex/package-lock.yml
@@ -1,4 +1,5 @@
 packages:
-- package: dbt-labs/dbt_utils
-  version: 1.3.0
-sha1_hash: 226ae69cdfbc9367e2aa2c472b01f99dbce11de0
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.4.1
+sha1_hash: 8b27037b26f3f630c6661194d2470e720c49f6ee

--- a/dbt_subprojects/dex/packages.yml
+++ b/dbt_subprojects/dex/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 1.3.0
+    version: 1.4.1

--- a/dbt_subprojects/hourly_spellbook/package-lock.yml
+++ b/dbt_subprojects/hourly_spellbook/package-lock.yml
@@ -1,4 +1,5 @@
 packages:
-  - package: dbt-labs/dbt_utils
-    version: 1.3.0
-sha1_hash: 226ae69cdfbc9367e2aa2c472b01f99dbce11de0
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.4.1
+sha1_hash: 8b27037b26f3f630c6661194d2470e720c49f6ee

--- a/dbt_subprojects/hourly_spellbook/packages.yml
+++ b/dbt_subprojects/hourly_spellbook/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 1.3.0
+    version: 1.4.1

--- a/dbt_subprojects/solana/package-lock.yml
+++ b/dbt_subprojects/solana/package-lock.yml
@@ -1,4 +1,5 @@
 packages:
-  - package: dbt-labs/dbt_utils
-    version: 1.3.0
-sha1_hash: 226ae69cdfbc9367e2aa2c472b01f99dbce11de0
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.4.1
+sha1_hash: 8b27037b26f3f630c6661194d2470e720c49f6ee

--- a/dbt_subprojects/solana/packages.yml
+++ b/dbt_subprojects/solana/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 1.3.0
+    version: 1.4.1

--- a/dbt_subprojects/tokens/package-lock.yml
+++ b/dbt_subprojects/tokens/package-lock.yml
@@ -1,8 +1,11 @@
 packages:
-  - package: dbt-labs/dbt_utils
-    version: 1.3.0
-  - package: dbt-labs/codegen
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.4.1
+  - name: codegen
+    package: dbt-labs/codegen
     version: 0.12.1
-  - package: starburstdata/trino_utils
+  - name: trino_utils
+    package: starburstdata/trino_utils
     version: 0.6.0
-sha1_hash: 9b90e2caa8f0dbe973100903ae2391c36d0de2de
+sha1_hash: 7568afb9f11fe17f524fb57c54df76f926697c46

--- a/dbt_subprojects/tokens/packages.yml
+++ b/dbt_subprojects/tokens/packages.yml
@@ -1,6 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 1.3.0
+    version: 1.4.1
   - package: dbt-labs/codegen
     version: 0.12.1
   - package: starburstdata/trino_utils


### PR DESCRIPTION
dbt-utils has been pinned at 1.3.0 in all five subprojects since Aug 2024. This bumps it to 1.4.1 (latest, 2026-06-28) and regenerates the five checked-in lock files.

Low-risk by inspection of the upstream diff: only six macro files changed between 1.3.0 and 1.4.1 (recency, unique_combination_of_columns, date_spine, get_filtered_columns_in_relation, star, union). `generate_surrogate_key` — the only changed-macro candidate used inside model bodies here (121 call sites) — is untouched, so no `state:modified` rebuild wave. The changed macros we use are generic tests, which get a one-time modified flag.

What it buys: dbt 2.x forward-compatibility (1.3.0's `require-dbt-version` refuses dbt 2.x; 1.3.2 widened it to `<3.0.0`) and a Fusion Jinja fix in `unique_combination_of_columns`, our most-used macro (4700+ uses). No model code changes needed.

tokens' codegen and trino_utils pins are deliberately untouched.
