### PR TITLE
oneinch: add cronos, monad, hyperevm to AR/LO lineage; fix robinhood mode classification

### DIFF
--- a/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_contracts_cfg_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/AR/oneinch_ar_contracts_cfg_macro.sql
@@ -199,7 +199,7 @@
         },
         "AggregationRouterV6": {
             "version": "6",
-            "blockchains": ["ethereum", "bnb", "polygon", "arbitrum", "optimism", "avalanche_c", "gnosis", "fantom", "base", "zksync", "linea", "sonic", "unichain", "robinhood"],
+            "blockchains": ["ethereum", "bnb", "polygon", "arbitrum", "optimism", "avalanche_c", "gnosis", "fantom", "base", "zksync", "linea", "sonic", "unichain", "robinhood", "cronos", "monad", "hyperevm"],
             "address": "0x111111125421ca6dc452d289314280a0f8842a65",
             "start": "2024-02-12",
             "methods": {
@@ -514,4 +514,67 @@
         "AggregationRouterV6"         : dict(contracts.AggregationRouterV6, address="0x111111125421ca6dc452d289314280a0f8842a65", methods=methods),
         "AggregationRouterV6Robinhood"  : dict(contracts.AggregationRouterV6, address="0x5a705de8982235a7fa45bb83dcacf03a211389c7", methods=methods),
     }) }}
+{% endmacro %}
+
+-- CRONOS AR CONFIG MACRO --
+{% macro oneinch_cronos_ar_contracts_cfg_macro() %}
+    {% set contracts = oneinch_ar_contracts_cfg_macro() %}
+    {{ return({ "AggregationRouterV6": dict(contracts.AggregationRouterV6, methods={
+            "swap"          : contracts.AggregationRouterV6.methods.swap,
+            "ethUnoswap"    : contracts.AggregationRouterV6.methods.ethUnoswap,
+            "ethUnoswap2"   : contracts.AggregationRouterV6.methods.ethUnoswap2,
+            "ethUnoswap3"   : contracts.AggregationRouterV6.methods.ethUnoswap3,
+            "ethUnoswapTo"  : contracts.AggregationRouterV6.methods.ethUnoswapTo,
+            "ethUnoswapTo2" : contracts.AggregationRouterV6.methods.ethUnoswapTo2,
+            "ethUnoswapTo3" : contracts.AggregationRouterV6.methods.ethUnoswapTo3,
+            "unoswap"       : contracts.AggregationRouterV6.methods.unoswap,
+            "unoswap2"      : contracts.AggregationRouterV6.methods.unoswap2,
+            "unoswap3"      : contracts.AggregationRouterV6.methods.unoswap3,
+            "unoswapTo"     : contracts.AggregationRouterV6.methods.unoswapTo,
+            "unoswapTo2"    : contracts.AggregationRouterV6.methods.unoswapTo2,
+            "unoswapTo3"    : contracts.AggregationRouterV6.methods.unoswapTo3,
+            "permitAndCall" : contracts.AggregationRouterV6.methods.permitAndCall,
+    }) }) }}
+{% endmacro %}
+
+-- MONAD AR CONFIG MACRO --
+{% macro oneinch_monad_ar_contracts_cfg_macro() %}
+    {% set contracts = oneinch_ar_contracts_cfg_macro() %}
+    {{ return({ "AggregationRouterV6": dict(contracts.AggregationRouterV6, methods={
+            "swap"          : contracts.AggregationRouterV6.methods.swap,
+            "ethUnoswap"    : contracts.AggregationRouterV6.methods.ethUnoswap,
+            "ethUnoswap2"   : contracts.AggregationRouterV6.methods.ethUnoswap2,
+            "ethUnoswap3"   : contracts.AggregationRouterV6.methods.ethUnoswap3,
+            "ethUnoswapTo"  : contracts.AggregationRouterV6.methods.ethUnoswapTo,
+            "ethUnoswapTo2" : contracts.AggregationRouterV6.methods.ethUnoswapTo2,
+            "ethUnoswapTo3" : contracts.AggregationRouterV6.methods.ethUnoswapTo3,
+            "unoswap"       : contracts.AggregationRouterV6.methods.unoswap,
+            "unoswap2"      : contracts.AggregationRouterV6.methods.unoswap2,
+            "unoswap3"      : contracts.AggregationRouterV6.methods.unoswap3,
+            "unoswapTo"     : contracts.AggregationRouterV6.methods.unoswapTo,
+            "unoswapTo2"    : contracts.AggregationRouterV6.methods.unoswapTo2,
+            "unoswapTo3"    : contracts.AggregationRouterV6.methods.unoswapTo3,
+            "permitAndCall" : contracts.AggregationRouterV6.methods.permitAndCall,
+    }) }) }}
+{% endmacro %}
+
+-- HYPEREVM AR CONFIG MACRO (chain-specific AggregationRouterV6 deployment address) --
+{% macro oneinch_hyperevm_ar_contracts_cfg_macro() %}
+    {% set contracts = oneinch_ar_contracts_cfg_macro() %}
+    {{ return({ "AggregationRouterV6": dict(contracts.AggregationRouterV6, address="0x5281602adc446a94eb48d055f514a6d8d5bee176", methods={
+            "swap"          : contracts.AggregationRouterV6.methods.swap,
+            "ethUnoswap"    : contracts.AggregationRouterV6.methods.ethUnoswap,
+            "ethUnoswap2"   : contracts.AggregationRouterV6.methods.ethUnoswap2,
+            "ethUnoswap3"   : contracts.AggregationRouterV6.methods.ethUnoswap3,
+            "ethUnoswapTo"  : contracts.AggregationRouterV6.methods.ethUnoswapTo,
+            "ethUnoswapTo2" : contracts.AggregationRouterV6.methods.ethUnoswapTo2,
+            "ethUnoswapTo3" : contracts.AggregationRouterV6.methods.ethUnoswapTo3,
+            "unoswap"       : contracts.AggregationRouterV6.methods.unoswap,
+            "unoswap2"      : contracts.AggregationRouterV6.methods.unoswap2,
+            "unoswap3"      : contracts.AggregationRouterV6.methods.unoswap3,
+            "unoswapTo"     : contracts.AggregationRouterV6.methods.unoswapTo,
+            "unoswapTo2"    : contracts.AggregationRouterV6.methods.unoswapTo2,
+            "unoswapTo3"    : contracts.AggregationRouterV6.methods.unoswapTo3,
+            "permitAndCall" : contracts.AggregationRouterV6.methods.permitAndCall,
+    }) }) }}
 {% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lo_contracts_cfg_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/LO/oneinch_lo_contracts_cfg_macro.sql
@@ -285,3 +285,21 @@
         "AggregationRouterV6Robinhood" : dict(contracts.AggregationRouterV6, address="0x5a705de8982235a7fa45bb83dcacf03a211389c7"),
     }) }}
 {% endmacro %}
+
+-- CRONOS LO CONFIG MACRO --
+{% macro oneinch_cronos_lo_contracts_cfg_macro() %}
+    {% set contracts = oneinch_lo_contracts_cfg_macro() %}
+    {{ return({ "AggregationRouterV6"   : dict(contracts.AggregationRouterV6) }) }}
+{% endmacro %}
+
+-- MONAD LO CONFIG MACRO --
+{% macro oneinch_monad_lo_contracts_cfg_macro() %}
+    {% set contracts = oneinch_lo_contracts_cfg_macro() %}
+    {{ return({ "AggregationRouterV6"   : dict(contracts.AggregationRouterV6) }) }}
+{% endmacro %}
+
+-- HYPEREVM LO CONFIG MACRO (chain-specific AggregationRouterV6 deployment address) --
+{% macro oneinch_hyperevm_lo_contracts_cfg_macro() %}
+    {% set contracts = oneinch_lo_contracts_cfg_macro() %}
+    {{ return({ "AggregationRouterV6"   : dict(contracts.AggregationRouterV6, address="0x5281602adc446a94eb48d055f514a6d8d5bee176") }) }}
+{% endmacro %}

--- a/dbt_subprojects/dex/macros/models/_project/oneinch/_meta/oneinch_meta_cfg_macro.sql
+++ b/dbt_subprojects/dex/macros/models/_project/oneinch/_meta/oneinch_meta_cfg_macro.sql
@@ -297,6 +297,8 @@
 
 {% macro oneinch_robinhood_cfg_macro() %}
     {# transfers_from_traces = false: robinhood tokens uses the newer base_transfers schema, no transfers_from_traces table #}
+    {# fusion_settlement_addresses: robinhood-specific settlement deployment, the canonical multichain settlement addresses are not deployed on this chain #}
+    {# escrow_factory_addresses: the cross-chain v1.2 factory (live since 2026-07-15, dominant line) first, then the v1-ABI factory; both drive LO factory_in_args detection (cross-chain mode) #}
     {{ return({
         "name"                          : "robinhood",
         "start"                         : "2026-06-01",
@@ -304,11 +306,61 @@
         "native_token_symbol"           : "'ETH'",
         "wrapped_native_token_address"  : "0x0bd7d308f8e1639fab988df18a8011f41eacad73",
         "explorer_link"                 : "'https://robinhoodchain.blockscout.com'",
-        "fusion_settlement_addresses"   : ['0x2ad5004c60e16e54d5007c80ce329adde5b51ef5', '0xabd4e5fb590aa132749bbf2a04ea57efbaac399e'],
-        "escrow_factory_addresses"      : ['0xa02b9cc95094bb27d1d041b9fbf09f65a366f7b3'],
+        "fusion_settlement_addresses"   : ['0xb55ba9617dafae1236313c3cb7806439ceefbd13'],
+        "escrow_factory_addresses"      : ['0x50d26ea1e2460b3a42ff47466b955fc6bd906013', '0xa02b9cc95094bb27d1d041b9fbf09f65a366f7b3'],
         "atokens"                       : false,
         "transfers_from_traces"         : false,
         "creations_parent_code_offset"  : 21,
+    }) }}
+{% endmacro %}
+
+{% macro oneinch_cronos_cfg_macro() %}
+    {# transfers_from_traces = false: cronos tokens uses the newer base_transfers schema, no transfers_from_traces table #}
+    {# fusion_settlement_addresses: chain-specific SimpleSettlement deployment, the canonical multichain settlement addresses are not deployed on this chain #}
+    {# escrow_factory_addresses: the active cross-chain v1.2 factory first, then the v1-ABI factory (deployed but unused); they drive LO factory_in_args detection (cross-chain mode); CC models are deferred until escrow decodings land #}
+    {{ return({
+        "name"                          : "cronos",
+        "start"                         : "2026-08-01",
+        "chain_id"                      : "25",
+        "native_token_symbol"           : "'CRO'",
+        "wrapped_native_token_address"  : "0x5c7f8a570d578ed84e63fdfa7b1ee72deae1ae23",
+        "explorer_link"                 : "'https://cronoscan.com'",
+        "fusion_settlement_addresses"   : ['0x65497e56cf49c51f1c1d54dc9005a7b38b98b30f'],
+        "escrow_factory_addresses"      : ['0x8e6c3c2e2631de0a1d4fd46a15f79a1373486fa4', '0x9e010857ed5aaa4fca6d5404f7c7c54b1bbb8ad2'],
+        "atokens"                       : false,
+        "transfers_from_traces"         : false,
+    }) }}
+{% endmacro %}
+
+{% macro oneinch_monad_cfg_macro() %}
+    {# fusion_settlement_addresses: chain-specific SimpleSettlement deployment, the canonical multichain settlement addresses are not deployed on this chain #}
+    {# escrow_factory_addresses: the active cross-chain v1.2 factory first, then the v1-ABI factory (deployed but unused); they drive LO factory_in_args detection (cross-chain mode); CC models are deferred until escrow decodings land #}
+    {{ return({
+        "name"                          : "monad",
+        "start"                         : "2026-08-01",
+        "chain_id"                      : "143",
+        "native_token_symbol"           : "'MON'",
+        "wrapped_native_token_address"  : "0x3bd359c1119da7da1d913d1c4d2b7c461115433a",
+        "explorer_link"                 : "'https://monadscan.com'",
+        "fusion_settlement_addresses"   : ['0x65497e56cf49c51f1c1d54dc9005a7b38b98b30f'],
+        "escrow_factory_addresses"      : ['0x8e6c3c2e2631de0a1d4fd46a15f79a1373486fa4', '0x9e010857ed5aaa4fca6d5404f7c7c54b1bbb8ad2'],
+        "atokens"                       : false,
+    }) }}
+{% endmacro %}
+
+{% macro oneinch_hyperevm_cfg_macro() %}
+    {# fusion_settlement_addresses: chain-specific SimpleSettlement deployment, the canonical multichain settlement addresses are not deployed on this chain #}
+    {# escrow_factory_addresses: the active cross-chain v1.2 factory first, then the v1-ABI factory (deployed but unused); they drive LO factory_in_args detection (cross-chain mode); CC models are deferred until escrow decodings land #}
+    {{ return({
+        "name"                          : "hyperevm",
+        "start"                         : "2026-08-01",
+        "chain_id"                      : "999",
+        "native_token_symbol"           : "'HYPE'",
+        "wrapped_native_token_address"  : "0x5555555555555555555555555555555555555555",
+        "explorer_link"                 : "'https://hyperevmscan.io'",
+        "fusion_settlement_addresses"   : ['0x65497e56cf49c51f1c1d54dc9005a7b38b98b30f'],
+        "escrow_factory_addresses"      : ['0x8e6c3c2e2631de0a1d4fd46a15f79a1373486fa4', '0x9e010857ed5aaa4fca6d5404f7c7c54b1bbb8ad2'],
+        "atokens"                       : false,
     }) }}
 {% endmacro %}
 
@@ -328,6 +380,7 @@
 -- EXPOSED --
 
 {% macro oneinch_blockchains_cfg_macro() %}
+    {# cronos/monad/hyperevm access tokens are deployed at their own addresses, not the canonical 0xacce55... vanity ones #}
     {{ return([
         dict(oneinch_ethereum_cfg_macro()   , evm=true  , fusionV1=true , exposed=["ar", "lo", "cc"] , contracts=oneinch_meta_contracts_cfg_macro()),
         dict(oneinch_bnb_cfg_macro()        , evm=true  , fusionV1=true , exposed=["ar", "lo", "cc"] , contracts=oneinch_meta_contracts_cfg_macro()),
@@ -350,6 +403,21 @@
         dict(oneinch_sonic_cfg_macro()      , evm=true  , fusionV1=false, exposed=["ar", "lo", "cc"], contracts=oneinch_meta_contracts_cfg_macro()),
         dict(oneinch_unichain_cfg_macro()   , evm=true  , fusionV1=false, exposed=["ar", "lo", "cc"], contracts=oneinch_meta_contracts_cfg_macro()),
         dict(oneinch_robinhood_cfg_macro()  , evm=true  , fusionV1=false, exposed=["ar", "lo", "cc"], contracts=oneinch_meta_contracts_cfg_macro()),
+        dict(oneinch_cronos_cfg_macro()     , evm=true  , fusionV1=false, exposed=["ar", "lo"]      , contracts={
+            "AccessTokenLimitsV1"       : dict(oneinch_meta_contracts_cfg_macro().AccessTokenLimitsV1       , address="0xaad580f37c74184e64bda5ebbfb46fba1e2871b7"),
+            "AccessTokenFusionV1"       : dict(oneinch_meta_contracts_cfg_macro().AccessTokenFusionV1       , address="0x826ff268ee2d9e7e7275b780d0f4a9d7aab0e533"),
+            "AccessTokenCrossChainV1"   : dict(oneinch_meta_contracts_cfg_macro().AccessTokenCrossChainV1   , address="0x14c635a133e51eb6a98ec98d51b37c7cf67be452"),
+        }),
+        dict(oneinch_monad_cfg_macro()      , evm=true  , fusionV1=false, exposed=["ar", "lo"]      , contracts={
+            "AccessTokenLimitsV1"       : dict(oneinch_meta_contracts_cfg_macro().AccessTokenLimitsV1       , address="0xaad580f37c74184e64bda5ebbfb46fba1e2871b7"),
+            "AccessTokenFusionV1"       : dict(oneinch_meta_contracts_cfg_macro().AccessTokenFusionV1       , address="0x826ff268ee2d9e7e7275b780d0f4a9d7aab0e533"),
+            "AccessTokenCrossChainV1"   : dict(oneinch_meta_contracts_cfg_macro().AccessTokenCrossChainV1   , address="0x14c635a133e51eb6a98ec98d51b37c7cf67be452"),
+        }),
+        dict(oneinch_hyperevm_cfg_macro()   , evm=true  , fusionV1=false, exposed=["ar", "lo"]      , contracts={
+            "AccessTokenLimitsV1"       : dict(oneinch_meta_contracts_cfg_macro().AccessTokenLimitsV1       , address="0xaad580f37c74184e64bda5ebbfb46fba1e2871b7"),
+            "AccessTokenFusionV1"       : dict(oneinch_meta_contracts_cfg_macro().AccessTokenFusionV1       , address="0x826ff268ee2d9e7e7275b780d0f4a9d7aab0e533"),
+            "AccessTokenCrossChainV1"   : dict(oneinch_meta_contracts_cfg_macro().AccessTokenCrossChainV1   , address="0x14c635a133e51eb6a98ec98d51b37c7cf67be452"),
+        }),
         dict(oneinch_aurora_cfg_macro()     , evm=true  , fusionV1=false),
         dict(oneinch_klaytn_cfg_macro()     , evm=true  , fusionV1=false),
         dict(oneinch_solana_cfg_macro()     , evm=false , fusionV1=false),

--- a/dbt_subprojects/dex/models/_projects/oneinch/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/oneinch/_schema.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: oneinch_ar
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood', 'cronos', 'monad', 'hyperevm']
       sector: oneinch
       contributors: ['max-morrow', 'grkhr', 'dodgervl']
     config:
@@ -69,7 +69,7 @@ models:
 
   - name: oneinch_lo
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood', 'cronos', 'monad', 'hyperevm']
       sector: oneinch
       contributors: ['max-morrow', 'grkhr', 'dodgervl']
     config:
@@ -206,9 +206,9 @@ models:
 
   - name: oneinch_cc_executions
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'base', 'zksync', 'linea', 'sonic', 'unichain']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
       sector: oneinch
-      contributors: ['max-morrow', 'grkhr']
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
     config:
       tags: ['oneinch', 'cc', 'executions']
     description: >
@@ -288,7 +288,7 @@ models:
 
   - name: oneinch_evms_transfers
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood', 'cronos', 'monad', 'hyperevm']
       sector: oneinch
       contributors: ['max-morrow', 'grkhr', 'dodgervl']
     config:
@@ -345,7 +345,7 @@ models:
 
   - name: oneinch_blockchains
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood', 'cronos', 'monad', 'hyperevm']
       sector: oneinch
       contributors: ['max-morrow', 'grkhr', 'dodgervl']
     config:
@@ -367,7 +367,7 @@ models:
 
   - name: oneinch_evms_ptfc
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood', 'cronos', 'monad', 'hyperevm']
       sector: oneinch
       contributors: ['max-morrow', 'grkhr', 'dodgervl']
     config:
@@ -389,7 +389,7 @@ models:
 
   - name: oneinch_ar_trades
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood', 'cronos', 'monad', 'hyperevm']
       sector: oneinch
       contributors: ['max-morrow', 'grkhr', 'thevaizman', 'dodgervl']
     config:
@@ -439,7 +439,7 @@ models:
 
   - name: oneinch_lop_own_trades
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood', 'cronos', 'monad', 'hyperevm']
       sector: oneinch
       contributors: ['max-morrow', 'grkhr', 'thevaizman', 'dodgervl']
     config:
@@ -1334,9 +1334,189 @@ models:
         with a maturity delay so the venue side's decoded events have landed before
         dex_robinhood_trades merges them.
 
+  - name: oneinch_cronos_lop_venue_settled_fills
+    meta:
+      blockchain: ['cronos']
+      sector: oneinch
+      contributors: ['thevaizman', 'dodgervl']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on cronos that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_cronos_base_trades). These fills are excluded from
+        oneinch_cronos_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_cronos_lop_own_trades
+    meta:
+      blockchain: ['cronos']
+      sector: oneinch
+      contributors: ['thevaizman', 'dodgervl']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on cronos - per-chain input for
+        dex_cronos_trades. Venue-settled fills are excluded here (see
+        oneinch_cronos_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_cronos_trades merges them.
+
+  - name: oneinch_monad_lop_venue_settled_fills
+    meta:
+      blockchain: ['monad']
+      sector: oneinch
+      contributors: ['thevaizman', 'dodgervl']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on monad that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_monad_base_trades). These fills are excluded from
+        oneinch_monad_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_monad_lop_own_trades
+    meta:
+      blockchain: ['monad']
+      sector: oneinch
+      contributors: ['thevaizman', 'dodgervl']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on monad - per-chain input for
+        dex_monad_trades. Venue-settled fills are excluded here (see
+        oneinch_monad_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_monad_trades merges them.
+
+  - name: oneinch_hyperevm_lop_venue_settled_fills
+    meta:
+      blockchain: ['hyperevm']
+      sector: oneinch
+      contributors: ['thevaizman', 'dodgervl']
+    config:
+      tags: ['oneinch', 'lo']
+    description: >
+        1inch limit order protocol fills on hyperevm that a resolver settled on an
+        underlying DEX in the same tx (the venue's own row co-occurs in
+        dex_hyperevm_base_trades). These fills are excluded from
+        oneinch_hyperevm_lop_own_trades (dex.trades) and emitted into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills nested under
+        a classic/fusion/cross-chain execution and direct fills are kept out of this set.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_month
+              - block_date
+              - execution_id
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_month
+        data_tests:
+          - not_null
+      - name: block_date
+        data_tests:
+          - not_null
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: execution_id
+        data_tests:
+          - not_null
+      - name: evt_index
+        data_tests:
+          - not_null
+
+  - name: oneinch_hyperevm_lop_own_trades
+    meta:
+      blockchain: ['hyperevm']
+      sector: oneinch
+      contributors: ['thevaizman', 'dodgervl']
+    config:
+      tags: ['oneinch', 'lo', 'trades']
+    description: >
+        1inch limit order protocol trades on hyperevm - per-chain input for
+        dex_hyperevm_trades. Venue-settled fills are excluded here (see
+        oneinch_hyperevm_lop_venue_settled_fills) and reclassified into
+        dex_aggregator.trades via oneinch_lop_aggregator_trades. Fills pass through
+        with a maturity delay so the venue side's decoded events have landed before
+        dex_hyperevm_trades merges them.
+
   - name: oneinch_lop_aggregator_trades
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood', 'cronos', 'monad', 'hyperevm']
       sector: oneinch
       contributors: ['thevaizman', 'dodgervl']
     config:
@@ -1390,7 +1570,7 @@ models:
 
   - name: oneinch_intent_resolvers
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood', 'cronos', 'monad', 'hyperevm']
       sector: oneinch
       contributors: ['max-morrow', 'dodgervl']
     config:
@@ -1417,7 +1597,7 @@ models:
 
   - name: oneinch_intent_executors
     meta:
-      blockchain: ['ethereum', 'optimism', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'bnb', 'fantom', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
+      blockchain: ['ethereum', 'optimism', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'bnb', 'fantom', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood', 'cronos', 'monad', 'hyperevm']
       sector: oneinch
       contributors: ['max-morrow', 'dodgervl']
     config:
@@ -1452,7 +1632,7 @@ models:
 
   - name: oneinch_intent_accounts
     meta:
-      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood']
+      blockchain: ['ethereum', 'bnb', 'polygon', 'arbitrum', 'avalanche_c', 'gnosis', 'optimism', 'fantom', 'base', 'zksync', 'linea', 'sonic', 'unichain', 'robinhood', 'cronos', 'monad', 'hyperevm']
       sector: oneinch
       contributors: ['max-morrow', 'dodgervl']
     config:

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_ar.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_ar.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_cronos_cfg_macro() -%}
+{%- set stream = oneinch_ar_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name,
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_ar_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_cronos_ar_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_ar_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_ar_executions.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_cronos_cfg_macro() -%}
+{%- set stream = oneinch_ar_executions_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_executions',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_ar_executions_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_ar_raw_calls.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_ar_raw_calls.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_cronos_cfg_macro() -%}
+{%- set stream = oneinch_ar_raw_calls_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_raw_calls',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_raw_calls_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_cronos_ar_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_lo.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_lo.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_cronos_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name,
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_lo_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_cronos_lo_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_lo_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_lo_executions.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_cronos_cfg_macro() -%}
+{%- set stream = oneinch_lo_executions_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_executions',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_lo_executions_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_lo_raw_calls.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_lo_raw_calls.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_cronos_cfg_macro() -%}
+{%- set stream = oneinch_lo_raw_calls_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_raw_calls',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_raw_calls_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_cronos_lo_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_lop_own_trades.sql
@@ -1,0 +1,15 @@
+{%- set blockchain = oneinch_cronos_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_lop_venue_settled_fills.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_cronos_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_schema.yml
@@ -1,0 +1,192 @@
+version: 2
+
+models:
+  - name: oneinch_cronos_ar
+    meta:
+      blockchain: ['cronos']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'ar', 'calls']
+    description: >
+        1inch aggregation router calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: chain_id
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: tx_success
+      - name: tx_from
+      - name: tx_to
+      - name: tx_nonce
+      - name: tx_gas_used
+      - name: tx_gas_price
+      - name: tx_priority_fee_per_gas
+      - name: tx_index
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_success
+      - name: call_gas_used
+      - name: call_selector
+      - name: call_method
+      - name: call_from
+      - name: call_to
+      - name: call_output
+      - name: call_error
+      - name: call_type
+      - name: protocol
+      - name: protocol_version
+      - name: contract_name
+      - name: src_receiver
+      - name: dst_receiver
+      - name: src_token_address
+      - name: dst_token_address
+      - name: src_token_amount
+      - name: dst_token_amount
+      - name: dst_token_amount_min
+      - name: router_type
+      - name: pools
+      - name: remains
+      - name: flags
+      - name: minute
+      - name: block_date
+      - name: block_month
+      - name: native_price
+      - name: native_decimals
+
+  - name: oneinch_cronos_lo
+    meta:
+      blockchain: ['cronos']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'lo', 'calls']
+    description: >
+        1inch limit order protocol calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: chain_id
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: tx_success
+      - name: tx_from
+      - name: tx_to
+      - name: tx_nonce
+      - name: tx_gas_used
+      - name: tx_gas_price
+      - name: tx_priority_fee_per_gas
+      - name: tx_index
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_success
+      - name: call_gas_used
+      - name: call_selector
+      - name: call_method
+      - name: call_from
+      - name: call_to
+      - name: call_output
+      - name: call_error
+      - name: call_type
+      - name: protocol
+      - name: protocol_version
+      - name: contract_name
+      - name: order_hash
+      - name: maker
+      - name: receiver
+      - name: maker_asset
+      - name: maker_amount
+      - name: making_amount
+      - name: taker_asset
+      - name: taker_amount
+      - name: taking_amount
+      - name: remains
+      - name: flags
+      - name: minute
+      - name: block_date
+      - name: block_month
+      - name: native_price
+      - name: native_decimals
+
+  - name: oneinch_cronos_transfers
+    meta:
+      blockchain: ['cronos']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'calls']
+    description: >
+        transfers within transactions with 1inch calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+              - transfer_trace_address
+              - transfer_contract_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_selector
+      - name: call_method
+      - name: call_to
+      - name: protocol
+      - name: contract_name
+      - name: transfer_trace_address
+        data_tests:
+          - not_null
+      - name: transfer_contract_address
+        data_tests:
+          - not_null
+      - name: transfer_native
+      - name: transfer_from
+      - name: transfer_to
+      - name: transfer_symbol
+      - name: transfer_amount
+      - name: transfer_amount_usd
+      - name: transfer_decimals
+      - name: trusted
+      - name: nested
+      - name: related
+      - name: same
+      - name: price
+      - name: block_date
+      - name: block_month
+      - name: transfer_id
+      - name: unique_key

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_transfers.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/cronos/oneinch_cronos_transfers.sql
@@ -1,0 +1,24 @@
+{%- set blockchain = oneinch_cronos_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'transfers',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address', 'transfer_trace_address', 'transfer_contract_address'],
+    )
+-}}
+
+{{-
+    oneinch_transfers_macro(
+        blockchain = blockchain,
+        streams = [
+            oneinch_ar_transfers_cfg_macro(),
+            oneinch_lo_transfers_cfg_macro(),
+        ]
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_ar.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_ar.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_hyperevm_cfg_macro() -%}
+{%- set stream = oneinch_ar_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name,
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_ar_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_hyperevm_ar_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_ar_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_ar_executions.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_hyperevm_cfg_macro() -%}
+{%- set stream = oneinch_ar_executions_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_executions',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_ar_executions_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_ar_raw_calls.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_ar_raw_calls.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_hyperevm_cfg_macro() -%}
+{%- set stream = oneinch_ar_raw_calls_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_raw_calls',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_raw_calls_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_hyperevm_ar_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_lo.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_lo.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_hyperevm_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name,
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_lo_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_hyperevm_lo_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_lo_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_lo_executions.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_hyperevm_cfg_macro() -%}
+{%- set stream = oneinch_lo_executions_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_executions',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_lo_executions_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_lo_raw_calls.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_lo_raw_calls.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_hyperevm_cfg_macro() -%}
+{%- set stream = oneinch_lo_raw_calls_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_raw_calls',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_raw_calls_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_hyperevm_lo_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_lop_own_trades.sql
@@ -1,0 +1,15 @@
+{%- set blockchain = oneinch_hyperevm_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_lop_venue_settled_fills.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_hyperevm_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_schema.yml
@@ -1,0 +1,192 @@
+version: 2
+
+models:
+  - name: oneinch_hyperevm_ar
+    meta:
+      blockchain: ['hyperevm']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'ar', 'calls']
+    description: >
+        1inch aggregation router calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: chain_id
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: tx_success
+      - name: tx_from
+      - name: tx_to
+      - name: tx_nonce
+      - name: tx_gas_used
+      - name: tx_gas_price
+      - name: tx_priority_fee_per_gas
+      - name: tx_index
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_success
+      - name: call_gas_used
+      - name: call_selector
+      - name: call_method
+      - name: call_from
+      - name: call_to
+      - name: call_output
+      - name: call_error
+      - name: call_type
+      - name: protocol
+      - name: protocol_version
+      - name: contract_name
+      - name: src_receiver
+      - name: dst_receiver
+      - name: src_token_address
+      - name: dst_token_address
+      - name: src_token_amount
+      - name: dst_token_amount
+      - name: dst_token_amount_min
+      - name: router_type
+      - name: pools
+      - name: remains
+      - name: flags
+      - name: minute
+      - name: block_date
+      - name: block_month
+      - name: native_price
+      - name: native_decimals
+
+  - name: oneinch_hyperevm_lo
+    meta:
+      blockchain: ['hyperevm']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'lo', 'calls']
+    description: >
+        1inch limit order protocol calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: chain_id
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: tx_success
+      - name: tx_from
+      - name: tx_to
+      - name: tx_nonce
+      - name: tx_gas_used
+      - name: tx_gas_price
+      - name: tx_priority_fee_per_gas
+      - name: tx_index
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_success
+      - name: call_gas_used
+      - name: call_selector
+      - name: call_method
+      - name: call_from
+      - name: call_to
+      - name: call_output
+      - name: call_error
+      - name: call_type
+      - name: protocol
+      - name: protocol_version
+      - name: contract_name
+      - name: order_hash
+      - name: maker
+      - name: receiver
+      - name: maker_asset
+      - name: maker_amount
+      - name: making_amount
+      - name: taker_asset
+      - name: taker_amount
+      - name: taking_amount
+      - name: remains
+      - name: flags
+      - name: minute
+      - name: block_date
+      - name: block_month
+      - name: native_price
+      - name: native_decimals
+
+  - name: oneinch_hyperevm_transfers
+    meta:
+      blockchain: ['hyperevm']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'calls']
+    description: >
+        transfers within transactions with 1inch calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+              - transfer_trace_address
+              - transfer_contract_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_selector
+      - name: call_method
+      - name: call_to
+      - name: protocol
+      - name: contract_name
+      - name: transfer_trace_address
+        data_tests:
+          - not_null
+      - name: transfer_contract_address
+        data_tests:
+          - not_null
+      - name: transfer_native
+      - name: transfer_from
+      - name: transfer_to
+      - name: transfer_symbol
+      - name: transfer_amount
+      - name: transfer_amount_usd
+      - name: transfer_decimals
+      - name: trusted
+      - name: nested
+      - name: related
+      - name: same
+      - name: price
+      - name: block_date
+      - name: block_month
+      - name: transfer_id
+      - name: unique_key

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_transfers.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/hyperevm/oneinch_hyperevm_transfers.sql
@@ -1,0 +1,24 @@
+{%- set blockchain = oneinch_hyperevm_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'transfers',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address', 'transfer_trace_address', 'transfer_contract_address'],
+    )
+-}}
+
+{{-
+    oneinch_transfers_macro(
+        blockchain = blockchain,
+        streams = [
+            oneinch_ar_transfers_cfg_macro(),
+            oneinch_lo_transfers_cfg_macro(),
+        ]
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_ar.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_ar.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_monad_cfg_macro() -%}
+{%- set stream = oneinch_ar_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name,
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_ar_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_monad_ar_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_ar_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_ar_executions.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_monad_cfg_macro() -%}
+{%- set stream = oneinch_ar_executions_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_executions',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_ar_executions_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_ar_raw_calls.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_ar_raw_calls.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_monad_cfg_macro() -%}
+{%- set stream = oneinch_ar_raw_calls_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_raw_calls',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_raw_calls_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_monad_ar_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_lo.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_lo.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_monad_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name,
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_lo_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_monad_lo_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_lo_executions.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_lo_executions.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_monad_cfg_macro() -%}
+{%- set stream = oneinch_lo_executions_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_executions',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_lo_executions_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_lo_raw_calls.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_lo_raw_calls.sql
@@ -1,0 +1,23 @@
+{%- set blockchain = oneinch_monad_cfg_macro() -%}
+{%- set stream = oneinch_lo_raw_calls_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = stream.name + '_raw_calls',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address'],
+    )
+-}}
+
+{{-
+    oneinch_raw_calls_macro(
+        blockchain = blockchain,
+        stream = stream,
+        contracts = oneinch_monad_lo_contracts_cfg_macro()
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_lop_own_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_lop_own_trades.sql
@@ -1,0 +1,15 @@
+{%- set blockchain = oneinch_monad_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_own_trades',
+        materialized = 'view',
+    )
+-}}
+
+{{-
+    oneinch_lop_own_trades_macro(
+        blockchain = blockchain
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_lop_venue_settled_fills.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_lop_venue_settled_fills.sql
@@ -1,0 +1,22 @@
+{%- set blockchain = oneinch_monad_cfg_macro() -%}
+{%- set stream = oneinch_lo_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'lop_venue_settled_fills',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'block_date', 'execution_id'],
+    )
+-}}
+
+{{-
+    oneinch_lop_venue_settled_fills_macro(
+        blockchain = blockchain,
+        stream = stream
+    )
+-}}

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_schema.yml
@@ -1,0 +1,192 @@
+version: 2
+
+models:
+  - name: oneinch_monad_ar
+    meta:
+      blockchain: ['monad']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'ar', 'calls']
+    description: >
+        1inch aggregation router calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: chain_id
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: tx_success
+      - name: tx_from
+      - name: tx_to
+      - name: tx_nonce
+      - name: tx_gas_used
+      - name: tx_gas_price
+      - name: tx_priority_fee_per_gas
+      - name: tx_index
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_success
+      - name: call_gas_used
+      - name: call_selector
+      - name: call_method
+      - name: call_from
+      - name: call_to
+      - name: call_output
+      - name: call_error
+      - name: call_type
+      - name: protocol
+      - name: protocol_version
+      - name: contract_name
+      - name: src_receiver
+      - name: dst_receiver
+      - name: src_token_address
+      - name: dst_token_address
+      - name: src_token_amount
+      - name: dst_token_amount
+      - name: dst_token_amount_min
+      - name: router_type
+      - name: pools
+      - name: remains
+      - name: flags
+      - name: minute
+      - name: block_date
+      - name: block_month
+      - name: native_price
+      - name: native_decimals
+
+  - name: oneinch_monad_lo
+    meta:
+      blockchain: ['monad']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'lo', 'calls']
+    description: >
+        1inch limit order protocol calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: chain_id
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: tx_success
+      - name: tx_from
+      - name: tx_to
+      - name: tx_nonce
+      - name: tx_gas_used
+      - name: tx_gas_price
+      - name: tx_priority_fee_per_gas
+      - name: tx_index
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_success
+      - name: call_gas_used
+      - name: call_selector
+      - name: call_method
+      - name: call_from
+      - name: call_to
+      - name: call_output
+      - name: call_error
+      - name: call_type
+      - name: protocol
+      - name: protocol_version
+      - name: contract_name
+      - name: order_hash
+      - name: maker
+      - name: receiver
+      - name: maker_asset
+      - name: maker_amount
+      - name: making_amount
+      - name: taker_asset
+      - name: taker_amount
+      - name: taking_amount
+      - name: remains
+      - name: flags
+      - name: minute
+      - name: block_date
+      - name: block_month
+      - name: native_price
+      - name: native_decimals
+
+  - name: oneinch_monad_transfers
+    meta:
+      blockchain: ['monad']
+      sector: oneinch
+      contributors: ['max-morrow', 'grkhr', 'dodgervl']
+    config:
+      tags: ['oneinch', 'calls']
+    description: >
+        transfers within transactions with 1inch calls
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - blockchain
+              - tx_hash
+              - call_trace_address
+              - transfer_trace_address
+              - transfer_contract_address
+    columns:
+      - name: blockchain
+        data_tests:
+          - not_null
+      - name: block_number
+      - name: block_time
+      - name: tx_hash
+        data_tests:
+          - not_null
+      - name: call_trace_address
+        data_tests:
+          - not_null
+      - name: call_selector
+      - name: call_method
+      - name: call_to
+      - name: protocol
+      - name: contract_name
+      - name: transfer_trace_address
+        data_tests:
+          - not_null
+      - name: transfer_contract_address
+        data_tests:
+          - not_null
+      - name: transfer_native
+      - name: transfer_from
+      - name: transfer_to
+      - name: transfer_symbol
+      - name: transfer_amount
+      - name: transfer_amount_usd
+      - name: transfer_decimals
+      - name: trusted
+      - name: nested
+      - name: related
+      - name: same
+      - name: price
+      - name: block_date
+      - name: block_month
+      - name: transfer_id
+      - name: unique_key

--- a/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_transfers.sql
+++ b/dbt_subprojects/dex/models/_projects/oneinch/blockchains/monad/oneinch_monad_transfers.sql
@@ -1,0 +1,24 @@
+{%- set blockchain = oneinch_monad_cfg_macro() -%}
+
+{{-
+    config(
+        schema = 'oneinch_' + blockchain.name,
+        alias = 'transfers',
+        partition_by = ['block_month'],
+        materialized = 'incremental',
+        file_format = 'delta',
+        incremental_strategy = 'merge',
+        incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')],
+        unique_key = ['block_month', 'tx_hash', 'call_trace_address', 'transfer_trace_address', 'transfer_contract_address'],
+    )
+-}}
+
+{{-
+    oneinch_transfers_macro(
+        blockchain = blockchain,
+        streams = [
+            oneinch_ar_transfers_cfg_macro(),
+            oneinch_lo_transfers_cfg_macro(),
+        ]
+    )
+-}}

--- a/dbt_subprojects/dex/models/trades/cronos/dex_cronos_trades.sql
+++ b/dbt_subprojects/dex/models/trades/cronos/dex_cronos_trades.sql
@@ -21,6 +21,9 @@ WITH dexs AS (
         )
     }}
 )
+, oneinch_lop AS (
+	{{ oneinch_lop_dex_trades_passthrough(blockchain = 'cronos') }}
+)
 
 SELECT
     blockchain
@@ -50,3 +53,34 @@ SELECT
     , current_timestamp AS _updated_at
 FROM
     dexs
+
+UNION ALL
+
+SELECT
+    blockchain
+    , project
+    , version
+    , block_month
+    , block_date
+    , block_time
+    , block_number
+    , token_bought_symbol
+    , token_sold_symbol
+    , token_pair
+    , token_bought_amount
+    , token_sold_amount
+    , token_bought_amount_raw
+    , token_sold_amount_raw
+    , amount_usd
+    , token_bought_address
+    , token_sold_address
+    , taker
+    , maker
+    , project_contract_address
+    , tx_hash
+    , tx_from
+    , tx_to
+    , evt_index
+    , current_timestamp AS _updated_at
+FROM
+    oneinch_lop

--- a/dbt_subprojects/dex/models/trades/hyperevm/dex_hyperevm_trades.sql
+++ b/dbt_subprojects/dex/models/trades/hyperevm/dex_hyperevm_trades.sql
@@ -21,6 +21,9 @@ WITH dexs AS (
         )
     }}
 )
+, oneinch_lop AS (
+	{{ oneinch_lop_dex_trades_passthrough(blockchain = 'hyperevm') }}
+)
 
 SELECT
     blockchain
@@ -50,4 +53,35 @@ SELECT
     , current_timestamp AS _updated_at
 FROM
     dexs
+
+UNION ALL
+
+SELECT
+    blockchain
+    , project
+    , version
+    , block_month
+    , block_date
+    , block_time
+    , block_number
+    , token_bought_symbol
+    , token_sold_symbol
+    , token_pair
+    , token_bought_amount
+    , token_sold_amount
+    , token_bought_amount_raw
+    , token_sold_amount_raw
+    , amount_usd
+    , token_bought_address
+    , token_sold_address
+    , taker
+    , maker
+    , project_contract_address
+    , tx_hash
+    , tx_from
+    , tx_to
+    , evt_index
+    , current_timestamp AS _updated_at
+FROM
+    oneinch_lop
 

--- a/dbt_subprojects/dex/models/trades/monad/dex_monad_trades.sql
+++ b/dbt_subprojects/dex/models/trades/monad/dex_monad_trades.sql
@@ -21,6 +21,9 @@ WITH dexs AS (
         )
     }}
 )
+, oneinch_lop AS (
+	{{ oneinch_lop_dex_trades_passthrough(blockchain = 'monad') }}
+)
 
 SELECT
     blockchain
@@ -50,4 +53,35 @@ SELECT
     , current_timestamp AS _updated_at
 FROM
     dexs
+
+UNION ALL
+
+SELECT
+    blockchain
+    , project
+    , version
+    , block_month
+    , block_date
+    , block_time
+    , block_number
+    , token_bought_symbol
+    , token_sold_symbol
+    , token_pair
+    , token_bought_amount
+    , token_sold_amount
+    , token_bought_amount_raw
+    , token_sold_amount_raw
+    , amount_usd
+    , token_bought_address
+    , token_sold_address
+    , taker
+    , maker
+    , project_contract_address
+    , tx_hash
+    , tx_from
+    , tx_to
+    , evt_index
+    , current_timestamp AS _updated_at
+FROM
+    oneinch_lop
 

--- a/sources/oneinch/cronos/oneinch_cronos_sources.yml
+++ b/sources/oneinch/cronos/oneinch_cronos_sources.yml
@@ -1,11 +1,9 @@
 version: 2
 
 sources:
-  - name: oneinch_robinhood
+  - name: oneinch_cronos
     tables:
       - name: AggregationRouterV6_call_swap
-      - name: AggregationRouterV6_call_clipperSwap
-      - name: AggregationRouterV6_call_clipperSwapTo
       - name: AggregationRouterV6_call_unoswap
       - name: AggregationRouterV6_call_unoswap2
       - name: AggregationRouterV6_call_unoswap3
@@ -23,8 +21,6 @@ sources:
       - name: AggregationRouterV6_call_fillContractOrder
       - name: AggregationRouterV6_call_fillContractOrderArgs
       - name: AggregationRouterV6_call_permitAndCall
-      - name: EscrowFactoryV1_call_addressOfEscrowSrc
-      - name: EscrowFactoryV1_call_createDstEscrow
       - name: AccessTokenFusionV1_evt_transfer
       - name: AccessTokenLimitsV1_evt_transfer
       - name: AccessTokenCrossChainV1_evt_transfer
@@ -32,6 +28,6 @@ sources:
       - name: lo
 
 
-  - name: tokens_robinhood
+  - name: tokens_cronos
     tables:
       - name: base_transfers

--- a/sources/oneinch/hyperevm/oneinch_hyperevm_sources.yml
+++ b/sources/oneinch/hyperevm/oneinch_hyperevm_sources.yml
@@ -1,11 +1,9 @@
 version: 2
 
 sources:
-  - name: oneinch_robinhood
+  - name: oneinch_hyperevm
     tables:
       - name: AggregationRouterV6_call_swap
-      - name: AggregationRouterV6_call_clipperSwap
-      - name: AggregationRouterV6_call_clipperSwapTo
       - name: AggregationRouterV6_call_unoswap
       - name: AggregationRouterV6_call_unoswap2
       - name: AggregationRouterV6_call_unoswap3
@@ -23,8 +21,6 @@ sources:
       - name: AggregationRouterV6_call_fillContractOrder
       - name: AggregationRouterV6_call_fillContractOrderArgs
       - name: AggregationRouterV6_call_permitAndCall
-      - name: EscrowFactoryV1_call_addressOfEscrowSrc
-      - name: EscrowFactoryV1_call_createDstEscrow
       - name: AccessTokenFusionV1_evt_transfer
       - name: AccessTokenLimitsV1_evt_transfer
       - name: AccessTokenCrossChainV1_evt_transfer
@@ -32,6 +28,6 @@ sources:
       - name: lo
 
 
-  - name: tokens_robinhood
+  - name: tokens_hyperevm
     tables:
-      - name: base_transfers
+      - name: transfers_from_traces

--- a/sources/oneinch/monad/oneinch_monad_sources.yml
+++ b/sources/oneinch/monad/oneinch_monad_sources.yml
@@ -1,11 +1,9 @@
 version: 2
 
 sources:
-  - name: oneinch_robinhood
+  - name: oneinch_monad
     tables:
       - name: AggregationRouterV6_call_swap
-      - name: AggregationRouterV6_call_clipperSwap
-      - name: AggregationRouterV6_call_clipperSwapTo
       - name: AggregationRouterV6_call_unoswap
       - name: AggregationRouterV6_call_unoswap2
       - name: AggregationRouterV6_call_unoswap3
@@ -23,8 +21,6 @@ sources:
       - name: AggregationRouterV6_call_fillContractOrder
       - name: AggregationRouterV6_call_fillContractOrderArgs
       - name: AggregationRouterV6_call_permitAndCall
-      - name: EscrowFactoryV1_call_addressOfEscrowSrc
-      - name: EscrowFactoryV1_call_createDstEscrow
       - name: AccessTokenFusionV1_evt_transfer
       - name: AccessTokenLimitsV1_evt_transfer
       - name: AccessTokenCrossChainV1_evt_transfer
@@ -32,6 +28,6 @@ sources:
       - name: lo
 
 
-  - name: tokens_robinhood
+  - name: tokens_monad
     tables:
-      - name: base_transfers
+      - name: transfers_from_traces


### PR DESCRIPTION
## What & why

Adds cronos, monad and hyperevm to the 1inch AggregationRouterV6 and Limit Order Protocol lineage, following the sonic/robinhood per-chain pattern. Cross-chain models stay deferred until escrow decodings land (fantom precedent, exposed ar/lo only). Cronos reads base_transfers like robinhood since it has no transfers_from_traces table.

Also fixes two robinhood mode-classification bugs: the configured fusion settlement addresses aren't deployed there (real settlement 0xb55ba9617dafae1236313c3cb7806439ceefbd13 has 77,902 live calls vs 0 for the config addresses), and the dominant v1.2 escrow factory (0x50d26ea1e2460b3a42ff47466b955fc6bd906013, 5,083 calls vs 1,126 on v1) was missing from escrow_factory_addresses, so its fills classified as limits instead of cross-chain.

All router, settlement, escrow factory and access token addresses verified against live decoded call/trace data on the three chains before landing. Prior art: #9969 (external contributor), which conflicts with main after #9769 rewrote oneinch_ar_executions_macro.sql; reimplemented on main with the same verified addresses, dropping the CI-only easy_date() clamp that PR marked revert-before-merge.

Towards CUR2-3908
