### PR TITLE
feat(dex): add SushiSwap V3 Stellar event, pool, swap, and liquidity models

### DIFF
--- a/dbt_subprojects/dex/models/_projects/sushiswap/stellar/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/sushiswap/stellar/_schema.yml
@@ -1,0 +1,280 @@
+version: 2
+
+models:
+  - name: sushiswap_v3_stellar_factories
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: sushiswap
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'sushiswap', 'v3', 'factories']
+    description: >
+      Canonical SushiSwap V3 contract ids on Stellar (factory, position manager, tick lens, quoter).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - contract_id
+    columns:
+      - name: blockchain
+        description: "Blockchain the contract is deployed on"
+      - name: project
+        description: "Project name"
+      - name: version
+        description: "SushiSwap pool version"
+      - name: contract_id
+        description: "Stellar contract id (C... strkey)"
+        data_tests:
+          - not_null
+      - name: contract_name
+        description: "Logical contract role (factory, position_manager, tick_lens, quoter)"
+
+  - name: sushiswap_v3_stellar_evt
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: sushiswap
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'sushiswap', 'v3', 'events']
+    description: >
+      Raw index of successful SushiSwap V3 Stellar contract events from
+      stellar.history_contract_events. Follows factory contracts plus pool
+      addresses seen on factory pool_created events. The only decode is
+      event_name from topics_decoded.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over block date, transaction, operation, contract, event, and raw payload"
+        data_tests:
+          - not_null
+      - name: blockchain
+        description: "Blockchain name"
+      - name: project
+        description: "Project name"
+      - name: version
+        description: "SushiSwap pool version"
+      - name: block_time
+        description: "Ledger close timestamp"
+      - name: ledger_sequence
+        description: "Stellar ledger sequence"
+      - name: tx_hash
+        description: "Transaction hash"
+      - name: transaction_id
+        description: "Transaction identifier (TOID)"
+      - name: operation_id
+        description: "Operation identifier (TOID); nullable on some source rows"
+      - name: contract_id
+        description: "Emitting contract id"
+      - name: event_name
+        description: "Soroban event name from topics_decoded"
+      - name: topics_decoded
+        description: "Raw decoded topics JSON"
+      - name: data_decoded
+        description: "Raw decoded data JSON"
+
+  - name: sushiswap_v3_stellar_pool_evt
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: sushiswap
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'sushiswap', 'v3', 'pools', 'events']
+    description: >
+      Factory and pool lifecycle events decoded from sushiswap_v3_stellar_evt.
+      Includes pool_created, init, upgrades, migrations, and factory admin events.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over block date, transaction, operation, contract, event, and raw payload"
+        data_tests:
+          - not_null
+      - name: blockchain
+        description: "Blockchain name"
+      - name: project
+        description: "Project name"
+      - name: version
+        description: "SushiSwap pool version"
+      - name: block_time
+        description: "Ledger close timestamp"
+      - name: ledger_sequence
+        description: "Stellar ledger sequence"
+      - name: tx_hash
+        description: "Transaction hash"
+      - name: transaction_id
+        description: "Transaction identifier (TOID)"
+      - name: operation_id
+        description: "Operation identifier (TOID); nullable on some source rows"
+      - name: contract_id
+        description: "Emitting contract id"
+      - name: event_name
+        description: "Decoded Soroban event name"
+      - name: pool_address
+        description: "Pool contract id from pool_created events"
+      - name: token0
+        description: "Token0 contract id"
+      - name: token1
+        description: "Token1 contract id"
+      - name: fee
+        description: "Pool fee in hundredths of a bip"
+      - name: tick_spacing
+        description: "Pool tick spacing"
+      - name: sender
+        description: "Event sender"
+      - name: tick
+        description: "Pool tick after init"
+      - name: sqrt_price_x96
+        description: "sqrtPriceX96 after init"
+
+  - name: sushiswap_v3_stellar_pools
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: sushiswap
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'sushiswap', 'v3', 'pools']
+    description: >
+      SushiSwap V3 Stellar pool registry. One row per pool from
+      sushiswap_v3_stellar_pool_evt where created_rank = 1.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - pool
+    columns:
+      - name: blockchain
+        description: "Blockchain the DEX is deployed on"
+      - name: project
+        description: "Project name of the DEX"
+      - name: version
+        description: "Version of the pool"
+      - name: pool
+        description: "Pool contract id"
+        data_tests:
+          - not_null
+      - name: fee
+        description: "Pool fee in hundredths of a bip"
+      - name: token0
+        description: "First token in the pool"
+      - name: token1
+        description: "Second token in the pool"
+      - name: tick_spacing
+        description: "Pool tick spacing"
+      - name: creation_block_time
+        description: "Ledger close time when the pool was created"
+      - name: creation_block_number
+        description: "Ledger sequence when the pool was created"
+      - name: contract_address
+        description: "Factory contract that created the pool"
+      - name: tx_hash
+        description: "Transaction hash of the first pool_created event"
+
+  - name: sushiswap_v3_stellar_liquidity_evt
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: sushiswap
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'sushiswap', 'v3', 'liquidity', 'events']
+    description: >
+      Mint, burn, and collect events decoded from sushiswap_v3_stellar_evt.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over block date, transaction, operation, contract, event, and raw payload"
+        data_tests:
+          - not_null
+      - name: event_name
+        description: "Decoded Soroban event name: mint, burn, or collect"
+      - name: pool
+        description: "Pool contract id"
+      - name: amount
+        description: "Liquidity delta for mint/burn"
+      - name: amount0
+        description: "Token0 amount"
+      - name: amount1
+        description: "Token1 amount"
+      - name: tick_lower
+        description: "Lower tick of the position"
+      - name: tick_upper
+        description: "Upper tick of the position"
+      - name: owner
+        description: "Position owner"
+      - name: sender
+        description: "Mint sender when present"
+      - name: recipient
+        description: "Collect recipient when present"
+
+  - name: sushiswap_v3_stellar_base_liquidity_events
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: sushiswap
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'sushiswap', 'v3', 'liquidity']
+    description: >
+      Structured SushiSwap V3 Stellar liquidity events. Mint amounts are positive
+      (tokens into the pool); burn and collect amounts are signed negative.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over the deduplicated liquidity event identity"
+        data_tests:
+          - not_null
+      - name: event_type
+        description: "mint, burn, or collect"
+      - name: pool
+        description: "Pool contract id"
+      - name: liquidity_raw
+        description: "Signed liquidity delta; negative on burn"
+      - name: amount0_raw
+        description: "Signed token0 amount; negative on burn and collect"
+      - name: amount1_raw
+        description: "Signed token1 amount; negative on burn and collect"
+      - name: tick_lower
+        description: "Lower tick of the position"
+      - name: tick_upper
+        description: "Upper tick of the position"
+      - name: tx_hash
+        description: "Transaction hash"

--- a/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_base_liquidity_events.sql
@@ -1,0 +1,65 @@
+{{ config(
+    schema = 'sushiswap_v3_stellar'
+    , alias = 'base_liquidity_events'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+-- Structured SushiSwap V3 Stellar liquidity events from liquidity_evt.
+-- Twin source rows are already dropped there via operation_id IS NOT NULL.
+-- Mint amounts stay positive (tokens into the pool); burn and collect are signed negative.
+
+SELECT
+    {{ dbt_utils.generate_surrogate_key([
+        'block_date'
+        , 'to_hex(tx_hash)'
+        , 'transaction_id'
+        , 'contract_id'
+        , 'event_name'
+        , 'topics'
+        , 'data'
+    ]) }} AS surrogate_key
+    , blockchain
+    , project
+    , version
+    , CAST(date_trunc('month', block_time) AS date) AS block_month
+    , block_date
+    , block_time
+    , ledger_sequence AS block_number
+    , event_name AS event_type
+    , pool
+    , pool AS id
+    , token0
+    , token1
+    , fee
+    , tick_spacing
+    , CASE
+        WHEN event_name = 'burn' THEN -1 * CAST(amount AS int256)
+        ELSE CAST(amount AS int256)
+    END AS liquidity_raw
+    , CASE
+        WHEN event_name IN ('burn', 'collect') THEN -1 * abs(amount0)
+        ELSE abs(amount0)
+    END AS amount0_raw
+    , CASE
+        WHEN event_name IN ('burn', 'collect') THEN -1 * abs(amount1)
+        ELSE abs(amount1)
+    END AS amount1_raw
+    , tick_lower
+    , tick_upper
+    , sender
+    , owner
+    , recipient
+    , tx_hash
+    , transaction_id
+    , operation_id
+FROM {{ ref('sushiswap_v3_stellar_liquidity_evt') }}
+WHERE event_name IN ('mint', 'burn', 'collect')
+    {% if is_incremental() -%}
+    AND {{ incremental_predicate('block_time') }}
+    {% endif -%}

--- a/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_evt.sql
@@ -1,0 +1,134 @@
+{{ config(
+    schema = 'sushiswap_v3_stellar'
+    , alias = 'evt'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set project_start_date = '2026-03-01' %}
+
+-- Raw index of SushiSwap V3 Stellar contract events.
+-- Follows factory contracts plus pool addresses seen on factory pool_created
+-- events. The only decode is event_name. Does not depend on the pools table.
+
+WITH factory AS (
+    SELECT contract_id
+    FROM {{ ref('sushiswap_v3_stellar_factories') }}
+    WHERE contract_name = 'factory'
+)
+
+, created_pools AS (
+    SELECT DISTINCT
+        json_extract_scalar(
+            element_at(
+                filter(
+                    CAST(COALESCE(json_extract(TRY(json_parse(e.data_decoded)), '$.map'), JSON '[]') AS array(json))
+                    , x -> json_extract_scalar(x, '$.key.symbol') = 'pool_address'
+                )
+                , 1
+            )
+            , '$.val.address'
+        ) AS pool_address
+    FROM {{ source('stellar', 'history_contract_events') }} e
+    INNER JOIN factory f
+        ON f.contract_id = e.contract_id
+    WHERE e.successful
+        AND e.type_string = 'ContractEventTypeContract'
+        AND json_extract_scalar(TRY(json_parse(e.topics_decoded)), '$[0].symbol') = 'pool_created'
+        {% if is_incremental() -%}
+        AND e.closed_at_date >= date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }})
+        AND {{ incremental_predicate('e.closed_at') }}
+        {% else -%}
+        AND e.closed_at_date >= DATE '{{ project_start_date }}'
+        AND e.closed_at >= TIMESTAMP '{{ project_start_date }}'
+        {% endif -%}
+)
+
+, contracts AS (
+    SELECT contract_id
+    FROM {{ ref('sushiswap_v3_stellar_factories') }}
+    UNION
+    SELECT pool_address AS contract_id
+    FROM created_pools
+    WHERE pool_address IS NOT NULL
+    {% if is_incremental() -%}
+    UNION
+    SELECT DISTINCT contract_id
+    FROM {{ this }}
+    {% endif -%}
+)
+
+, events AS (
+    SELECT
+        e.closed_at_date AS block_date
+        , e.closed_at AS block_time
+        , e.ledger_sequence
+        , e.transaction_hash AS tx_hash
+        , e.transaction_id
+        , e.operation_id
+        , e.contract_id
+        , e.successful
+        , e.in_successful_contract_call
+        , e.type
+        , e.type_string
+        , json_extract_scalar(TRY(json_parse(e.topics_decoded)), '$[0].symbol') AS event_name
+        , e.topics
+        , e.topics_decoded
+        , e.data
+        , e.data_decoded
+        , e.contract_event_xdr
+        , e.updated_at
+        , e.ingested_at
+    FROM {{ source('stellar', 'history_contract_events') }} e
+    INNER JOIN contracts c
+        ON c.contract_id = e.contract_id
+    WHERE e.successful
+        AND e.type_string = 'ContractEventTypeContract'
+        {% if is_incremental() -%}
+        AND e.closed_at_date >= date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }})
+        AND {{ incremental_predicate('e.closed_at') }}
+        {% else -%}
+        AND e.closed_at_date >= DATE '{{ project_start_date }}'
+        AND e.closed_at >= TIMESTAMP '{{ project_start_date }}'
+        {% endif -%}
+)
+
+SELECT
+    {{ dbt_utils.generate_surrogate_key([
+        'block_date'
+        , 'to_hex(tx_hash)'
+        , 'transaction_id'
+        , 'operation_id'
+        , 'contract_id'
+        , 'event_name'
+        , 'topics'
+        , 'data'
+    ]) }} AS surrogate_key
+    , CAST('stellar' AS varchar) AS blockchain
+    , CAST('sushiswap' AS varchar) AS project
+    , CAST('3' AS varchar) AS version
+    , block_date
+    , block_time
+    , ledger_sequence
+    , tx_hash
+    , transaction_id
+    , operation_id
+    , contract_id
+    , successful
+    , in_successful_contract_call
+    , type
+    , type_string
+    , event_name
+    , topics
+    , topics_decoded
+    , data
+    , data_decoded
+    , contract_event_xdr
+    , updated_at
+    , ingested_at
+FROM events

--- a/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_evt.sql
@@ -41,11 +41,9 @@ WITH factory AS (
         AND e.type_string = 'ContractEventTypeContract'
         AND json_extract_scalar(TRY(json_parse(e.topics_decoded)), '$[0].symbol') = 'pool_created'
         {% if is_incremental() -%}
-        AND e.closed_at_date >= date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }})
         AND {{ incremental_predicate('e.closed_at') }}
         {% else -%}
         AND e.closed_at_date >= DATE '{{ project_start_date }}'
-        AND e.closed_at >= TIMESTAMP '{{ project_start_date }}'
         {% endif -%}
 )
 
@@ -90,11 +88,9 @@ WITH factory AS (
     WHERE e.successful
         AND e.type_string = 'ContractEventTypeContract'
         {% if is_incremental() -%}
-        AND e.closed_at_date >= date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }})
         AND {{ incremental_predicate('e.closed_at') }}
         {% else -%}
         AND e.closed_at_date >= DATE '{{ project_start_date }}'
-        AND e.closed_at >= TIMESTAMP '{{ project_start_date }}'
         {% endif -%}
 )
 

--- a/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_factories.sql
+++ b/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_factories.sql
@@ -1,0 +1,25 @@
+{{ config(
+    schema = 'sushiswap_v3_stellar'
+    , alias = 'factories'
+    , materialized = 'view'
+    , tags = ['static']
+    )
+}}
+
+-- Canonical SushiSwap V3 contracts on Stellar.
+-- https://docs.sushi.com/sdk/reference/stellar/config
+-- ci-stamp: 2
+
+SELECT
+    blockchain
+    , project
+    , version
+    , contract_id
+    , contract_name
+FROM (
+    VALUES
+        ('stellar', 'sushiswap', '3', 'CD3KRKGDRVWPXVB3VXLUMQKMX6XZ6Q2H334IVZD4XXNAMKSRVQL5GLYF', 'factory')
+        , ('stellar', 'sushiswap', '3', 'CARTUL5AWDZYBSN7HUUJZSKCAKCIAKM7M54Z76G6KRYCK4XPR3OHUQZ4', 'position_manager')
+        , ('stellar', 'sushiswap', '3', 'CASKWJSINHFW7BF7RUOA4E2FP6B2TYRKFX2UOPWLCPOOPUR6UU3G2RWC', 'tick_lens')
+        , ('stellar', 'sushiswap', '3', 'CDMIM23WOUL5CZBKX3GOA3V5R5AMVIMTCP52KCDQORWELAPLJ27WZCHL', 'quoter')
+) AS t(blockchain, project, version, contract_id, contract_name)

--- a/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_liquidity_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_liquidity_evt.sql
@@ -1,0 +1,176 @@
+{{ config(
+    schema = 'sushiswap_v3_stellar'
+    , alias = 'liquidity_evt'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+-- Mint, burn, and collect events decoded from the raw SushiSwap V3 Stellar event index.
+-- stellar.history_contract_events stores each Soroban event twice: once with
+-- operation_id and once with a null operation_id. The null twin has the same
+-- payload, so keep only operation_id IS NOT NULL.
+
+WITH pools AS (
+    SELECT
+        pool
+        , token0
+        , token1
+        , fee
+        , tick_spacing
+    FROM {{ ref('sushiswap_v3_stellar_pools') }}
+)
+
+, events AS (
+    SELECT
+        e.surrogate_key
+        , e.blockchain
+        , e.project
+        , e.version
+        , e.block_date
+        , e.block_time
+        , e.ledger_sequence
+        , e.tx_hash
+        , e.transaction_id
+        , e.operation_id
+        , e.contract_id
+        , e.successful
+        , e.in_successful_contract_call
+        , e.type
+        , e.type_string
+        , e.event_name
+        , e.topics
+        , e.topics_decoded
+        , e.data
+        , e.data_decoded
+        , e.contract_event_xdr
+        , p.pool
+        , p.token0
+        , p.token1
+        , p.fee
+        , p.tick_spacing
+        , CAST(COALESCE(json_extract(TRY(json_parse(e.data_decoded)), '$.map'), JSON '[]') AS array(json)) AS data_map
+        , e.updated_at
+        , e.ingested_at
+    FROM {{ ref('sushiswap_v3_stellar_evt') }} e
+    INNER JOIN pools p
+        ON p.pool = e.contract_id
+    WHERE e.event_name IN (
+        'mint'
+        , 'burn'
+        , 'collect'
+    )
+        AND e.operation_id IS NOT NULL
+        {% if is_incremental() -%}
+        AND {{ incremental_predicate('e.block_time') }}
+        {% endif -%}
+)
+
+SELECT
+    surrogate_key
+    , blockchain
+    , project
+    , version
+    , block_date
+    , block_time
+    , ledger_sequence
+    , tx_hash
+    , transaction_id
+    , operation_id
+    , contract_id
+    , successful
+    , in_successful_contract_call
+    , type
+    , type_string
+    , event_name
+    , topics
+    , topics_decoded
+    , data
+    , data_decoded
+    , contract_event_xdr
+    , pool
+    , token0
+    , token1
+    , fee
+    , tick_spacing
+    , json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'sender')
+            , 1
+        )
+        , '$.val.address'
+    ) AS sender
+    , json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'owner')
+            , 1
+        )
+        , '$.val.address'
+    ) AS owner
+    , json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'recipient')
+            , 1
+        )
+        , '$.val.address'
+    ) AS recipient
+    , TRY_CAST(json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'amount')
+            , 1
+        )
+        , '$.val.u128'
+    ) AS uint256) AS amount
+    , COALESCE(
+        TRY_CAST(json_extract_scalar(
+            element_at(
+                filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'amount0')
+                , 1
+            )
+            , '$.val.i128'
+        ) AS int256)
+        , TRY_CAST(json_extract_scalar(
+            element_at(
+                filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'amount0')
+                , 1
+            )
+            , '$.val.u128'
+        ) AS int256)
+    ) AS amount0
+    , COALESCE(
+        TRY_CAST(json_extract_scalar(
+            element_at(
+                filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'amount1')
+                , 1
+            )
+            , '$.val.i128'
+        ) AS int256)
+        , TRY_CAST(json_extract_scalar(
+            element_at(
+                filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'amount1')
+                , 1
+            )
+            , '$.val.u128'
+        ) AS int256)
+    ) AS amount1
+    , TRY_CAST(json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'tick_lower')
+            , 1
+        )
+        , '$.val.i32'
+    ) AS integer) AS tick_lower
+    , TRY_CAST(json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'tick_upper')
+            , 1
+        )
+        , '$.val.i32'
+    ) AS integer) AS tick_upper
+    , updated_at
+    , ingested_at
+FROM events

--- a/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_pool_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_pool_evt.sql
@@ -1,0 +1,177 @@
+{{ config(
+    schema = 'sushiswap_v3_stellar'
+    , alias = 'pool_evt'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+-- Factory and pool lifecycle events decoded from the raw SushiSwap V3 Stellar event index.
+-- stellar.history_contract_events stores each Soroban event twice: once with
+-- operation_id and once with a null operation_id. The null twin has the same
+-- payload, so keep only operation_id IS NOT NULL.
+
+WITH events AS (
+    SELECT
+        e.surrogate_key
+        , e.blockchain
+        , e.project
+        , e.version
+        , e.block_date
+        , e.block_time
+        , e.ledger_sequence
+        , e.tx_hash
+        , e.transaction_id
+        , e.operation_id
+        , e.contract_id
+        , e.successful
+        , e.in_successful_contract_call
+        , e.type
+        , e.type_string
+        , e.event_name
+        , e.topics
+        , e.topics_decoded
+        , e.data
+        , e.data_decoded
+        , e.contract_event_xdr
+        , CAST(COALESCE(json_extract(TRY(json_parse(e.data_decoded)), '$.map'), JSON '[]') AS array(json)) AS data_map
+        , e.updated_at
+        , e.ingested_at
+    FROM {{ ref('sushiswap_v3_stellar_evt') }} e
+    WHERE e.event_name IN (
+        'pool_created'
+        , 'pool_upgraded'
+        , 'pool_migrated'
+        , 'wasm_approved'
+        , 'set_protocol_fee'
+        , 'init'
+        , 'upgraded'
+        , 'migrated'
+    )
+        AND e.operation_id IS NOT NULL
+        {% if is_incremental() -%}
+        AND {{ incremental_predicate('e.block_time') }}
+        {% endif -%}
+)
+
+, decoded AS (
+    SELECT
+        surrogate_key
+        , blockchain
+        , project
+        , version
+        , block_date
+        , block_time
+        , ledger_sequence
+        , tx_hash
+        , transaction_id
+        , operation_id
+        , contract_id
+        , successful
+        , in_successful_contract_call
+        , type
+        , type_string
+        , event_name
+        , topics
+        , topics_decoded
+        , data
+        , data_decoded
+        , contract_event_xdr
+        , json_extract_scalar(
+            element_at(
+                filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'pool_address')
+                , 1
+            )
+            , '$.val.address'
+        ) AS pool_address
+        , json_extract_scalar(
+            element_at(
+                filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'token0')
+                , 1
+            )
+            , '$.val.address'
+        ) AS token0
+        , json_extract_scalar(
+            element_at(
+                filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'token1')
+                , 1
+            )
+            , '$.val.address'
+        ) AS token1
+        , TRY_CAST(json_extract_scalar(
+            element_at(
+                filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'fee')
+                , 1
+            )
+            , '$.val.u32'
+        ) AS integer) AS fee
+        , TRY_CAST(json_extract_scalar(
+            element_at(
+                filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'tick_spacing')
+                , 1
+            )
+            , '$.val.i32'
+        ) AS integer) AS tick_spacing
+        , json_extract_scalar(
+            element_at(
+                filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'sender')
+                , 1
+            )
+            , '$.val.address'
+        ) AS sender
+        , TRY_CAST(json_extract_scalar(
+            element_at(
+                filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'sqrt_price_x96')
+                , 1
+            )
+            , '$.val.u256'
+        ) AS uint256) AS sqrt_price_x96
+        , TRY_CAST(json_extract_scalar(
+            element_at(
+                filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'tick')
+                , 1
+            )
+            , '$.val.i32'
+        ) AS integer) AS tick
+        , updated_at
+        , ingested_at
+    FROM events
+)
+
+SELECT
+    surrogate_key
+    , blockchain
+    , project
+    , version
+    , block_date
+    , block_time
+    , ledger_sequence
+    , tx_hash
+    , transaction_id
+    , operation_id
+    , contract_id
+    , successful
+    , in_successful_contract_call
+    , type
+    , type_string
+    , event_name
+    , topics
+    , topics_decoded
+    , data
+    , data_decoded
+    , contract_event_xdr
+    , pool_address
+    , token0
+    , token1
+    , fee
+    , tick_spacing
+    , sender
+    , sqrt_price_x96
+    , tick
+    , updated_at
+    , ingested_at
+FROM decoded

--- a/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_pools.sql
+++ b/dbt_subprojects/dex/models/_projects/sushiswap/stellar/sushiswap_v3_stellar_pools.sql
@@ -1,0 +1,54 @@
+{{ config(
+    schema = 'sushiswap_v3_stellar'
+    , alias = 'pools'
+    , materialized = 'view'
+    , filtering_columns = ['pool']
+    )
+}}
+
+-- SushiSwap V3 Stellar pool registry.
+-- One row per pool from decoded pool_created events. Rank is computed here
+-- over the full pool_evt table so incremental twins stay consistent.
+
+WITH created AS (
+    SELECT
+        blockchain
+        , project
+        , version
+        , pool_address AS pool
+        , fee
+        , token0
+        , token1
+        , tick_spacing
+        , block_time AS creation_block_time
+        , ledger_sequence AS creation_block_number
+        , contract_id AS contract_address
+        , sender
+        , tx_hash
+        , transaction_id
+        , ROW_NUMBER() OVER (
+            PARTITION BY pool_address
+            ORDER BY block_time, CASE WHEN operation_id IS NOT NULL THEN 0 ELSE 1 END, transaction_id
+        ) AS created_rank
+    FROM {{ ref('sushiswap_v3_stellar_pool_evt') }}
+    WHERE event_name = 'pool_created'
+        AND pool_address IS NOT NULL
+)
+
+SELECT
+    blockchain
+    , project
+    , version
+    , pool
+    , fee
+    , token0
+    , token1
+    , tick_spacing
+    , creation_block_time
+    , creation_block_number
+    , contract_address
+    , sender
+    , tx_hash
+    , transaction_id
+FROM created
+WHERE created_rank = 1

--- a/dbt_subprojects/dex/models/trades/stellar/_schema.yml
+++ b/dbt_subprojects/dex/models/trades/stellar/_schema.yml
@@ -1,0 +1,132 @@
+version: 2
+
+models:
+  - name: sushiswap_v3_stellar_swap_evt
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: sushiswap
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'dex', 'trades', 'sushiswap', 'v3']
+    description: >
+      Swap events decoded from sushiswap_v3_stellar_evt. Retains raw topic/data
+      columns plus decoded tick, liquidity, amounts, and pool metadata.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over block date, transaction, operation, contract, event, and raw payload"
+        data_tests:
+          - not_null
+      - name: blockchain
+        description: "Blockchain name"
+      - name: project
+        description: "Project name"
+      - name: version
+        description: "SushiSwap pool version"
+      - name: block_time
+        description: "Ledger close timestamp"
+      - name: ledger_sequence
+        description: "Stellar ledger sequence"
+      - name: tx_hash
+        description: "Transaction hash"
+      - name: transaction_id
+        description: "Transaction identifier (TOID)"
+      - name: operation_id
+        description: "Operation identifier (TOID); nullable on some source rows"
+      - name: contract_id
+        description: "Pool contract that emitted the swap"
+      - name: event_name
+        description: "Decoded Soroban event name"
+      - name: pool
+        description: "SushiSwap pool contract id"
+      - name: token0
+        description: "Token0 contract id"
+      - name: token1
+        description: "Token1 contract id"
+      - name: fee
+        description: "Pool fee in hundredths of a bip"
+      - name: tick_spacing
+        description: "Pool tick spacing"
+      - name: sender
+        description: "Swap sender"
+      - name: recipient
+        description: "Swap recipient"
+      - name: amount0
+        description: "Signed token0 delta; negative means token0 left the pool"
+      - name: amount1
+        description: "Signed token1 delta; negative means token1 left the pool"
+      - name: liquidity
+        description: "Pool liquidity after the swap"
+      - name: sqrt_price_x96
+        description: "sqrtPriceX96 after the swap"
+      - name: tick
+        description: "Pool tick after the swap"
+
+  - name: sushiswap_v3_stellar_base_trades
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: sushiswap
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'dex', 'trades', 'sushiswap', 'v3']
+    description: >
+      Structured SushiSwap V3 Stellar base trades. Maps signed amount0/amount1 onto
+      bought/sold tokens using Uniswap V3 sign convention. Not yet wired into dex.trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over the deduplicated swap identity"
+        data_tests:
+          - not_null
+      - name: blockchain
+        description: "Blockchain name"
+      - name: project
+        description: "Project name"
+      - name: version
+        description: "SushiSwap pool version"
+      - name: block_month
+        description: "Ledger close month"
+      - name: block_time
+        description: "Ledger close timestamp"
+      - name: block_number
+        description: "Stellar ledger sequence"
+      - name: token_bought_amount_raw
+        description: "Raw amount of the token bought"
+      - name: token_sold_amount_raw
+        description: "Raw amount of the token sold"
+      - name: token_bought_address
+        description: "Token bought contract id"
+      - name: token_sold_address
+        description: "Token sold contract id"
+      - name: taker
+        description: "Swap recipient"
+      - name: maker
+        description: "Pool contract id"
+      - name: project_contract_address
+        description: "Pool contract id"
+      - name: tx_hash
+        description: "Transaction hash"
+      - name: tick
+        description: "Pool tick after the swap"
+      - name: fee
+        description: "Pool fee in hundredths of a bip"

--- a/dbt_subprojects/dex/models/trades/stellar/platforms/sushiswap_v3_stellar_base_trades.sql
+++ b/dbt_subprojects/dex/models/trades/stellar/platforms/sushiswap_v3_stellar_base_trades.sql
@@ -1,0 +1,57 @@
+{{ config(
+    schema = 'sushiswap_v3_stellar'
+    , alias = 'base_trades'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+-- Structured SushiSwap V3 Stellar trades from swap_evt.
+-- Twin source rows are already dropped there via operation_id IS NOT NULL.
+
+SELECT
+    {{ dbt_utils.generate_surrogate_key([
+        'block_date'
+        , 'to_hex(tx_hash)'
+        , 'transaction_id'
+        , 'contract_id'
+        , 'topics'
+        , 'data'
+    ]) }} AS surrogate_key
+    , blockchain
+    , project
+    , version
+    , CAST(date_trunc('month', block_time) AS date) AS block_month
+    , block_date
+    , block_time
+    , ledger_sequence AS block_number
+    , CASE WHEN amount0 < INT256 '0' THEN abs(amount0) ELSE abs(amount1) END AS token_bought_amount_raw
+    , CASE WHEN amount0 < INT256 '0' THEN abs(amount1) ELSE abs(amount0) END AS token_sold_amount_raw
+    , CASE WHEN amount0 < INT256 '0' THEN token0 ELSE token1 END AS token_bought_address
+    , CASE WHEN amount0 < INT256 '0' THEN token1 ELSE token0 END AS token_sold_address
+    , recipient AS taker
+    , pool AS maker
+    , pool AS project_contract_address
+    , sender
+    , recipient
+    , amount0
+    , amount1
+    , liquidity
+    , sqrt_price_x96
+    , tick
+    , fee
+    , tick_spacing
+    , token0
+    , token1
+    , tx_hash
+    , transaction_id
+    , operation_id
+FROM {{ ref('sushiswap_v3_stellar_swap_evt') }}
+WHERE event_name = 'swap'
+    {% if is_incremental() -%}
+    AND {{ incremental_predicate('block_time') }}
+    {% endif -%}

--- a/dbt_subprojects/dex/models/trades/stellar/platforms/sushiswap_v3_stellar_swap_evt.sql
+++ b/dbt_subprojects/dex/models/trades/stellar/platforms/sushiswap_v3_stellar_swap_evt.sql
@@ -1,0 +1,147 @@
+{{ config(
+    schema = 'sushiswap_v3_stellar'
+    , alias = 'swap_evt'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+-- Swap events decoded from the raw SushiSwap V3 Stellar event index.
+-- stellar.history_contract_events stores each Soroban event twice: once with
+-- operation_id and once with a null operation_id. The null twin has the same
+-- payload, so keep only operation_id IS NOT NULL.
+
+WITH pools AS (
+    SELECT
+        pool
+        , token0
+        , token1
+        , fee
+        , tick_spacing
+    FROM {{ ref('sushiswap_v3_stellar_pools') }}
+)
+
+, events AS (
+    SELECT
+        e.surrogate_key
+        , e.blockchain
+        , e.project
+        , e.version
+        , e.block_date
+        , e.block_time
+        , e.ledger_sequence
+        , e.tx_hash
+        , e.transaction_id
+        , e.operation_id
+        , e.contract_id
+        , e.successful
+        , e.in_successful_contract_call
+        , e.type
+        , e.type_string
+        , e.event_name
+        , e.topics
+        , e.topics_decoded
+        , e.data
+        , e.data_decoded
+        , e.contract_event_xdr
+        , p.pool
+        , p.token0
+        , p.token1
+        , p.fee
+        , p.tick_spacing
+        , CAST(COALESCE(json_extract(TRY(json_parse(e.data_decoded)), '$.map'), JSON '[]') AS array(json)) AS data_map
+        , e.updated_at
+        , e.ingested_at
+    FROM {{ ref('sushiswap_v3_stellar_evt') }} e
+    INNER JOIN pools p
+        ON p.pool = e.contract_id
+    WHERE e.event_name = 'swap' -- only swap-like event on factory + pools; no swap_limit / swap_exact
+        AND e.operation_id IS NOT NULL
+        {% if is_incremental() -%}
+        AND {{ incremental_predicate('e.block_time') }}
+        {% endif -%}
+)
+
+SELECT
+    surrogate_key
+    , blockchain
+    , project
+    , version
+    , block_date
+    , block_time
+    , ledger_sequence
+    , tx_hash
+    , transaction_id
+    , operation_id
+    , contract_id
+    , successful
+    , in_successful_contract_call
+    , type
+    , type_string
+    , event_name
+    , topics
+    , topics_decoded
+    , data
+    , data_decoded
+    , contract_event_xdr
+    , pool
+    , token0
+    , token1
+    , fee
+    , tick_spacing
+    , json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'sender')
+            , 1
+        )
+        , '$.val.address'
+    ) AS sender
+    , json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'recipient')
+            , 1
+        )
+        , '$.val.address'
+    ) AS recipient
+    , TRY_CAST(json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'amount0')
+            , 1
+        )
+        , '$.val.i128'
+    ) AS int256) AS amount0
+    , TRY_CAST(json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'amount1')
+            , 1
+        )
+        , '$.val.i128'
+    ) AS int256) AS amount1
+    , TRY_CAST(json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'liquidity')
+            , 1
+        )
+        , '$.val.u128'
+    ) AS uint256) AS liquidity
+    , TRY_CAST(json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'sqrt_price_x96')
+            , 1
+        )
+        , '$.val.u256'
+    ) AS uint256) AS sqrt_price_x96
+    , TRY_CAST(json_extract_scalar(
+        element_at(
+            filter(data_map, x -> json_extract_scalar(x, '$.key.symbol') = 'tick')
+            , 1
+        )
+        , '$.val.i32'
+    ) AS integer) AS tick
+    , updated_at
+    , ingested_at
+FROM events

--- a/sources/_base_sources/other/stellar_base_sources.yml
+++ b/sources/_base_sources/other/stellar_base_sources.yml
@@ -51,3 +51,59 @@ sources:
             description: "Last update timestamp on the source row"
           - name: ingested_at
             description: "Ingestion timestamp on the source row"
+      - name: history_contract_events
+        description: "Soroban contract events emitted during successful and diagnostic contract execution"
+        columns:
+          - name: closed_at_date
+            description: "Ledger close date; partition column"
+          - name: transaction_hash
+            description: "Transaction hash"
+          - name: transaction_id
+            description: "Transaction identifier (TOID)"
+          - name: successful
+            description: "Whether the enclosing transaction succeeded"
+          - name: in_successful_contract_call
+            description: "Whether the event occurred during a successful contract call"
+          - name: contract_id
+            description: "Contract that emitted the event (C... strkey)"
+          - name: type
+            description: "Numeric contract event type"
+          - name: type_string
+            description: "Contract event type label (Contract, Diagnostic, or System)"
+          - name: topics
+            description: "Encoded event topics"
+          - name: topics_decoded
+            description: "JSON-decoded event topics"
+          - name: data
+            description: "Encoded event data"
+          - name: data_decoded
+            description: "JSON-decoded event data"
+          - name: contract_event_xdr
+            description: "Raw XDR for the contract event"
+          - name: closed_at
+            description: "Ledger close timestamp"
+          - name: ledger_sequence
+            description: "Ledger sequence number"
+          - name: operation_id
+            description: "Operation identifier (TOID); nullable for some Soroban events"
+          - name: updated_at
+            description: "Last update timestamp on the source row"
+          - name: ingested_at
+            description: "Ingestion timestamp on the source row"
+      - name: history_transactions
+        description: "Stellar transactions, including Soroban resource and fee metadata"
+        columns:
+          - name: closed_at_date
+            description: "Ledger close date; partition column"
+          - name: id
+            description: "Transaction identifier (TOID)"
+          - name: transaction_hash
+            description: "Transaction hash"
+          - name: ledger_sequence
+            description: "Ledger sequence number"
+          - name: account
+            description: "Source account that originated the transaction"
+          - name: successful
+            description: "Whether the transaction succeeded"
+          - name: closed_at
+            description: "Ledger close timestamp"


### PR DESCRIPTION
## Summary
- Add standalone SushiSwap V3 Stellar models: factory registry, raw event index, decoded pool/swap/liquidity events, pool registry, and structured base trades / liquidity events.
- Register `stellar.history_contract_events` and `stellar.history_transactions` sources.
- Does not wire into `dex.trades` or the cross-chain `sushiswap.pools` union.

Replaces locked PR https://github.com/duneanalytics/spellbook/pull/9991 after CLA Assistant locked conversation on close.

## Test plan
- [x] `dbt compile` of the new Stellar models
- [x] Query CI/tmp tables: 58 pools, 81,371 decoded swaps, 0 leftover twins, 0 null trade amounts
- [x] Horizon-checked sample swap `0x26cdeae8...69b3` on USDC/XLM pool
- [ ] New PR CI (`dbt-ci/dex`) green
- [ ] Sign CLA on this PR if asked

Made with [Cursor](https://cursor.com)