### PR TITLE
Incrementally rebuild THORChain daily TVL

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/thorchain/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/_schema.yml
@@ -179,6 +179,25 @@ models:
               - _unique_key
 
   - name: thorchain_silver_total_value_locked
+    description: "Daily THORChain pooled, bonded, and combined total value locked amounts denominated in RUNE."
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - day
+    columns:
+      - name: day
+        description: "UTC calendar day for the total value locked snapshot."
+        data_tests:
+          - not_null
+      - name: total_value_pooled
+        description: "Total RUNE value pooled across THORChain liquidity pools at the end of the day."
+      - name: total_value_bonded
+        description: "Cumulative total RUNE bonded by THORChain nodes through the day."
+      - name: total_value_locked
+        description: "Combined total RUNE value pooled and bonded through the day."
+      - name: _inserted_timestamp
+        description: "Latest ingestion timestamp among bond events included for the day."
 
   - name: thorchain_silver_transfer_events
 

--- a/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_total_value_locked.sql
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_total_value_locked.sql
@@ -1,13 +1,28 @@
 {{ config(
     schema = 'thorchain_silver',
     alias = 'total_value_locked',
-    materialized = 'table',
+    materialized = 'incremental',
     file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['day'],
     partition_by = ['day'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
     tags = ['thorchain', 'total_value_locked', 'silver']
 ) }}
 
-WITH bond_type_day AS (
+-- ci-stamp: 1
+
+WITH prior_total_value_bonded AS (
+    {% if is_incremental() -%}
+    SELECT
+        COALESCE(MAX_BY(total_value_bonded, day), 0) AS total_value_bonded
+    FROM {{ this }}
+    WHERE NOT {{ incremental_predicate('day') }}
+    {% else -%}
+    SELECT 0 AS total_value_bonded
+    {% endif -%}
+),
+bond_type_day AS (
     SELECT
         cast(date_trunc('day', b.block_timestamp) AS date) AS day,
         bond_type,
@@ -17,6 +32,17 @@ WITH bond_type_day AS (
         {{ ref('thorchain_silver_bond_events') }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
+    {% if is_incremental() -%}
+        AND a.block_timestamp >= cast(
+            to_unixtime(
+                date_trunc(
+                    '{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}',
+                    now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}
+                )
+            ) * 1e9 AS bigint
+        )
+        AND {{ incremental_predicate('b.block_date') }}
+    {% endif -%}
     GROUP BY
         cast(date_trunc('day', b.block_timestamp) AS date),
         bond_type
@@ -69,6 +95,17 @@ total_pool_depth AS (
         {{ ref('thorchain_silver_block_pool_depths') }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
+    {% if is_incremental() -%}
+        AND a.block_timestamp >= cast(
+            to_unixtime(
+                date_trunc(
+                    '{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}',
+                    now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}
+                )
+            ) * 1e9 AS bigint
+        )
+        AND {{ incremental_predicate('b.block_date') }}
+    {% endif -%}
     WHERE LOWER(pool_name) NOT LIKE 'thor.%'
 ),
 total_pool_depth_max AS (
@@ -104,19 +141,20 @@ SELECT
         total_value_pooled,
         0
     ) AS total_value_pooled,
-    COALESCE(SUM(total_value_bonded) over (ORDER BY COALESCE(total_value_bonded_tbl.day, total_value_pooled_tbl.day) ASC), 0) AS total_value_bonded,
+    prior_total_value_bonded.total_value_bonded
+        + SUM(COALESCE(total_value_bonded_tbl.total_value_bonded, 0)) over (
+            ORDER BY COALESCE(total_value_bonded_tbl.day, total_value_pooled_tbl.day) ASC
+        ) AS total_value_bonded,
     COALESCE(
         total_value_pooled,
         0
-    ) + SUM(COALESCE(total_value_bonded, 0)) over (
-        ORDER BY
-            COALESCE(
-            total_value_bonded_tbl.day,
-            total_value_pooled_tbl.day
-            ) ASC
-    ) AS total_value_locked,
+    ) + prior_total_value_bonded.total_value_bonded
+        + SUM(COALESCE(total_value_bonded_tbl.total_value_bonded, 0)) over (
+            ORDER BY COALESCE(total_value_bonded_tbl.day, total_value_pooled_tbl.day) ASC
+        ) AS total_value_locked,
     total_value_bonded_tbl._inserted_timestamp
 FROM
   total_value_bonded_tbl full
 JOIN total_value_pooled_tbl
   ON total_value_bonded_tbl.day = total_value_pooled_tbl.day
+CROSS JOIN prior_total_value_bonded

--- a/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_total_value_locked.sql
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_total_value_locked.sql
@@ -6,18 +6,41 @@
     incremental_strategy = 'merge',
     unique_key = ['day'],
     partition_by = ['day'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
     tags = ['thorchain', 'total_value_locked', 'silver']
 ) }}
 
 -- ci-stamp: 1
 
-WITH prior_total_value_bonded AS (
+WITH
+{% if is_incremental() -%}
+incremental_rebuild_bounds AS (
+    SELECT
+        MIN(day) AS rebuild_start,
+        cast(to_unixtime(cast(MIN(day) AS timestamp)) * 1e9 AS bigint) AS rebuild_start_timestamp
+    FROM (
+        SELECT cast(
+            date_trunc(
+                '{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}',
+                now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}
+            ) AS date
+        ) AS day
+        UNION ALL
+        SELECT cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date) AS day
+        FROM {{ ref('thorchain_silver_bond_events') }}
+        WHERE {{ incremental_predicate('_inserted_timestamp') }}
+        UNION ALL
+        SELECT cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date) AS day
+        FROM {{ ref('thorchain_silver_block_pool_depths') }}
+        WHERE {{ incremental_predicate('_inserted_timestamp') }}
+    )
+),
+{% endif -%}
+prior_total_value_bonded AS (
     {% if is_incremental() -%}
     SELECT
         COALESCE(MAX_BY(total_value_bonded, day), 0) AS total_value_bonded
     FROM {{ this }}
-    WHERE NOT {{ incremental_predicate('day') }}
+    WHERE day < (SELECT rebuild_start FROM incremental_rebuild_bounds)
     {% else -%}
     SELECT 0 AS total_value_bonded
     {% endif -%}
@@ -33,15 +56,8 @@ bond_type_day AS (
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
     {% if is_incremental() -%}
-        AND a.block_timestamp >= cast(
-            to_unixtime(
-                date_trunc(
-                    '{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}',
-                    now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}
-                )
-            ) * 1e9 AS bigint
-        )
-        AND {{ incremental_predicate('b.block_date') }}
+        AND a.block_timestamp >= (SELECT rebuild_start_timestamp FROM incremental_rebuild_bounds)
+        AND b.block_date >= (SELECT rebuild_start FROM incremental_rebuild_bounds)
     {% endif -%}
     GROUP BY
         cast(date_trunc('day', b.block_timestamp) AS date),
@@ -96,15 +112,8 @@ total_pool_depth AS (
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
     {% if is_incremental() -%}
-        AND a.block_timestamp >= cast(
-            to_unixtime(
-                date_trunc(
-                    '{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}',
-                    now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}
-                )
-            ) * 1e9 AS bigint
-        )
-        AND {{ incremental_predicate('b.block_date') }}
+        AND a.block_timestamp >= (SELECT rebuild_start_timestamp FROM incremental_rebuild_bounds)
+        AND b.block_date >= (SELECT rebuild_start FROM incremental_rebuild_bounds)
     {% endif -%}
     WHERE LOWER(pool_name) NOT LIKE 'thor.%'
 ),


### PR DESCRIPTION
## What & why
Rebuild THORChain daily TVL incrementally instead of replacing the full table on every run.
Seed each rolling rebuild with the prior bonded value, then merge recomputed days by `day`.
Add uniqueness and non-null coverage for the daily key.
- No visual surface (dbt model only)

## Architecture
- `dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_total_value_locked.sql`: business-critical TVL calculation now uses a rolling incremental merge while preserving cumulative bonded value across the rebuild boundary.
- +1 file: schema documentation and structural dbt tests for `day`.
- Tested: standard compile, forced-incremental compile, structural dbt tests, and a Dune settled-window comparison with zero diff. Production has 1,928 unique, non-null days.
- Not tested: local `dbt test` execution was blocked because `trino:1234` was unavailable.
- Needs human eyes: first production incremental run across the rolling-window boundary.
- Cross-system blast radius: downstream consumers of `thorchain_silver.total_value_locked`; incorrect boundary seeding would shift bonded and total TVL values in rebuilt days.

<details><summary>Agent context</summary>

- No agent review yet.
- Verification completed: standard compile, forced-incremental compile, structural dbt tests, Dune settled-window zero diff, and production key validation across 1,928 days.
- Local `dbt test` could not execute because the configured Trino endpoint `trino:1234` was unavailable.
</details>

Towards CUR2-3651