### PR TITLE
fix(nft): correct declared blockchains on nft.trades and nft.wash_trades

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/nft/trades/nft_trades.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/nft/trades/nft_trades.sql
@@ -3,7 +3,7 @@
     alias = 'trades',
     materialized = 'view',
     filtering_columns = ['blockchain', 'project', 'block_month'],
-    post_hook='{{ expose_spells(\'["ethereum","solana","bnb","optimism","arbitrum","polygon","zksync", "blast", "ronin", "nova", "abstract", "apechain"]\',
+    post_hook='{{ expose_spells(\'["abstract", "apechain", "arbitrum", "avalanche_c", "base", "blast", "bnb", "celo", "ethereum", "fantom", "linea", "nova", "optimism", "polygon", "ronin", "scroll", "zksync", "zora"]\',
                     "sector",
                     "nft",
                     \'["soispoke","0xRob", "hildobby", "0xr3x"]\') }}')

--- a/dbt_subprojects/hourly_spellbook/models/_sector/nft/wash_trades/nft_wash_trades.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/nft/wash_trades/nft_wash_trades.sql
@@ -3,7 +3,7 @@
         schema = 'nft',
         filtering_columns = ['blockchain'],
         
-        post_hook='{{ expose_spells(\'["arbitrum", "avalanche_c", "bnb", "ethereum", "gnosis", "optimism", "polygon", "celo", "zksync", "base", "scroll", "zora", "blast", "fantom", "ronin", "nova", "linea", "abstract"]\',
+        post_hook='{{ expose_spells(\'["abstract", "apechain", "arbitrum", "avalanche_c", "base", "blast", "bnb", "celo", "ethereum", "fantom", "linea", "nova", "optimism", "polygon", "ronin", "scroll", "zksync", "zora"]\',
                                     "sector",
                                     "nft",
                                     \'["hildobby", "0xr3x"]\') }}')


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

The `expose_spells()` blockchain list is a hand-maintained JSON string that lands in the `dune.data_explorer.blockchains` table property, which drives the chain badges and chain filter shown for a table in the Data Explorer. Nothing validates it against the chains the model actually unions, so both nft lists had drifted.

`nft.trades` advertised `solana` (no solana model exists anywhere in the nft sector) while omitting `base`, `avalanche_c`, `scroll`, `linea`, `zora`, `fantom` and `celo` — `base` alone is 28.0M trades and the 3rd-largest chain in the table, so users searching the chain filter for it got "No results found". `nft.wash_trades` drifted the other way: it advertised `gnosis` (0 rows) and omitted `apechain`, which is in its own `nft_wash_models` list. Both now declare the same 18 chains that are present in the data.

**Architecture**

- `nft_trades.sql`, `nft_wash_trades.sql` — post-hook metadata only. No SQL, schema or row-level change; the served data is identical before and after.
- Chain list verified three ways: `select blockchain, count(*) from nft.trades group by 1` ([query 8389179](https://dune.com/queries/8389179), 18 chains) and the same on `nft.wash_trades` ([query 8389226](https://dune.com/queries/8389226), identical 18), matching the 18 chain dirs under `trades/chains/` and the 18 `ref()`s in `nft_base_trades.sql`.
- Not tested: `expose_spells()` is `target.name == 'prod'`-gated, so CI never executes this post-hook. The corrected property only lands on the next hourly prod run of the nft sub-project.
- Needs human eyes: dropping `gnosis` from `nft.wash_trades`. `nft_gnosis_wash_trades` still builds and is still unioned in, but it resolves to 0 rows (its parent `nft.trades` has no gnosis), so the badge advertised an empty chain. If gnosis is expected to come back, keep it listed and ignore that half of the diff.
- Blast radius: Data Explorer chain badges and the chain filter for these two tables. `dune.data_explorer.blockchains` is only consumed as Data Explorer display metadata (`internalAllowedProperties` in `core-go/catalog/accesscontrol/table_properties.go`); no query, API or downstream model reads it.

<details><summary>Agent context</summary>

- No agent review yet.
- Live property confirmed in core's catalog before the change: `select table_type_metadata from mentat.catalog_tables where schema_name='nft' and table_name='trades'` returned `data_explorer_metadata.spell_table.blockchains = ["ethereum","solana","bnb","optimism","arbitrum","polygon","zksync","blast","ronin","nova","abstract","apechain"]` — 12 entries, matching the "3 icons + 9" badge count in the reported UI.
- Follow-up worth considering (not in this PR): assert the declared list against the model's chain `ref()`s at parse time so this cannot drift again silently.
- A second, stale copy of this metadata exists in `dune_table_metadata.spell_metadata.tags` for `nft.trades` (still the pre-migration schema, also tagging solana). Unclear whether anything still reads it; not touched here.

</details>

Prompted by: Karim Hassan

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)