### PR TITLE
feat(ekubo): decode pool state from the anonymous swap log

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/ekubo_compatible_liquidity.sql
+++ b/dbt_subprojects/dex/macros/models/_project/ekubo_compatible_liquidity.sql
@@ -33,14 +33,24 @@ swap_events as (
             then varbinary_to_int256(varbinary_concat(from_hex('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'), substr(el."data", 69, 16)))
             else varbinary_to_int256(varbinary_concat(from_hex('0x00000000000000000000000000000000'), substr(el."data", 69, 16)))
         end as amount1,
+        -- The trailing 32 bytes carry the pool state after the swap:
+        -- sqrtRatio (uint96 SqrtRatio float), tick (int32), liquidity (uint128).
+        varbinary_to_uint256(substr(el."data", 85, 12)) as sqrt_ratio_after,
+        case
+            when bitwise_and(varbinary_to_bigint(substr(el."data", 97, 1)), from_base('80', 16)) = from_base('80', 16)
+            then varbinary_to_bigint(substr(el."data", 97, 4)) - 4294967296
+            else varbinary_to_bigint(substr(el."data", 97, 4))
+        end as tick_after,
+        varbinary_to_uint256(substr(el."data", 101, 16)) as liquidity_after,
         el.tx_hash,
         el.index as evt_index,
         'swap' as event_type
-    from 
-    {{ source (blockchain, 'logs') }} el 
+    from
+    {{ source (blockchain, 'logs') }} el
     where block_number >= {{ start_block_number }}
     and contract_address = {{ ekubo_core_contract }}
-    and topic0 is null 
+    and topic0 is null
+    and length(el."data") = 116
     {%- if is_incremental() %}
     and {{ incremental_predicate('block_time') }}
     {%- endif %} 
@@ -57,6 +67,9 @@ liquidity_events as (
         poolId as id,
         delta0 as amount0,
         delta1 as amount1,
+        cast(null as uint256) as sqrt_ratio_after,
+        cast(null as bigint) as tick_after,
+        cast(null as uint256) as liquidity_after,
         evt_tx_hash as tx_hash,
         evt_index,
         'modify_liquidity' as event_type 
@@ -82,9 +95,12 @@ liquidity_events as (
             then varbinary_to_int256(varbinary_concat(from_hex('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'), substr(balanceUpdate, 1+16, 16)))
             else varbinary_to_int256(varbinary_concat(from_hex('0x00000000000000000000000000000000'), substr(balanceUpdate, 1+16, 16)))
         end as amount1,
+        cast(null as uint256) as sqrt_ratio_after,
+        cast(null as bigint) as tick_after,
+        cast(null as uint256) as liquidity_after,
         evt_tx_hash as tx_hash,
         evt_index,
-        'modify_liquidity' as event_type 
+        'modify_liquidity' as event_type
     from 
     {{ position_updated }}
     {%- if is_incremental() %}
@@ -102,6 +118,9 @@ liquidity_events as (
         poolId as id,
         -amount0 as amount0,
         -amount1 as amount1,
+        cast(null as uint256) as sqrt_ratio_after,
+        cast(null as bigint) as tick_after,
+        cast(null as uint256) as liquidity_after,
         evt_tx_hash as tx_hash,
         evt_index,
         'fees_collected' as event_type 
@@ -120,9 +139,12 @@ liquidity_events as (
         poolId as id,
         amount0 as amount0,
         amount1 as amount1,
+        cast(null as uint256) as sqrt_ratio_after,
+        cast(null as bigint) as tick_after,
+        cast(null as uint256) as liquidity_after,
         evt_tx_hash as tx_hash,
         evt_index,
-        'fees_accumulated' as event_type 
+        'fees_accumulated' as event_type
     from 
     {{ position_fees_accumulated }}
     {%- if is_incremental() %}
@@ -166,8 +188,12 @@ get_pools as (
         ep.token0,
         ep.token1,
         CAST(ae.amount0 AS double) as amount0_raw,
-        CAST(ae.amount1 AS double) as amount1_raw
-    from 
+        CAST(ae.amount1 AS double) as amount1_raw,
+        ae.sqrt_ratio_after,
+        {{ ekubo_sqrt_ratio_to_fixed('ae.sqrt_ratio_after') }} as sqrt_ratio_after_fixed,
+        CAST(ae.tick_after AS integer) as tick_after,
+        ae.liquidity_after
+    from
     all_events ae 
     inner join 
     get_pools ep 

--- a/dbt_subprojects/dex/macros/models/_project/ekubo_sqrt_ratio_to_fixed.sql
+++ b/dbt_subprojects/dex/macros/models/_project/ekubo_sqrt_ratio_to_fixed.sql
@@ -1,0 +1,41 @@
+{#
+    Converts an Ekubo `SqrtRatio` from its packed uint96 float representation to a
+    Q128 fixed point value (i.e. sqrt(price) * 2^128), which is the form the Ekubo
+    contracts and interface expose as `sqrtRatio`.
+
+    Layout of the uint96 float:
+        bits 95..94 : exponent (0-3)
+        bits 93..0  : mantissa
+
+        fixed = mantissa << (32 * exponent + 2)
+
+    `sqrt_ratio_float` must be a uint256-typed expression holding the 12 raw bytes.
+    Returns null when the input is null, so non-swap events pass through untouched.
+#}
+
+{% macro ekubo_sqrt_ratio_to_fixed(sqrt_ratio_float) %}
+    (
+        (
+            {{ sqrt_ratio_float }} - CASE {{ ekubo_sqrt_ratio_exponent(sqrt_ratio_float) }}
+                WHEN 0 THEN varbinary_to_uint256(0x000000000000000000000000)
+                WHEN 1 THEN varbinary_to_uint256(0x400000000000000000000000)
+                WHEN 2 THEN varbinary_to_uint256(0x800000000000000000000000)
+                ELSE        varbinary_to_uint256(0xC00000000000000000000000)
+            END
+        )
+        * CASE {{ ekubo_sqrt_ratio_exponent(sqrt_ratio_float) }}
+            WHEN 0 THEN varbinary_to_uint256(0x04)
+            WHEN 1 THEN varbinary_to_uint256(0x0400000000)
+            WHEN 2 THEN varbinary_to_uint256(0x040000000000000000)
+            ELSE        varbinary_to_uint256(0x04000000000000000000000000)
+        END
+    )
+{% endmacro %}
+
+{#
+    The two most significant bits of the 96-bit float, as a bigint 0-3.
+    2^94 = 19807040628566084398385987584.
+#}
+{% macro ekubo_sqrt_ratio_exponent(sqrt_ratio_float) %}
+    cast({{ sqrt_ratio_float }} / varbinary_to_uint256(0x400000000000000000000000) as bigint)
+{% endmacro %}

--- a/dbt_subprojects/dex/models/_projects/ekubo/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/ekubo/_schema.yml
@@ -116,7 +116,19 @@ models:
         description: "Liquidity amount of token0 in USD"
       - &amount1_usd
         name: amount1_usd
-        description: "Liquidity amount of token1 in USD"       
+        description: "Liquidity amount of token1 in USD"
+      - &sqrt_ratio_after
+        name: sqrt_ratio_after
+        description: "Pool sqrt ratio immediately after the swap, as the raw uint96 SqrtRatio float. Null for non-swap events"
+      - &sqrt_ratio_after_fixed
+        name: sqrt_ratio_after_fixed
+        description: "Pool sqrt ratio immediately after the swap as Q128 fixed point, i.e. sqrt(token1/token0 in raw units) * 2^128. Null for non-swap events"
+      - &tick_after
+        name: tick_after
+        description: "Pool tick immediately after the swap. Null for non-swap events"
+      - &liquidity_after
+        name: liquidity_after
+        description: "Pool active liquidity immediately after the swap. Null for non-swap events"
 
   - name: ekubo_base_liquidity_events
     meta:
@@ -152,6 +164,10 @@ models:
       - *token1
       - *amount0_raw
       - *amount1_raw
+      - *sqrt_ratio_after
+      - *sqrt_ratio_after_fixed
+      - *tick_after
+      - *liquidity_after
 
   - name: ekubo_daily_agg_liquidity_events
     meta:

--- a/dbt_subprojects/dex/models/_projects/ekubo/ekubo_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/ekubo/ekubo_base_liquidity_events.sql
@@ -32,6 +32,10 @@ with base_union as (
                 , token1
                 , amount0_raw
                 , amount1_raw
+                , sqrt_ratio_after
+                , sqrt_ratio_after_fixed
+                , tick_after
+                , liquidity_after
         FROM
             {{ model }}
         {% if not loop.last %}

--- a/dbt_subprojects/dex/models/_projects/ekubo/ekubo_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/ekubo/ekubo_liquidity_events.sql
@@ -41,6 +41,10 @@ WITH dexes AS (
                 , amount1
                 , amount0_usd
                 , amount1_usd
+                , sqrt_ratio_after
+                , sqrt_ratio_after_fixed
+                , tick_after
+                , liquidity_after
            FROM
                 dexes
           {% if is_incremental() %}


### PR DESCRIPTION
## Summary

Ekubo's swap parser currently reads the token amount deltas but leaves the post-swap pool state undecoded. This PR decodes the final 32 bytes of Core's 116-byte anonymous swap log, making price and active-liquidity history available directly from the liquidity-event tables.

Adds four columns to the Ethereum v1/v3 base models and exposes them through `ekubo.base_liquidity_events` and `ekubo.liquidity_events`. All four are null for non-swap events.

| Column | Value immediately after the swap |
|---|---|
| `sqrt_ratio_after` | Raw packed uint96 `SqrtRatio` float |
| `sqrt_ratio_after_fixed` | Q128 fixed point: `sqrt(token1/token0 in raw units) * 2^128` |
| `tick_after` | Signed pool tick |
| `liquidity_after` | Active liquidity |

## Implementation

- `ekubo_compatible_liquidity_events` reads `sqrtRatio` at byte offset 84 (12 bytes), `tick` at 96 (4 bytes, signed), and `liquidity` at 100 (16 bytes). Offsets are zero-based; SQL substrings are one-based.
- New macro `ekubo_sqrt_ratio_to_fixed` converts the packed value using `fixed = mantissa << (32 * exponent + 2)`, matching the contract's `toFixed`. The upper two bits hold the exponent; the remaining 94 bits hold the mantissa. Four `CASE` branches use uint256 multiplication to implement the shifts.
- Adds `length(data) = 116` alongside `topic0 is null` to reject unexpected anonymous-log lengths before decoding.

## Compatibility and rollout

Existing columns retain their values. The length guard excluded no rows in the original validation: all 5.27 million anonymous logs checked across both Core versions were 116 bytes. `dex.trades` does not consume the new columns.

Historical values in the incremental models require Dune's normal post-merge full refresh.

## Validation

- [CI on the current commit](https://github.com/duneanalytics/spellbook/actions/runs/34387586349) compiled successfully, built all four affected models (5,740,754 rows in the enriched table), and passed uniqueness tests and incremental reruns.
- Original Dune validation for August 26 returned 6,705 swaps with all four fields populated and nulls for non-swap events.
- For [this USDC/USDG swap](https://etherscan.io/tx/0x24b3dff976e1fdc9d8cbc2a7c0bf21e6fcb80d74baa0dd698db57d90c74dac93), decoded values matched an independent `CoreDataFetcher.poolState` RPC read at the following block: tick `-165`, fixed sqrt ratio `340254383154770049453632155902269194240`, and liquidity `10035484459699841`.
- Additional local arithmetic checks passed for 4,012 packed values across all four exponents and eight signed-tick boundary/sample cases. These checks validate the constants and arithmetic against the contract formula; they are separate from the Dune CI tests.
