### PR TITLE
chore(monitoring): add writer arms for hourly_spellbook, solana and tokens (CUR2-4006)

### DIFF
--- a/dbt_subprojects/hourly_spellbook/models/monitoring/_schema.yml
+++ b/dbt_subprojects/hourly_spellbook/models/monitoring/_schema.yml
@@ -1,0 +1,42 @@
+version: 2
+
+models:
+  - name: monitoring_config_spellbook_hourly_spellbook
+    description: >
+      The hourly_spellbook subproject's arm of the freshness monitoring config
+      (`delta_prod.monitoring.config` in curated-data): one row per model in this subproject
+      that declares `meta.monitoring.enabled: true`, read out of the parsed manifest at compile
+      time. Consumers read the curated-data view, never this table. Row shape must stay identical
+      to curated-data's `monitoring_config_curated_data`.
+    columns:
+      - name: table_name
+        description: >
+          Prod-qualified physical relation, `delta_prod.<schema>.<table>` — matching the `table`
+          label on the lag metric. Not the model name.
+        data_tests:
+          - not_null
+          - unique
+      - name: event_time_column
+        description: >
+          Column freshness is measured on, from the model's `event_time` config — an event
+          timestamp such as `block_time`, never a write timestamp.
+        data_tests:
+          - not_null
+      - name: partition_column
+        description: >
+          Column the scan fallback prunes on, from the model's `partition_by` config. Nullable by
+          design — NULL means prune on `event_time_column`.
+      - name: warn_seconds
+        description: Staleness at which the table warns (notification, no page), in seconds.
+        data_tests:
+          - not_null
+      - name: critical_seconds
+        description: >
+          Staleness at which the table is critical, in seconds. Greater than `warn_seconds`,
+          otherwise the warn tier can never fire first.
+        data_tests:
+          - not_null
+      - name: oncall
+        description: Whether breaching `critical_seconds` should page. False means notify only.
+        data_tests:
+          - not_null

--- a/dbt_subprojects/hourly_spellbook/models/monitoring/monitoring_config_spellbook_hourly_spellbook.sql
+++ b/dbt_subprojects/hourly_spellbook/models/monitoring/monitoring_config_spellbook_hourly_spellbook.sql
@@ -1,0 +1,17 @@
+{{ config(
+    schema = 'monitoring'
+    , alias = 'config_spellbook_hourly_spellbook'
+    , materialized = 'table'
+    , file_format = 'delta'
+) }}
+
+/*
+    The hourly_spellbook subproject's arm of the freshness monitoring config: one row per model
+    here declaring `meta.monitoring.enabled`, read from the parsed manifest. One writer table
+    per subproject — subprojects deploy independently and Delta takes no concurrent writers.
+    Consumers read the delta_prod.monitoring.config view in curated-data, never this table.
+    No ref() on purpose: it reads declarations, not data, so it emits rows even when upstream
+    builds fail.
+*/
+
+{{ monitoring_config_select() }}

--- a/dbt_subprojects/solana/models/monitoring/_schema.yml
+++ b/dbt_subprojects/solana/models/monitoring/_schema.yml
@@ -1,0 +1,42 @@
+version: 2
+
+models:
+  - name: monitoring_config_spellbook_solana
+    description: >
+      The solana subproject's arm of the freshness monitoring config
+      (`delta_prod.monitoring.config` in curated-data): one row per model in this subproject
+      that declares `meta.monitoring.enabled: true`, read out of the parsed manifest at compile
+      time. Consumers read the curated-data view, never this table. Row shape must stay identical
+      to curated-data's `monitoring_config_curated_data`.
+    columns:
+      - name: table_name
+        description: >
+          Prod-qualified physical relation, `delta_prod.<schema>.<table>` — matching the `table`
+          label on the lag metric. Not the model name.
+        data_tests:
+          - not_null
+          - unique
+      - name: event_time_column
+        description: >
+          Column freshness is measured on, from the model's `event_time` config — an event
+          timestamp such as `block_time`, never a write timestamp.
+        data_tests:
+          - not_null
+      - name: partition_column
+        description: >
+          Column the scan fallback prunes on, from the model's `partition_by` config. Nullable by
+          design — NULL means prune on `event_time_column`.
+      - name: warn_seconds
+        description: Staleness at which the table warns (notification, no page), in seconds.
+        data_tests:
+          - not_null
+      - name: critical_seconds
+        description: >
+          Staleness at which the table is critical, in seconds. Greater than `warn_seconds`,
+          otherwise the warn tier can never fire first.
+        data_tests:
+          - not_null
+      - name: oncall
+        description: Whether breaching `critical_seconds` should page. False means notify only.
+        data_tests:
+          - not_null

--- a/dbt_subprojects/solana/models/monitoring/monitoring_config_spellbook_solana.sql
+++ b/dbt_subprojects/solana/models/monitoring/monitoring_config_spellbook_solana.sql
@@ -1,0 +1,17 @@
+{{ config(
+    schema = 'monitoring'
+    , alias = 'config_spellbook_solana'
+    , materialized = 'table'
+    , file_format = 'delta'
+) }}
+
+/*
+    The solana subproject's arm of the freshness monitoring config: one row per model
+    here declaring `meta.monitoring.enabled`, read from the parsed manifest. One writer table
+    per subproject — subprojects deploy independently and Delta takes no concurrent writers.
+    Consumers read the delta_prod.monitoring.config view in curated-data, never this table.
+    No ref() on purpose: it reads declarations, not data, so it emits rows even when upstream
+    builds fail.
+*/
+
+{{ monitoring_config_select() }}

--- a/dbt_subprojects/tokens/models/monitoring/_schema.yml
+++ b/dbt_subprojects/tokens/models/monitoring/_schema.yml
@@ -1,0 +1,42 @@
+version: 2
+
+models:
+  - name: monitoring_config_spellbook_tokens
+    description: >
+      The tokens subproject's arm of the freshness monitoring config
+      (`delta_prod.monitoring.config` in curated-data): one row per model in this subproject
+      that declares `meta.monitoring.enabled: true`, read out of the parsed manifest at compile
+      time. Consumers read the curated-data view, never this table. Row shape must stay identical
+      to curated-data's `monitoring_config_curated_data`.
+    columns:
+      - name: table_name
+        description: >
+          Prod-qualified physical relation, `delta_prod.<schema>.<table>` — matching the `table`
+          label on the lag metric. Not the model name.
+        data_tests:
+          - not_null
+          - unique
+      - name: event_time_column
+        description: >
+          Column freshness is measured on, from the model's `event_time` config — an event
+          timestamp such as `block_time`, never a write timestamp.
+        data_tests:
+          - not_null
+      - name: partition_column
+        description: >
+          Column the scan fallback prunes on, from the model's `partition_by` config. Nullable by
+          design — NULL means prune on `event_time_column`.
+      - name: warn_seconds
+        description: Staleness at which the table warns (notification, no page), in seconds.
+        data_tests:
+          - not_null
+      - name: critical_seconds
+        description: >
+          Staleness at which the table is critical, in seconds. Greater than `warn_seconds`,
+          otherwise the warn tier can never fire first.
+        data_tests:
+          - not_null
+      - name: oncall
+        description: Whether breaching `critical_seconds` should page. False means notify only.
+        data_tests:
+          - not_null

--- a/dbt_subprojects/tokens/models/monitoring/monitoring_config_spellbook_tokens.sql
+++ b/dbt_subprojects/tokens/models/monitoring/monitoring_config_spellbook_tokens.sql
@@ -1,0 +1,17 @@
+{{ config(
+    schema = 'monitoring'
+    , alias = 'config_spellbook_tokens'
+    , materialized = 'table'
+    , file_format = 'delta'
+) }}
+
+/*
+    The tokens subproject's arm of the freshness monitoring config: one row per model
+    here declaring `meta.monitoring.enabled`, read from the parsed manifest. One writer table
+    per subproject — subprojects deploy independently and Delta takes no concurrent writers.
+    Consumers read the delta_prod.monitoring.config view in curated-data, never this table.
+    No ref() on purpose: it reads declarations, not data, so it emits rows even when upstream
+    builds fail.
+*/
+
+{{ monitoring_config_select() }}


### PR DESCRIPTION
Adds one freshness-monitoring writer per subproject that holds Data Explorer tables we intend to declare — hourly_spellbook (nft.trades, nft.mints, gas.fees and the per-chain gas_*.fees), solana (dex_solana.trades, gas_solana.fees) and tokens (tokens.transfers and the per-chain tokens_*.transfers) — each mirroring dbt_subprojects/dex/models/monitoring and writing delta_prod.monitoring.config_spellbook_<subproject>; daily_spellbook and the sqlmesh-owned tables (tokens.erc20, tokens.supply_latest, tokens_solana.fungible) need none. No model declares meta.monitoring yet, so all three compile to the macro's empty branch — the same six typed columns as the dex writer, WHERE FALSE — and each is state:new, so the next prod deploy of that subproject creates an empty table and nothing else rebuilds. The follow-up curated-data PR adding these to monitoring_config_sources() cannot merge until each of these three tables exists in prod, because a missing relation stops delta_prod.monitoring.config from building.