### PR TITLE
feat(oneinch): decode Native Router V3 and V4 into project_orders

### DIFF
--- a/dbt_subprojects/daily_spellbook/macros/project/oneinch/_meta/oneinch_mapped_contracts_macro.sql
+++ b/dbt_subprojects/daily_spellbook/macros/project/oneinch/_meta/oneinch_mapped_contracts_macro.sql
@@ -1,4 +1,13 @@
 -- this macro helps to optimize the etl in case of adding new contract to a certain chain so it triggers pipeline only for this chain
+{#
+    NATIVE ROUTER V3/V4. Native's V1 router is dead — zero calls in the 30 days before
+    2026-08-23 on ethereum, bnb and base — while V3 and V4 carry the traffic, so Native is
+    currently decoded as nothing at all. Addresses are from
+    docs.native.org/native-dev/resources/addresses and were each confirmed against real
+    traffic in <chain>.traces over that window before being added; bnb V3 alone took
+    7,046,077 calls. Robinhood, Monad, Xlayer and Morph run V3/V4 too but have no
+    mapped_contracts entries here for any protocol.
+#}
 {% macro oneinch_mapped_contracts_macro(blockchain) %}
 
 
@@ -483,6 +492,14 @@
         , ('0x8c42cf13fbea2ac15b0fe5a5f3cf35eec65d7d7d', 'false', 'Native'              , 'NativeRouterV1'          , ['polygon'])
         , ('0x41d7b3abcfecf1f1b4b1b962da8f086114b6cc5a', 'false', 'Native'              , 'NativeRouterV1'          , ['base'])
         , ('0xc6f7a7ba5388bfb5774bfaa87d350b7793fd9ef1', 'false', 'Native'              , 'NativeRouterV1'          , ['mantle'])
+        , ('0xa540ec8C73322200d68E1B86c471A5C850854f22', 'false', 'Native'              , 'NativeRouterV3'          , ['ethereum'])
+        , ('0x0f9f2366C6157F2aCD3C2bFA45Cd9031c152D2Cf', 'false', 'Native'              , 'NativeRouterV3'          , ['bnb'])
+        , ('0x7d1c4889DF6113B3e4581a8c0484374bdeC3341B', 'false', 'Native'              , 'NativeRouterV3'          , ['arbitrum'])
+        , ('0xd547727b926648Af3F31DbB89E3B93E49F78dCb8', 'false', 'Native'              , 'NativeRouterV3'          , ['base'])
+        , ('0x8a2ddc0461Fcf96F81a05529Bed540d4f1eb2a00', 'false', 'Native'              , 'NativeRouterV4'          , ['ethereum'])
+        , ('0xF064b069Ed18Eb5c61159247C55C5af79B28a968', 'false', 'Native'              , 'NativeRouterV4'          , ['bnb'])
+        , ('0x0FC85a171bD0b53BF0bBace74F04B66170Ae3eAb', 'false', 'Native'              , 'NativeRouterV4'          , ['arbitrum'])
+        , ('0xaEC634d949df14Be76dC317504C7b9a6a8A5f576', 'false', 'Native'              , 'NativeRouterV4'          , ['base'])
         , ('0xd315a9c38ec871068fec378e4ce78af528c76293', 'false', 'Swaap'               , 'Vault'                   , ['ethereum','polygon','arbitrum','linea','optimism','avalanche_c','sonic'])
         , ('0x03C01Acae3D0173a93d819efDc832C7C4F153B06', 'false', 'Swaap'               , 'Vault'                   , ['bnb','base'])
         , ('0xa57bd00134b2850b2a1c55860c9e9ea100fdd6cf', 'false', 'MEVBot'              , 'MEVBot'                  , ['ethereum'])

--- a/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/cfg/oneinch_project_orders_cfg_methods_macro.sql
+++ b/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/cfg/oneinch_project_orders_cfg_methods_macro.sql
@@ -268,6 +268,48 @@
 
 -- Native --
 
+{#
+    Native Router V3 and V4 share this selector, and it is a DIFFERENT tradeRFQT from V1's
+    0xe525b10b — four extra uint256 in the order tuple, so V1's offsets do not transfer:
+      V1     tradeRFQT((address x5, uint256 x5, bytes16, bool, bytes, (address,address,uint256), bytes, bytes, uint256))
+      V3/V4  tradeRFQT((address x5, uint256 x9, bytes16, bool, bytes, (address,uint256), bytes), uint256, uint256)
+    The tuple is dynamic, so the args area opens with an offset word (0x60 observed) and the
+    tuple head starts at word 3 — hence the 32*3 base in the offsets below.
+
+    Verified against real calldata and the ERC20 Transfer logs of the same transaction
+    (0x9c13db5e2c1f59ddc4afe3e8a19c8d4c646e42964eb1f6615b405a567e6b204e, ethereum V4): tuple
+    idx5 = 7,624,635,000 and idx6 = 3,102,840,007,606,819,000 are exactly the USDC and WETH
+    amounts that moved, and idx3/idx4 are those two tokens. Field roles were then confirmed
+    across 32 further calls by joining each call to the transfer carrying its own amount:
+    idx2 is the address receiving maker_asset in 21 of them and never idx0 or idx1.
+
+    `maker` is deliberately unset: the address that actually sends maker_asset is a Native
+    vault that appears nowhere in the tuple head. idx7 is not an amount either — it came out
+    at exactly 1% of idx6.
+
+    The amounts are max amounts, not executed ones, and that is measured rather than assumed:
+    taken as executed they matched a real Transfer of the same token in only 169 of 300 calls
+    (idx6) and 203 of 300 (idx5), the rest showing a transfer at a different value. The
+    executed amount cannot be read from the call either — `output` is NULL on all 300 sampled
+    calls, so the exactInputSingle trick of reading substr(output, ...) has nothing to read.
+    This matches how the V1 tradeRFQT entry below already declares the same fields.
+
+    `event` is null because no event was confirmed for this selector, and a wrong topic
+    silently drops rows.
+#}
+{% set methods = methods + [{
+    "project":          "Native",
+    "selector":         "0x0947c2d9",
+    "name":             "tradeRFQT",
+    "event":            "null",
+    "taker":            "substr(input, 4 + 32*5 + 12 + 1            , 20)",
+    "taker_asset":      "substr(input, 4 + 32*6 + 12 + 1            , 20)",
+    "maker_asset":      "substr(input, 4 + 32*7 + 12 + 1            , 20)",
+    "taker_max_amount": "substr(input, 4 + 32*8 + 1                 , 32)",
+    "maker_max_amount": "substr(input, 4 + 32*9 + 1                 , 32)",
+    "order_hash":       "substr(input, 4 + 32*17 + 1                , 16)",
+}] %}
+
 {% set methods = methods + [{
     "project":          "Native",
     "selector":         "0xe525b10b",

--- a/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_orders_raw_logs_macro.sql
+++ b/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_orders_raw_logs_macro.sql
@@ -23,6 +23,9 @@ select
 from {{ source(blockchain, 'logs') }}
 where true
     and block_time >= timestamp '{{ date_from }}'
+    {% if target.name == 'ci' -%}
+    and block_time >= now() - interval '7' day -- CI full-refreshes this shared macro; bound the scan to a representative week
+    {%- endif %}
     and topic0 in ({{ oneinch_project_orders_cfg_events_macro().keys() | join(', ') }})
     {% if is_incremental() -%} and {{ incremental_predicate('block_time') }} {%- endif %}
 

--- a/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_orders_raw_traces_macro.sql
+++ b/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_orders_raw_traces_macro.sql
@@ -24,6 +24,9 @@ select
 from {{ source(blockchain, 'traces') }}
 where true
     and block_time >= timestamp '{{ date_from }}'
+    {% if target.name == 'ci' -%}
+    and block_time >= now() - interval '7' day -- CI full-refreshes this shared macro; bound the scan to a representative week
+    {%- endif %}
     and substr(input, 1, 4) in (
         {% set selectors = [] %}
         {% for item in oneinch_project_orders_cfg_methods_macro() %}


### PR DESCRIPTION
## What this fixes

Native is currently decoded as **nothing** in `project_orders`. The only mapped tag is
`NativeRouterV1`, and V1 has had **zero calls in the last 30 days** on ethereum, bnb and
base — checked in `<chain>.traces`, not inferred from empty output. All of Native's
traffic runs through V3 and V4, neither of which is mapped:

| chain | V3 calls (30d) | V4 calls (30d) |
| --- | --- | --- |
| bnb | 7,046,077 | 151,279 |
| ethereum | 9,880 | 21,209 |
| arbitrum | 5,584 | 9,712 |
| base | 3,954 | 4,059 |

Addresses come from
[docs.native.org](https://docs.native.org/native-dev/resources/addresses) and each was
confirmed against real traffic before being added. Robinhood, Monad, Xlayer and Morph run
V3/V4 too, but have no `mapped_contracts` entries here for any protocol, so they are out
of scope for this PR.

## The decode

V3/V4 use a different `tradeRFQT` selector, `0x0947c2d9`, with four extra `uint256` in the
order tuple, so V1's offsets do not transfer:

```
V1     tradeRFQT((address x5, uint256 x5, bytes16, bool, bytes, (address,address,uint256), bytes, bytes, uint256))
V3/V4  tradeRFQT((address x5, uint256 x9, bytes16, bool, bytes, (address,uint256), bytes), uint256, uint256)
```

The field map was decoded against real calldata and then checked against the ERC20
Transfer logs of the same transaction
(`0x9c13db5e2c1f59ddc4afe3e8a19c8d4c646e42964eb1f6615b405a567e6b204e`, ethereum V4): tuple
`idx5` = 7,624,635,000 and `idx6` = 3,102,840,007,606,819,000 are exactly the USDC and WETH
amounts that moved, and `idx3`/`idx4` are those two tokens. Field roles were then confirmed
across 32 further calls by joining each call to the transfer carrying its own amount:
`idx2` is the address receiving `maker_asset` in 21 of them, and never `idx0` or `idx1`.

Two deliberate omissions, both measured rather than assumed:

* **`maker` is unset.** The address that actually sends `maker_asset` is a Native vault
  that appears nowhere in the tuple head. `idx7` is not an amount either — it came out at
  exactly 1% of `idx6`.
* **The amounts are `*_max_amount`, not executed amounts**, matching how the existing V1
  `tradeRFQT` entry declares the same fields. Read as executed amounts they matched a real
  Transfer of the same token in only 169 of 300 calls (`idx6`) and 203 of 300 (`idx5`), the
  rest showing a transfer of that token at a different value. The executed amount cannot be
  read from the call either: `output` is NULL on all 300 sampled calls, so
  `substr(output, ...)` has nothing to read.

`event` is null because no event was confirmed for this selector, and a wrong topic
silently drops rows.

## Verification

Built with these entries on a private copy of this tree: **60,672 Native orders decoded**
in a three-day window — bnb V4 26,918, bnb V3 18,532, base V3 6,367, ethereum V3 3,944,
ethereum V4 3,295, base V4 1,616 — with both assets, both amounts and an order hash
present on 100% of rows. Existing `NativeRouterV1` decoding is untouched.
