### PR TITLE
fix(nexusmutual): capital_pool_mcr stale since 2025-10-30 (MCR merged into new Pool contract)

### DIFF
--- a/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/capital_pool/nexusmutual_ethereum_capital_pool_mcr.sql
+++ b/dbt_subprojects/daily_spellbook/models/nexusmutual/ethereum/capital_pool/nexusmutual_ethereum_capital_pool_mcr.sql
@@ -35,6 +35,13 @@ mcr_events as (
     cast(mcrFloor as double) / 1e18 as mcr_floor,
     cast(mcrETHWithGear as double) / 1e18 as mcr_cover_min
   from {{ source('nexusmutual_ethereum', 'MCR_evt_MCRUpdated') }}
+  union all
+  select
+    date_trunc('day', evt_block_time) as block_date,
+    cast(mcr as double) / 1e18 as mcr_eth,
+    cast(mcrFloor as double) / 1e18 as mcr_floor,
+    cast(mcrETHWithGear as double) / 1e18 as mcr_cover_min
+  from {{ source('nexusmutual_ethereum', 'Pool_evt_MCRUpdated') }}
 ),
 
 mcr_daily_avgs as (

--- a/sources/nexusmutual/ethereum/nexusmutual_ethereum_sources.yml
+++ b/sources/nexusmutual/ethereum/nexusmutual_ethereum_sources.yml
@@ -1,6 +1,6 @@
 version: 2
 
-sources: 
+sources:
   - name: nexusmutual_ethereum
     tables:
       - name: QuotationData_evt_CoverDetailsEvent
@@ -20,6 +20,7 @@ sources:
       - name: SafeTrackerNXMIS_evt_CoverReInvestmentUSDCUpdated
       - name: MCR_evt_MCREvent
       - name: MCR_evt_MCRUpdated
+      - name: Pool_evt_MCRUpdated
       - name: Cover_evt_ProductTypeSet
       - name: Cover_call_setProductTypes
       - name: Cover_evt_ProductSet


### PR DESCRIPTION
**Bug fix**: `nexusmutual_ethereum.capital_pool_mcr` has served a stale MCR value since 2025-10-30.

In Nexus Mutual's 2025-10-30 release, the standalone MCR contract (`0xcafea92739e411a4d95bbc2275ca61de6993c9a7`) was retired and MCR logic moved into the new Pool proxy. The event signature is unchanged (topic0 `0x6e87c25e322c4ad68faf7916d0788baaf714d806fe887a84ee4b84ad9666f686`) and is already decoded as `nexusmutual_ethereum.Pool_evt_MCRUpdated`, but the spell only reads the retired contract's tables, so its forward-fill repeats the 2025-10-30 value indefinitely.

**Expected value (block explorer):** https://etherscan.io/address/0xcafea91714e55756c125b509274ede9bc91697cb#events — latest `MCRUpdated` (2026-08-20) has `mcr` ≈ 10,176.8 ETH.
**Incorrect value (Dune):** `select max(block_date), max_by(mcr_eth_total, block_date) from nexusmutual_ethereum.capital_pool_mcr` → stuck at 7,556.6 ETH (~26% understated).
**Scale:** every row since 2025-10-30 (~300 days); feeds the MCR and MCR% charts on the Nexus Mutual Capital Pool dashboard.

**Fix:** add `Pool_evt_MCRUpdated` as a third union branch in `mcr_events` (identical column names) and register the source.
