### PR TITLE
feat(dex): declare freshness monitoring for dex_aggregator.trades and dex_evm.trades

### DIFF
--- a/dbt_subprojects/dex/models/aggregator_trades/_schema.yml
+++ b/dbt_subprojects/dex/models/aggregator_trades/_schema.yml
@@ -8,8 +8,14 @@ models:
       contributors: bh2smith, Henrystats, jeff-dude, rantum, thevaizman
       docs_slug: /curated/dex-trades/evm/dex-aggregator-trades
       short_description: "Trades routed through DEX aggregators (e.g. 1inch, CowSwap, Paraswap), recording swap execution details across various aggregators and blockchains."
+      monitoring:
+        enabled: true
+        warn_after: {count: 24, period: hour}
+        critical_after: {count: 48, period: hour}
+        oncall: false
     config:
       tags: ['ethereum', 'gnosis', 'avalanche_c', 'fantom', 'aggregator', 'dex', 'trades', 'cross-chain']
+      event_time: block_time
     description: >
       The dex_aggregator.trades table captures data on actions taken on aggregators - recording all events across various aggregators and blockchains.
     data_tests:

--- a/dbt_subprojects/dex/models/trades/_schema.yml
+++ b/dbt_subprojects/dex/models/trades/_schema.yml
@@ -104,8 +104,14 @@ models:
       sector: dex_evm
       short_description: "DEX trades across EVM-compatible chains, exposed under the explicit dex_evm namespace."
       contributors: 0xRob, hosuke, jeff-dude, tomfutago, viniabussafi
+      monitoring:
+        enabled: true
+        warn_after: {count: 24, period: hour}
+        critical_after: {count: 48, period: hour}
+        oncall: false
     config:
       tags: ['dex', 'trades', 'evm']
+      event_time: block_time
     description: >
       Compatibility view over dex.trades. It exposes the same column contract and chain coverage
       under dex_evm.trades for consumers that need an explicitly EVM-scoped namespace.


### PR DESCRIPTION
Declares freshness monitoring on the two Data Explorer tables in the dex subproject that were still uncovered — dex_aggregator.trades and dex_evm.trades — both on block_time at the generic 24h warn / 48h critical / oncall false tier, in the properties yml so the change stays state:modified.configs and nothing rebuilds; the writer compiles to three rows, with partition_column block_month for dex_aggregator.trades and NULL for the dex_evm.trades view.

dex_evm.trades is a compatibility view over the already-declared dex.trades, so its series duplicates that table's lag rather than adding new coverage, and its collection mode is unmeasured — it is declared anyway, deliberately, because whether a relation reads through table statistics or through a scan is not a reason to leave it unmonitored: no monitoring is strictly worse than expensive monitoring, and arrakis-jobs#9332 adds the alert that will tell us if the scan collector starts failing under the added load, so its cost gets measured rather than assumed.

dex_solana.trades, nft.trades, nft.transfers and nft.wash_trades are still not here, but only because they live in the solana and hourly_spellbook subprojects; spellbook#9983 has since merged the writer arms that blocked them, and the probe measures all four as stats, so declaring them is a separate change in those subprojects and never was a mode question.
