### PR TITLE
fix(oneinch): drop merge target predicate that duplicated cross-chain executions

### DIFF
--- a/dbt_subprojects/dex/models/_projects/oneinch/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/oneinch/_schema.yml
@@ -204,6 +204,88 @@ models:
       - name: native_price
       - name: native_decimals
 
+  - name: oneinch_cc_executions
+    meta:
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr']
+    config:
+      tags: ['oneinch', 'cc', 'executions']
+    description: >
+        1inch cross-chain executions: one row per source-chain escrow creation, enriched with
+        every action of the trade collected across chains by order hash and hashlock
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - block_month
+              - tx_hash
+              - call_trace_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: chain_id
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: tx_success
+      - name: tx_from
+      - name: tx_to
+      - name: tx_nonce
+      - name: tx_gas_used
+      - name: tx_gas_price
+      - name: tx_priority_fee_per_gas
+      - name: tx_index
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_success
+      - name: call_gas_used
+      - name: call_selector
+      - name: call_method
+      - name: call_from
+      - name: call_to
+      - name: call_output
+      - name: call_error
+      - name: call_type
+      - name: protocol
+      - name: protocol_version
+      - name: contract_name
+      - name: amount_usd
+      - name: execution_cost
+      - name: user
+      - name: receiver
+      - name: src_token_address
+      - name: src_token_amount
+      - name: src_executed_address
+      - name: src_executed_symbol
+      - name: src_executed_amount
+      - name: src_executed_amount_usd
+      - name: dst_blockchain
+      - name: dst_token_address
+      - name: dst_token_amount
+      - name: dst_executed_address
+      - name: dst_executed_symbol
+      - name: dst_executed_amount
+      - name: dst_executed_amount_usd
+      - name: order_hash
+      - name: hashlock
+      - name: actions
+      - name: complement
+      - name: remains
+      - name: flags
+      - name: minute
+      - name: block_date
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: native_price
+      - name: native_decimals
+
   - name: oneinch_evms_transfers
     meta:
       blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']

--- a/dbt_subprojects/dex/models/_projects/oneinch/streams/oneinch_cc_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/streams/oneinch_cc_executions.sql
@@ -1,5 +1,9 @@
 {%- set stream = oneinch_cc_executions_cfg_macro() -%}
 
+-- No incremental_predicate on the merge target: the source below re-emits a trade's full history
+-- by hashlock, so a time-bounded target leaves the older rows of a late-settled trade unmatchable
+-- and the merge inserts duplicates of them instead of updating them.
+
 {{-
     config(
         schema = 'oneinch',
@@ -7,7 +11,6 @@
         materialized = 'incremental',
         file_format = 'delta',
         incremental_strategy = 'merge',
-        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
         partition_by = ['blockchain', 'block_month'],
         unique_key = ['blockchain', 'block_month', 'tx_hash', 'call_trace_address'],
     )


### PR DESCRIPTION
## What & why
`oneinch.cc_executions` has been appending duplicate copies of cross-chain trades instead of
updating them — 944 surplus rows across 35 trades since April 2025. The merge target was
time-bounded while the source deliberately re-emits a trade's full history, so rows older than
the window could not be matched and got inserted again on every run.
No schema or column changes; a full refresh on merge drops the existing duplicates.

## Architecture
- `streams/oneinch_cc_executions.sql` — removed `incremental_predicates`, so the merge matches on the unique key across the whole target. Business-critical: this table feeds `oneinch.swaps` → `dex_aggregator.trades` → `dex.trades`. Also restores the late-settlement update the hashlock re-emission was written for, which had silently degraded into inserts.
- `_schema.yml` — registers the model (it had no entry at all) with `unique_combination_of_columns` on its exact unique key plus `not_null` on all four key columns.
- Tested: source query validated against prod — 233,965 rows with 0 duplicate merge keys, and 234,909 − 944 = 233,965 exactly, so a full refresh comes back clean and the new test passes. `dbt parse` and `dbt compile` clean.
- Not tested: the incremental merge path itself. CI builds full-refresh, so update-in-place lands unverified until the first prod incremental run.
- Needs human eyes: `--full-refresh` on `oneinch_cc_executions` at deploy, otherwise the 944 rows persist. Separately, `oneinch_swaps` still filters its cc source by `block_time`, so late-settled trade corrections will not propagate into `oneinch.swaps` — pre-existing, deliberately not addressed here.
- Blast radius: unbounded target scan replaces a partition-pruned one on a 234,909-row table spanning 25 months and 12 chains — negligible. No external consumers outside the dex lineage (checked `oneinch_cc_executions+`).

<details><summary>Agent context</summary>

No agent review yet.

Failure that surfaced this: Prefect run `a187210d-d07e-4f2a-b699-974ee360532b`, `oneinch_swaps` aborted with `MERGE_TARGET_ROW_MULTIPLE_MATCHES` (Trino `20260811_225918_62929_cp2xt`) after a manual 7-day-lookback run.

Mechanism: any trade whose legs straddle a UTC day boundary spends one full day with its
`src_creation` row aged out of the target window while its hashlock is still inside the source
window, collecting one duplicate per hourly run (~25). Observed copy counts 24–31, and one 91 for
a trade cancelled ~3 days later. The window size only decided visibility: duplicates are by
construction older than the window, and `oneinch_swaps` filters its source with the same window,
so at the default 3 days it never saw them.

Repro / validation:
- Duplicates: `select blockchain, block_month, tx_hash, call_trace_address, count(*) from oneinch.cc_executions group by 1,2,3,4 having count(*) > 1`
- Source uniqueness: union the 12 per-chain `oneinch_<chain>.cc_executions` on `flow = 'src_creation'`, group by the unique key — 0 duplicate keys.
- Per-chain sources are clean; the macro filters on `block_time` only, so no change needed there.
</details>