### PR TITLE
fix(prices): add native USDC to prices_hyperevm_tokens

### DIFF
--- a/dbt_subprojects/tokens/models/prices/hyperevm/prices_hyperevm_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/hyperevm/prices_hyperevm_tokens.sql
@@ -19,6 +19,7 @@ FROM
 (
     VALUES
     ('usdt-tether', 'USDT0', 0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb, 6)
+    , ('usdc-usd-coin', 'USDC', 0xb88339cb7199b77e23db6e890353e22632ba630f, 6)
     , ('hype-hyperliquid', 'WHYPE', 0x5555555555555555555555555555555555555555, 18)
     , ('eth-ethereum', 'UETH', 0xbe6727b535545c67d5caa73dea54865b92cf7907, 18)
     , ('btc-bitcoin', 'UBTC', 0x9fdbda0a5e284c32744d2f17ee5c74b284993463, 8)


### PR DESCRIPTION
## Problem

Native USDC on **hyperevm** (`0xb88339cb7199b77e23db6e890353e22632ba630f`) is missing from `prices.tokens`, so `prices.usd` never produces a feed for it. Downstream, `tokens.transfers` and the balances tables return `NULL` for `price` / `amount_usd` on every USDC transfer on hyperevm.

Verified on Dune:

| source | result |
|---|---|
| `tokens.erc20` (hyperevm, that address) | `symbol = USDC`, `decimals = 6` |
| `prices.tokens` (hyperevm, that address) | **no row** |
| `prices.usd_latest` (hyperevm, that address) | **no row** |

## Fix

Add the token to `prices_hyperevm_tokens`:

```sql
, ('usdc-usd-coin', 'USDC', 0xb88339cb7199b77e23db6e890353e22632ba630f, 6)
```

- `token_id` `usdc-usd-coin` is the CoinPaprika id already used for USDC on every other chain in this repo (arbitrum, base, polygon, linea, unichain, …).
- Address confirmed as Circle's native USDC deployment on HyperEVM per [Circle's own multi-chain page](https://www.circle.com/multi-chain-usdc/hyperevm) (~$5.6B circulating supply).
- `decimals = 6` matches `tokens.erc20`, so the existing `test_prices_tokens_against_erc20` data test passes, and the new address does not collide with the `unique_combination_of_columns` test on `contract_address`.

## Note on backfill

Adding the token here registers it with the price backend; the historical `prices.usd` feed is populated by a backend backfill that typically lands a few days after merge. `tokens.transfers` / balances will keep showing `NULL` until that backfill completes.

Prompted by: Karim Hassan
