### PR TITLE
CUR2-3852: Add per-chain Uniswap V4 aggregator hook registries

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/uniswap_v4_chain_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_v4_chain_aggregator_hooks.sql
@@ -1,0 +1,25 @@
+{% macro uniswap_v4_chain_aggregator_hooks(blockchain) %}
+{#- Per-chain BaseAggregatorHook registry. Used only by
+    uniswap_v4_{chain}_aggregator_hooks models. The cross-chain
+    uniswap_v4.aggregator_hooks model keeps its own inline copy so a change
+    here does not mark that shared table as state:modified.macros. -#}
+select
+    '{{ blockchain }}' as blockchain
+    , address
+    , min(block_time) as created_at
+from {{ source(blockchain, 'creation_traces') }}
+where bytearray_position(code, 0x633f7d1179) > 0   -- PUSH4 + pollTokenJar()
+  and bytearray_position(code, 0x632d910fb4) > 0   -- PUSH4 + pseudoTotalValueLocked(bytes32)
+  and address is not null
+  -- BaseAggregatorHook takes the PoolManager in its constructor; the earliest V4
+  -- PoolManager deploy is unichain, late Dec 2024, so no aggregator hook can predate this
+  and block_time >= timestamp '2024-11-01'
+{% if is_incremental() -%}
+  -- deliberately wider than incremental_predicate (3d): a creation_traces ingestion
+  -- lag beyond the lookback would permanently miss a hook; this scan is tiny
+  and block_time >= now() - interval '30' day
+{% endif %}
+-- metamorphic CREATE2 redeploys can emit two creation rows for one address;
+-- duplicate source keys would fail the Trino MERGE
+group by 1, 2
+{% endmacro %}

--- a/dbt_subprojects/dex/models/_projects/uniswap/arbitrum/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/arbitrum/_schema.yml
@@ -376,6 +376,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_arbitrum_aggregator_hooks
+    meta:
+      blockchain: arbitrum
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['arbitrum', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on arbitrum, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_arbitrum_swaps
     meta:
       blockchain: arbitrum

--- a/dbt_subprojects/dex/models/_projects/uniswap/arbitrum/uniswap_v4_arbitrum_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/arbitrum/uniswap_v4_arbitrum_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_arbitrum'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('arbitrum') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/avalanche_c/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/avalanche_c/_schema.yml
@@ -346,6 +346,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_avalanche_c_aggregator_hooks
+    meta:
+      blockchain: avalanche_c
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['avalanche_c', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on avalanche_c, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_avalanche_c_swaps
     meta:
       blockchain: avalanche_c

--- a/dbt_subprojects/dex/models/_projects/uniswap/avalanche_c/uniswap_v4_avalanche_c_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/avalanche_c/uniswap_v4_avalanche_c_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_avalanche_c'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('avalanche_c') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/base/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/base/_schema.yml
@@ -376,6 +376,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_base_aggregator_hooks
+    meta:
+      blockchain: base
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['base', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on base, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_base_swaps
     meta:
       blockchain: base

--- a/dbt_subprojects/dex/models/_projects/uniswap/base/uniswap_v4_base_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/base/uniswap_v4_base_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_base'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('base') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/blast/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/blast/_schema.yml
@@ -351,6 +351,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_blast_aggregator_hooks
+    meta:
+      blockchain: blast
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['blast', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on blast, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_blast_swaps
     meta:
       blockchain: blast

--- a/dbt_subprojects/dex/models/_projects/uniswap/blast/uniswap_v4_blast_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/blast/uniswap_v4_blast_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_blast'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('blast') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/bnb/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/bnb/_schema.yml
@@ -351,6 +351,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_bnb_aggregator_hooks
+    meta:
+      blockchain: bnb
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['bnb', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on bnb, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_bnb_swaps
     meta:
       blockchain: bnb

--- a/dbt_subprojects/dex/models/_projects/uniswap/bnb/uniswap_v4_bnb_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/bnb/uniswap_v4_bnb_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_bnb'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('bnb') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/celo/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/celo/_schema.yml
@@ -283,6 +283,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_celo_aggregator_hooks
+    meta:
+      blockchain: celo
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['celo', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on celo, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_celo_swaps
     meta:
       blockchain: celo

--- a/dbt_subprojects/dex/models/_projects/uniswap/celo/uniswap_v4_celo_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/celo/uniswap_v4_celo_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_celo'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('celo') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/ethereum/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/ethereum/_schema.yml
@@ -381,6 +381,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_ethereum_aggregator_hooks
+    meta:
+      blockchain: ethereum
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['ethereum', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on ethereum, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_ethereum_swaps
     meta:
       blockchain: ethereum

--- a/dbt_subprojects/dex/models/_projects/uniswap/ethereum/uniswap_v4_ethereum_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/ethereum/uniswap_v4_ethereum_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_ethereum'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('ethereum') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/ink/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/ink/_schema.yml
@@ -351,6 +351,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_ink_aggregator_hooks
+    meta:
+      blockchain: ink
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['ink', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on ink, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_ink_swaps
     meta:
       blockchain: ink

--- a/dbt_subprojects/dex/models/_projects/uniswap/ink/uniswap_v4_ink_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/ink/uniswap_v4_ink_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_ink'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('ink') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/monad/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/monad/_schema.yml
@@ -346,6 +346,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_monad_aggregator_hooks
+    meta:
+      blockchain: monad
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['monad', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on monad, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_monad_swaps
     meta:
       blockchain: monad

--- a/dbt_subprojects/dex/models/_projects/uniswap/monad/uniswap_v4_monad_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/monad/uniswap_v4_monad_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_monad'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('monad') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/optimism/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/optimism/_schema.yml
@@ -354,6 +354,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_optimism_aggregator_hooks
+    meta:
+      blockchain: optimism
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['optimism', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on optimism, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_optimism_swaps
     meta:
       blockchain: optimism

--- a/dbt_subprojects/dex/models/_projects/uniswap/optimism/uniswap_v4_optimism_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/optimism/uniswap_v4_optimism_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_optimism'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('optimism') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/polygon/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/polygon/_schema.yml
@@ -351,6 +351,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_polygon_aggregator_hooks
+    meta:
+      blockchain: polygon
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['polygon', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on polygon, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_polygon_swaps
     meta:
       blockchain: polygon

--- a/dbt_subprojects/dex/models/_projects/uniswap/polygon/uniswap_v4_polygon_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/polygon/uniswap_v4_polygon_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_polygon'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('polygon') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/tempo/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/tempo/_schema.yml
@@ -1,6 +1,34 @@
 version: 2
 
 models:
+  - name: uniswap_v4_tempo_aggregator_hooks
+    meta:
+      blockchain: tempo
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['tempo', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on tempo, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_tempo_swaps
     meta:
       blockchain: tempo

--- a/dbt_subprojects/dex/models/_projects/uniswap/tempo/uniswap_v4_tempo_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/tempo/uniswap_v4_tempo_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_tempo'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('tempo') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/unichain/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/unichain/_schema.yml
@@ -381,6 +381,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_unichain_aggregator_hooks
+    meta:
+      blockchain: unichain
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['unichain', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on unichain, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_unichain_swaps
     meta:
       blockchain: unichain

--- a/dbt_subprojects/dex/models/_projects/uniswap/unichain/uniswap_v4_unichain_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/unichain/uniswap_v4_unichain_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_unichain'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('unichain') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/worldchain/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/worldchain/_schema.yml
@@ -288,6 +288,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_worldchain_aggregator_hooks
+    meta:
+      blockchain: worldchain
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['worldchain', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on worldchain, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_worldchain_swaps
     meta:
       blockchain: worldchain

--- a/dbt_subprojects/dex/models/_projects/uniswap/worldchain/uniswap_v4_worldchain_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/worldchain/uniswap_v4_worldchain_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_worldchain'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('worldchain') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/xlayer/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/xlayer/_schema.yml
@@ -2,6 +2,34 @@ version: 2
 
 models:
 
+  - name: uniswap_v4_xlayer_aggregator_hooks
+    meta:
+      blockchain: xlayer
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['xlayer', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on xlayer, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_xlayer_swaps
     meta:
       blockchain: xlayer

--- a/dbt_subprojects/dex/models/_projects/uniswap/xlayer/uniswap_v4_xlayer_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/xlayer/uniswap_v4_xlayer_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_xlayer'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('xlayer') }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/zora/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/zora/_schema.yml
@@ -351,6 +351,34 @@ models:
               - tx_hash
               - evt_index
 
+  - name: uniswap_v4_zora_aggregator_hooks
+    meta:
+      blockchain: zora
+      sector: dex
+      project: uniswap
+      contributors: thevaizman
+    config:
+      tags: ['zora', 'dex', 'uniswap', 'v4', 'hooks']
+    description: >
+      Registry of Uniswap V4 BaseAggregatorHook contracts on zora, detected
+      deterministically from deployed bytecode (PUSH4-prefixed selectors of pollTokenJar()
+      and pseudoTotalValueLocked(bytes32)). These hooks route swaps to an external DEX, so
+      their pools' swaps are classified as aggregator trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: address
+        data_tests:
+          - not_null
+      - name: created_at
+
   - name: uniswap_v4_zora_swaps
     meta:
       blockchain: zora

--- a/dbt_subprojects/dex/models/_projects/uniswap/zora/uniswap_v4_zora_aggregator_hooks.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/zora/uniswap_v4_zora_aggregator_hooks.sql
@@ -1,0 +1,15 @@
+{{ config(
+    schema = 'uniswap_v4_zora'
+    , alias = 'aggregator_hooks'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['blockchain', 'address']
+    )
+}}
+
+-- Per-chain registry of Uniswap V4 BaseAggregatorHook contracts.
+-- Same detection as uniswap_v4.aggregator_hooks, scoped to this chain so a new
+-- V4 chain can be onboarded without marking every other chain's swaps modified.
+
+{{ uniswap_v4_chain_aggregator_hooks('zora') }}


### PR DESCRIPTION
## What & why
Adds unused per-chain Uniswap V4 BaseAggregatorHook registries so later PRs can stop every chain's swaps depending on one shared table. No swaps, `dex.trades`, or `uniswap_v4_chains()` changes in this PR. Follow-up to CUR2-3840 / the #9950 full-refresh incident.

**Stack 1 of 3.** Merge this first, then https://github.com/duneanalytics/spellbook/pull/9959 (PR 2), then https://github.com/duneanalytics/spellbook/pull/9960 (PR 3).

## Deploy (this PR)
Normal `spellbook_dex` deploy is fine. These are new tiny incrementals; nothing existing refs them yet, so `dex_{chain}.base_trades` is not in the modified graph.

Wait until the 16 `uniswap_v4_{chain}.aggregator_hooks` tables exist in prod (this deploy or the next cadence) before merging PR 2.

## Architecture

**Today (the #9950 problem):**
```
uniswap_v4_chains()                 # 1-line add
  -> uniswap_v4.aggregator_hooks    # modified.macros
    -> uniswap_v4_{chain}.swaps     # all V4 chains, not just the new one
      -> uniswap_v4_{chain}.base_trades
        -> dex_{chain}.base_trades
          -> dex.trades, sandwiches, arbs, volumes, ...
```

**After the full stack:**
```
uniswap_v4_{chain}.aggregator_hooks     # this PR, unused until PR 2
  -> uniswap_v4_{chain}.swaps           # PR 2
    -> uniswap_v4_{chain}.base_trades
      -> dex_{chain}.base_trades        # only the onboarded chain

uniswap_v4_chains()                     # PR 3 adds xlayer
  -> uniswap_v4.aggregator_hooks        # leftover shared registry, not on dex.trades
  -> uniswap_v4.aggregator_base_trades  # dex_aggregator.* only
```

- `dbt_subprojects/dex/macros/models/_project/uniswap_v4_chain_aggregator_hooks.sql`: new per-chain bytecode scan. Shared `uniswap_v4.aggregator_hooks` keeps its own inline copy so this macro cannot mark it `modified.macros`.
- +16 models: `uniswap_v4_{chain}_aggregator_hooks` for the 16 chains whose swaps currently ref the shared table (robinhood does not).
- Tested: local Bugbot on branch changes. Not compiled locally (no Spellbook Trino creds in this environment).
- Needs human eyes: first prod run of the new registries vs `uniswap_v4.aggregator_hooks` filtered to the same chain.
- Blast radius: none for existing tables. New unused incrementals only.

<details><summary>Agent context</summary>

- Coverage ledger: local Bugbot on this branch, no findings.
- Linear: https://linear.app/dune/issue/CUR2-3852
- Related: https://github.com/duneanalytics/spellbook/pull/9950 (reverted), https://github.com/duneanalytics/spellbook/pull/9954 (xlayer dex.trades without the chain-list add)
- Next: https://github.com/duneanalytics/spellbook/pull/9959, https://github.com/duneanalytics/spellbook/pull/9960
- Repro: `uv run dbt compile --select uniswap_v4_bnb_aggregator_hooks --project-dir dbt_subprojects/dex/`
</details>