### PR TITLE
CUR2-3852: Point Uniswap V4 swaps at per-chain aggregator hook registries

### DIFF
--- a/dbt_subprojects/dex/models/_projects/uniswap/arbitrum/uniswap_v4_arbitrum_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/arbitrum/uniswap_v4_arbitrum_swaps.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_arbitrum', 'PoolManager_evt_Swap')
         , pool_manager_addr = '0x360e68faccca8ca495c1b759fd9eee466db9fb32'
         , start_date = '2025-01-23'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_arbitrum_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/avalanche_c/uniswap_v4_avalanche_c_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/avalanche_c/uniswap_v4_avalanche_c_swaps.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_avalanche_c', 'PoolManager_evt_Swap') 
         , pool_manager_addr = '0x06380c0e0912312b5150364b9dc4542ba0dbbc85'
         , start_date = '2025-01-23'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_avalanche_c_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/base/uniswap_v4_base_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/base/uniswap_v4_base_swaps.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_base', 'PoolManager_evt_Swap') 
         , pool_manager_addr = '0x498581ff718922c3f8e6a244956af099b2652b2b'
         , start_date = '2025-01-23'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_base_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/blast/uniswap_v4_blast_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/blast/uniswap_v4_blast_swaps.sql
@@ -20,6 +20,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_blast', 'PoolManager_evt_Swap') 
         , pool_manager_addr = '0x1631559198a9e474033433b2958dabc135ab6446'
         , start_date = '2025-01-23'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_blast_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/bnb/uniswap_v4_bnb_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/bnb/uniswap_v4_bnb_swaps.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_bnb', 'PoolManager_evt_Swap') 
         , pool_manager_addr = '0x28e2ea090877bf75740558f6bfb36a5ffee9e9df'
         , start_date = '2025-01-23'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_bnb_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/celo/uniswap_v4_celo_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/celo/uniswap_v4_celo_swaps.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_celo', 'PoolManager_evt_Swap')
         , pool_manager_addr = '0x288dc841a52fca2707c6947b3a777c5e56cd87bc'
         , start_date = '2025-10-22'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_celo_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/ethereum/uniswap_v4_ethereum_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/ethereum/uniswap_v4_ethereum_swaps.sql
@@ -19,6 +19,6 @@
         , filter_angstrom_addr = '0x0000000aa232009084Bd71A5797d089AA4Edfad4'
         , pool_manager_addr = '0x000000000004444c5dc75cb358380d2e3de08a90'
         , start_date = '2025-01-23'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_ethereum_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/ink/uniswap_v4_ink_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/ink/uniswap_v4_ink_swaps.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_ink', 'PoolManager_evt_Swap') 
         , pool_manager_addr = '0x360e68faccca8ca495c1b759fd9eee466db9fb32'
         , start_date = '2025-02-21'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_ink_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/monad/uniswap_v4_monad_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/monad/uniswap_v4_monad_swaps.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_monad', 'PoolManager_evt_Swap') 
         , pool_manager_addr = '0x188d586ddcf52439676ca21a244753fa19f9ea8e'
         , start_date = '2025-10-20'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_monad_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/optimism/uniswap_v4_optimism_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/optimism/uniswap_v4_optimism_swaps.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_optimism', 'PoolManager_evt_Swap') 
         , pool_manager_addr = '0x9a13f98cb987694c9f086b1f5eb990eea8264ec3'
         , start_date = '2025-01-23'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_optimism_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/polygon/uniswap_v4_polygon_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/polygon/uniswap_v4_polygon_swaps.sql
@@ -20,6 +20,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_polygon', 'PoolManager_evt_Swap') 
         , pool_manager_addr = '0x67366782805870060151383f4bbff9dab53e5cd6'
         , start_date = '2025-01-22'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_polygon_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/tempo/uniswap_v4_tempo_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/tempo/uniswap_v4_tempo_swaps.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_tempo', 'PoolManager_evt_Swap')
         , pool_manager_addr = '0x33620f62c5b9b2086dd6b62f4a297a9f30347029'
         , start_date = '2026-02-26'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_tempo_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/unichain/uniswap_v4_unichain_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/unichain/uniswap_v4_unichain_swaps.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_unichain', 'PoolManager_evt_Swap') 
         , pool_manager_addr = '0x1F98400000000000000000000000000000000004'
         , start_date = '2024-12-29'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_unichain_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/worldchain/uniswap_v4_worldchain_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/worldchain/uniswap_v4_worldchain_swaps.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_worldchain', 'PoolManager_evt_Swap') 
         , pool_manager_addr = '0xb1860d529182ac3bc1f51fa2abd56662b7d13f33'
         , start_date = '2025-01-23'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_worldchain_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/xlayer/uniswap_v4_xlayer_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/xlayer/uniswap_v4_xlayer_swaps.sql
@@ -18,6 +18,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_xlayer', 'PoolManager_evt_Swap')
         , pool_manager_addr = '0x360e68faccca8ca495c1b759fd9eee466db9fb32'
         , start_date = '2025-12-08'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_xlayer_aggregator_hooks')
     )
 }}

--- a/dbt_subprojects/dex/models/_projects/uniswap/zora/uniswap_v4_zora_swaps.sql
+++ b/dbt_subprojects/dex/models/_projects/uniswap/zora/uniswap_v4_zora_swaps.sql
@@ -19,6 +19,6 @@
         , PoolManager_evt_Swap = source('uniswap_v4_zora', 'PoolManager_evt_Swap') 
         , pool_manager_addr = '0x0575338e4c17006ae181b47900a84404247ca30f'
         , start_date = '2025-01-23'
-        , aggregator_hooks = ref('uniswap_v4_aggregator_hooks')
+        , aggregator_hooks = ref('uniswap_v4_zora_aggregator_hooks')
     )
 }}


### PR DESCRIPTION
## What & why
Points each Uniswap V4 swaps model at its own chain's hook registry instead of the shared `uniswap_v4.aggregator_hooks` table. After this, adding a chain to `uniswap_v4_chains()` no longer rebuilds every other chain's `dex_{chain}.base_trades`. Classification logic is unchanged.

**Stack 2 of 3.** Depends on https://github.com/duneanalytics/spellbook/pull/9958. Do not merge until PR 1 tables exist in prod.

## Deploy (this PR)
**Required: `skip_state_modified=true` on `spellbook_dex` for the first cycle after merge.**

That skips `state:modified --full-refresh` of the 16 swaps models and their downstream `dex.trades` graph. The next cadence incrementally re-runs swaps for the usual lookback against the already-filled per-chain registries.

Do not convert `uniswap_v4.aggregator_hooks` from incremental table to view in this deploy.

After the skip cycle (manifest reset), merge PR 3.

## Architecture
```
uniswap_v4_{chain}.aggregator_hooks     # from PR 1, now actually used
  -> uniswap_v4_{chain}.swaps           # this PR
    -> uniswap_v4_{chain}.base_trades
      -> dex_{chain}.base_trades        # only this chain

uniswap_v4.aggregator_hooks             # still scanned by uniswap_v4_chains(); nothing on dex.trades refs it
```

- 16 files: `aggregator_hooks = ref('uniswap_v4_{chain}_aggregator_hooks')`. robinhood swaps never used the shared table.
- Shared `uniswap_v4.aggregator_hooks` SQL is untouched.
- Tested: local Bugbot vs PR 1 branch, no findings.
- Needs human eyes: first cadence after skip, confirm `is_aggregator_hook_swap` on a chain that has live hooks (for example base or unichain) still matches the old table.
- Blast radius: historical swaps rows are not rebuilt. Only the incremental lookback is re-joined. Unsafe if PR 1 tables are missing.

<details><summary>Agent context</summary>

- Coverage ledger: local Bugbot vs CUR2-3852-per-chain-aggregator-hooks, no findings.
- Linear: https://linear.app/dune/issue/CUR2-3852
- Parent: https://github.com/duneanalytics/spellbook/pull/9958
- Next: CUR2-3852-xlayer-aggregator-union
</details>

Made with [Cursor](https://cursor.com)