### PR TITLE
CUR2-3852: Add xlayer to the Uniswap V4 aggregator union

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/uniswap_v4_chains.sql
+++ b/dbt_subprojects/dex/macros/models/_project/uniswap_v4_chains.sql
@@ -1,7 +1,9 @@
 {% macro uniswap_v4_chains() %}
-{#- single owner of the Uniswap V4 chain list. Used by the aggregator-hook
-    registry (uniswap_v4_aggregator_hooks) and the cross-chain aggregator
-    union (uniswap_v4_aggregator_base_trades) — when onboarding a new V4
-    chain, adding it here covers both, alongside the per-chain models. -#}
-{{ return(['arbitrum','avalanche_c','base','blast','bnb','celo','ethereum','ink','monad','optimism','polygon','tempo','unichain','worldchain','zora']) }}
+{#- Chain list for the leftover cross-chain aggregator-hook registry
+    (uniswap_v4_aggregator_hooks) and the cross-chain aggregator union
+    (uniswap_v4_aggregator_base_trades). Per-chain swaps ref
+    uniswap_v4_{chain}_aggregator_hooks, not this list, so adding a chain
+    here does not rebuild dex_{other_chain}.base_trades. Onboarding still
+    needs the per-chain models. -#}
+{{ return(['arbitrum','avalanche_c','base','blast','bnb','celo','ethereum','ink','monad','optimism','polygon','tempo','unichain','worldchain','xlayer','zora']) }}
 {% endmacro %}

--- a/dbt_subprojects/dex/models/_projects/uniswap/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/uniswap/_schema.yml
@@ -276,7 +276,7 @@ models:
 
   - name: uniswap_v4_aggregator_hooks
     meta:
-      blockchain: ethereum,arbitrum,base,optimism,polygon,zora,blast,bnb,avalanche_c,worldchain,ink,unichain,celo,monad,tempo
+      blockchain: ethereum,arbitrum,base,optimism,polygon,zora,blast,bnb,avalanche_c,worldchain,ink,unichain,celo,monad,tempo,xlayer
       sector: dex
       project: uniswap
       contributors: thevaizman
@@ -304,7 +304,7 @@ models:
 
   - name: uniswap_v4_aggregator_base_trades
     meta:
-      blockchain: ethereum,arbitrum,base,optimism,polygon,zora,blast,bnb,avalanche_c,worldchain,ink,unichain,celo,monad,tempo
+      blockchain: ethereum,arbitrum,base,optimism,polygon,zora,blast,bnb,avalanche_c,worldchain,ink,unichain,celo,monad,tempo,xlayer
       sector: dex_aggregator
       project: uniswap
       contributors: thevaizman


### PR DESCRIPTION
## What & why
Adds X Layer to `uniswap_v4_chains()` so `uniswap_v4.aggregator_base_trades` (and the leftover shared hook registry) include it. Safe only because PR 2 already moved swaps off that shared graph. X Layer V4 is already in `dex.trades` from #9954; this is the aggregator-union plumbing that #9954 deliberately skipped.

**Stack 3 of 3.** Depends on https://github.com/duneanalytics/spellbook/pull/9959. Merge after PR 2's skip-state-modified cycle has reset the dex manifest.

## Deploy (this PR)
Normal `spellbook_dex` deploy. `uniswap_v4_chains()` change marks `uniswap_v4.aggregator_hooks` and `uniswap_v4.aggregator_base_trades` as `modified.macros`. Swaps no longer ref the shared table, so `dex_bnb.base_trades` and the rest of the V4 `dex.trades` graph stay off that list.

Expected rebuild: the small shared hook registry plus the aggregator union view / `dex_aggregator.*`. Not all `dex_{chain}.base_trades`.

## Architecture
```
uniswap_v4_xlayer.aggregator_hooks
  -> uniswap_v4_xlayer.swaps
    -> dex_xlayer.base_trades          # already live from #9954

uniswap_v4_chains()                    # this PR adds xlayer
  -> uniswap_v4.aggregator_hooks       # leftover shared registry
  -> uniswap_v4.aggregator_base_trades # now includes xlayer -> dex_aggregator.*
```

Adding a future V4 chain: new per-chain hooks model, point that chain's swaps at it, then add the chain to `uniswap_v4_chains()` only if you want aggregator-union coverage.

- `uniswap_v4_chains.sql`: add `xlayer`; comment now says this list is not on the `dex.trades` path.
- `_schema.yml`: declare xlayer on the two cross-chain models.
- Tested: local Bugbot vs PR 2 branch, no findings.
- Needs human eyes: after deploy, `uniswap_v4.aggregator_base_trades` has `blockchain = 'xlayer'` (model may be empty until a BaseAggregatorHook lands on X Layer).
- Blast radius: `dex_aggregator.*` only. `dex.trades` unchanged.

<details><summary>Agent context</summary>

- Coverage ledger: local Bugbot vs CUR2-3852-switch-swaps-to-per-chain-hooks, no findings.
- Linear: https://linear.app/dune/issue/CUR2-3852
- Parent: https://github.com/duneanalytics/spellbook/pull/9959
- Related: https://github.com/duneanalytics/spellbook/pull/9954
- Note: `check_dex_aggregator_seed` for xlayer is still a no-op until a BaseAggregatorHook exists on chain.
</details>

Made with [Cursor](https://cursor.com)