### PR TITLE
Exclude discarded Cronos fork blocks from the cronos dex base_trades models

### DIFF
--- a/dbt_subprojects/dex/models/trades/cronos/platforms/cronaswap_cronos_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/cronos/platforms/cronaswap_cronos_base_trades.sql
@@ -9,6 +9,7 @@
     )
 }}
 
+with base as (
 {{
     uniswap_compatible_v2_trades(
         blockchain = 'cronos'
@@ -18,3 +19,14 @@
         , Factory_evt_PairCreated = source('cronaswap_cronos', 'CronaSwapFactory_evt_PairCreated')
     )
 }}
+)
+
+select *
+from base
+-- Cronos validators rolled the chain back on 2026-08-30 (Tectonic exploit) and discarded blocks
+-- 90896189..90907150. Dune's raw cronos tables still carry that dead fork, and the same transactions
+-- are now being re-included on the canonical chain with identical tx_hash/evt_index, so the merge
+-- key double-matches (MERGE_TARGET_ROW_MULTIPLE_MATCHES, 2026-09-01/02). Frozen fence: exclude the
+-- dead-fork block range until raw cronos is re-ingested from the canonical chain, then drop this
+-- filter and full-refresh the cronos dex models.
+where not (block_number between 90896189 and 90907150)

--- a/dbt_subprojects/dex/models/trades/cronos/platforms/ferro_cronos_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/cronos/platforms/ferro_cronos_base_trades.sql
@@ -86,3 +86,10 @@ SELECT
     , dexs.evt_index
 FROM
     dexs
+-- Cronos validators rolled the chain back on 2026-08-30 (Tectonic exploit) and discarded blocks
+-- 90896189..90907150. Dune's raw cronos tables still carry that dead fork, and the same transactions
+-- are now being re-included on the canonical chain with identical tx_hash/evt_index, so the merge
+-- key double-matches (MERGE_TARGET_ROW_MULTIPLE_MATCHES, 2026-09-01/02). Frozen fence: exclude the
+-- dead-fork block range until raw cronos is re-ingested from the canonical chain, then drop this
+-- filter and full-refresh the cronos dex models.
+WHERE NOT (dexs.block_number BETWEEN 90896189 AND 90907150)

--- a/dbt_subprojects/dex/models/trades/cronos/platforms/vvs_finance_v2_cronos_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/cronos/platforms/vvs_finance_v2_cronos_base_trades.sql
@@ -9,6 +9,7 @@
     )
 }}
 
+with base as (
 {{
     uniswap_compatible_v2_trades(
         blockchain = 'cronos'
@@ -18,3 +19,14 @@
         , Factory_evt_PairCreated = source('vvsfinance_cronos', 'VVSFactory_evt_PairCreated')
     )
 }}
+)
+
+select *
+from base
+-- Cronos validators rolled the chain back on 2026-08-30 (Tectonic exploit) and discarded blocks
+-- 90896189..90907150. Dune's raw cronos tables still carry that dead fork, and the same transactions
+-- are now being re-included on the canonical chain with identical tx_hash/evt_index, so the merge
+-- key double-matches (MERGE_TARGET_ROW_MULTIPLE_MATCHES, 2026-09-01/02). Frozen fence: exclude the
+-- dead-fork block range until raw cronos is re-ingested from the canonical chain, then drop this
+-- filter and full-refresh the cronos dex models.
+where not (block_number between 90896189 and 90907150)

--- a/dbt_subprojects/dex/models/trades/cronos/platforms/vvs_finance_v3_cronos_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/cronos/platforms/vvs_finance_v3_cronos_base_trades.sql
@@ -9,6 +9,7 @@
     )
 }}
 
+with base as (
 {{
     uniswap_compatible_v3_trades(
         blockchain = 'cronos'
@@ -18,3 +19,14 @@
         , Factory_evt_PoolCreated = source('vvsfinance_cronos', 'VVSV3Factory_evt_PoolCreated')
     )
 }}
+)
+
+select *
+from base
+-- Cronos validators rolled the chain back on 2026-08-30 (Tectonic exploit) and discarded blocks
+-- 90896189..90907150. Dune's raw cronos tables still carry that dead fork, and the same transactions
+-- are now being re-included on the canonical chain with identical tx_hash/evt_index, so the merge
+-- key double-matches (MERGE_TARGET_ROW_MULTIPLE_MATCHES, 2026-09-01/02). Frozen fence: exclude the
+-- dead-fork block range until raw cronos is re-ingested from the canonical chain, then drop this
+-- filter and full-refresh the cronos dex models.
+where not (block_number between 90896189 and 90907150)


### PR DESCRIPTION
## What & why
The spellbook_dex cadence has failed since 2026-09-02 14:12 UTC on `vvs_finance_v2_cronos_base_trades` (`MERGE_TARGET_ROW_MULTIPLE_MATCHES`), and everything downstream of it, `dex.trades` included, is skipped: every chain's latest trade in `dex.trades` is stuck at about 13:10 UTC (https://dune.com/queries/8587038).
Cronos validators rolled the chain back on 2026-08-30 and discarded blocks 90896189..90907150; the raw cronos tables still carry that dead fork, and the same transactions are now re-included on the canonical chain with identical `tx_hash`/`evt_index`, so the merge sees two source rows per key.
This filters the discarded block range out of the four cronos platform models. The cadence passes on the next run and no further non-canonical rows enter.

## Architecture
- Interfaces: none. No schema, column or unique_key change; a `where` filter on `block_number` appended to four models.
- Business-critical files (all on the `dex.trades` path):
  - `dbt_subprojects/dex/models/trades/cronos/platforms/vvs_finance_v2_cronos_base_trades.sql`: the failing model; filter removes the fork-side copy of each colliding key.
  - `.../cronaswap_cronos_base_trades.sql`, `.../vvs_finance_v3_cronos_base_trades.sql`, `.../ferro_cronos_base_trades.sql`: same filter, pre-empting the same collision as more fork txs get re-included (https://dune.com/queries/8586249).
- Why it is safe: the excluded range contains only blocks the canonical chain does not have (fork extent https://dune.com/queries/8586235; Dune's block hash diverges from the public RPC at 90896189, rejoins at 90907151). Each of the 3 colliding keys has one copy inside the range and one outside, so the surviving row is the canonical one. Incremental merge only touches rows in the 3-day window, so nothing outside it changes.
- What it does not do: the non-canonical rows already in the tables stay (dex.trades cronos, 2026-08-30: 75,126 rows, https://dune.com/queries/8586254) until raw cronos is re-ingested from the canonical chain and the cronos dex models are full-refreshed. The filter and its comment come out at that point.
- Tested: dbt parse. Not tested locally: dbt compile/run (CI covers the four models).
- Needs human eyes: first cadence run after deploy succeeds and `dex.trades` latest block_time advances on all chains.
- Blast radius: `dex.trades`, `dex.base_trades` and every consumer of them resume updating; cronos rows for 2026-08-30 12:38 to 14:32 UTC stop growing. Rollback is a revert of this PR.

<details><summary>Agent context</summary>

- Root cause verified independently three times (public Cronos RPC block hashes for 90896188/89/90907150/51, own queries on `cronos.blocks`, `cronos.transactions`, `vvsfinance_cronos.vvspair_evt_swap`, target table dup check): https://dune.com/queries/8586235 https://dune.com/queries/8586249 https://dune.com/queries/8586254
- No spellbook change is involved: last commits touching the cronos trades dir 2026-07-16, `uniswap_compatible_trades.sql` 2026-06-10, `incremental_predicate.sql` 2024-08-06.
- Repro of the collision: `select evt_tx_hash, evt_index, count(*) from vvsfinance_cronos.vvspair_evt_swap where evt_block_time >= timestamp '2026-08-30 00:00:00 UTC' group by 1,2 having count(*) > 1` returns 3 keys.
- Failing runs: Trino query ids 20260902_141218_08746_red5a and 20260902_151159_46254_red5a.
</details>
