### PR TITLE
fix(oneinch): remove comment that broke oneinch_cc_executions compilation

### DIFF
--- a/dbt_subprojects/dex/models/_projects/oneinch/streams/oneinch_cc_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/streams/oneinch_cc_executions.sql
@@ -1,9 +1,5 @@
 {%- set stream = oneinch_cc_executions_cfg_macro() -%}
 
--- No incremental_predicate on the merge target: the source below re-emits a trade's full history
--- by hashlock, so a time-bounded target leaves the older rows of a late-settled trade unmatchable
--- and the merge inserts duplicates of them instead of updating them.
-
 {{-
     config(
         schema = 'oneinch',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

`oneinch_cc_executions` started failing in production with:

```
SYNTAX_ERROR — line 13:1: mismatched input 'incremental'. Expecting: 'WITH', <query>
```

The explanatory `--` comment added in #9928 sits between whitespace-trimming Jinja tags (`{{- config(...) -}}` and `{%- set date_from ... -%}`). Those tags strip the newlines around them, so the compiled SQL collapsed `with` onto the end of the last comment line, leaving the query body to start at `incremental as (`.

This removes the comment, restoring the file to its previously compiling layout. The config change from #9928 (dropping `incremental_predicates` from the merge target) is untouched.

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duneanalytics.slack.com/archives/C0B3X5RNDCJ/p1786544887125889?thread_ts=1786544887.125889&cid=C0B3X5RNDCJ)

<div><a href="https://cursor.com/agents/bc-676ae62f-e9e1-5370-a588-020357771413?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-676ae62f-e9e1-5370-a588-020357771413&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

