### PR TITLE
feat(prices): add reUSD (Re Protocol) on solana + 6 EVM chains

### DIFF
--- a/dbt_subprojects/tokens/models/prices/arbitrum/prices_arbitrum_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/arbitrum/prices_arbitrum_tokens.sql
@@ -237,5 +237,6 @@ FROM
     ('hyper-hyperlane', 'arbitrum', 'HYPER', 0xc9d23ed2adb0f551369946bd377f8644ce1ca5c4, 18),
     ('usdai-usdai', 'arbitrum', 'USDai', 0x0a1a1a107e45b7ced86833863f482bc5f4ed82ef, 18),
     ('logx-logx-network', 'arbitrum', 'LOGX', 0x59062301fb510f4ea2417b67404cb16d31e604ba, 18),
-    ('usdg-global-dollar', 'arbitrum', 'USDG', 0x004B506865409877C9fA29bfb1ebA929984B9bbC, 6)
+    ('usdg-global-dollar', 'arbitrum', 'USDG', 0x004B506865409877C9fA29bfb1ebA929984B9bbC, 6),
+    ('reusd-re-protocol-reusd', 'arbitrum', 'reUSD', 0x76ce01f0ef25aa66cc5f1e546a005e4a63b25609, 18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/avalanche_c/prices_avalanche_c_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/avalanche_c/prices_avalanche_c_tokens.sql
@@ -109,6 +109,7 @@ FROM
     --('joe-lfj', 'avalanche_c', 'JOE', 0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd, 18),
     ('egg-chikn-egg', 'avalanche_c', 'EGG', 0x7761e2338b35bceb6bda6ce477ef012bde7ae611, 18),
     ('cra-crabada', 'avalanche_c', 'CRA', 0xa32608e873f9ddef944b24798db69d80bbb4d1ed, 18),
-    ('ket-ket2', 'avalanche_c', 'KET', 0xffff003a6bad9b743d658048742935fffe2b6ed7, 18)
+    ('ket-ket2', 'avalanche_c', 'KET', 0xffff003a6bad9b743d658048742935fffe2b6ed7, 18),
+    ('reusd-re-protocol-reusd', 'avalanche_c', 'reUSD', 0x180af87b47bf272b2df59dccf2d76a6eafa625bf, 18)
 
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/base/prices_base_tokens.sql
@@ -245,5 +245,6 @@ FROM
     ('up-superform', 'base', 'UP', 0x5b2193fDc451C1f847bE09CA9d13A4Bf60f8c86B, 18),
     ('fun-sportfun', 'base', 'FUN', 0x16EE7ecAc70d1028E7712751E2Ee6BA808a7dd92, 18),
     --Coinpaprika RWA tokenized stocks, ETFs & FX
-    ('mxne-real-mxn-1', 'base', 'MXNe', 0x269cae7dc59803e5c596c95756faeebb6030e0af, 6)
+    ('mxne-real-mxn-1', 'base', 'MXNe', 0x269cae7dc59803e5c596c95756faeebb6030e0af, 6),
+    ('reusd-re-protocol-reusd', 'base', 'reUSD', 0x7d214438d0f27afccc23b3d1e1a53906ace5cfea, 18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/bnb/prices_bnb_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/bnb/prices_bnb_tokens.sql
@@ -417,7 +417,8 @@ FROM
     --Coinpaprika RWA tokens recently activated (was inactive in source mapping)
     ('nteson-netease-tokenized-stock-ondo', 'bnb', 'NTESon', 0x282973969118f9fe39bf2ff3d8dd1efee82ccb11, 18),
     ('wulfon-terawulf-ondo-tokenized', 'bnb', 'WULFon', 0xad56701d9e57957e28e546db7db508a16d4f86cc, 18),
-    ('vtvon-vanguard-value-tokenized-etf-ondo', 'bnb', 'VTVon', 0xc2dd31b1b3a2f515ce0d48de712c6744c3475170, 18)
+    ('vtvon-vanguard-value-tokenized-etf-ondo', 'bnb', 'VTVon', 0xc2dd31b1b3a2f515ce0d48de712c6744c3475170, 18),
+    ('reusd-re-protocol-reusd', 'bnb', 'reUSD', 0xba9425ec55ee0e72216d18e0ad8bbba2553bfb60, 18)
 
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)
 where contract_address not in (

--- a/dbt_subprojects/tokens/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -2050,7 +2050,8 @@ FROM
     ('amcon-amc-entertainment-ondo-tokenized-stocks', 'ethereum', 'AMCon', 0x592643a667633bca51cb2387c98b6de6ce549a45, 18),
     ('ethaon-ishares-ethereum-trust-tokenized-stock-ondo', 'ethereum', 'ETHAon', 0x98284fbc11edd7540e29b896a49817bbe52ddcbd, 18),
     ('enlvon-enlivex-therapeutics-tokenized-stock-ondo', 'ethereum', 'ENLVon', 0xc4e6e80295154d3968519851f73f8dc1a227286f, 18),
-    ('schwon-charles-schwab-ondo-tokenized-stock', 'ethereum', 'SCHWon', 0xe737f948bdfe3beae9423292853ec0579173cebb, 18)
+    ('schwon-charles-schwab-ondo-tokenized-stock', 'ethereum', 'SCHWon', 0xe737f948bdfe3beae9423292853ec0579173cebb, 18),
+    ('reusd-re-protocol-reusd', 'ethereum', 'reUSD', 0x5086bf358635b81d8c47c66d1c8b9e567db70c72, 18)
    ) as temp (token_id, blockchain, symbol, contract_address, decimals)
 where contract_address not in (
     -- bad price feeds

--- a/dbt_subprojects/tokens/models/prices/ink/prices_ink_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/ink/prices_ink_tokens.sql
@@ -25,4 +25,5 @@ FROM
     , ('usdt-tether', 'USD₮0', 0x0200C29006150606B650577BBE7B6248F58470c1, 6)
     , ('kbtc-kraken-wrapped-bitcoin', 'kBTC', 0x73e0c0d45e048d25fc26fa3159b0aa04bfa4db98, 8)
     , ('usdg-global-dollar', 'USDG', 0xe343167631d89b6ffc58b88d6b7fb0228795491d, 6)
+    , ('reusd-re-protocol-reusd', 'reUSD', 0x5bcf6b008bf80b9296238546bace1797657b05d6, 18)
 ) as temp (token_id, symbol, contract_address, decimals)

--- a/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/solana/prices_solana_tokens.sql
@@ -866,6 +866,7 @@ FROM
         ('xomx-exxon-mobil-tokenized-stock-xstock','solana','XOMx','XsaHND8sHyfMfsWPj6kSdd5VwvCayZvjYgKmmcNL5qh',8),
         ('pltrx-palantir-tokenized-stock-xstock','solana','PLTRx','XsoBhf2ufR8fTyNSjqfU71DYGaE6Z3SUGAidpzriAA4',8),
         ('mrvlx-marvell-tokenized-stock-xstock','solana','MRVLx','XsuxRGDzbLjnJ72v74b7p9VY6N66uYgTCyfwwRjVCJA',8),
-        ('pmx-philip-morris-xstock','solana','PMx','Xsba6tUnSjDae2VcopDB6FGGDaxRrewFCDa5hKn5vT3',8)
+        ('pmx-philip-morris-xstock','solana','PMx','Xsba6tUnSjDae2VcopDB6FGGDaxRrewFCDa5hKn5vT3',8),
+        ('reusd-re-protocol-reusd','solana','reUSD','2uxaYT1fVrp6Fg2BrxQcyKSW91hefM6dG9krpbeDiirT',9)
 
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄

### Description:

Adds **reUSD** (Re Protocol, [`reusd-re-protocol-reusd`](https://api.coinpaprika.com/v1/coins/reusd-re-protocol-reusd)) to `prices.tokens` on all 7 chains CoinPaprika lists a contract for.

| chain | contract | decimals |
|---|---|---|
| solana | `2uxaYT1fVrp6Fg2BrxQcyKSW91hefM6dG9krpbeDiirT` | 9 |
| ethereum | `0x5086bf358635b81d8c47c66d1c8b9e567db70c72` | 18 |
| base | `0x7d214438d0f27afccc23b3d1e1a53906ace5cfea` | 18 |
| bnb | `0xba9425ec55ee0e72216d18e0ad8bbba2553bfb60` | 18 |
| arbitrum | `0x76ce01f0ef25aa66cc5f1e546a005e4a63b25609` | 18 |
| avalanche_c | `0x180af87b47bf272b2df59dccf2d76a6eafa625bf` | 18 |
| ink | `0x5bcf6b008bf80b9296238546bace1797657b05d6` | 18 |

Verification:
- CoinPaprika feed is live: `"is_active": true`, `"type": "token"`, all 7 contracts present on the coin record.
- Symbol and decimals confirmed onchain — EVM rows against `tokens.erc20` ([query](https://dune.com/queries/8380679)), the Solana mint against `tokens_solana.fungible` ([query](https://dune.com/queries/8380682)); both return symbol `reUSD`, decimals 18 / 9 respectively.

Prompted by: Karim Hassan
