### PR TITLE
perf(thorchain): incrementally rebuild block rewards

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/thorchain/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/_schema.yml
@@ -8,6 +8,31 @@ models:
   - name: thorchain_silver_block_pool_depths
 
   - name: thorchain_silver_block_rewards
+    description: "Daily THORChain rewards, earnings, liquidity fees, and average active node count."
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - day
+    columns:
+      - name: day
+        description: "UTC calendar day for the reward totals."
+        data_tests:
+          - not_null
+      - name: liquidity_fee
+        description: "Total liquidity fees denominated in RUNE."
+      - name: block_rewards
+        description: "Total pool and bond rewards denominated in RUNE."
+      - name: earnings
+        description: "Total rewards and liquidity fees denominated in RUNE."
+      - name: bonding_earnings
+        description: "Total bond rewards denominated in RUNE."
+      - name: liquidity_earnings
+        description: "Total pool rewards and liquidity fees denominated in RUNE."
+      - name: avg_node_count
+        description: "Average active node count during the day."
+      - name: _inserted_timestamp
+        description: "Latest source ingestion timestamp represented by the day."
 
   - name: thorchain_silver_bond_events
 

--- a/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_block_rewards.sql
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_block_rewards.sql
@@ -1,17 +1,25 @@
 {{ config(
     schema = 'thorchain_silver',
     alias = 'block_rewards',
-    materialized = 'table',
+    materialized = 'incremental',
     file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['day'],
     partition_by = ['day'],
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
     tags = ['thorchain', 'block_rewards', 'silver']
 ) }}
+
+-- ci-stamp: 1
 
 WITH all_block_id AS (
     SELECT
         block_timestamp,
         MAX(_inserted_timestamp) AS _inserted_timestamp
     FROM {{ ref('thorchain_silver_block_pool_depths') }}
+    {% if is_incremental() -%}
+    WHERE {{ incremental_predicate('cast(from_unixtime(cast(block_timestamp / 1e9 as bigint)) as timestamp)') }}
+    {% endif -%}
     GROUP BY block_timestamp
 )
 , avg_nodes_tbl AS (
@@ -25,19 +33,49 @@ WITH all_block_id AS (
             END
         ) AS delta
     FROM {{ ref('thorchain_silver_update_node_account_status_events') }}
+    {% if is_incremental() -%}
+    WHERE {{ incremental_predicate('cast(from_unixtime(cast(block_timestamp / 1e9 as bigint)) as timestamp)') }}
+    {% endif -%}
     GROUP BY block_timestamp
+)
+, historical_node_count AS (
+    SELECT
+        {% if is_incremental() -%}
+        -- Full history includes the two initial nodes added explicitly by the legacy full-build path.
+        COALESCE(
+            SUM(
+                CASE
+                    WHEN current_status = 'Active' THEN 1
+                    WHEN former_status = 'Active' THEN -1
+                    ELSE 0
+                END
+            ),
+            0
+        ) AS active_nodes
+        FROM {{ ref('thorchain_silver_update_node_account_status_events') }}
+        WHERE NOT {{ incremental_predicate('cast(from_unixtime(cast(block_timestamp / 1e9 as bigint)) as timestamp)') }}
+        {% else -%}
+        0 AS active_nodes
+        {% endif -%}
 )
 , all_block_with_nodes AS (
     SELECT
         abi.block_timestamp,
         ant.delta,
+        {% if is_incremental() -%}
+        hnc.active_nodes + COALESCE(SUM(ant.delta) OVER (
+            ORDER BY abi.block_timestamp ASC
+        ), 0) AS avg_nodes,
+        {% else -%}
         SUM(ant.delta) OVER (
             ORDER BY abi.block_timestamp ASC
         ) AS avg_nodes,
+        {% endif -%}
         abi._inserted_timestamp
     FROM all_block_id as abi
     LEFT JOIN avg_nodes_tbl as ant
         ON abi.block_timestamp = ant.block_timestamp
+    CROSS JOIN historical_node_count as hnc
 )
 , all_block_with_nodes_date AS (
     SELECT
@@ -47,6 +85,9 @@ WITH all_block_id AS (
     FROM all_block_with_nodes as abwn
     JOIN {{ ref('thorchain_silver_block_log') }} as b
         ON abwn.block_timestamp = b.timestamp
+    {% if is_incremental() -%}
+    WHERE {{ incremental_predicate('b.block_timestamp') }}
+    {% endif -%}
     GROUP BY cast(date_trunc('day', b.block_timestamp) AS date)
 )
 , liquidity_fee_tbl AS (
@@ -56,6 +97,10 @@ WITH all_block_id AS (
     FROM {{ ref('thorchain_silver_swap_events') }} as a
     JOIN {{ ref('thorchain_silver_block_log') }} as b
         ON a.block_timestamp = b.timestamp
+    {% if is_incremental() -%}
+        AND {{ incremental_predicate('b.block_timestamp') }}
+    WHERE {{ incremental_predicate('cast(from_unixtime(cast(a.block_timestamp / 1e9 as bigint)) as timestamp)') }}
+    {% endif -%}
     GROUP BY cast(date_trunc('day', b.block_timestamp) AS date)
 )
 , bond_earnings_tbl AS (
@@ -66,6 +111,10 @@ WITH all_block_id AS (
         {{ ref('thorchain_silver_rewards_events') }} as a
         JOIN {{ ref('thorchain_silver_block_log') }} as b
         ON a.block_timestamp = b.timestamp
+        {% if is_incremental() -%}
+            AND {{ incremental_predicate('b.block_timestamp') }}
+        WHERE {{ incremental_predicate('cast(from_unixtime(cast(a.block_timestamp / 1e9 as bigint)) as timestamp)') }}
+        {% endif -%}
     GROUP BY
         cast(date_trunc('day', b.block_timestamp) AS date)
 )
@@ -77,6 +126,10 @@ WITH all_block_id AS (
         {{ ref('thorchain_silver_rewards_event_entries') }} as a
         JOIN {{ ref('thorchain_silver_block_log') }} as b
         ON a.block_timestamp = b.timestamp
+        {% if is_incremental() -%}
+            AND {{ incremental_predicate('b.block_timestamp') }}
+        WHERE {{ incremental_predicate('cast(from_unixtime(cast(a.block_timestamp / 1e9 as bigint)) as timestamp)') }}
+        {% endif -%}
     GROUP BY
         cast(date_trunc('day', b.block_timestamp) AS date)
 )
@@ -129,7 +182,11 @@ SELECT
         10,
         8
     ) AS liquidity_earnings,
+    {% if is_incremental() -%}
+    all_block_with_nodes_date.avg_nodes AS avg_node_count,
+    {% else -%}
     all_block_with_nodes_date.avg_nodes + 2 AS avg_node_count,
+    {% endif -%}
     all_block_with_nodes_date._inserted_timestamp
 FROM
     all_block_with_nodes_date

--- a/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_block_rewards.sql
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_block_rewards.sql
@@ -11,60 +11,73 @@
 
 -- ci-stamp: 2
 
-WITH
 {% if is_incremental() -%}
-rolling_floor AS (
-    SELECT cast(
-        date_trunc(
-            '{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}',
-            now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}
-        ) AS date
-    ) AS day
-)
-, newly_ingested_event_days AS (
-    SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
-    FROM {{ ref('thorchain_silver_block_pool_depths') }}
-    WHERE {{ incremental_predicate('_inserted_timestamp') }}
+    {%- set rolling_floor = "cast(date_trunc('" ~ var("DBT_ENV_INCREMENTAL_TIME_UNIT") ~ "', now() - interval '" ~ var("DBT_ENV_INCREMENTAL_TIME") ~ "' " ~ var("DBT_ENV_INCREMENTAL_TIME_UNIT") ~ ") AS date)" -%}
+    {%- set rebuild_start = rolling_floor -%}
+    {%- set rebuild_start_query -%}
+        WITH newly_ingested_event_days AS (
+            SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
+            FROM {{ ref('thorchain_silver_block_pool_depths') }}
+            WHERE {{ incremental_predicate('_inserted_timestamp') }}
 
-    UNION ALL
+            UNION ALL
 
-    SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
-    FROM {{ ref('thorchain_silver_update_node_account_status_events') }}
-    WHERE {{ incremental_predicate('_inserted_timestamp') }}
+            SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
+            FROM {{ ref('thorchain_silver_update_node_account_status_events') }}
+            WHERE {{ incremental_predicate('_inserted_timestamp') }}
 
-    UNION ALL
+            UNION ALL
 
-    SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
-    FROM {{ ref('thorchain_silver_swap_events') }}
-    WHERE {{ incremental_predicate('_inserted_timestamp') }}
+            SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
+            FROM {{ ref('thorchain_silver_swap_events') }}
+            WHERE {{ incremental_predicate('_inserted_timestamp') }}
 
-    UNION ALL
+            UNION ALL
 
-    SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
-    FROM {{ ref('thorchain_silver_rewards_events') }}
-    WHERE {{ incremental_predicate('_inserted_timestamp') }}
+            SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
+            FROM {{ ref('thorchain_silver_rewards_events') }}
+            WHERE {{ incremental_predicate('_inserted_timestamp') }}
 
-    UNION ALL
+            UNION ALL
 
-    SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
-    FROM {{ ref('thorchain_silver_rewards_event_entries') }}
-    WHERE {{ incremental_predicate('_inserted_timestamp') }}
-)
-, rebuild_start AS (
-    SELECT LEAST(rf.day, COALESCE(MIN(nied.day), rf.day)) AS day
-    FROM rolling_floor AS rf
-    CROSS JOIN newly_ingested_event_days AS nied
-    GROUP BY rf.day
-)
-,
+            SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
+            FROM {{ ref('thorchain_silver_rewards_event_entries') }}
+            WHERE {{ incremental_predicate('_inserted_timestamp') }}
+        )
+        SELECT LEAST(
+            cast(
+                date_trunc(
+                    '{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}',
+                    now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}
+                ) AS date
+            ),
+            COALESCE(
+                MIN(day),
+                cast(
+                    date_trunc(
+                        '{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}',
+                        now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}
+                    ) AS date
+                )
+            )
+        ) AS day
+        FROM newly_ingested_event_days
+    {%- endset -%}
+    {%- if execute and not var('force-incremental', False) -%}
+        {%- set rebuild_start_result = run_query(rebuild_start_query) -%}
+        {%- if rebuild_start_result is not none -%}
+            {%- set rebuild_start = "DATE '" ~ rebuild_start_result.columns[0].values()[0] ~ "'" -%}
+        {%- endif -%}
+    {%- endif -%}
 {% endif -%}
+WITH
 all_block_id AS (
     SELECT
         block_timestamp,
         MAX(_inserted_timestamp) AS _inserted_timestamp
     FROM {{ ref('thorchain_silver_block_pool_depths') }}
     {% if is_incremental() -%}
-    WHERE cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date) >= (SELECT day FROM rebuild_start)
+    WHERE cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date) >= {{ rebuild_start }}
     {% endif -%}
     GROUP BY block_timestamp
 )
@@ -80,7 +93,7 @@ all_block_id AS (
         ) AS delta
     FROM {{ ref('thorchain_silver_update_node_account_status_events') }}
     {% if is_incremental() -%}
-    WHERE cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date) >= (SELECT day FROM rebuild_start)
+    WHERE cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date) >= {{ rebuild_start }}
     {% endif -%}
     GROUP BY block_timestamp
 )
@@ -99,7 +112,7 @@ all_block_id AS (
             0
         ) AS active_nodes
         FROM {{ ref('thorchain_silver_update_node_account_status_events') }}
-        WHERE cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date) < (SELECT day FROM rebuild_start)
+        WHERE cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date) < {{ rebuild_start }}
         {% else -%}
         0 AS active_nodes
         {% endif -%}
@@ -132,7 +145,7 @@ all_block_id AS (
     JOIN {{ ref('thorchain_silver_block_log') }} as b
         ON abwn.block_timestamp = b.timestamp
     {% if is_incremental() -%}
-    WHERE b.block_date >= (SELECT day FROM rebuild_start)
+    WHERE b.block_date >= {{ rebuild_start }}
     {% endif -%}
     GROUP BY cast(date_trunc('day', b.block_timestamp) AS date)
 )
@@ -144,8 +157,8 @@ all_block_id AS (
     JOIN {{ ref('thorchain_silver_block_log') }} as b
         ON a.block_timestamp = b.timestamp
     {% if is_incremental() -%}
-        AND b.block_date >= (SELECT day FROM rebuild_start)
-    WHERE cast(from_unixtime(cast(a.block_timestamp / 1e9 AS bigint)) AS date) >= (SELECT day FROM rebuild_start)
+        AND b.block_date >= {{ rebuild_start }}
+    WHERE cast(from_unixtime(cast(a.block_timestamp / 1e9 AS bigint)) AS date) >= {{ rebuild_start }}
     {% endif -%}
     GROUP BY cast(date_trunc('day', b.block_timestamp) AS date)
 )
@@ -158,8 +171,8 @@ all_block_id AS (
         JOIN {{ ref('thorchain_silver_block_log') }} as b
         ON a.block_timestamp = b.timestamp
         {% if is_incremental() -%}
-            AND b.block_date >= (SELECT day FROM rebuild_start)
-        WHERE cast(from_unixtime(cast(a.block_timestamp / 1e9 AS bigint)) AS date) >= (SELECT day FROM rebuild_start)
+            AND b.block_date >= {{ rebuild_start }}
+        WHERE cast(from_unixtime(cast(a.block_timestamp / 1e9 AS bigint)) AS date) >= {{ rebuild_start }}
         {% endif -%}
     GROUP BY
         cast(date_trunc('day', b.block_timestamp) AS date)
@@ -173,8 +186,8 @@ all_block_id AS (
         JOIN {{ ref('thorchain_silver_block_log') }} as b
         ON a.block_timestamp = b.timestamp
         {% if is_incremental() -%}
-            AND b.block_date >= (SELECT day FROM rebuild_start)
-        WHERE cast(from_unixtime(cast(a.block_timestamp / 1e9 AS bigint)) AS date) >= (SELECT day FROM rebuild_start)
+            AND b.block_date >= {{ rebuild_start }}
+        WHERE cast(from_unixtime(cast(a.block_timestamp / 1e9 AS bigint)) AS date) >= {{ rebuild_start }}
         {% endif -%}
     GROUP BY
         cast(date_trunc('day', b.block_timestamp) AS date)

--- a/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_block_rewards.sql
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_block_rewards.sql
@@ -6,19 +6,65 @@
     incremental_strategy = 'merge',
     unique_key = ['day'],
     partition_by = ['day'],
-    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.day')],
     tags = ['thorchain', 'block_rewards', 'silver']
 ) }}
 
--- ci-stamp: 1
+-- ci-stamp: 2
 
-WITH all_block_id AS (
+WITH
+{% if is_incremental() -%}
+rolling_floor AS (
+    SELECT cast(
+        date_trunc(
+            '{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}',
+            now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}
+        ) AS date
+    ) AS day
+)
+, newly_ingested_event_days AS (
+    SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
+    FROM {{ ref('thorchain_silver_block_pool_depths') }}
+    WHERE {{ incremental_predicate('_inserted_timestamp') }}
+
+    UNION ALL
+
+    SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
+    FROM {{ ref('thorchain_silver_update_node_account_status_events') }}
+    WHERE {{ incremental_predicate('_inserted_timestamp') }}
+
+    UNION ALL
+
+    SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
+    FROM {{ ref('thorchain_silver_swap_events') }}
+    WHERE {{ incremental_predicate('_inserted_timestamp') }}
+
+    UNION ALL
+
+    SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
+    FROM {{ ref('thorchain_silver_rewards_events') }}
+    WHERE {{ incremental_predicate('_inserted_timestamp') }}
+
+    UNION ALL
+
+    SELECT MIN(cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date)) AS day
+    FROM {{ ref('thorchain_silver_rewards_event_entries') }}
+    WHERE {{ incremental_predicate('_inserted_timestamp') }}
+)
+, rebuild_start AS (
+    SELECT LEAST(rf.day, COALESCE(MIN(nied.day), rf.day)) AS day
+    FROM rolling_floor AS rf
+    CROSS JOIN newly_ingested_event_days AS nied
+    GROUP BY rf.day
+)
+,
+{% endif -%}
+all_block_id AS (
     SELECT
         block_timestamp,
         MAX(_inserted_timestamp) AS _inserted_timestamp
     FROM {{ ref('thorchain_silver_block_pool_depths') }}
     {% if is_incremental() -%}
-    WHERE {{ incremental_predicate('cast(from_unixtime(cast(block_timestamp / 1e9 as bigint)) as timestamp)') }}
+    WHERE cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date) >= (SELECT day FROM rebuild_start)
     {% endif -%}
     GROUP BY block_timestamp
 )
@@ -34,7 +80,7 @@ WITH all_block_id AS (
         ) AS delta
     FROM {{ ref('thorchain_silver_update_node_account_status_events') }}
     {% if is_incremental() -%}
-    WHERE {{ incremental_predicate('cast(from_unixtime(cast(block_timestamp / 1e9 as bigint)) as timestamp)') }}
+    WHERE cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date) >= (SELECT day FROM rebuild_start)
     {% endif -%}
     GROUP BY block_timestamp
 )
@@ -53,7 +99,7 @@ WITH all_block_id AS (
             0
         ) AS active_nodes
         FROM {{ ref('thorchain_silver_update_node_account_status_events') }}
-        WHERE NOT {{ incremental_predicate('cast(from_unixtime(cast(block_timestamp / 1e9 as bigint)) as timestamp)') }}
+        WHERE cast(from_unixtime(cast(block_timestamp / 1e9 AS bigint)) AS date) < (SELECT day FROM rebuild_start)
         {% else -%}
         0 AS active_nodes
         {% endif -%}
@@ -86,7 +132,7 @@ WITH all_block_id AS (
     JOIN {{ ref('thorchain_silver_block_log') }} as b
         ON abwn.block_timestamp = b.timestamp
     {% if is_incremental() -%}
-    WHERE {{ incremental_predicate('b.block_timestamp') }}
+    WHERE b.block_date >= (SELECT day FROM rebuild_start)
     {% endif -%}
     GROUP BY cast(date_trunc('day', b.block_timestamp) AS date)
 )
@@ -98,8 +144,8 @@ WITH all_block_id AS (
     JOIN {{ ref('thorchain_silver_block_log') }} as b
         ON a.block_timestamp = b.timestamp
     {% if is_incremental() -%}
-        AND {{ incremental_predicate('b.block_timestamp') }}
-    WHERE {{ incremental_predicate('cast(from_unixtime(cast(a.block_timestamp / 1e9 as bigint)) as timestamp)') }}
+        AND b.block_date >= (SELECT day FROM rebuild_start)
+    WHERE cast(from_unixtime(cast(a.block_timestamp / 1e9 AS bigint)) AS date) >= (SELECT day FROM rebuild_start)
     {% endif -%}
     GROUP BY cast(date_trunc('day', b.block_timestamp) AS date)
 )
@@ -112,8 +158,8 @@ WITH all_block_id AS (
         JOIN {{ ref('thorchain_silver_block_log') }} as b
         ON a.block_timestamp = b.timestamp
         {% if is_incremental() -%}
-            AND {{ incremental_predicate('b.block_timestamp') }}
-        WHERE {{ incremental_predicate('cast(from_unixtime(cast(a.block_timestamp / 1e9 as bigint)) as timestamp)') }}
+            AND b.block_date >= (SELECT day FROM rebuild_start)
+        WHERE cast(from_unixtime(cast(a.block_timestamp / 1e9 AS bigint)) AS date) >= (SELECT day FROM rebuild_start)
         {% endif -%}
     GROUP BY
         cast(date_trunc('day', b.block_timestamp) AS date)
@@ -127,8 +173,8 @@ WITH all_block_id AS (
         JOIN {{ ref('thorchain_silver_block_log') }} as b
         ON a.block_timestamp = b.timestamp
         {% if is_incremental() -%}
-            AND {{ incremental_predicate('b.block_timestamp') }}
-        WHERE {{ incremental_predicate('cast(from_unixtime(cast(a.block_timestamp / 1e9 as bigint)) as timestamp)') }}
+            AND b.block_date >= (SELECT day FROM rebuild_start)
+        WHERE cast(from_unixtime(cast(a.block_timestamp / 1e9 AS bigint)) AS date) >= (SELECT day FROM rebuild_start)
         {% endif -%}
     GROUP BY
         cast(date_trunc('day', b.block_timestamp) AS date)


### PR DESCRIPTION
## What & why
Rebuild THORChain daily block rewards incrementally, merging recomputed rows by `day` instead of replacing the full table.
Filter large reward, swap, block, pool-depth, and node-status sources to the incremental window.
Seed active-node state from complete status history so rolling rebuilds preserve the correct node count.
Add uniqueness and non-null coverage for the daily key.
- No visual surface (dbt model only)

## Architecture
- `dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_block_rewards.sql`: business-critical reward calculation now uses a daily incremental merge, bounds large source scans, and carries active-node state across the rebuild boundary.
- `dbt_subprojects/daily_spellbook/models/thorchain/_schema.yml`: documents the model and adds `day` uniqueness and non-null tests.
- Tested: `dbt compile` passes. A Dune incremental simulation has zero diff rows across complete days and all numeric outputs match at `1e-9` tolerance.
- Not tested: local `dbt test` execution was blocked because the Trino router had zero active backends.
- Needs human eyes: the first production incremental run across the rolling-window boundary.
- Cross-system blast radius: `thorchain_silver.daily_earnings` and `thorchain.defi_block_rewards` consume this model; incorrect historical node-state seeding or daily merges would alter downstream reward and earnings values.

<details><summary>Agent context</summary>

- No agent review yet.
- Validation: `dbt compile` passed.
- Dune incremental simulation: zero diff rows across complete days; all numeric outputs matched at `1e-9` tolerance.
- Local `dbt test`: blocked because the Trino router had zero active backends.
</details>

Towards CUR2-3651