### PR TITLE
Add staking_plume.deposits model

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/_sector/staking/plume/staking_plume_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/staking/plume/staking_plume_deposits.sql
@@ -1,0 +1,66 @@
+{{ config(
+
+    schema = 'staking_plume',
+    alias = 'deposits',
+    materialized = 'incremental',
+    file_format = 'delta',
+    incremental_strategy = 'merge',
+    incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+    unique_key = ['tx_hash', 'evt_index'],
+    post_hook = '{{ expose_spells(\'["plume"]\',
+                                "sector",
+                                "staking",
+                                \'["lukasrozado"]\') }}')
+}}
+
+/*
+    Plume staking deposits.
+
+    Fully derived from plume.logs (contract is not yet ABI-decoded on Dune, so
+    indexed/non-indexed params are decoded manually by topic position -- see
+    docs/general/best_practices.md and the precedent in
+    dbt_subprojects/daily_spellbook/models/toroperp/sei/toroperp_sei_deposits.sql
+    and .../chainlink/*/chainlink_*_ccip_nop_paid_logs.sql for the same pattern).
+
+    Staking contract: 0x30c791E4654EdAc575FA1700eD8633CB2FEDE871
+    Stake event topic0: 0x521d5961e1d8e7e104af28f00e1f7e11655e7cc7e8d7a9b7a07e959a1598e215
+
+    Decoded fields:
+    - topic1 (indexed): depositor address (right-aligned in the 32-byte topic,
+      hence bytearray_substring(topic1, 13) to take the trailing 20 bytes)
+    - topic2 (indexed): validator id (read as a full-width uint256 topic --
+      no substring needed, matching the pattern used for uint topics elsewhere
+      in this repo, e.g. varbinary_to_uint256(topic3) in
+      toroperp_sei_deposits.sql)
+    - data (non-indexed): amount staked (first 32-byte word)
+
+    Verified on Dune (2026-08-29) against plume.logs for this contract_address +
+    topic0: 2,108,504 events since 2025-05-31, 138,784 distinct topic1 values
+    (consistent with a per-depositor address) and 12 distinct topic2 values
+    (consistent with a small, fixed validator set) -- confirms the topic0 and
+    the topic1/topic2 field mapping match the issue's description.
+*/
+
+{% set blockchain = 'plume' %}
+{% set staking_contract = 0x30c791E4654EdAc575FA1700eD8633CB2FEDE871 %}
+{% set stake_evt_topic0 = 0x521d5961e1d8e7e104af28f00e1f7e11655e7cc7e8d7a9b7a07e959a1598e215 %}
+{% set project_start_date = '2025-05-31' %} -- verified via Dune query against plume.logs (first_seen)
+
+SELECT
+    '{{ blockchain }}' AS blockchain
+    , l.block_time
+    , l.block_number
+    , l.tx_hash
+    , l.index AS evt_index
+    , bytearray_substring(l.topic1, 13) AS depositor_address
+    , bytearray_to_uint256(l.topic2) AS validator_id
+    , bytearray_to_uint256(bytearray_substring(l.data, 1, 32)) AS amount_staked
+    , l.contract_address
+FROM {{ source('plume', 'logs') }} l
+WHERE l.contract_address = {{ staking_contract }}
+    AND l.topic0 = {{ stake_evt_topic0 }}
+    {% if is_incremental() %}
+    AND {{ incremental_predicate('l.block_time') }}
+    {% else %}
+    AND l.block_time >= TIMESTAMP '{{ project_start_date }}'
+    {% endif %}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/staking/plume/staking_plume_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/staking/plume/staking_plume_deposits.sql
@@ -20,7 +20,8 @@
     indexed/non-indexed params are decoded manually by topic position -- see
     docs/general/best_practices.md and the precedent in
     dbt_subprojects/daily_spellbook/models/toroperp/sei/toroperp_sei_deposits.sql
-    and .../chainlink/*/chainlink_*_ccip_nop_paid_logs.sql for the same pattern).
+    and the chainlink CCIP nop-paid-logs models under
+    dbt_subprojects/daily_spellbook/models/chainlink for the same pattern).
 
     Staking contract: 0x30c791E4654EdAc575FA1700eD8633CB2FEDE871
     Stake event topic0: 0x521d5961e1d8e7e104af28f00e1f7e11655e7cc7e8d7a9b7a07e959a1598e215

--- a/dbt_subprojects/hourly_spellbook/models/_sector/staking/plume/staking_plume_deposits.sql
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/staking/plume/staking_plume_deposits.sql
@@ -43,8 +43,6 @@
 */
 
 {% set blockchain = 'plume' %}
-{% set staking_contract = 0x30c791E4654EdAc575FA1700eD8633CB2FEDE871 %}
-{% set stake_evt_topic0 = 0x521d5961e1d8e7e104af28f00e1f7e11655e7cc7e8d7a9b7a07e959a1598e215 %}
 {% set project_start_date = '2025-05-31' %} -- verified via Dune query against plume.logs (first_seen)
 
 SELECT
@@ -58,8 +56,8 @@ SELECT
     , bytearray_to_uint256(bytearray_substring(l.data, 1, 32)) AS amount_staked
     , l.contract_address
 FROM {{ source('plume', 'logs') }} l
-WHERE l.contract_address = {{ staking_contract }}
-    AND l.topic0 = {{ stake_evt_topic0 }}
+WHERE l.contract_address = 0x30c791E4654EdAc575FA1700eD8633CB2FEDE871
+    AND l.topic0 = 0x521d5961e1d8e7e104af28f00e1f7e11655e7cc7e8d7a9b7a07e959a1598e215
     {% if is_incremental() %}
     AND {{ incremental_predicate('l.block_time') }}
     {% else %}

--- a/dbt_subprojects/hourly_spellbook/models/_sector/staking/plume/staking_plume_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/_sector/staking/plume/staking_plume_schema.yml
@@ -1,0 +1,55 @@
+version: 2
+
+models:
+  - name: staking_plume_deposits
+    meta:
+      blockchain: plume
+      sector: staking
+      short_description: "Plume staking deposit events, decoded from raw contract logs (contract not yet ABI-decoded on Dune)."
+      contributors: lukasrozado
+      docs_slug: /curated/staking/deposits
+    config:
+      tags: ['plume', 'staking', 'deposits']
+    description: >
+        Canonical record of staking deposit activity on Plume, with one row per
+        on-chain staking action. Fully derived from plume.logs by decoding raw
+        event topics/data for the Plume staking contract
+        (0x30c791E4654EdAc575FA1700eD8633CB2FEDE871). No aggregation or pricing
+        logic is applied.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - tx_hash
+              - evt_index
+    columns:
+      - name: blockchain
+        description: "Blockchain the deposit occurred on (always 'plume')"
+      - name: block_time
+        description: "Block time of the staking deposit transaction"
+        data_tests:
+          - not_null
+      - name: block_number
+        description: "Block number of the staking deposit transaction"
+        data_tests:
+          - not_null
+      - name: tx_hash
+        description: "Transaction hash of the staking deposit"
+        data_tests:
+          - not_null
+      - name: evt_index
+        description: "Log index of the stake event within the block"
+        data_tests:
+          - not_null
+      - name: depositor_address
+        description: "Address that made the staking deposit (decoded from topic1)"
+        data_tests:
+          - not_null
+      - name: validator_id
+        description: "Identifier of the validator being staked to (decoded from topic2)"
+      - name: amount_staked
+        description: "Raw amount staked in the deposit event, in the token's minimal unit (decoded from data)"
+        data_tests:
+          - not_null
+      - name: contract_address
+        description: "Address of the Plume staking contract that emitted this event"


### PR DESCRIPTION
Closes #9535

Adds `staking_plume.deposits`, a canonical record of staking deposit activity on the Plume staking contract (`0x30c791E4654EdAc575FA1700eD8633CB2FEDE871`).

## What this adds
- New incremental model `staking_plume_deposits` under `_sector/staking/plume/`, mirroring the shape of `staking_ethereum.deposits`.
- One row per staking deposit: `block_time`, `block_number`, `tx_hash`, `evt_index`, `depositor_address`, `validator_id`, `amount_staked`, `contract_address`, `blockchain`.
- `schema.yml` with column descriptions and a `dbt_utils.unique_combination_of_columns` test on `(tx_hash, evt_index)`, plus `not_null` tests on the required fields.

## Data source
Fully derived from `plume.logs`, decoded by topic position (the contract is not yet ABI-decoded on Dune) -- topic1 = depositor address, topic2 = validator id, data = amount staked. This follows the same raw-log-decoding pattern used elsewhere in this repo for undecoded contracts (e.g. `toroperp_sei_deposits.sql`, the `chainlink_*_ccip_nop_paid_logs.sql` models).

## Verification
Queried `plume.logs` directly on Dune for this `contract_address` + `topic0`: 2,108,504 events since 2025-05-31, with 138,784 distinct `topic1` values (consistent with per-depositor addresses) and 12 distinct `topic2` values (consistent with a small, fixed validator set). This confirms the topic0 and the topic1/topic2 field mapping described in the issue. `project_start_date` is set to the verified first-seen date (2025-05-31).

`dbt compile` passes cleanly against this model and the full project (2300 models, 0 errors).

## Open question for maintainers
This is a first contribution to this sector for a new chain (Plume). I used `expose_spells()` (public) rather than `hide_spells()` since there's no downstream `staking_plume_flows` model yet and the issue frames this as a directly queryable canonical table -- happy to switch to `hide_spells()` if that's not the right call here.
