### PR TITLE
fix(thorchain): restore wstETH LP unit baseline

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/thorchain/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/thorchain/_schema.yml
@@ -116,6 +116,9 @@ models:
 
   - name: thorchain_silver_pool_block_statistics
     data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "total_stake >= 0"
       # A pool holding liquidity units can never back its synths with negative units;
       # this guards the THORNode-aligned floor on the (2 * asset_depth - synth_depth) denominator.
       - dbt_utils.expression_is_true:

--- a/dbt_subprojects/hourly_spellbook/models/thorchain/silver/thorchain_silver_pool_block_statistics.sql
+++ b/dbt_subprojects/hourly_spellbook/models/thorchain/silver/thorchain_silver_pool_block_statistics.sql
@@ -328,7 +328,7 @@ lp_unit_baselines AS (
     SELECT
         'ETH.WSTETH-0X7F39C581F595B53C5CB19BD0B3F8DA6C935E2CA0' AS pool_name,
         DATE '2024-07-30' AS day,
-        CAST(3383237352182 AS BIGINT) AS units
+        CAST(3383237352182 AS BIGINT) AS baseline_units
 ),
 joined AS (
     SELECT
@@ -432,7 +432,7 @@ joined AS (
             0
         ) AS units,
         COALESCE(
-            lp_unit_baselines.units,
+            lp_unit_baselines.baseline_units,
             0
         ) AS baseline_units,
         COALESCE(

--- a/dbt_subprojects/hourly_spellbook/models/thorchain/silver/thorchain_silver_pool_block_statistics.sql
+++ b/dbt_subprojects/hourly_spellbook/models/thorchain/silver/thorchain_silver_pool_block_statistics.sql
@@ -321,6 +321,15 @@ asset_price_usd_tbl AS (
     WHERE
         block_id = max_block_id
 ),
+lp_unit_baselines AS (
+    -- This pool received liquidity while THORChain emitted stake_units = 0. Its later 100%
+    -- withdrawal proves the missing balance: tx 29F7510E2406C2938CC01F6E9216E7E9D281C5B07E3421C102E485C1AEBC4DEC
+    -- withdrew exactly 3,383,237,352,182 LP units on 2024-07-30.
+    SELECT
+        'ETH.WSTETH-0X7F39C581F595B53C5CB19BD0B3F8DA6C935E2CA0' AS pool_name,
+        DATE '2024-07-30' AS day,
+        CAST(3383237352182 AS BIGINT) AS units
+),
 joined AS (
     SELECT
         pool_depth.day AS day,
@@ -423,6 +432,10 @@ joined AS (
             0
         ) AS units,
         COALESCE(
+            lp_unit_baselines.units,
+            0
+        ) AS baseline_units,
+        COALESCE(
             withdraw_asset_volume,
             0
         ) AS withdraw_asset_volume,
@@ -472,11 +485,14 @@ joined AS (
     LEFT JOIN asset_price_usd_tbl
         ON pool_depth.pool_name = asset_price_usd_tbl.pool_name
         AND pool_depth.day = asset_price_usd_tbl.day
+    LEFT JOIN lp_unit_baselines
+        ON pool_depth.pool_name = lp_unit_baselines.pool_name
+        AND pool_depth.day = lp_unit_baselines.day
 )
 , total_stake AS (
     select
         *
-        , SUM(COALESCE(added_stake, 0) - COALESCE(withdrawn_stake, 0)) over (
+        , SUM(COALESCE(added_stake, 0) - COALESCE(withdrawn_stake, 0) + baseline_units) over (
             PARTITION BY asset
             ORDER BY  day ASC
         ) AS total_stake


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:

## What & why
Restore the missing 3,383,237,352,182 LP-unit balance for the THORChain wstETH pool on 2024-07-30.
THORChain emitted zero units for preceding liquidity additions, then reported the full balance in a 100% withdrawal, which made the zero-based running sum negative.
The corrected row resolves to zero `total_stake` and `pool_units`; no schema changes.

## Architecture
- `dbt_subprojects/hourly_spellbook/models/thorchain/silver/thorchain_silver_pool_block_statistics.sql` - business-critical LP-unit calculation; adds the verified pool/day baseline before the cumulative sum.
- `dbt_subprojects/hourly_spellbook/models/thorchain/_schema.yml` - adds a regression test requiring non-negative `total_stake`.
- Tested: `dbt parse`, targeted `dbt compile`, live event audit, and full-table negative-balance audit. Not tested: PR CI output is pending.
- Needs human eyes: compare the PR CI table for 2024-07-25 through 2024-08-05 and confirm the 2024-07-30 wstETH row resolves to zero.
- Blast radius: `thorchain.defi_pool_block_statistics` and its external replicas receive corrected wstETH LP-unit values when the normal post-merge rebuild runs. No interface or deployment-order change.

<details><summary>Agent context</summary>

- Coverage ledger: no agent review yet.
- Evidence: [event timeline](https://dune.com/queries/8432815), [100% withdrawal](https://dune.com/queries/8432817), [zero-unit additions](https://dune.com/queries/8432830), [negative-row scope](https://dune.com/queries/8432844).
- Repro: `uv run dbt parse --project-dir dbt_subprojects/hourly_spellbook --profiles-dir dbt_subprojects/hourly_spellbook`
- Repro: `uv run dbt compile --select thorchain_silver_pool_block_statistics --project-dir dbt_subprojects/hourly_spellbook --profiles-dir dbt_subprojects/hourly_spellbook`
- Source withdrawal: `29F7510E2406C2938CC01F6E9216E7E9D281C5B07E3421C102E485C1AEBC4DEC`, `basis_points = 10000`, `stake_units = 3383237352182`.
</details>

Prompted by: jeff

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)