### PR TITLE
fix: map Ethereum AUSD to Coinpaprika pricing

### DIFF
--- a/dbt_subprojects/tokens/models/prices/ethereum/prices_ethereum_tokens.sql
+++ b/dbt_subprojects/tokens/models/prices/ethereum/prices_ethereum_tokens.sql
@@ -43,6 +43,7 @@ FROM
     ('auc-auctus', 'ethereum', 'AUC', 0xc12d099be31567add4e4e4d0d45691c3f58f5663, 18),
     ('aud-australian-dollar-token', 'ethereum', 'ibAUD', 0xfafdf0c4c1cb09d430bf88c75d88bb46dae09967, 18),
     ('audio-audius', 'ethereum', 'AUDIO', 0x18aaa7115705e8be94bffebde57af9bfc265b998, 18),
+    ('ausd-agora-dollar', 'ethereum', 'AUSD', 0x00000000efe302beaa2b3e6e1b18d08d69a9012a, 6),
     ('awc-atomic-wallet-coin', 'ethereum', 'AWC', 0xad22f63404f7305e4713ccbd4f296f34770513f4, 8),
     ('axlatom-axelar-wrapped-atom', 'ethereum', 'axlATOM', 0x27292cf0016e5df1d8b37306b2a98588acbd6fca, 6),
     ('axs-axie-infinity', 'ethereum', 'AXS', 0xf5d669627376ebd411e34b98f19c868c8aba5ada, 18),


### PR DESCRIPTION
## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review.

### Description:

Map Ethereum AUSD (`0x00000000efe302beaa2b3e6e1b18d08d69a9012a`, 6 decimals) to Coinpaprika's `ausd-agora-dollar` feed.
The feed is already ingested, but the live `prices.tokens` mapping is absent, leaving the hybrid prices on the anomalous DEX source.
Once the mapping is deployed and downstream Coinpaprika history is populated, the existing hybrid selector will prefer Coinpaprika automatically.

**Architecture and validation**

- Critical file: `dbt_subprojects/tokens/models/prices/ethereum/prices_ethereum_tokens.sql`, one mapping row. No new schema or pricing algorithm.
- Live validation: proposed mapping joined to `prices.coinpaprika_raw` returns 1,440 minute observations per day for September 3-9, 2026, with daily averages $1.000060-$1.000194. Token ID is present in raw ingestion; production contract mapping returned zero rows.
- Local validation: Jinja-rendered model executes via Trino-to-DuckDB transpilation and returns exactly one expected AUSD mapping; diff check passed. Full `dbt compile` could not run because this sandbox has no dbt profile. Existing uniqueness and ERC20 metadata tests remain available to CI.
- Needs human eyes: CI-built mapping and production source transition after deploy/backfill. Do not mark resolved solely because the mapping PR merges.
- Blast radius: `prices.tokens` -> `prices.tokens_patched` -> `prices.coinpaprika` -> Coinpaprika minute/hour/day/latest -> hybrid selector and `prices.*`. Populate historical Coinpaprika partitions for the incident window, refresh metadata/latest/selector and downstream hybrid materializations, then verify live `source = 'coinpaprika'` and prices near the external feed. Confirm older historical coverage before switching the global selector, which selects a source per token rather than per date.
- This mapping does not repair `prices_dex.*`. The independent [AUSD DEX quarantine proposal](https://github.com/duneanalytics/spellbook-sqlmesh/pull/543) remains separate; it is not a prerequisite for switching hybrid pricing to Coinpaprika.

<details><summary>Agent context</summary>

No agent review yet. Read-only mapping validation execution: `01M26HQ1S9570XZ23AFNWTQFS0`.

Provider listing: [Agora Dollar on Coinpaprika](https://coinpaprika.com/coin/ausd-agora-dollar/).
The ID was supplied by the requester and verified against Dune's live ingested feed; no current-price claim relies on the cached provider webpage.

Verification SQL:

```sql
select cast(minute as date) as day, count(*) as observations, avg(price) as price
from prices.coinpaprika_raw
where token_id = 'ausd-agora-dollar'
  and minute >= timestamp '2026-09-03'
  and minute < timestamp '2026-09-10'
group by 1 order by 1 limit 7
```

</details>

Prompted by: Karim Hassan

---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
