### PR TITLE
CI only: validate 1inch Robinhood integration

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_contracts_cfg_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_contracts_cfg_macro.sql
@@ -199,7 +199,7 @@
         },
         "AggregationRouterV6": {
             "version": "6",
-            "blockchains": ["ethereum", "bnb", "polygon", "arbitrum", "optimism", "avalanche_c", "gnosis", "fantom", "base", "zksync", "linea", "sonic", "unichain"],
+            "blockchains": ["ethereum", "bnb", "polygon", "arbitrum", "optimism", "avalanche_c", "gnosis", "fantom", "base", "zksync", "linea", "sonic", "unichain", "robinhood"],
             "address": "0x111111125421ca6dc452d289314280a0f8842a65",
             "start": "2024-02-12",
             "methods": {
@@ -467,4 +467,51 @@
             "unoswapTo3"    : contracts.AggregationRouterV6.methods.unoswapTo3,
             "permitAndCall" : contracts.AggregationRouterV6.methods.permitAndCall,
     }) }) }}
+{% endmacro %}
+
+-- ROBINHOOD AR CONFIG MACRO --
+{% macro oneinch_robinhood_ar_contracts_cfg_macro() %}
+    {% set contracts = oneinch_ar_contracts_cfg_macro() %}
+    {% set methods = {
+        "swap"          : contracts.AggregationRouterV6.methods.swap,
+        "ethUnoswap"    : contracts.AggregationRouterV6.methods.ethUnoswap,
+        "ethUnoswap2"   : contracts.AggregationRouterV6.methods.ethUnoswap2,
+        "ethUnoswap3"   : contracts.AggregationRouterV6.methods.ethUnoswap3,
+        "ethUnoswapTo"  : contracts.AggregationRouterV6.methods.ethUnoswapTo,
+        "ethUnoswapTo2" : contracts.AggregationRouterV6.methods.ethUnoswapTo2,
+        "ethUnoswapTo3" : contracts.AggregationRouterV6.methods.ethUnoswapTo3,
+        "unoswap"       : contracts.AggregationRouterV6.methods.unoswap,
+        "unoswap2"      : contracts.AggregationRouterV6.methods.unoswap2,
+        "unoswap3"      : contracts.AggregationRouterV6.methods.unoswap3,
+        "unoswapTo"     : contracts.AggregationRouterV6.methods.unoswapTo,
+        "unoswapTo2"    : contracts.AggregationRouterV6.methods.unoswapTo2,
+        "unoswapTo3"    : contracts.AggregationRouterV6.methods.unoswapTo3,
+        "permitAndCall" : contracts.AggregationRouterV6.methods.permitAndCall,
+    } %}
+    {{ return({ "AggregationRouterV6": dict(contracts.AggregationRouterV6, methods=methods) }) }}
+{% endmacro %}
+
+-- ROBINHOOD AR RAW CALLS CONFIG MACRO (both AggregationRouterV6 deployments on chain) --
+{% macro oneinch_robinhood_ar_raw_contracts_cfg_macro() %}
+    {% set contracts = oneinch_ar_contracts_cfg_macro() %}
+    {% set methods = {
+        "swap"          : contracts.AggregationRouterV6.methods.swap,
+        "ethUnoswap"    : contracts.AggregationRouterV6.methods.ethUnoswap,
+        "ethUnoswap2"   : contracts.AggregationRouterV6.methods.ethUnoswap2,
+        "ethUnoswap3"   : contracts.AggregationRouterV6.methods.ethUnoswap3,
+        "ethUnoswapTo"  : contracts.AggregationRouterV6.methods.ethUnoswapTo,
+        "ethUnoswapTo2" : contracts.AggregationRouterV6.methods.ethUnoswapTo2,
+        "ethUnoswapTo3" : contracts.AggregationRouterV6.methods.ethUnoswapTo3,
+        "unoswap"       : contracts.AggregationRouterV6.methods.unoswap,
+        "unoswap2"      : contracts.AggregationRouterV6.methods.unoswap2,
+        "unoswap3"      : contracts.AggregationRouterV6.methods.unoswap3,
+        "unoswapTo"     : contracts.AggregationRouterV6.methods.unoswapTo,
+        "unoswapTo2"    : contracts.AggregationRouterV6.methods.unoswapTo2,
+        "unoswapTo3"    : contracts.AggregationRouterV6.methods.unoswapTo3,
+        "permitAndCall" : contracts.AggregationRouterV6.methods.permitAndCall,
+    } %}
+    {{ return({
+        "AggregationRouterV6"         : dict(contracts.AggregationRouterV6, address="0x111111125421ca6dc452d289314280a0f8842a65", methods=methods),
+        "AggregationRouterV6Robinhood"  : dict(contracts.AggregationRouterV6, address="0x5a705de8982235a7fa45bb83dcacf03a211389c7", methods=methods),
+    }) }}
 {% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_executions_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_executions_macro.sql
@@ -5,7 +5,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
+{%- set date_from = [blockchain.start, stream.start] | max -%}
 
 
 

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_executions_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_executions_macro.sql
@@ -5,7 +5,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start] | max -%}
+{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
 
 
 

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_macro.sql
@@ -6,7 +6,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
+{%- set date_from = [blockchain.start, stream.start] | max -%}
 {%- set wrapper = blockchain.wrapped_native_token_address -%}
 {%- set native = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' -%}
 {%- set nullss = '0x0000000000000000000000000000000000000000' -%}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_macro.sql
@@ -6,7 +6,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start] | max -%}
+{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
 {%- set wrapper = blockchain.wrapped_native_token_address -%}
 {%- set native = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' -%}
 {%- set nullss = '0x0000000000000000000000000000000000000000' -%}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/CC/oneinch_cc_contracts_cfg_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/CC/oneinch_cc_contracts_cfg_macro.sql
@@ -116,6 +116,8 @@
 {% macro oneinch_base_cc_contracts_cfg_macro() %} {{ return(oneinch_cc_contracts_cfg_macro()) }} {% endmacro %}
 
 -- ZKSYNC CC CONFIG MACRO --
+-- zkSync Era is not EVM-equivalent, so Dune cannot decode the minimal-proxy EscrowSrc/Dst clones.
+-- Their calldata is parsed from raw `call_input` (type="raw").
 {% macro oneinch_zksync_cc_contracts_cfg_macro() %}
     {% set contracts = oneinch_cc_contracts_cfg_macro() %}
     {% set methodsV1 = oneinch_cc_methods_cfg_macro(type="raw").v1 %}
@@ -146,3 +148,31 @@
 
 -- UNICHAIN CC CONFIG MACRO --
 {% macro oneinch_unichain_cc_contracts_cfg_macro() %} {{ return(oneinch_cc_contracts_cfg_macro()) }} {% endmacro %}
+
+-- ROBINHOOD CC CONFIG MACRO --
+-- Robinhood has its own escrow factory + implementation deployments.
+-- The Dune decoded EscrowSrcV1/EscrowDstV1 mappings on robinhood are contaminated: all escrow clones and both
+-- implementations appear under both contract names, which mislabels src/dst flows and duplicates rows.
+-- So escrow clones are resolved from creation traces and their calldata is parsed from raw `call_input`
+-- (type="raw"), like on zksync. The factory (single healthy address) stays on decoded tables.
+{% macro oneinch_robinhood_cc_contracts_cfg_macro() %}
+    {% set contracts = oneinch_cc_contracts_cfg_macro() %}
+    {% set methodsV1 = oneinch_cc_methods_cfg_macro(type="raw").v1 %}
+    {{ return({
+        "EscrowFactoryV1": dict(contracts.EscrowFactoryV1, address="0xa02b9cc95094bb27d1d041b9fbf09f65a366f7b3"),
+        "EscrowSrcV1": dict(contracts.EscrowSrcV1, initial_address="0xb077a4326f1e875c21d74028a1499eafcee43bf3", methods={
+            "withdraw"      : dict(methodsV1.withdraw       , flow="'src_withdraw'", secret="substr(call_input, 4 + 32*0 + 1, 32)"),
+            "withdrawTo"    : dict(methodsV1.withdrawTo     , flow="'src_withdraw'", secret="substr(call_input, 4 + 32*0 + 1, 32)", receiver="substr(call_input, 4 + 32*1 + 12 + 1, 20)"),
+            "publicWithdraw": dict(methodsV1.publicWithdraw , flow="'src_withdraw'", secret="substr(call_input, 4 + 32*0 + 1, 32)"),
+            "cancel"        : dict(methodsV1.cancel         , flow="'src_cancel'"),
+            "publicCancel"  : dict(methodsV1.publicCancel   , flow="'src_cancel'"),
+            "rescueFunds"   : dict(methodsV1.rescueFunds    , flow="'src_rescue'"),
+        }),
+        "EscrowDstV1": dict(contracts.EscrowDstV1, initial_address="0x104f09ea1f9c09662635ad581d0bef8b15d16f4f", methods={
+            "withdraw"      : dict(methodsV1.withdraw       , flow="'dst_withdraw'", secret="substr(call_input, 4 + 32*0 + 1, 32)"),
+            "publicWithdraw": dict(methodsV1.publicWithdraw , flow="'dst_withdraw'", secret="substr(call_input, 4 + 32*0 + 1, 32)"),
+            "cancel"        : dict(methodsV1.cancel         , flow="'dst_cancel'"),
+            "rescueFunds"   : dict(methodsV1.rescueFunds    , flow="'dst_rescue'"),
+        }),
+    }) }}
+{% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/CC/oneinch_cc_executions_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/CC/oneinch_cc_executions_macro.sql
@@ -5,7 +5,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
+{%- set date_from = [blockchain.start, stream.start] | max -%}
 
 {#- chains without transfers_from_traces (e.g. robinhood) have event-based transfers with no trace_address, so the nested flag can't attribute them to sibling calls; CC transfers always touch the escrow address, which gives exact attribution instead -#}
 {%- set transfers_from_traces = blockchain.get('transfers_from_traces', true) -%}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/CC/oneinch_cc_executions_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/CC/oneinch_cc_executions_macro.sql
@@ -5,7 +5,10 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start] | max -%}
+{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
+
+{#- chains without transfers_from_traces (e.g. robinhood) have event-based transfers with no trace_address, so the nested flag can't attribute them to sibling calls; CC transfers always touch the escrow address, which gives exact attribution instead -#}
+{%- set transfers_from_traces = blockchain.get('transfers_from_traces', true) -%}
 
 
 
@@ -23,13 +26,14 @@ calls as (
     select *
     from {{ ref('oneinch_' + blockchain.name + '_transfers') }}
     where true
-        and nested
+        {% if transfers_from_traces -%} and nested {%- endif %}
         and block_date >= timestamp '{{ date_from }}'
         {% if is_incremental() -%} and {{ incremental_predicate('block_time') }} {%- endif %}
 )
 
 {%- set data = 'cast(row(transfer_to, transfer_contract_address, transfer_symbol, transfer_amount, transfer_amount_usd, transfer_decimals, trusted) as row(receiver varbinary, address varbinary, symbol varchar, amount uint256, amount_usd double, decimals bigint, trusted boolean))' -%}
-{%- set condition = 'array_position(same, token) > 0' %}
+{%- set escrow_filter = '' if transfers_from_traces else ' and (transfer_from = escrow or transfer_to = escrow)' -%}
+{%- set condition = 'array_position(same, token) > 0' + escrow_filter %}
 
 , amounts as (
     select

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/CC/oneinch_cc_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/CC/oneinch_cc_macro.sql
@@ -8,7 +8,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
+{%- set date_from = [blockchain.start, stream.start] | max -%}
 {%- set wrapper = blockchain.wrapped_native_token_address -%}
 
 

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/CC/oneinch_cc_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/CC/oneinch_cc_macro.sql
@@ -8,7 +8,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start] | max -%}
+{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
 {%- set wrapper = blockchain.wrapped_native_token_address -%}
 
 

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lo_contracts_cfg_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lo_contracts_cfg_macro.sql
@@ -270,3 +270,18 @@
     {% set contracts = oneinch_lo_contracts_cfg_macro() %}
     {{ return({ "AggregationRouterV6"   : dict(contracts.AggregationRouterV6) }) }}
 {% endmacro %}
+
+-- ROBINHOOD LO CONFIG MACRO --
+{% macro oneinch_robinhood_lo_contracts_cfg_macro() %}
+    {% set contracts = oneinch_lo_contracts_cfg_macro() %}
+    {{ return({ "AggregationRouterV6"   : dict(contracts.AggregationRouterV6) }) }}
+{% endmacro %}
+
+-- ROBINHOOD LO RAW CALLS CONFIG MACRO (both AggregationRouterV6 deployments on chain) --
+{% macro oneinch_robinhood_lo_raw_contracts_cfg_macro() %}
+    {% set contracts = oneinch_lo_contracts_cfg_macro() %}
+    {{ return({
+        "AggregationRouterV6"        : dict(contracts.AggregationRouterV6, address="0x111111125421ca6dc452d289314280a0f8842a65"),
+        "AggregationRouterV6Robinhood" : dict(contracts.AggregationRouterV6, address="0x5a705de8982235a7fa45bb83dcacf03a211389c7"),
+    }) }}
+{% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lo_executions_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lo_executions_macro.sql
@@ -5,7 +5,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
+{%- set date_from = [blockchain.start, stream.start] | max -%}
 
 
 

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lo_executions_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lo_executions_macro.sql
@@ -5,7 +5,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start] | max -%}
+{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
 
 
 

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lo_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lo_macro.sql
@@ -6,7 +6,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
+{%- set date_from = [blockchain.start, stream.start] | max -%}
 {%- set wrapper = blockchain.wrapped_native_token_address -%}
 {%- set settlements = blockchain.fusion_settlement_addresses | join(', ') -%}
 {%- set factories = blockchain.escrow_factory_addresses | join(', ') -%}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lo_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lo_macro.sql
@@ -6,7 +6,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start] | max -%}
+{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
 {%- set wrapper = blockchain.wrapped_native_token_address -%}
 {%- set settlements = blockchain.fusion_settlement_addresses | join(', ') -%}
 {%- set factories = blockchain.escrow_factory_addresses | join(', ') -%}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/_meta/oneinch_easy_date.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/_meta/oneinch_easy_date.sql
@@ -1,6 +1,0 @@
--- TEMP, CI ONLY -- REVERT THIS COMMIT BEFORE MERGE --
--- Clamps every oneinch model's start date to a rolling two-day window so CI builds only
--- recent data while shared macro changes force the complete oneinch lineage to rebuild.
-{% macro oneinch_easy_date() %}
-    {{ return((modules.datetime.date.today() - modules.datetime.timedelta(days=2)).isoformat()) }}
-{% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/_meta/oneinch_easy_date.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/_meta/oneinch_easy_date.sql
@@ -1,0 +1,6 @@
+-- TEMP, CI ONLY -- REVERT THIS COMMIT BEFORE MERGE --
+-- Clamps every oneinch model's start date to a rolling two-day window so CI builds only
+-- recent data while shared macro changes force the complete oneinch lineage to rebuild.
+{% macro oneinch_easy_date() %}
+    {{ return((modules.datetime.date.today() - modules.datetime.timedelta(days=2)).isoformat()) }}
+{% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/_meta/oneinch_meta_cfg_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/_meta/oneinch_meta_cfg_macro.sql
@@ -283,6 +283,23 @@
     }) }}
 {% endmacro %}
 
+{% macro oneinch_robinhood_cfg_macro() %}
+    {# transfers_from_traces = false: robinhood tokens uses the newer base_transfers schema, no transfers_from_traces table #}
+    {{ return({
+        "name"                          : "robinhood",
+        "start"                         : "2026-06-01",
+        "chain_id"                      : "4663",
+        "native_token_symbol"           : "'ETH'",
+        "wrapped_native_token_address"  : "0x0bd7d308f8e1639fab988df18a8011f41eacad73",
+        "explorer_link"                 : "'https://robinhoodchain.blockscout.com'",
+        "fusion_settlement_addresses"   : ['0x2ad5004c60e16e54d5007c80ce329adde5b51ef5', '0xabd4e5fb590aa132749bbf2a04ea57efbaac399e'],
+        "escrow_factory_addresses"      : ['0xa02b9cc95094bb27d1d041b9fbf09f65a366f7b3'],
+        "atokens"                       : false,
+        "transfers_from_traces"         : false,
+        "creations_parent_code_offset"  : 21,
+    }) }}
+{% endmacro %}
+
 {% macro oneinch_solana_cfg_macro() %}
     {{ return({
         "name"                          : "solana",
@@ -320,6 +337,7 @@
         dict(oneinch_linea_cfg_macro()      , evm=true  , fusionV1=false, exposed=["ar", "lo", "cc"], contracts=oneinch_meta_contracts_cfg_macro()),
         dict(oneinch_sonic_cfg_macro()      , evm=true  , fusionV1=false, exposed=["ar", "lo", "cc"], contracts=oneinch_meta_contracts_cfg_macro()),
         dict(oneinch_unichain_cfg_macro()   , evm=true  , fusionV1=false, exposed=["ar", "lo", "cc"], contracts=oneinch_meta_contracts_cfg_macro()),
+        dict(oneinch_robinhood_cfg_macro()  , evm=true  , fusionV1=false, exposed=["ar", "lo", "cc"], contracts=oneinch_meta_contracts_cfg_macro()),
         dict(oneinch_aurora_cfg_macro()     , evm=true  , fusionV1=false),
         dict(oneinch_klaytn_cfg_macro()     , evm=true  , fusionV1=false),
         dict(oneinch_solana_cfg_macro()     , evm=false , fusionV1=false),

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/oneinch_raw_calls_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/oneinch_raw_calls_macro.sql
@@ -7,7 +7,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start] | max -%}
+{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
 
 
 
@@ -16,7 +16,8 @@ with
 {% if type == "raw" -%} creations as (
     select
         distinct address as contract_address
-        , substr(code, 13, 20) as parent
+        {#- the escrow implementation address position in the clone creation code differs by chain: standard EVM EIP-1167 clones hold it at byte 21, zksync bytecode differs (byte 13) -#}
+        , substr(code, {{ blockchain.get('creations_parent_code_offset', 13) }}, 20) as parent
     from {{ source(blockchain.name, 'creation_traces') }}
     where true
         and "from" in ({{ blockchain.escrow_factory_addresses | join(', ') }})

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/oneinch_raw_calls_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/oneinch_raw_calls_macro.sql
@@ -7,7 +7,7 @@
     )
 -%}
 
-{%- set date_from = [blockchain.start, stream.start, oneinch_easy_date()] | max -%}
+{%- set date_from = [blockchain.start, stream.start] | max -%}
 
 
 

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/oneinch_transfers_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/oneinch_transfers_macro.sql
@@ -8,6 +8,9 @@
 {%- set wrapper = blockchain.wrapped_native_token_address -%}
 {%- set nsymbol = blockchain.native_token_symbol -%}
 {%- set same = '0x0000000000000000000000000000000000000000, 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' -%}
+{#- chains onboarded to the legacy tokens schema expose transfers_from_traces; newer chains (e.g. robinhood) expose base_transfers instead -#}
+{%- set transfers_from_traces = blockchain.get('transfers_from_traces', true) -%}
+{%- set transfers_table = 'transfers_from_traces' if transfers_from_traces else 'base_transfers' -%}
 
 
 
@@ -19,7 +22,7 @@ calls as (
     from (
         {%- for stream in streams %}
         -- STREAM: {{ stream }} --
-            {% set date_from = stream.start %}
+            {% set date_from = [stream.start, oneinch_easy_date()] | max %}
             select
                 block_number
                 , block_month
@@ -64,7 +67,11 @@ calls as (
         , contract_name
         , call_method
         , call_selector
+        {%- if transfers_from_traces %}
         , trace_address as transfer_trace_address
+        {%- else %}
+        , coalesce(trace_address, array[-1, evt_index]) as transfer_trace_address -- event-based transfers in base_transfers have no trace_address; build a unique non-null pseudo trace from evt_index (real traces never contain negative elements)
+        {%- endif %}
         , contract_address as transfer_contract_address -- original
         , if(token_standard = 'native', {{ wrapper }}, {% if blockchain.atokens %}coalesce(underlying_address, contract_address){% else %}contract_address{% endif %}) as contract_address
         , if(token_standard = 'native', {{ nsymbol }}{% if blockchain.atokens %}, atoken_symbol{% endif %}) as _symbol
@@ -74,10 +81,22 @@ calls as (
         , "to" as transfer_to
         , date_trunc('minute', block_time) as minute
         , block_date
+        {%- if transfers_from_traces %}
         , slice(trace_address, 1, cardinality(call_trace_address)) = call_trace_address as nested -- nested transfers only
         , reduce(call_trace_addresses, call_trace_address, (r, x) -> if(slice(trace_address, 1, cardinality(x)) = x and x > r, x, r), r -> r) = call_trace_address as related -- transfers related to the call only, i.e. without transfers in nested calls
+        {%- else %}
+        {#- event-based transfers can't be placed in the call subtree; attribute them to the call only when all tracked calls of the tx are within this call's subtree (i.e. the call is the outermost one), so sibling calls in batched txs are never cross-attributed -#}
+        , coalesce(
+            slice(trace_address, 1, cardinality(call_trace_address)) = call_trace_address
+            , all_match(call_trace_addresses, x -> slice(x, 1, cardinality(call_trace_address)) = call_trace_address)
+        ) as nested -- nested transfers only
+        , if(trace_address is not null
+            , reduce(call_trace_addresses, call_trace_address, (r, x) -> if(slice(trace_address, 1, cardinality(x)) = x and x > r, x, r), r -> r) = call_trace_address
+            , all_match(call_trace_addresses, x -> slice(x, 1, cardinality(call_trace_address)) = call_trace_address)
+        ) as related -- transfers related to the call only, i.e. without transfers in nested calls
+        {%- endif %}
     from calls
-    join {{ source('tokens_' + blockchain.name, 'transfers_from_traces') }} using(block_month, block_date, block_number, tx_hash)
+    join {{ source('tokens_' + blockchain.name, transfers_table) }} using(block_month, block_date, block_number, tx_hash)
     {% if blockchain.atokens %}left join atokens using(contract_address){% endif %}
 )
 

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/oneinch_transfers_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/oneinch_transfers_macro.sql
@@ -22,7 +22,7 @@ calls as (
     from (
         {%- for stream in streams %}
         -- STREAM: {{ stream }} --
-            {% set date_from = [stream.start, oneinch_easy_date()] | max %}
+            {% set date_from = stream.start %}
             select
                 block_number
                 , block_month

--- a/dbt_subprojects/dex/models/_projects/oneinch/_meta/oneinch_intent_accounts.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/_meta/oneinch_intent_accounts.sql
@@ -9,7 +9,7 @@
     )
 -}}
 
-{%- set date_from = oneinch_lo_fusion_cfg_macro().start -%}
+{%- set date_from = [oneinch_lo_fusion_cfg_macro().start, oneinch_easy_date()] | max -%}
 
 
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/_meta/oneinch_intent_accounts.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/_meta/oneinch_intent_accounts.sql
@@ -9,7 +9,7 @@
     )
 -}}
 
-{%- set date_from = [oneinch_lo_fusion_cfg_macro().start, oneinch_easy_date()] | max -%}
+{%- set date_from = oneinch_lo_fusion_cfg_macro().start -%}
 
 
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/_meta/oneinch_intent_executors.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/_meta/oneinch_intent_executors.sql
@@ -76,8 +76,18 @@ promotions as (
         , first_access_transfer_at
         , last_access_transfer_at
         , coalesce(last_promoted_at, last_access_transfer_at) as last_time
-    from promotions
-    left join {{ ref('oneinch_blockchains') }} as meta using(chain_id)
+    from (
+        -- promotions can target chain ids missing from the blockchains cfg (e.g. a promotion to chain id 38): label them '#<chain_id>' to keep blockchain non-null --
+        select
+            coalesce(meta.blockchain, '#' || cast(chain_id as varchar)) as blockchain
+            , resolver_address
+            , executor_address
+            , promotion_mode
+            , first_promoted_at
+            , last_promoted_at
+        from promotions
+        left join {{ ref('oneinch_blockchains') }} as meta using(chain_id)
+    )
     full join accesses using(blockchain, executor_address)
 )
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/oneinch/_schema.yml
@@ -3,9 +3,9 @@ version: 2
 models:
   - name: oneinch_ar
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['max-morrow', 'grkhr']
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
     config:
       tags: ['oneinch', 'ar', 'calls']
     description: >
@@ -69,9 +69,9 @@ models:
 
   - name: oneinch_lo
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['max-morrow', 'grkhr']
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
     config:
       tags: ['oneinch', 'lo', 'calls']
     description: >
@@ -135,9 +135,9 @@ models:
 
   - name: oneinch_cc
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['max-morrow', 'grkhr']
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
     config:
       tags: ['oneinch', 'cc', 'calls']
     description: >
@@ -288,9 +288,9 @@ models:
 
   - name: oneinch_evms_transfers
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['max-morrow', 'grkhr']
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
     config:
       tags: ['oneinch', 'transfers']
     description: >
@@ -345,9 +345,9 @@ models:
 
   - name: oneinch_blockchains
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['max-morrow', 'grkhr']
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
     config:
       tags: ['oneinch', 'blockchain']
     description: >
@@ -367,9 +367,9 @@ models:
 
   - name: oneinch_evms_ptfc
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['max-morrow', 'grkhr']
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
     config:
       tags: ['oneinch', 'internal']
     description: >
@@ -389,9 +389,9 @@ models:
 
   - name: oneinch_ar_trades
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['max-morrow', 'grkhr', 'thevaizman']
+      contributors: ['max-morrow', 'grkhr', 'thevaizman', 'dodgervl']
     config:
       tags: ['oneinch', 'ar', 'trades']
     description: >
@@ -439,9 +439,9 @@ models:
 
   - name: oneinch_lop_own_trades
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['max-morrow', 'grkhr', 'thevaizman']
+      contributors: ['max-morrow', 'grkhr', 'thevaizman', 'dodgervl']
     config:
       tags: ['oneinch', 'lo', 'trades']
     description: >
@@ -1274,11 +1274,71 @@ models:
         with a maturity delay so the venue side's decoded events have landed before
         dex_unichain_trades merges them.
 
+  - name: oneinch_robinhood_lop_venue_settled_fills
+    meta:
+      blockchain: ['robinhood']
+      sector: oneinch
+      contributors: ['thevaizman', 'dodgervl']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on robinhood that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_robinhood_base_trades). These fills are excluded from
+        oneinch_robinhood_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_robinhood_lop_own_trades
+    meta:
+      blockchain: ['robinhood']
+      sector: oneinch
+      contributors: ['thevaizman', 'dodgervl']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on robinhood - per-chain input for
+        dex_robinhood_trades. Venue-settled fills are excluded here (see
+        oneinch_robinhood_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_robinhood_trades merges them.
+
   - name: oneinch_lop_aggregator_trades
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['thevaizman']
+      contributors: ['thevaizman', 'dodgervl']
     config:
       tags: ['oneinch', 'lo', 'trades']
     description: >
@@ -1296,11 +1356,6 @@ models:
               - tx_hash
               - trace_address
               - evt_index
-      - check_dex_aggregator_seed:
-          arguments:
-            blockchain: arbitrum
-            project: 1inch-LOP
-            version: '4.0'
     columns:
       - name: blockchain
         data_tests:
@@ -1335,9 +1390,9 @@ models:
 
   - name: oneinch_intent_resolvers
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['max-morrow']
+      contributors: ['max-morrow', 'dodgervl']
     config:
       tags: ['oneinch', 'metadata']
     description: >
@@ -1362,9 +1417,9 @@ models:
 
   - name: oneinch_intent_executors
     meta:
-      blockchain: ['ethereum', 'optimism', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'bnb', 'fantom', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'optimism', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'bnb', 'fantom', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['max-morrow']
+      contributors: ['max-morrow', 'dodgervl']
     config:
       tags: ['oneinch', 'metadata']
     description: >
@@ -1397,9 +1452,9 @@ models:
 
   - name: oneinch_intent_accounts
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['max-morrow']
+      contributors: ['max-morrow', 'dodgervl']
     config:
       tags: ['oneinch', 'metadata']
     description: >

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_ar.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_ar.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_robinhood_cfg_macro() -%}
+{%- set stream = oneinch_ar_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name,
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_ar_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_robinhood_ar_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_ar_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_ar_executions.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_robinhood_cfg_macro() -%}
+{%- set stream = oneinch_ar_executions_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_executions',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_ar_executions_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_ar_raw_calls.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_ar_raw_calls.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_robinhood_cfg_macro() -%}
+{%- set stream = oneinch_ar_raw_calls_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_raw_calls',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_raw_calls_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_robinhood_ar_raw_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_cc.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_cc.sql
@@ -1,0 +1,25 @@
+{%- set blockchain = oneinch_robinhood_cfg_macro() -%}
+{%- set stream = oneinch_cc_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name,
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_cc_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_robinhood_cc_contracts_cfg_macro(),
+        initial = oneinch_robinhood_lo_contracts_cfg_macro(),
+        type = "raw",
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_cc_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_cc_executions.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_robinhood_cfg_macro() -%}
+{%- set stream = oneinch_cc_executions_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_executions',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_cc_executions_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_cc_raw_calls.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_cc_raw_calls.sql
@@ -1,0 +1,24 @@
+{%- set blockchain = oneinch_robinhood_cfg_macro() -%}
+{%- set stream = oneinch_cc_raw_calls_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_raw_calls',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_raw_calls_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_robinhood_cc_contracts_cfg_macro(),
+        type = "raw",
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_lo.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_lo.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_robinhood_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name,
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_lo_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_robinhood_lo_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_lo_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_lo_executions.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_robinhood_cfg_macro() -%}
+{%- set stream = oneinch_lo_executions_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_executions',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_lo_executions_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_lo_raw_calls.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_lo_raw_calls.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_robinhood_cfg_macro() -%}
+{%- set stream = oneinch_lo_raw_calls_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_raw_calls',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_raw_calls_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_robinhood_lo_raw_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_lop_own_trades.sql
@@ -1,0 +1,15 @@
+{%- set blockchain = oneinch_robinhood_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_lop_venue_settled_fills.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_robinhood_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_schema.yml
@@ -1,0 +1,262 @@
+version: 2
+
+models:
+  - name: oneinch_robinhood_ar
+    meta:
+      blockchain: ['robinhood']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'ar', 'calls']
+    description: >
+        1inch aggregation router calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: chain_id
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: tx_success
+      - name: tx_from
+      - name: tx_to
+      - name: tx_nonce
+      - name: tx_gas_used
+      - name: tx_gas_price
+      - name: tx_priority_fee_per_gas
+      - name: tx_index
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_success
+      - name: call_gas_used
+      - name: call_selector
+      - name: call_method
+      - name: call_from
+      - name: call_to
+      - name: call_output
+      - name: call_error
+      - name: call_type
+      - name: protocol
+      - name: protocol_version
+      - name: contract_name
+      - name: src_receiver
+      - name: dst_receiver
+      - name: src_token_address
+      - name: dst_token_address
+      - name: src_token_amount
+      - name: dst_token_amount
+      - name: dst_token_amount_min
+      - name: router_type
+      - name: pools
+      - name: remains
+      - name: flags
+      - name: minute
+      - name: block_date
+      - name: block_month
+      - name: native_price
+      - name: native_decimals
+
+  - name: oneinch_robinhood_lo
+    meta:
+      blockchain: ['robinhood']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'lo', 'calls']
+    description: >
+        1inch limit order protocol calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: chain_id
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: tx_success
+      - name: tx_from
+      - name: tx_to
+      - name: tx_nonce
+      - name: tx_gas_used
+      - name: tx_gas_price
+      - name: tx_priority_fee_per_gas
+      - name: tx_index
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_success
+      - name: call_gas_used
+      - name: call_selector
+      - name: call_method
+      - name: call_from
+      - name: call_to
+      - name: call_output
+      - name: call_error
+      - name: call_type
+      - name: protocol
+      - name: protocol_version
+      - name: contract_name
+      - name: order_hash
+      - name: maker
+      - name: receiver
+      - name: maker_asset
+      - name: maker_amount
+      - name: making_amount
+      - name: taker_asset
+      - name: taker_amount
+      - name: taking_amount
+      - name: remains
+      - name: flags
+      - name: minute
+      - name: block_date
+      - name: block_month
+      - name: native_price
+      - name: native_decimals
+
+  - name: oneinch_robinhood_cc
+    meta:
+      blockchain: ['robinhood']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'cc', 'calls']
+    description: >
+        1inch cross-chain calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: chain_id
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: tx_success
+      - name: tx_from
+      - name: tx_to
+      - name: tx_nonce
+      - name: tx_gas_used
+      - name: tx_gas_price
+      - name: tx_priority_fee_per_gas
+      - name: tx_index
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_success
+      - name: call_gas_used
+      - name: call_selector
+      - name: call_method
+      - name: call_from
+      - name: call_to
+      - name: call_output
+      - name: call_error
+      - name: call_type
+      - name: protocol
+      - name: protocol_version
+      - name: contract_name
+      - name: action
+      - name: action_id
+      - name: order_hash
+      - name: hashlock
+      - name: flow
+      - name: escrow
+      - name: secret
+      - name: maker
+      - name: receiver
+      - name: taker
+      - name: token
+      - name: amount
+      - name: safety_deposit
+      - name: timelocks
+      - name: complement
+      - name: remains
+      - name: minute
+      - name: block_date
+      - name: block_month
+      - name: native_price
+      - name: native_decimals
+
+  - name: oneinch_robinhood_transfers
+    meta:
+      blockchain: ['robinhood']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'calls']
+    description: >
+        transfers within transactions with 1inch calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+              - transfer_trace_address
+              - transfer_contract_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_selector
+      - name: call_method
+      - name: call_to
+      - name: protocol
+      - name: contract_name
+      - name: transfer_trace_address
+        data_tests:
+          - not_null
+      - name: transfer_contract_address
+        data_tests:
+          - not_null
+      - name: transfer_from
+      - name: transfer_to
+      - name: transfer_symbol
+      - name: transfer_amount
+      - name: transfer_amount_usd
+      - name: transfer_decimals
+      - name: trusted
+      - name: nested
+      - name: related
+      - name: same
+      - name: price
+      - name: block_date
+      - name: block_month
+      - name: transfer_id
+      - name: unique_key

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_transfers.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/robinhood/oneinch_robinhood_transfers.sql
@@ -1,0 +1,25 @@
+{%- set blockchain = oneinch_robinhood_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'transfers',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address', 'transfer_trace_address', 'transfer_contract_address'],
+    )
+-}}
+
+{{-
+    oneinch_transfers_macro(
+        blockchain = blockchain,
+        streams = [
+            oneinch_ar_transfers_cfg_macro(),
+            oneinch_lo_transfers_cfg_macro(),
+            oneinch_cc_transfers_cfg_macro(),
+        ]
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/streams/oneinch_cc_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/streams/oneinch_cc_executions.sql
@@ -12,7 +12,7 @@
     )
 -}}
 
-{%- set date_from = [stream.start, oneinch_easy_date()] | max -%}
+{%- set date_from = stream.start -%}
 
 
 

--- a/dbt_subprojects/dex/models/_projects/oneinch/streams/oneinch_cc_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/streams/oneinch_cc_executions.sql
@@ -12,7 +12,7 @@
     )
 -}}
 
-{%- set date_from = stream.start -%}
+{%- set date_from = [stream.start, oneinch_easy_date()] | max -%}
 
 
 

--- a/dbt_subprojects/dex/models/trades/robinhood/dex_robinhood_trades.sql
+++ b/dbt_subprojects/dex/models/trades/robinhood/dex_robinhood_trades.sql
@@ -21,6 +21,9 @@ WITH dexs AS (
         )
     }}
 )
+, oneinch_lop AS (
+	{{ oneinch_lop_dex_trades_passthrough(blockchain = 'robinhood') }}
+)
 
 SELECT
     blockchain
@@ -50,3 +53,34 @@ SELECT
     , current_timestamp AS _updated_at
 FROM
     dexs
+
+UNION ALL
+
+SELECT
+    blockchain
+    , project
+    , version
+    , block_month
+    , block_date
+    , block_time
+    , block_number
+    , token_bought_symbol
+    , token_sold_symbol
+    , token_pair
+    , token_bought_amount
+    , token_sold_amount
+    , token_bought_amount_raw
+    , token_sold_amount_raw
+    , amount_usd
+    , token_bought_address
+    , token_sold_address
+    , taker
+    , maker
+    , project_contract_address
+    , tx_hash
+    , tx_from
+    , tx_to
+    , evt_index
+    , current_timestamp AS _updated_at
+FROM
+    oneinch_lop

--- a/sources/oneinch/robinhood/oneinch_robinhood_sources.yml
+++ b/sources/oneinch/robinhood/oneinch_robinhood_sources.yml
@@ -1,0 +1,48 @@
+version: 2
+
+sources:
+  - name: oneinch_robinhood
+    tables:
+      - name: AggregationRouterV6_call_swap
+      - name: AggregationRouterV6_call_clipperSwap
+      - name: AggregationRouterV6_call_clipperSwapTo
+      - name: AggregationRouterV6_call_unoswap
+      - name: AggregationRouterV6_call_unoswap2
+      - name: AggregationRouterV6_call_unoswap3
+      - name: AggregationRouterV6_call_unoswapTo
+      - name: AggregationRouterV6_call_unoswapTo2
+      - name: AggregationRouterV6_call_unoswapTo3
+      - name: AggregationRouterV6_call_ethUnoswap
+      - name: AggregationRouterV6_call_ethUnoswap2
+      - name: AggregationRouterV6_call_ethUnoswap3
+      - name: AggregationRouterV6_call_ethUnoswapTo
+      - name: AggregationRouterV6_call_ethUnoswapTo2
+      - name: AggregationRouterV6_call_ethUnoswapTo3
+      - name: AggregationRouterV6_call_fillOrder
+      - name: AggregationRouterV6_call_fillOrderArgs
+      - name: AggregationRouterV6_call_fillContractOrder
+      - name: AggregationRouterV6_call_fillContractOrderArgs
+      - name: AggregationRouterV6_call_permitAndCall
+      - name: EscrowFactoryV1_call_addressOfEscrowSrc
+      - name: EscrowFactoryV1_call_createDstEscrow
+      - name: EscrowFactoryV1_evt_SrcEscrowCreated
+      - name: EscrowSrcV1_call_withdraw
+      - name: EscrowSrcV1_call_withdrawTo
+      - name: EscrowSrcV1_call_publicWithdraw
+      - name: EscrowSrcV1_call_cancel
+      - name: EscrowSrcV1_call_publicCancel
+      - name: EscrowSrcV1_call_rescueFunds
+      - name: EscrowDstV1_call_withdraw
+      - name: EscrowDstV1_call_publicWithdraw
+      - name: EscrowDstV1_call_cancel
+      - name: EscrowDstV1_call_rescueFunds
+      - name: AccessTokenFusionV1_evt_transfer
+      - name: AccessTokenLimitsV1_evt_transfer
+      - name: AccessTokenCrossChainV1_evt_transfer
+      - name: ar
+      - name: lo
+
+
+  - name: tokens_robinhood
+    tables:
+      - name: base_transfers


### PR DESCRIPTION
## What & why
Temporary same-repository CI mirror of [#9918](https://github.com/duneanalytics/spellbook/pull/9918).
The fork workflow cannot wake the DEX cluster, so this branch runs the same code with trusted internal CI credentials.
It includes the rolling two-day 1inch clamp and omits the stale Arbitrum seed assertion.
Do not merge; close this draft after CI validation.
- No visual surface (dbt-only CI validation)

## Architecture
- The 1inch AR, LO, CC, transfer, execution, and Robinhood model changes match #9918 at `87166f2de`.
- Tested: the complete 1inch model path compiles locally. Runtime initial and incremental validation is delegated to this PR CI.
- Needs human eyes: confirm the DEX initial and incremental jobs finish green.
- Cross-system blast radius: none; this is a draft CI mirror and must not merge.

<details><summary>Agent context</summary>

- Source PR: https://github.com/duneanalytics/spellbook/pull/9918
- Fork CI run blocked during DEX cluster activation: https://github.com/duneanalytics/spellbook/actions/runs/32069124428
- Repro: `uv run dbt compile --select path:models/_projects/oneinch --project-dir dbt_subprojects/dex/`
</details>