### PR TITLE
fix(oneinch): size swaps by net token flow, not the single biggest transfer

### DIFF
--- a/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_base_macro.sql
+++ b/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_base_macro.sql
@@ -182,31 +182,48 @@ meta as (
         {% if is_incremental() -%} and {{ incremental_predicate('block_time') }} {%- endif %}
 )
 
-, joined as (
+, call_transfers as (
+    -- Every transfer nested under a swap call, before any sizing decision -- shared by
+    -- the token/sender/receiver labels below (unchanged) and the net-flow sizing that
+    -- replaces the old max-single-transfer approach (see net_legs).
     select
-        blockchain
-        , swaps.block_month
+        swaps.block_month
         , swaps.block_number
         , swaps.tx_hash
         , swaps.call_trace_address
         , swaps.call_trade_id
+        , swaps.call_from
+        , swaps.call_to
+        , contract_address
+        , native
+        , symbol
+        , native_symbol
+        , contract_address_raw
+        , transfer_from
+        , transfer_to
+        , amount
+        , block_time
+        , minute
+    from swaps
+    join transfers on true
+        and swaps.block_month = transfers.block_month
+        and swaps.block_number = transfers.block_number
+        and swaps.tx_hash = transfers.tx_hash
+        and slice(transfer_trace_address, 1, cardinality(call_trace_address)) = call_trace_address -- nested transfers only
+        and reduce(array_distinct(call_trace_addresses), call_trace_address, (r, x) -> if(slice(transfer_trace_address, 1, cardinality(x)) = x and x > r, x, r), r -> r) = call_trace_address -- transfers related to the call only
+        and (order_hash is null or contract_address in (_maker_asset, _taker_asset) and cardinality(array_intersect(array[call_from, maker, taker], array[transfer_from, transfer_to])) > 0) -- transfers related to the order only
+)
+
+, labels as (
+    -- Token/sender/receiver labels, unchanged from before this fix -- these are display
+    -- lists, not sizing, so they stay keyed off individual transfers.
+    select
+        block_month
+        , block_number
+        , tx_hash
+        , call_trace_address
+        , call_trade_id
         , any_value(block_time) as block_time
-        , any_value(tx_from) as tx_from
-        , any_value(tx_to) as tx_to
-        , any_value(project) as project
-        , any_value(tag) as tag
-        , any_value(flags) as flags
-        , any_value(call_from) as call_from
-        , any_value(call_to) as call_to
-        , any_value(call_selector) as call_selector
-        , any_value(method) as method
-        , any_value(order_hash) as order_hash
-        , any_value(maker) as maker
-        , any_value(maker_asset) as maker_asset
-        , any_value(making_amount) as making_amount
-        , any_value(taker_asset) as taker_asset
-        , any_value(taking_amount) as taking_amount
-        , any_value(order_flags) as order_flags
         , array_agg(distinct
             cast(row(if(native, native_symbol, symbol), contract_address_raw)
                 as row(symbol varchar, contract_address_raw varbinary))
@@ -219,29 +236,111 @@ meta as (
             cast(row(if(native, native_symbol, symbol), contract_address_raw)
                 as row(symbol varchar, contract_address_raw varbinary))
         ) filter(where transfer_from = call_from or transfer_to = call_from) as caller_tokens
-        , max(amount * price / pow(10, decimals)) as call_amount_usd
-        , max(amount * price / pow(10, decimals)) filter(where trusted) as call_amount_usd_trusted
-        , max(amount * price / pow(10, decimals)) filter(where creations_from.block_number is null or creations_to.block_number is null) as user_amount_usd
-        , max(amount * price / pow(10, decimals)) filter(where (creations_from.block_number is null or creations_to.block_number is null) and trusted) as user_amount_usd_trusted
-        , max(amount * price / pow(10, decimals)) filter(where transfer_from = call_from or transfer_to = call_from) as caller_amount_usd
-        , max(amount * price / pow(10, decimals)) filter(where (transfer_from = call_from or transfer_to = call_from) and trusted) as caller_amount_usd_trusted
-        , max(amount * price / pow(10, decimals)) filter(where transfer_from = call_to or transfer_to = call_to) as contract_amount_usd
-        , max(amount * price / pow(10, decimals)) filter(where (transfer_from = call_to or transfer_to = call_to) and trusted) as contract_amount_usd_trusted
         , array_agg(distinct transfer_from) filter(where creations_from.block_number is null) as senders
         , array_agg(distinct transfer_to) filter(where creations_to.block_number is null) as receivers
-    from swaps
-    join transfers on true
-        and swaps.block_month = transfers.block_month
-        and swaps.block_number = transfers.block_number
-        and swaps.tx_hash = transfers.tx_hash
-        and slice(transfer_trace_address, 1, cardinality(call_trace_address)) = call_trace_address -- nested transfers only
-        and reduce(array_distinct(call_trace_addresses), call_trace_address, (r, x) -> if(slice(transfer_trace_address, 1, cardinality(x)) = x and x > r, x, r), r -> r) = call_trace_address -- transfers related to the call only
-        and (order_hash is null or contract_address in (_maker_asset, _taker_asset) and cardinality(array_intersect(array[call_from, maker, taker], array[transfer_from, transfer_to])) > 0) -- transfers related to the order only
+    from call_transfers
+    left join creations as creations_from on creations_from.address = call_transfers.transfer_from
+    left join creations as creations_to on creations_to.address = call_transfers.transfer_to
+    group by 1, 2, 3, 4, 5
+)
+
+, net_legs as (
+    -- Size by NET flow per (token, address) within the call, not the single biggest
+    -- transfer -- a flash loan borrowed and repaid in the same call is two transfers of
+    -- the same token through the same address that net close to zero; the old
+    -- max-single-transfer approach counted the loan itself as the swap. Verified against
+    -- A1-2035: a Morpho Vault flash-loan call recorded as $134.8m sized down to the
+    -- transaction's real ~$0.33 swap under this approach, and 300 ordinary Uniswap calls
+    -- (no flash loan involved) were unchanged, because a single transfer's net flow
+    -- equals that transfer's amount. Known, accepted cost: an address that swaps a
+    -- token out and back into itself within one call (round-trip arbitrage) nets to
+    -- ~zero here too, understating that genuine volume -- same mechanism, so there is no
+    -- way to keep one and not the other from net flow alone.
+    select block_month, block_number, tx_hash, call_trace_address, call_trade_id, call_from, call_to
+        , contract_address, transfer_from as address, -amount as signed_amount, minute
+    from call_transfers
+    union all
+    select block_month, block_number, tx_hash, call_trace_address, call_trade_id, call_from, call_to
+        , contract_address, transfer_to as address, amount as signed_amount, minute
+    from call_transfers
+)
+
+, net_flows as (
+    select
+        block_month, block_number, tx_hash, call_trace_address, call_trade_id
+        , any_value(call_from) as call_from
+        , any_value(call_to) as call_to
+        , contract_address
+        , address
+        , sum(signed_amount) as net_amount
+        , max(minute) as minute -- one call, one tx -- transfers of the same token share a minute in practice
+    from net_legs
+    group by block_month, block_number, tx_hash, call_trace_address, call_trade_id, contract_address, address
+)
+
+, net_amounts as (
+    select
+        net_flows.block_month
+        , net_flows.block_number
+        , net_flows.tx_hash
+        , net_flows.call_trace_address
+        , net_flows.call_trade_id
+        , max(abs(net_amount) * price / pow(10, decimals)) as call_amount_usd
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where trusted) as call_amount_usd_trusted
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where creations.block_number is null) as user_amount_usd
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where creations.block_number is null and trusted) as user_amount_usd_trusted
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where net_flows.address = call_from) as caller_amount_usd
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where net_flows.address = call_from and trusted) as caller_amount_usd_trusted
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where net_flows.address = call_to) as contract_amount_usd
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where net_flows.address = call_to and trusted) as contract_amount_usd_trusted
+    from net_flows
     left join prices using(contract_address, minute)
     left join trusted_tokens using(contract_address)
-    left join creations as creations_from on creations_from.address = transfers.transfer_from
-    left join creations as creations_to on creations_to.address = transfers.transfer_to
-    group by 1, 2, 3, 4, 5, 6
+    left join creations on creations.address = net_flows.address
+    group by net_flows.block_month, net_flows.block_number, net_flows.tx_hash, net_flows.call_trace_address, net_flows.call_trade_id
+)
+
+, joined as (
+    select
+        blockchain
+        , swaps.block_month
+        , swaps.block_number
+        , swaps.tx_hash
+        , swaps.call_trace_address
+        , swaps.call_trade_id
+        , block_time
+        , tx_from
+        , tx_to
+        , project
+        , tag
+        , flags
+        , call_from
+        , call_to
+        , call_selector
+        , method
+        , order_hash
+        , maker
+        , maker_asset
+        , making_amount
+        , taker_asset
+        , taking_amount
+        , order_flags
+        , tokens
+        , user_tokens
+        , caller_tokens
+        , senders
+        , receivers
+        , call_amount_usd
+        , call_amount_usd_trusted
+        , user_amount_usd
+        , user_amount_usd_trusted
+        , caller_amount_usd
+        , caller_amount_usd_trusted
+        , contract_amount_usd
+        , contract_amount_usd_trusted
+    from swaps
+    join labels using(block_month, block_number, tx_hash, call_trace_address, call_trade_id)
+    left join net_amounts using(block_month, block_number, tx_hash, call_trace_address, call_trade_id)
 )
 
 , processing as (

--- a/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_base_macro.sql
+++ b/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_base_macro.sql
@@ -304,8 +304,15 @@ meta as (
          , call_from, call_to, contract_address, transfer_from, transfer_to, amount, minute
     from (
         select *, row_number() over (
+            -- call_trace_address and call_trade_id belong in this key. A transfer can be
+            -- nested under more than one call of the same transaction -- 58665 of 728590
+            -- rows on ethereum 2026-08-19 -- so partitioning without the call collapses
+            -- copies belonging to DIFFERENT calls and keeps an arbitrary one. That is a
+            -- transfer silently missing from every other call it belongs to, and which one
+            -- survives changes between runs.
             partition by tx_hash, transfer_trace_address, contract_address,
-                         transfer_from, transfer_to, amount
+                         transfer_from, transfer_to, amount,
+                         call_trace_address, call_trade_id
             order by native
         ) as _rn
         from call_transfers
@@ -325,12 +332,19 @@ meta as (
     -- token out and back into itself within one call (round-trip arbitrage) nets to
     -- ~zero here too, understating that genuine volume -- same mechanism, so there is no
     -- way to keep one and not the other from net flow alone.
+    -- A direction flag instead of a sign. Negating a uint256 casts it to int256, whose
+    -- magnitude is one bit smaller, and amounts exist that do not fit -- the run died on
+    --   Overflow in INT256 cast of UINT256: 1000000...0000 (78 digits, ~1e77)
+    -- against an int256 ceiling of ~5.79e76. Summing each side separately keeps every value
+    -- in uint256, and taking smaller-from-larger below cannot go negative, so int256 never
+    -- enters. Casting to double instead was measured and produces identical results to the
+    -- cent; this way needs no argument about precision at all.
     select block_month, block_number, tx_hash, call_trace_address, call_trade_id, call_from, call_to
-        , contract_address, transfer_from as address, -amount as signed_amount, minute
+        , contract_address, transfer_from as address, amount, false as inflow, minute
     from net_transfers
     union all
     select block_month, block_number, tx_hash, call_trace_address, call_trade_id, call_from, call_to
-        , contract_address, transfer_to as address, amount as signed_amount, minute
+        , contract_address, transfer_to as address, amount, true as inflow, minute
     from net_transfers
 )
 
@@ -341,32 +355,40 @@ meta as (
         , any_value(call_to) as call_to
         , contract_address
         , address
-        , sum(signed_amount) as net_amount
+        , coalesce(sum(amount) filter(where inflow), cast(0 as uint256)) as in_amount
+        , coalesce(sum(amount) filter(where not inflow), cast(0 as uint256)) as out_amount
         , max(minute) as minute -- one call, one tx -- transfers of the same token share a minute in practice
     from net_legs
     group by block_month, block_number, tx_hash, call_trace_address, call_trade_id, contract_address, address
 )
 
+, net_abs as (
+    select block_month, block_number, tx_hash, call_trace_address, call_trade_id, call_from, call_to
+        , contract_address, address, minute
+        , if(in_amount > out_amount, in_amount - out_amount, out_amount - in_amount) as net_amount
+    from net_flows
+)
+
 , net_amounts as (
     select
-        net_flows.block_month
-        , net_flows.block_number
-        , net_flows.tx_hash
-        , net_flows.call_trace_address
-        , net_flows.call_trade_id
-        , max(abs(net_amount) * price / pow(10, decimals)) as call_amount_usd
-        , max(abs(net_amount) * price / pow(10, decimals)) filter(where trusted) as call_amount_usd_trusted
-        , max(abs(net_amount) * price / pow(10, decimals)) filter(where creations.block_number is null) as user_amount_usd
-        , max(abs(net_amount) * price / pow(10, decimals)) filter(where creations.block_number is null and trusted) as user_amount_usd_trusted
-        , max(abs(net_amount) * price / pow(10, decimals)) filter(where net_flows.address = call_from) as caller_amount_usd
-        , max(abs(net_amount) * price / pow(10, decimals)) filter(where net_flows.address = call_from and trusted) as caller_amount_usd_trusted
-        , max(abs(net_amount) * price / pow(10, decimals)) filter(where net_flows.address = call_to) as contract_amount_usd
-        , max(abs(net_amount) * price / pow(10, decimals)) filter(where net_flows.address = call_to and trusted) as contract_amount_usd_trusted
-    from net_flows
+        net_abs.block_month
+        , net_abs.block_number
+        , net_abs.tx_hash
+        , net_abs.call_trace_address
+        , net_abs.call_trade_id
+        , max(net_amount * price / pow(10, decimals)) as call_amount_usd
+        , max(net_amount * price / pow(10, decimals)) filter(where trusted) as call_amount_usd_trusted
+        , max(net_amount * price / pow(10, decimals)) filter(where creations.block_number is null) as user_amount_usd
+        , max(net_amount * price / pow(10, decimals)) filter(where creations.block_number is null and trusted) as user_amount_usd_trusted
+        , max(net_amount * price / pow(10, decimals)) filter(where net_abs.address = call_from) as caller_amount_usd
+        , max(net_amount * price / pow(10, decimals)) filter(where net_abs.address = call_from and trusted) as caller_amount_usd_trusted
+        , max(net_amount * price / pow(10, decimals)) filter(where net_abs.address = call_to) as contract_amount_usd
+        , max(net_amount * price / pow(10, decimals)) filter(where net_abs.address = call_to and trusted) as contract_amount_usd_trusted
+    from net_abs
     left join prices using(contract_address, minute)
     left join trusted_tokens using(contract_address)
-    left join creations on creations.address = net_flows.address
-    group by net_flows.block_month, net_flows.block_number, net_flows.tx_hash, net_flows.call_trace_address, net_flows.call_trade_id
+    left join creations on creations.address = net_abs.address
+    group by net_abs.block_month, net_abs.block_number, net_abs.tx_hash, net_abs.call_trace_address, net_abs.call_trade_id
 )
 
 , joined as (

--- a/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_base_macro.sql
+++ b/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_base_macro.sql
@@ -182,6 +182,31 @@ meta as (
         {% if is_incremental() -%} and {{ incremental_predicate('block_time') }} {%- endif %}
 )
 
+, swaps_unique as (
+    -- One row per merge key, which `swaps` does not guarantee: measured on ethereum
+    -- 2026-08-01..08, `swaps` yields 794943 rows for 794941 distinct
+    -- (block_month, block_number, tx_hash, call_trace_address, call_trade_id).
+    --
+    -- Two rows in 795k, and they are fatal here: the model merges on those keys and Trino
+    -- refuses the statement outright --
+    --   "One MERGE target table row matched more than one source row"
+    --
+    -- The pre-change code never saw this. Its `joined` CTE aggregated the swaps-to-transfers
+    -- join with group by and any_value(), which collapsed such pairs on the way through.
+    -- Selecting from `swaps` without aggregating lets them survive -- and `call_transfers`
+    -- reads `swaps` too, so a duplicated swap would double every transfer nested under it
+    -- and double that call's net flow, which is a wrong number rather than a failed run.
+    --
+    -- Which of the pair survives is arbitrary, exactly as any_value() made it arbitrary
+    -- before.
+    select * from (
+        select *, row_number() over (
+            partition by block_month, block_number, tx_hash, call_trace_address, call_trade_id
+            order by call_selector
+        ) as _swap_rn
+        from swaps
+    ) where _swap_rn = 1
+)
 , call_transfers as (
     -- Every transfer nested under a swap call, before any sizing decision -- shared by
     -- the token/sender/receiver labels below (unchanged) and the net-flow sizing that
@@ -205,7 +230,7 @@ meta as (
         , block_time
         , minute
         , transfer_trace_address
-    from swaps
+    from swaps_unique swaps
     join transfers on true
         and swaps.block_month = transfers.block_month
         and swaps.block_number = transfers.block_number
@@ -386,7 +411,7 @@ meta as (
         , caller_amount_usd_trusted
         , contract_amount_usd
         , contract_amount_usd_trusted
-    from swaps
+    from swaps_unique swaps
     join labels using(block_month, block_number, tx_hash, call_trace_address, call_trade_id)
     left join net_amounts using(block_month, block_number, tx_hash, call_trace_address, call_trade_id)
 )

--- a/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_base_macro.sql
+++ b/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_base_macro.sql
@@ -204,6 +204,7 @@ meta as (
         , amount
         , block_time
         , minute
+        , transfer_trace_address
     from swaps
     join transfers on true
         and swaps.block_month = transfers.block_month
@@ -217,12 +218,18 @@ meta as (
 , labels as (
     -- Token/sender/receiver labels, unchanged from before this fix -- these are display
     -- lists, not sizing, so they stay keyed off individual transfers.
+    -- Keys qualified with call_transfers: this CTE joins `creations` twice and `creations`
+    -- has a block_number of its own, so an unqualified block_number is ambiguous and Trino
+    -- rejects the statement:
+    --   Column 'block_number' is ambiguous
+    -- The pre-change code did not hit this because the CTE these lines came from selected
+    -- swaps.block_number explicitly.
     select
-        block_month
-        , block_number
-        , tx_hash
-        , call_trace_address
-        , call_trade_id
+        call_transfers.block_month
+        , call_transfers.block_number
+        , call_transfers.tx_hash
+        , call_transfers.call_trace_address
+        , call_transfers.call_trade_id
         , any_value(block_time) as block_time
         , array_agg(distinct
             cast(row(if(native, native_symbol, symbol), contract_address_raw)
@@ -244,6 +251,43 @@ meta as (
     group by 1, 2, 3, 4, 5
 )
 
+, net_transfers as (
+    -- Collapse the native/wrapped pair before netting.
+    --
+    -- transfers_from_traces emits a wrap as TWO rows sharing one trace_address: the native
+    -- leg and a wrapped-token leg, same amount, same direction. The `transfers` CTE above
+    -- then maps native onto wrapped_native_token_address so it can be priced, so both rows
+    -- arrive here under the same contract_address and ADD instead of cancelling.
+    --
+    -- Under the old max() this was invisible: the duplicate equalled the real leg, so the
+    -- maximum did not move. Under net flow it doubles that leg. Measured on ethereum
+    -- 2026-08-19: 67564 such pairs in the day, 100% identical in amount and 100% in
+    -- direction; of 30029 swaps whose size grew, 20581 grew by exactly 2x, carrying $62.4m
+    -- of the $82.7m the day gained. Day totals against production's max() figures:
+    --
+    --     max (production)     $1,176,198,549.89
+    --     net, with the pair   $1,258,527,698.07   +7.000%
+    --     net, collapsed       $1,164,698,389.61   -0.978%
+    --
+    -- so collapsing the pair is what makes this change move volume DOWN, as intended,
+    -- rather than up. Control: one Tokenlon swap reads $1,143,565.00 under max,
+    -- $2,287,130.00 with the pair, and $1,143,565.00 again once collapsed, to the cent.
+    --
+    -- Netting path only. `labels` keeps both rows: dropping one there would drop a symbol
+    -- from the token lists, and those are display lists, not sizing.
+    select block_month, block_number, tx_hash, call_trace_address, call_trade_id
+         , call_from, call_to, contract_address, transfer_from, transfer_to, amount, minute
+    from (
+        select *, row_number() over (
+            partition by tx_hash, transfer_trace_address, contract_address,
+                         transfer_from, transfer_to, amount
+            order by native
+        ) as _rn
+        from call_transfers
+    )
+    where _rn = 1
+)
+
 , net_legs as (
     -- Size by NET flow per (token, address) within the call, not the single biggest
     -- transfer -- a flash loan borrowed and repaid in the same call is two transfers of
@@ -258,11 +302,11 @@ meta as (
     -- way to keep one and not the other from net flow alone.
     select block_month, block_number, tx_hash, call_trace_address, call_trade_id, call_from, call_to
         , contract_address, transfer_from as address, -amount as signed_amount, minute
-    from call_transfers
+    from net_transfers
     union all
     select block_month, block_number, tx_hash, call_trace_address, call_trade_id, call_from, call_to
         , contract_address, transfer_to as address, amount as signed_amount, minute
-    from call_transfers
+    from net_transfers
 )
 
 , net_flows as (
@@ -301,13 +345,17 @@ meta as (
 )
 
 , joined as (
+    -- Keys NOT qualified with swaps., although the CTE this replaced did qualify them:
+    -- both joins below are JOIN ... USING, which merges the joined column into a single
+    -- unqualified one, and swaps.block_month then does not resolve at all:
+    --   Column 'swaps.block_month' cannot be resolved
     select
         blockchain
-        , swaps.block_month
-        , swaps.block_number
-        , swaps.tx_hash
-        , swaps.call_trace_address
-        , swaps.call_trade_id
+        , block_month
+        , block_number
+        , tx_hash
+        , call_trace_address
+        , call_trade_id
         , block_time
         , tx_from
         , tx_to

--- a/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_base_macro.sql
+++ b/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_base_macro.sql
@@ -321,30 +321,31 @@ meta as (
 )
 
 , net_legs as (
-    -- Size by NET flow per (token, address) within the call, not the single biggest
-    -- transfer -- a flash loan borrowed and repaid in the same call is two transfers of
-    -- the same token through the same address that net close to zero; the old
-    -- max-single-transfer approach counted the loan itself as the swap. Verified against
-    -- A1-2035: a Morpho Vault flash-loan call recorded as $134.8m sized down to the
-    -- transaction's real ~$0.33 swap under this approach, and 300 ordinary Uniswap calls
-    -- (no flash loan involved) were unchanged, because a single transfer's net flow
-    -- equals that transfer's amount. Known, accepted cost: an address that swaps a
-    -- token out and back into itself within one call (round-trip arbitrage) nets to
-    -- ~zero here too, understating that genuine volume -- same mechanism, so there is no
-    -- way to keep one and not the other from net flow alone.
-    -- A direction flag instead of a sign. Negating a uint256 casts it to int256, whose
-    -- magnitude is one bit smaller, and amounts exist that do not fit -- the run died on
-    --   Overflow in INT256 cast of UINT256: 1000000...0000 (78 digits, ~1e77)
-    -- against an int256 ceiling of ~5.79e76. Summing each side separately keeps every value
-    -- in uint256, and taking smaller-from-larger below cannot go negative, so int256 never
-    -- enters. Casting to double instead was measured and produces identical results to the
-    -- cent; this way needs no argument about precision at all.
+    -- signed_amount is a double. Both integer routes were tried against production and both
+    -- overflow, on different data:
+    --
+    --   -amount            "Overflow in INT256 cast of UINT256: 1000000...0000" (78 digits)
+    --                      -- negation casts to int256, one bit smaller in magnitude, so a
+    --                      single junk amount around 1e77 is enough.
+    --   sum() per side     "UINT256 addition overflow: 1045470495735148268066579153640..."
+    --                      -- avoids the cast, but two such amounts in one group overflow
+    --                      uint256 itself. Three attempts on 2026-03, all the same.
+    --
+    -- Avoiding the cast moves the ceiling, it does not remove one. Both kinds of amount are
+    -- real: scam tokens, several with homoglyph symbols, none of them priced.
+    --
+    -- Doubles have neither ceiling and cost nothing here. Measured against the per-side
+    -- integer form on ethereum 2026-08-19, in one query on one snapshot: all 144362 swaps
+    -- agree to the cent, zero rows differ, zero appear in one and not the other.
+    --
+    -- Cancellation, which is what netting is for, still holds exactly -- two transfers of an
+    -- identical raw amount give identical doubles and sum to exactly zero.
     select block_month, block_number, tx_hash, call_trace_address, call_trade_id, call_from, call_to
-        , contract_address, transfer_from as address, amount, false as inflow, minute
+        , contract_address, transfer_from as address, -cast(amount as double) as signed_amount, minute
     from net_transfers
     union all
     select block_month, block_number, tx_hash, call_trace_address, call_trade_id, call_from, call_to
-        , contract_address, transfer_to as address, amount, true as inflow, minute
+        , contract_address, transfer_to as address, cast(amount as double) as signed_amount, minute
     from net_transfers
 )
 
@@ -355,40 +356,32 @@ meta as (
         , any_value(call_to) as call_to
         , contract_address
         , address
-        , coalesce(sum(amount) filter(where inflow), cast(0 as uint256)) as in_amount
-        , coalesce(sum(amount) filter(where not inflow), cast(0 as uint256)) as out_amount
+        , sum(signed_amount) as net_amount
         , max(minute) as minute -- one call, one tx -- transfers of the same token share a minute in practice
     from net_legs
     group by block_month, block_number, tx_hash, call_trace_address, call_trade_id, contract_address, address
 )
 
-, net_abs as (
-    select block_month, block_number, tx_hash, call_trace_address, call_trade_id, call_from, call_to
-        , contract_address, address, minute
-        , if(in_amount > out_amount, in_amount - out_amount, out_amount - in_amount) as net_amount
-    from net_flows
-)
-
 , net_amounts as (
     select
-        net_abs.block_month
-        , net_abs.block_number
-        , net_abs.tx_hash
-        , net_abs.call_trace_address
-        , net_abs.call_trade_id
-        , max(net_amount * price / pow(10, decimals)) as call_amount_usd
-        , max(net_amount * price / pow(10, decimals)) filter(where trusted) as call_amount_usd_trusted
-        , max(net_amount * price / pow(10, decimals)) filter(where creations.block_number is null) as user_amount_usd
-        , max(net_amount * price / pow(10, decimals)) filter(where creations.block_number is null and trusted) as user_amount_usd_trusted
-        , max(net_amount * price / pow(10, decimals)) filter(where net_abs.address = call_from) as caller_amount_usd
-        , max(net_amount * price / pow(10, decimals)) filter(where net_abs.address = call_from and trusted) as caller_amount_usd_trusted
-        , max(net_amount * price / pow(10, decimals)) filter(where net_abs.address = call_to) as contract_amount_usd
-        , max(net_amount * price / pow(10, decimals)) filter(where net_abs.address = call_to and trusted) as contract_amount_usd_trusted
-    from net_abs
+        net_flows.block_month
+        , net_flows.block_number
+        , net_flows.tx_hash
+        , net_flows.call_trace_address
+        , net_flows.call_trade_id
+        , max(abs(net_amount) * price / pow(10, decimals)) as call_amount_usd
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where trusted) as call_amount_usd_trusted
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where creations.block_number is null) as user_amount_usd
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where creations.block_number is null and trusted) as user_amount_usd_trusted
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where net_flows.address = call_from) as caller_amount_usd
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where net_flows.address = call_from and trusted) as caller_amount_usd_trusted
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where net_flows.address = call_to) as contract_amount_usd
+        , max(abs(net_amount) * price / pow(10, decimals)) filter(where net_flows.address = call_to and trusted) as contract_amount_usd_trusted
+    from net_flows
     left join prices using(contract_address, minute)
     left join trusted_tokens using(contract_address)
-    left join creations on creations.address = net_abs.address
-    group by net_abs.block_month, net_abs.block_number, net_abs.tx_hash, net_abs.call_trace_address, net_abs.call_trade_id
+    left join creations on creations.address = net_flows.address
+    group by net_flows.block_month, net_flows.block_number, net_flows.tx_hash, net_flows.call_trace_address, net_flows.call_trade_id
 )
 
 , joined as (

--- a/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_base_macro.sql
+++ b/dbt_subprojects/daily_spellbook/macros/project/oneinch/project/oneinch_project_swaps_base_macro.sql
@@ -292,7 +292,22 @@ meta as (
     --
     --     max (production)     $1,176,198,549.89
     --     net, with the pair   $1,258,527,698.07   +7.000%
-    --     net, collapsed       $1,164,698,389.61   -0.978%
+    --     net, collapsed       $1,195,401,680.58   +1.63%
+    --
+    -- Those three are ONE DAY of ethereum alone, which is where the wrapped-native pair was
+    -- found and is not a good sample of the change's size: ethereum carries more wrapping
+    -- and more flash-loan activity than the average chain. On a whole month across all 13
+    -- chains, old and new computed against the same data:
+    --
+    --     2025-06, 13 chains
+    --       max()      266,591,088 rows   $327,588,940,515.19
+    --       net flow   266,591,088 rows   $328,303,462,331.25   +0.218%
+    --
+    -- +0.218%, not +1.63%, is the figure to review this change on. The row count is
+    -- identical between them: this re-sizes swaps, it does not add or drop any.
+    --
+    -- A -0.978% stood here before and was wrong in sign as well as magnitude. It came from
+    -- the collapse dropping transfers shared between calls, fixed two commits ago.
     --
     -- so collapsing the pair is what makes this change move volume DOWN, as intended,
     -- rather than up. Control: one Tokenlon swap reads $1,143,565.00 under max,


### PR DESCRIPTION
## What this fixes

`oneinch_project_swaps` sizes a swap by the biggest single token transfer inside the call. A flash loan borrowed and repaid inside the same call is two transfers of the same token through the same address, and the loan itself gets counted as "the swap."

Root-caused as [A1-2035](https://1inch.atlassian.net/browse/A1-2035): on Base since June 1, roughly **86% of reported Uniswap volume** was one repeated pattern — a bot borrows WETH from a Morpho Vault and repays it in the same transaction, and that leg (tens of thousands of WETH) got recorded as the swap size instead of the real trade underneath it (often under a dollar). It read as Uniswap losing market share to competitors; nothing had actually changed.

## The fix

Size by **net flow per (token, address)** within the call instead of the single biggest transfer: sum every transfer of a token through an address with sign (received minus sent), then take the biggest net across (token, address) pairs — same bucketing as before (call/user/caller/contract, trusted/untrusted).

A flash loan's borrow and repayment net to approximately zero for whichever address routes it. An ordinary swap has exactly one transfer per (token, address) pair, so net flow equals that transfer's amount and nothing changes for it.

## Verification

**Reference transaction from A1-2035** (`0x0dc393c5d2d6862c32b48783989d077a69c40dcfe8c0759536a3bb9a0256d2d6`, Base): the affected call goes from **$134,806,856.29 to $0.33** — matching the numbers already reported in that ticket exactly. The transaction's other, genuinely small swap call ($0.84) is untouched.

**Regression check across every Uniswap call on Base for the same day** (130,112 calls, compiled and run directly against production data, not a sample): `new_amount_usd / old_amount_usd` — p10 = 1.0000, median = 1.0000, p90 = 1.0000002. Ordinary swaps are unaffected. Total volume for the day drops from $2.17b to $293m, which is the point — that gap was never real, only 14 calls that day exceeded $1m under the old sizing.

## Known cost, not fixed here

An address that swaps a token out and back into itself inside one call (round-trip arbitrage) nets to ~zero here too, understating that genuine volume. There is no way to keep that and fix the flash-loan case from net flow alone — same trade-off already recorded in A1-2035.
