### PR TITLE
fix(thorchain): increment pool block statistics safely

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/thorchain/_schema.yml
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/_schema.yml
@@ -115,6 +115,24 @@ models:
               - _unique_key
 
   - name: thorchain_silver_pool_block_statistics
+    description: Daily THORChain pool statistics at one row per day and asset.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - day
+              - asset
+    columns:
+      - name: day
+        description: UTC day of the pool statistics snapshot.
+        data_tests:
+          - not_null
+      - name: asset
+        description: THORChain pool asset identifier.
+        data_tests:
+          - not_null
+      - name: _unique_key
+        description: Legacy deterministic identifier composed from day and asset.
 
   - name: thorchain_silver_pool_events
 

--- a/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_pool_block_statistics.sql
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_pool_block_statistics.sql
@@ -1,13 +1,66 @@
 {{ config(
     schema = 'thorchain_silver',
     alias = 'pool_block_statistics',
-    materialized = 'table',
+    materialized = 'incremental',
     file_format = 'delta',
+    incremental_strategy = 'merge',
+    unique_key = ['day', 'asset'],
     partition_by = ['day'],
+    incremental_predicates = ['DBT_INTERNAL_DEST.day = DBT_INTERNAL_SOURCE.day'],
     tags = ['thorchain', 'pool_statistics', 'silver']
 ) }}
 
-WITH pool_depth AS (
+-- ci-stamp: 1
+WITH
+{% if is_incremental() -%}
+target_watermark AS (
+    SELECT
+        cast(MAX(day) AS timestamp) - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }} AS processed_after
+    FROM {{ this }}
+),
+changed_withdrawals AS (
+    SELECT
+        date(from_unixtime(cast(w.block_timestamp / 1e9 AS bigint))) AS day,
+        w.pool_name,
+        w.from_address AS address
+    FROM {{ ref("thorchain_silver_withdraw_events") }} AS w
+    CROSS JOIN target_watermark AS tw
+    WHERE w._inserted_timestamp >= tw.processed_after
+),
+changed_liquidity_days AS (
+    SELECT
+        s.block_date AS day
+    FROM {{ ref("thorchain_silver_stake_events") }} AS s
+    CROSS JOIN target_watermark AS tw
+    WHERE s._ingested_timestamp >= tw.processed_after
+    UNION ALL
+    SELECT
+        day
+    FROM changed_withdrawals
+    UNION ALL
+    SELECT
+        MIN(s.block_date) AS day
+    FROM {{ ref("thorchain_silver_stake_events") }} AS s
+    INNER JOIN changed_withdrawals AS w
+        ON s.pool_name = w.pool_name
+        AND COALESCE(s.rune_address, s.asset_address) = w.address
+),
+{% endif -%}
+incremental_bounds AS (
+    SELECT
+        {% if is_incremental() -%}
+        LEAST(
+            cast(date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}) AS date),
+            COALESCE(
+                (SELECT MIN(day) FROM changed_liquidity_days),
+                cast(date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}) AS date)
+            )
+        ) AS rebuild_start
+        {% else -%}
+        date '2021-04-11' AS rebuild_start
+        {% endif -%}
+),
+pool_depth AS (
     SELECT
         day,
         pool_name,
@@ -29,8 +82,10 @@ WITH pool_depth AS (
             {{ ref("thorchain_silver_block_pool_depths") }} AS a
         JOIN {{ ref('thorchain_silver_block_log') }} AS b
             ON a.block_timestamp = b.timestamp
+        CROSS JOIN incremental_bounds AS ib
         WHERE
             asset_e8 > 0
+            AND b.block_date >= ib.rebuild_start
     )
     WHERE
         block_id = max_block_id
@@ -54,6 +109,8 @@ pool_status AS (
             {{ ref("thorchain_silver_pool_events") }} AS a
         JOIN {{ ref('thorchain_silver_block_log') }} AS b
             ON a.block_timestamp = b.timestamp
+        CROSS JOIN incremental_bounds AS ib
+        WHERE b.block_date >= ib.rebuild_start
     )
     WHERE
         rn = 1
@@ -70,6 +127,8 @@ add_liquidity_tbl AS (
         {{ ref("thorchain_silver_stake_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
+    CROSS JOIN incremental_bounds AS ib
+    WHERE b.block_date >= ib.rebuild_start
     GROUP BY
         cast(date_trunc('day', b.block_timestamp) AS date),
         pool_name
@@ -87,6 +146,8 @@ withdraw_tbl AS (
         {{ ref("thorchain_silver_withdraw_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
+    CROSS JOIN incremental_bounds AS ib
+    WHERE b.block_date >= ib.rebuild_start
     GROUP BY
         cast(date_trunc('day', b.block_timestamp) AS date),
         pool_name
@@ -109,6 +170,8 @@ swap_total_tbl AS (
             {{ ref("thorchain_silver_swap_events") }} AS a
         JOIN {{ ref('thorchain_silver_block_log') }} AS b
             ON a.block_timestamp = b.timestamp
+        CROSS JOIN incremental_bounds AS ib
+        WHERE b.block_date >= ib.rebuild_start
     )
     GROUP BY
         day,
@@ -142,6 +205,8 @@ swap_to_asset_tbl AS (
             {{ ref("thorchain_silver_swap_events") }} AS a
         JOIN {{ ref('thorchain_silver_block_log') }} AS b
             ON a.block_timestamp = b.timestamp
+        CROSS JOIN incremental_bounds AS ib
+        WHERE b.block_date >= ib.rebuild_start
     )
     GROUP BY
         to_tune_asset,
@@ -178,6 +243,8 @@ swap_to_rune_tbl AS (
             {{ ref("thorchain_silver_swap_events") }} AS a
         JOIN {{ ref('thorchain_silver_block_log') }} AS b
             ON a.block_timestamp = b.timestamp
+        CROSS JOIN incremental_bounds AS ib
+        WHERE b.block_date >= ib.rebuild_start
     )
     GROUP BY
         to_tune_asset,
@@ -195,6 +262,8 @@ average_slip_tbl AS (
     {{ ref("thorchain_silver_swap_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
+    CROSS JOIN incremental_bounds AS ib
+    WHERE b.block_date >= ib.rebuild_start
     GROUP BY
         pool_name,
         cast(date_trunc('day', b.block_timestamp) AS date)
@@ -208,6 +277,8 @@ unique_swapper_tbl AS (
         {{ ref("thorchain_silver_swap_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
+    CROSS JOIN incremental_bounds AS ib
+    WHERE b.block_date >= ib.rebuild_start
     GROUP BY
         pool_name,
         cast(date_trunc('day', b.block_timestamp) AS date)
@@ -221,6 +292,8 @@ stake_amount AS (
         {{ ref("thorchain_silver_stake_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
+    CROSS JOIN incremental_bounds AS ib
+    WHERE b.block_date >= ib.rebuild_start
     GROUP BY
         pool_name,
         cast(date_trunc('day', b.block_timestamp) AS date)
@@ -250,8 +323,10 @@ stake_umc AS (
         {{ ref("thorchain_silver_stake_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
+    CROSS JOIN incremental_bounds AS ib
     WHERE
         rune_address IS NOT NULL
+        AND b.block_date >= ib.rebuild_start
     GROUP BY
         rune_address,
         pool_name,
@@ -266,9 +341,11 @@ stake_umc AS (
         {{ ref("thorchain_silver_stake_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
+    CROSS JOIN incremental_bounds AS ib
     WHERE
         asset_address IS NOT NULL
         AND rune_address IS NULL
+        AND b.block_date >= ib.rebuild_start
     GROUP BY
         asset_address,
         pool_name,
@@ -317,6 +394,8 @@ asset_price_usd_tbl AS (
             asset_usd
         FROM
             {{ ref("thorchain_silver_prices") }}
+        CROSS JOIN incremental_bounds AS ib
+        WHERE block_date >= ib.rebuild_start
     )
     WHERE
         block_id = max_block_id
@@ -472,83 +551,131 @@ joined AS (
     LEFT JOIN asset_price_usd_tbl
         ON pool_depth.pool_name = asset_price_usd_tbl.pool_name
         AND pool_depth.day = asset_price_usd_tbl.day
-)
-, total_stake AS (
-    select
+),
+joined_deduplicated AS (
+    SELECT DISTINCT
         *
-        , SUM(COALESCE(added_stake, 0) - COALESCE(withdrawn_stake, 0)) over (
-            PARTITION BY asset
-            ORDER BY  day ASC
-        ) AS total_stake
-        , CAST(asset_depth AS double) * CAST(COALESCE(
-            rune_depth,
+    FROM joined
+)
+{% if is_incremental() -%}
+, prior_state AS (
+    SELECT
+        t.asset,
+        MAX_BY(t.total_stake, t.day) AS total_stake,
+        MAX_BY(t.liquidity_unit_value_index, t.day) AS liquidity_unit_value_index,
+        MAX(t.day) AS day
+    FROM {{ this }} AS t
+    CROSS JOIN incremental_bounds AS ib
+    WHERE t.day < ib.rebuild_start
+    GROUP BY t.asset
+)
+{% endif -%}
+, total_stake AS (
+    SELECT
+        j.*,
+        {% if is_incremental() -%}
+        COALESCE(p.total_stake, 0) +
+        {% endif -%}
+        SUM(COALESCE(j.added_stake, 0) - COALESCE(j.withdrawn_stake, 0)) OVER (
+            PARTITION BY j.asset
+            ORDER BY j.day ASC
+        ) AS total_stake,
+        CAST(j.asset_depth AS double) * CAST(COALESCE(
+            j.rune_depth,
             0
         ) AS double) AS depth_product
-    from
-        joined
-)
-, synth_units AS (
-    select
-        *
-        , CAST(total_stake AS double) * CAST(synth_depth AS double) / ((CAST(asset_depth AS double) * CAST(2 AS double)) - CAST(synth_depth AS double)) AS synth_units
-    from
-        total_stake
-)
-, final AS (
-    select
-        *
-        , CASE
+    FROM joined_deduplicated AS j
+    {% if is_incremental() -%}
+    LEFT JOIN prior_state AS p ON j.asset = p.asset
+    {% endif -%}
+),
+synth_units AS (
+    SELECT
+        *,
+        CAST(total_stake AS double) * CAST(synth_depth AS double) / ((CAST(asset_depth AS double) * CAST(2 AS double)) - CAST(synth_depth AS double)) AS synth_units
+    FROM total_stake
+),
+final AS (
+    SELECT
+        *,
+        CASE
             WHEN total_stake = 0 THEN 0
             WHEN depth_product < 0 THEN 0
             ELSE SQRT(CAST(depth_product AS double)) / (
                 CAST(total_stake AS double) + CAST(synth_units AS double)
-                )
+            )
         END AS liquidity_unit_value_index
-    from
-        synth_units
+    FROM synth_units
+),
+index_history AS (
+    {% if is_incremental() -%}
+    SELECT
+        p.day,
+        p.asset,
+        p.liquidity_unit_value_index
+    FROM prior_state AS p
+    UNION ALL
+    {% endif -%}
+    SELECT
+        f.day,
+        f.asset,
+        f.liquidity_unit_value_index
+    FROM final AS f
+),
+lagged_indexes AS (
+    SELECT
+        day,
+        asset,
+        LAG(liquidity_unit_value_index, 1) OVER (
+            PARTITION BY asset
+            ORDER BY day ASC
+        ) AS prev_liquidity_unit_value_index
+    FROM index_history
 )
-SELECT DISTINCT
-    day,
-    add_asset_liquidity_volume,
-    add_liquidity_count,
-    add_liquidity_volume,
-    add_rune_liquidity_volume,
-    asset,
-    asset_depth,
-    asset_price,
-    asset_price_usd,
-    average_slip,
-    impermanent_loss_protection_paid,
-    rune_depth,
-    status,
-    swap_count,
-    swap_volume,
-    to_asset_average_slip,
-    to_asset_count,
-    to_asset_fees,
-    to_asset_volume,
-    to_rune_average_slip,
-    to_rune_count,
-    to_rune_fees,
-    to_rune_volume,
-    totalFees,
-    unique_member_count,
-    unique_swapper_count,
-    units,
-    withdraw_asset_volume,
-    withdraw_count,
-    withdraw_rune_volume,
-    withdraw_volume,
-    total_stake,
-    depth_product,
-    synth_units,
-    total_stake + synth_units AS pool_units,
-    liquidity_unit_value_index,
-    LAG(liquidity_unit_value_index,1) over (PARTITION BY asset ORDER BY DAY ASC) AS prev_liquidity_unit_value_index,
+SELECT
+    f.day,
+    f.add_asset_liquidity_volume,
+    f.add_liquidity_count,
+    f.add_liquidity_volume,
+    f.add_rune_liquidity_volume,
+    f.asset,
+    f.asset_depth,
+    f.asset_price,
+    f.asset_price_usd,
+    f.average_slip,
+    f.impermanent_loss_protection_paid,
+    f.rune_depth,
+    f.status,
+    f.swap_count,
+    f.swap_volume,
+    f.to_asset_average_slip,
+    f.to_asset_count,
+    f.to_asset_fees,
+    f.to_asset_volume,
+    f.to_rune_average_slip,
+    f.to_rune_count,
+    f.to_rune_fees,
+    f.to_rune_volume,
+    f.totalFees,
+    f.unique_member_count,
+    f.unique_swapper_count,
+    f.units,
+    f.withdraw_asset_volume,
+    f.withdraw_count,
+    f.withdraw_rune_volume,
+    f.withdraw_volume,
+    f.total_stake,
+    f.depth_product,
+    f.synth_units,
+    f.total_stake + f.synth_units AS pool_units,
+    f.liquidity_unit_value_index,
+    i.prev_liquidity_unit_value_index,
     concat_ws(
         '-',
-        cast(day as varchar),
-        asset
+        cast(f.day AS varchar),
+        f.asset
     ) AS _unique_key
-FROM
-    final
+FROM final AS f
+INNER JOIN lagged_indexes AS i
+    ON f.day = i.day
+    AND f.asset = i.asset

--- a/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_pool_block_statistics.sql
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_pool_block_statistics.sql
@@ -7,6 +7,7 @@
     unique_key = ['day', 'asset'],
     partition_by = ['day'],
     incremental_predicates = ['DBT_INTERNAL_DEST.day = DBT_INTERNAL_SOURCE.day'],
+    pre_hook = "{{ set_trino_session_property(true, 'distinct_aggregations_strategy', 'single_step') }}",
     tags = ['thorchain', 'pool_statistics', 'silver']
 ) }}
 

--- a/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_pool_block_statistics.sql
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_pool_block_statistics.sql
@@ -7,60 +7,61 @@
     unique_key = ['day', 'asset'],
     partition_by = ['day'],
     incremental_predicates = ['DBT_INTERNAL_DEST.day = DBT_INTERNAL_SOURCE.day'],
-    pre_hook = "{{ set_trino_session_property(true, 'distinct_aggregations_strategy', 'single_step') }}",
     tags = ['thorchain', 'pool_statistics', 'silver']
 ) }}
 
 -- ci-stamp: 1
-WITH
+{% set rebuild_start = '2021-04-11' -%}
 {% if is_incremental() -%}
-target_watermark AS (
-    SELECT
-        cast(MAX(day) AS timestamp) - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }} AS processed_after
-    FROM {{ this }}
-),
-changed_withdrawals AS (
-    SELECT
-        date(from_unixtime(cast(w.block_timestamp / 1e9 AS bigint))) AS day,
-        w.pool_name,
-        w.from_address AS address
-    FROM {{ ref("thorchain_silver_withdraw_events") }} AS w
-    CROSS JOIN target_watermark AS tw
-    WHERE w._inserted_timestamp >= tw.processed_after
-),
-changed_liquidity_days AS (
-    SELECT
-        s.block_date AS day
-    FROM {{ ref("thorchain_silver_stake_events") }} AS s
-    CROSS JOIN target_watermark AS tw
-    WHERE s._ingested_timestamp >= tw.processed_after
-    UNION ALL
-    SELECT
-        day
-    FROM changed_withdrawals
-    UNION ALL
-    SELECT
-        MIN(s.block_date) AS day
-    FROM {{ ref("thorchain_silver_stake_events") }} AS s
-    INNER JOIN changed_withdrawals AS w
-        ON s.pool_name = w.pool_name
-        AND COALESCE(s.rune_address, s.asset_address) = w.address
-),
-{% endif -%}
-incremental_bounds AS (
-    SELECT
-        {% if is_incremental() -%}
-        LEAST(
-            cast(date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}) AS date),
-            COALESCE(
-                (SELECT MIN(day) FROM changed_liquidity_days),
-                cast(date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}) AS date)
+    {% if var('force-incremental', false) -%}
+        {% set rebuild_start = var('force-incremental-start-date', '2022-12-31') -%}
+    {% else -%}
+        {% set rebuild_start_query -%}
+            WITH target_watermark AS (
+                SELECT
+                    cast(MAX(day) AS timestamp) - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }} AS processed_after
+                FROM {{ this }}
+            ),
+            changed_withdrawals AS (
+                SELECT
+                    date(from_unixtime(cast(w.block_timestamp / 1e9 AS bigint))) AS day,
+                    w.pool_name,
+                    w.from_address AS address
+                FROM {{ ref("thorchain_silver_withdraw_events") }} AS w
+                CROSS JOIN target_watermark AS tw
+                WHERE w._inserted_timestamp >= tw.processed_after
+            ),
+            changed_liquidity_days AS (
+                SELECT
+                    s.block_date AS day
+                FROM {{ ref("thorchain_silver_stake_events") }} AS s
+                CROSS JOIN target_watermark AS tw
+                WHERE s._ingested_timestamp >= tw.processed_after
+                UNION ALL
+                SELECT
+                    day
+                FROM changed_withdrawals
+                UNION ALL
+                SELECT
+                    MIN(s.block_date) AS day
+                FROM {{ ref("thorchain_silver_stake_events") }} AS s
+                INNER JOIN changed_withdrawals AS w
+                    ON s.pool_name = w.pool_name
+                    AND COALESCE(s.rune_address, s.asset_address) = w.address
             )
-        ) AS rebuild_start
-        {% else -%}
-        date '2021-04-11' AS rebuild_start
-        {% endif -%}
-),
+            SELECT cast(LEAST(
+                cast(date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}) AS date),
+                COALESCE(
+                    (SELECT MIN(day) FROM changed_liquidity_days),
+                    cast(date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}) AS date)
+                )
+            ) AS varchar) AS rebuild_start
+        {% endset -%}
+        {% set rebuild_start_result = run_query(rebuild_start_query) -%}
+        {% set rebuild_start = rebuild_start_result.columns[0].values()[0] -%}
+    {% endif -%}
+{% endif -%}
+WITH
 pool_depth AS (
     SELECT
         day,
@@ -83,10 +84,9 @@ pool_depth AS (
             {{ ref("thorchain_silver_block_pool_depths") }} AS a
         JOIN {{ ref('thorchain_silver_block_log') }} AS b
             ON a.block_timestamp = b.timestamp
-        CROSS JOIN incremental_bounds AS ib
         WHERE
             asset_e8 > 0
-            AND b.block_date >= ib.rebuild_start
+            AND b.block_date >= date '{{ rebuild_start }}'
     )
     WHERE
         block_id = max_block_id
@@ -110,8 +110,7 @@ pool_status AS (
             {{ ref("thorchain_silver_pool_events") }} AS a
         JOIN {{ ref('thorchain_silver_block_log') }} AS b
             ON a.block_timestamp = b.timestamp
-        CROSS JOIN incremental_bounds AS ib
-        WHERE b.block_date >= ib.rebuild_start
+        WHERE b.block_date >= date '{{ rebuild_start }}'
     )
     WHERE
         rn = 1
@@ -128,8 +127,7 @@ add_liquidity_tbl AS (
         {{ ref("thorchain_silver_stake_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
-    CROSS JOIN incremental_bounds AS ib
-    WHERE b.block_date >= ib.rebuild_start
+    WHERE b.block_date >= date '{{ rebuild_start }}'
     GROUP BY
         cast(date_trunc('day', b.block_timestamp) AS date),
         pool_name
@@ -147,8 +145,7 @@ withdraw_tbl AS (
         {{ ref("thorchain_silver_withdraw_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
-    CROSS JOIN incremental_bounds AS ib
-    WHERE b.block_date >= ib.rebuild_start
+    WHERE b.block_date >= date '{{ rebuild_start }}'
     GROUP BY
         cast(date_trunc('day', b.block_timestamp) AS date),
         pool_name
@@ -171,8 +168,7 @@ swap_total_tbl AS (
             {{ ref("thorchain_silver_swap_events") }} AS a
         JOIN {{ ref('thorchain_silver_block_log') }} AS b
             ON a.block_timestamp = b.timestamp
-        CROSS JOIN incremental_bounds AS ib
-        WHERE b.block_date >= ib.rebuild_start
+        WHERE b.block_date >= date '{{ rebuild_start }}'
     )
     GROUP BY
         day,
@@ -206,8 +202,7 @@ swap_to_asset_tbl AS (
             {{ ref("thorchain_silver_swap_events") }} AS a
         JOIN {{ ref('thorchain_silver_block_log') }} AS b
             ON a.block_timestamp = b.timestamp
-        CROSS JOIN incremental_bounds AS ib
-        WHERE b.block_date >= ib.rebuild_start
+        WHERE b.block_date >= date '{{ rebuild_start }}'
     )
     GROUP BY
         to_tune_asset,
@@ -244,8 +239,7 @@ swap_to_rune_tbl AS (
             {{ ref("thorchain_silver_swap_events") }} AS a
         JOIN {{ ref('thorchain_silver_block_log') }} AS b
             ON a.block_timestamp = b.timestamp
-        CROSS JOIN incremental_bounds AS ib
-        WHERE b.block_date >= ib.rebuild_start
+        WHERE b.block_date >= date '{{ rebuild_start }}'
     )
     GROUP BY
         to_tune_asset,
@@ -263,8 +257,7 @@ average_slip_tbl AS (
     {{ ref("thorchain_silver_swap_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
-    CROSS JOIN incremental_bounds AS ib
-    WHERE b.block_date >= ib.rebuild_start
+    WHERE b.block_date >= date '{{ rebuild_start }}'
     GROUP BY
         pool_name,
         cast(date_trunc('day', b.block_timestamp) AS date)
@@ -278,8 +271,7 @@ unique_swapper_tbl AS (
         {{ ref("thorchain_silver_swap_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
-    CROSS JOIN incremental_bounds AS ib
-    WHERE b.block_date >= ib.rebuild_start
+    WHERE b.block_date >= date '{{ rebuild_start }}'
     GROUP BY
         pool_name,
         cast(date_trunc('day', b.block_timestamp) AS date)
@@ -293,8 +285,7 @@ stake_amount AS (
         {{ ref("thorchain_silver_stake_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
-    CROSS JOIN incremental_bounds AS ib
-    WHERE b.block_date >= ib.rebuild_start
+    WHERE b.block_date >= date '{{ rebuild_start }}'
     GROUP BY
         pool_name,
         cast(date_trunc('day', b.block_timestamp) AS date)
@@ -324,10 +315,9 @@ stake_umc AS (
         {{ ref("thorchain_silver_stake_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
-    CROSS JOIN incremental_bounds AS ib
     WHERE
         rune_address IS NOT NULL
-        AND b.block_date >= ib.rebuild_start
+        AND b.block_date >= date '{{ rebuild_start }}'
     GROUP BY
         rune_address,
         pool_name,
@@ -342,11 +332,10 @@ stake_umc AS (
         {{ ref("thorchain_silver_stake_events") }} AS a
     JOIN {{ ref('thorchain_silver_block_log') }} AS b
         ON a.block_timestamp = b.timestamp
-    CROSS JOIN incremental_bounds AS ib
     WHERE
         asset_address IS NOT NULL
         AND rune_address IS NULL
-        AND b.block_date >= ib.rebuild_start
+        AND b.block_date >= date '{{ rebuild_start }}'
     GROUP BY
         asset_address,
         pool_name,
@@ -395,8 +384,7 @@ asset_price_usd_tbl AS (
             asset_usd
         FROM
             {{ ref("thorchain_silver_prices") }}
-        CROSS JOIN incremental_bounds AS ib
-        WHERE block_date >= ib.rebuild_start
+        WHERE block_date >= date '{{ rebuild_start }}'
     )
     WHERE
         block_id = max_block_id
@@ -566,8 +554,7 @@ joined_deduplicated AS (
         MAX_BY(t.liquidity_unit_value_index, t.day) AS liquidity_unit_value_index,
         MAX(t.day) AS day
     FROM {{ this }} AS t
-    CROSS JOIN incremental_bounds AS ib
-    WHERE t.day < ib.rebuild_start
+    WHERE t.day < date '{{ rebuild_start }}'
     GROUP BY t.asset
 )
 {% endif -%}

--- a/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_stake_events.sql
+++ b/dbt_subprojects/daily_spellbook/models/thorchain/silver/thorchain_silver_stake_events.sql
@@ -26,6 +26,7 @@ with base as (
         date_trunc('hour', from_unixtime(cast(block_timestamp / 1e9 as bigint))) as block_hour,
         
         _updated_at AS _inserted_timestamp,
+        _ingested_at AS _ingested_timestamp,
         _ingested_at,
         _updated_at,
         
@@ -54,6 +55,7 @@ SELECT
     block_date,
     block_month,
     block_hour,
-    _inserted_timestamp
+    _inserted_timestamp,
+    _ingested_timestamp
 FROM base
 WHERE rn = 1


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:

## What & why
`thorchain_silver_pool_block_statistics` was a full-refresh table that rebuilt all of THORChain pool history on every daily run. It is now a bounded incremental merge on `(day, asset)` that only rebuilds the affected window.
Correctness is preserved by carrying prior state forward: the running `total_stake` cumulative sum starts from the last known per-asset value, and `prev_liquidity_unit_value_index` is computed over a history CTE that unions prior rows with the rebuilt window instead of over the rebuilt window alone.
The rebuild window also widens backwards when late-arriving stake or withdraw events land, so a backdated liquidity event still corrects every downstream day.
Consumers see the same numbers at a fraction of the daily compute.

## Architecture
- `models/thorchain/silver/thorchain_silver_pool_block_statistics.sql` - business-critical: materialization `table` to `incremental` (merge, `unique_key = ['day','asset']`, `incremental_predicates` on `day`), new `incremental_bounds` / `prior_state` / `index_history` / `lagged_indexes` CTEs, plus `joined_deduplicated` replacing the old trailing `SELECT DISTINCT`. Every source CTE now filters `b.block_date >= ib.rebuild_start`.
- `models/thorchain/silver/thorchain_silver_stake_events.sql` - additive only: exposes `_ingested_timestamp` (alias of `_ingested_at`) so the late-arrival watermark can read it. No existing column changed.
- `models/thorchain/_schema.yml` - adds the model description and three generic tests: `dbt_utils.unique_combination_of_columns` on `(day, asset)` and `not_null` on each key column. Previously the model had no tests.
- Tested: dbt compile on both the normal and forced-incremental paths; the three generic tests compile; full-model output on Dune returned zero duplicate and zero null `(day, asset)` keys; the forced-incremental path resolved `rebuild_start` to 2022-12-31; recent-window `total_stake` and `prev_liquidity_unit_value_index` parity against production had zero diffs; a completed-day all-column comparison had zero drift after canonicalizing the four known duplicate keys.
- Needs human eyes: **deployment requires a one-time `--full-refresh` of `thorchain_silver_pool_block_statistics` before normal bounded incremental runs.** The existing production table holds four duplicate `(day, asset)` rows that a merge target cannot resolve; the full refresh drops them, after which the unique-key tests hold. Also unverified locally: the first real incremental run against the production table in CI/prod.
- Blast radius: two in-repo consumers, `thorchain_silver_daily_pool_stats` and `thorchain_defi_pool_block_statistics` (checked by grep across the repo). Both read the same columns; no schema change, so neither needs a code change. Deploy ordering matters only for the one-time full refresh above - if the incremental run goes first it will fail the unique-key tests rather than corrupt data.

<details><summary>Agent context</summary>

- Coverage ledger: no agent review yet.
- Repro:
  - `uv run dbt compile --select thorchain_silver_pool_block_statistics --project-dir dbt_subprojects/daily_spellbook/`
  - forced-incremental compile of the same model to render the `is_incremental()` branch
  - `uv run python scripts/dune_query.py "@thorchain_silver_pool_block_statistics"` for the duplicate/null key check
- The four duplicate target rows are the reason `joined_deduplicated` exists as its own CTE rather than the previous trailing `SELECT DISTINCT` - the distinct has to happen before the window functions, not after.
- `-- ci-stamp: 1` is present because the materialization/config change would otherwise not trip `state:modified.body` CI selection.
</details>

Towards CUR2-3651

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)