### PR TITLE
fix(dex): remove whitespace padding from four dex.trades seed rows

### DIFF
--- a/dbt_subprojects/dex/models/trades/base/platforms/horizondex_base_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/base/platforms/horizondex_base_base_trades.sql
@@ -10,6 +10,8 @@
     )
 }}
 
+-- ci-stamp: 1
+
 WITH dexs AS
 (
     SELECT

--- a/dbt_subprojects/dex/models/trades/peaq/platforms/machinex_v3_peaq_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/peaq/platforms/machinex_v3_peaq_base_trades.sql
@@ -10,6 +10,8 @@
     )
 }}
 
+-- ci-stamp: 1
+
 {% set machinex_start_date = "2025-05-25" %}
 
 WITH pool_tokens AS (

--- a/dbt_subprojects/dex/models/trades/plume/platforms/rooster_protocol_plume_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/plume/platforms/rooster_protocol_plume_base_trades.sql
@@ -10,6 +10,8 @@
     )
 }}
 
+-- ci-stamp: 1
+
 {{
     maverick_compatible_v2_trades(
         blockchain = 'plume',

--- a/dbt_subprojects/dex/models/trades/somnia/platforms/quickswap_v3_somnia_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/somnia/platforms/quickswap_v3_somnia_base_trades.sql
@@ -10,6 +10,8 @@
     )
 }}
 
+-- ci-stamp: 1
+
 {% set quickswap_start_date = "2025-08-29" %}
 
 WITH dexs AS (


### PR DESCRIPTION
### Description:

Four seed rows under `dbt_subprojects/dex/seeds/trades/` carry a leading or trailing space inside a
field. Same class as the `icecreamswap` seed fix in #9974, but with an important difference: all four
of these models are **wired and live in production today**, where icecreamswap was never wired at all.

| seed | line | column | value | introduced | age |
| --- | --- | --- | --- | --- | --- |
| `horizondex_base_base_trades_seed.csv` | 2 | `tx_hash` | `0x0936…b75e` + trailing space | #5319, 2024-02-15 | ~30 months |
| `rooster_protocol_plume_base_trades_seed.csv` | 2 | `token_sold_address` | leading space + `0x593c…88db` | #8276, 2025-06-12 | ~14 months |
| `machinex_v3_peaq_base_trades_seed.csv` | 2 | `block_date` | `2025-09-29` + trailing space | #8782, 2025-09-30 | ~11 months |
| `quickswap_v3_somnia_base_trades_seed.csv` | 6 | `block_date` | `2025-09-01` + trailing space | #8820, 2025-10-01 | ~11 months |

`check_dex_base_trades_seed` matches on `tx_hash` and `evt_index` and checks `block_number`, both
token addresses and both raw amounts. So the horizondex padding sits on a **matching** column and the
rooster padding on a **checked** column. The two `block_date` ones sit on a column the test neither
matches nor checks, so they are hygiene rather than a broken assertion, but they are the same defect
and the same directory.

### Why this PR opens with a diagnostic commit

I can trace the whitespace deterministically up to the point it reaches DuneSQL, and no further:

- `column_types` keys become `text_columns` (`dbt/context/providers.py:1333`), which forces every
  named column to `agate.data_types.Text` in `build_type_tester`.
- `agate.Text.cast()` returns `str(d)` and strips only for the null-value comparison, so the padding
  survives CSV parsing into the seed table.
- `trino__load_csv_rows` → `create_bindings` takes the non-varchar branch for a `varbinary` or
  `timestamp` column and emits the value inside a type-constructor literal, so the seed row becomes
  `VARBINARY '0x0936…b75e '` with the space inside the literal.

What I cannot determine locally is what DuneSQL does with that: reject it, decode it to different
bytes, or trim it. Those three give completely different answers about whether anything is actually
broken, and I did not want to assert one. These models' seed tests only run when something attached
to them is modified, and nothing has been for the ages above, so there is no recent CI evidence either.

So the first commit only adds `-- ci-stamp: 1` to the four models, changing no data. That is the
mechanism `AGENTS.md` documents for pulling a model into `state:modified.body`, and it makes CI build
them and run their seed tests against the padded seeds exactly as they stand today. Whatever that run
reports is the real before state:

- **seed load fails** → DuneSQL rejects the padded literal.
- **seed loads, test fails** → the padded value decodes to different bytes and the row never matches.
- **everything passes** → DuneSQL trims, the padding is harmless, and I will say so plainly and close
  this rather than ship a fix for a non-problem. That outcome would also mean the corresponding
  sentence in #9974's description overstates the icecreamswap case, and I would correct it there.

The second commit removes the whitespace and the stamps, so the net diff is four one-character seed
edits and nothing else.

### Not touched

Five more padded fields exist in `dbt_subprojects/dex/seeds/_project/zeroex/*_sample.csv`
(`zeroex_native_fills_sample`, the bnb/polygon/ethereum native-fills samples, and
`zeroex_base_api_fills_sample`). Those feed a different test family, so I left them out rather than
widen this PR. Happy to take them in a follow-up if you want them.

### Testing

- `dbt deps`, `dbt parse` clean on the `dex` sub-project.
- No Trino credentials in my environment, so the before and after measurements come from this PR's
  own CI runs rather than from anything I ran locally.
