### PR TITLE
feat(zeroex): add Robinhood Settler trades

### DIFF
--- a/dbt_subprojects/dex/models/_projects/zeroex/robinhood/zeroex_robinhood_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/robinhood/zeroex_robinhood_schema.yml
@@ -1,0 +1,105 @@
+version: 2
+
+models:
+  - name: zeroex_robinhood_settler_addresses
+    meta:
+      blockchain: robinhood
+      project: zeroex
+      contributors: bakabhai993
+    config:
+      tags: ['robinhood', '0x', 'settler']
+    description: >
+      0x Settler addresses registered on Robinhood Chain, including their activation periods.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - settler_address
+              - token_id
+    columns:
+      - name: settler_address
+        description: "Address authorised to settle 0x trades"
+        data_tests:
+          - not_null
+      - name: token_id
+        description: "Registry token ID associated with the Settler address"
+        data_tests:
+          - not_null
+      - name: begin_block_time
+        description: "UTC timestamp when the Settler address became active"
+      - name: end_block_time
+        description: "UTC timestamp when the Settler address stopped being active"
+
+  - name: zeroex_v2_robinhood_settler_txs
+    meta:
+      blockchain: robinhood
+      project: zeroex
+      contributors: bakabhai993
+    config:
+      tags: ['robinhood', '0x', 'settler']
+    description: >
+      Staged 0x Settler calls on Robinhood Chain, decoded once from Robinhood traces.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - tx_hash
+              - rn
+    columns:
+      - name: block_month
+        description: "UTC month partition derived from block_time"
+        data_tests:
+          - not_null
+      - name: tx_hash
+        description: "Transaction hash containing the Settler call"
+        data_tests:
+          - not_null
+      - name: rn
+        description: "Settler-call sequence within the transaction"
+        data_tests:
+          - not_null
+      - name: tag
+        description: "Three-byte integrator tag extracted from the tracker calldata"
+
+  - name: zeroex_v2_robinhood_trades
+    meta:
+      blockchain: robinhood
+      project: zeroex
+      contributors: bakabhai993
+    config:
+      tags: ['robinhood', '0x', 'settler', 'dex_aggregator', 'dex', 'aggregator']
+    description: >
+      Deduplicated 0x API trades executed through Settler contracts on Robinhood Chain.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - tx_hash
+              - evt_index
+              - trace_address
+    columns:
+      - name: block_month
+        description: "UTC month partition derived from block_time"
+        data_tests:
+          - not_null
+      - name: block_date
+        description: "UTC date of the trade"
+        data_tests:
+          - not_null
+      - name: tx_hash
+        description: "Transaction hash containing the trade"
+        data_tests:
+          - not_null
+      - name: evt_index
+        description: "Synthetic event index used by the aggregator union"
+        data_tests:
+          - not_null
+      - name: trace_address
+        description: "Trace path of the Settler call"
+        data_tests:
+          - not_null
+      - name: tag
+        description: "Three-byte integrator tag exposed as affiliate_address downstream"

--- a/dbt_subprojects/dex/models/_projects/zeroex/robinhood/zeroex_robinhood_settler_addresses.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/robinhood/zeroex_robinhood_settler_addresses.sql
@@ -3,7 +3,7 @@
         schema = 'zeroex_robinhood',
         alias = 'settler_addresses',
         materialized = 'incremental',
-        unique_key = ['settler_address'],
+        unique_key = ['settler_address', 'token_id'],
         on_schema_change = 'sync_all_columns',
         file_format = 'delta',
         incremental_strategy = 'merge'

--- a/dbt_subprojects/dex/models/_projects/zeroex/robinhood/zeroex_robinhood_settler_addresses.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/robinhood/zeroex_robinhood_settler_addresses.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        schema = 'zeroex_robinhood',
+        alias = 'settler_addresses',
+        materialized = 'incremental',
+        unique_key = ['settler_address'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge'
+    )
+}}
+
+{{ zeroex_settler_addresses('robinhood') }}

--- a/dbt_subprojects/dex/models/_projects/zeroex/robinhood/zeroex_v2_robinhood_settler_txs.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/robinhood/zeroex_v2_robinhood_settler_txs.sql
@@ -1,0 +1,29 @@
+{{
+    config(
+        schema = 'zeroex_v2_robinhood',
+        alias = 'settler_txs',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'tx_hash', 'rn'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set zeroex_settler_start_date = '2026-04-30' %}
+{% set blockchain = 'robinhood' %}
+
+-- Materialize the trace scan once so downstream 0x Settler models do not rescan Robinhood traces.
+select
+    settler_txs.*
+    , cast(date_trunc('month', block_time) as date) as block_month
+from (
+    {{
+        zeroex_settler_txs_cte(
+            blockchain = blockchain,
+            start_date = zeroex_settler_start_date
+        )
+    }}
+) as settler_txs

--- a/dbt_subprojects/dex/models/_projects/zeroex/robinhood/zeroex_v2_robinhood_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/robinhood/zeroex_v2_robinhood_trades.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        schema = 'zeroex_v2_robinhood',
+        alias = 'trades',
+        materialized = 'incremental',
+        partition_by = ['block_month'],
+        unique_key = ['block_month', 'block_date', 'tx_hash', 'evt_index', 'trace_address'],
+        on_schema_change = 'sync_all_columns',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{{
+    zeroex_settler_agg(
+        blockchain = 'robinhood',
+        start_date = '2026-04-30'
+    )
+}}

--- a/dbt_subprojects/dex/models/_projects/zeroex/zeroex_api_fills_deduped.sql
+++ b/dbt_subprojects/dex/models/_projects/zeroex/zeroex_api_fills_deduped.sql
@@ -36,6 +36,7 @@
   ,ref('zeroex_v2_berachain_trades')
   ,ref('zeroex_v2_ink_trades')
   ,ref('zeroex_v2_monad_trades')
+  ,ref('zeroex_v2_robinhood_trades')
 ] %}
 
 

--- a/dbt_subprojects/dex/models/_projects/zeroex/zeroex_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/zeroex_schema.yml
@@ -119,9 +119,11 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
+              - blockchain
               - block_date
               - tx_hash
               - evt_index
+              - trace_address
       - check_seed:
           arguments:
             seed_file: ref('zeroex_api_fills_deduped_sample')
@@ -159,6 +161,8 @@ models:
       - *tx_to
       - *evt_index
       - *blockchain
+      - name: trace_address
+        description: "Trace path of the Settler call for Settler-derived rows"
 
   - name: zeroex_trades
     meta:

--- a/dbt_subprojects/dex/models/_projects/zeroex/zeroex_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/zeroex/zeroex_schema.yml
@@ -107,12 +107,12 @@ models:
 
   - name: zeroex_api_fills_deduped
     meta: 
-      blockchain: ethereum, optimism, polygon, arbitrum, fantom, avalanche, bnb, base, scroll, linea, blast, mantle, worldchain, berachain, ink, monad
+      blockchain: ethereum, optimism, polygon, arbitrum, fantom, avalanche, bnb, base, scroll, linea, blast, mantle, worldchain, berachain, ink, monad, robinhood
       sector: dex
       project: zeroex
       contributors: rantum, bakabhai993
     config:
-      tags: ['ethereum', 'optimism', 'polygon', 'bnb', 'avalanche', '0x','trades', 'dex', 'jeff-dude','cross-chain']
+      tags: ['ethereum', 'optimism', 'polygon', 'bnb', 'avalanche', 'robinhood', '0x','trades', 'dex', 'jeff-dude','cross-chain']
     description: >
         Zeroex API on all chains across all contracts and versions. This table will load dex trades downstream.
     data_tests:


### PR DESCRIPTION
Adds Robinhood Chain Settler trades to `zeroex.api_fills_deduped` using the existing shared Settler pattern.