### PR TITLE
fix(tokens): stop pricing native and TRC10 Tron transfers

### DIFF
--- a/dbt_subprojects/tokens/models/transfers_and_balances/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/_schema.yml
@@ -11,7 +11,8 @@ models:
       tags: ['tokens','transfers','evm']
     description: >
       Transfers of all kinds of fungible tokens across all EVM-compatible networks on Dune. This model contains
-      EVM-only data.
+      EVM-only data. On Tron, price_usd and amount_usd are only set for trc20 transfers: native and trc10
+      transfers share the same transactions.value field and cannot be told apart, so neither is priced.
     columns:
       - &unique_key
         name: unique_key

--- a/dbt_subprojects/tokens/models/transfers_and_balances/tron/_schema.yml
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/tron/_schema.yml
@@ -103,9 +103,9 @@ models:
       - name: amount
         description: "The formatted amount of the transfer"
       - name: price_usd
-        description: "The USD price used to calculate the amount_usd"
+        description: "The USD price used to calculate the amount_usd. Only set for trc20 transfers; null for native and trc10 transfers, which Tron's Ethereum JSON-RPC cannot tell apart"
       - name: amount_usd
-        description: "The USD amount of the transfer"
+        description: "The USD amount of the transfer. Only set for trc20 transfers; null for native and trc10 transfers, which Tron's Ethereum JSON-RPC cannot tell apart"
       - name: _updated_at
         description: "Timestamp when this row was last written"
 

--- a/dbt_subprojects/tokens/models/transfers_and_balances/tron/tokens_tron_transfers.sql
+++ b/dbt_subprojects/tokens/models/transfers_and_balances/tron/tokens_tron_transfers.sql
@@ -128,8 +128,12 @@ WITH base_transfers as (
         , symbol
         , amount_raw
         , amount
-        , price_usd
+        /* Only TRC20 tokens are priced. Tron's Ethereum JSON-RPC puts the amount of every
+           contract type into transactions.value, so native TRX transfers cannot be told apart
+           from TRC10 transfers and pricing both at the TRX price inflates volume. */
+        , CASE WHEN token_standard = 'trc20' THEN price_usd END AS price_usd
         , CASE
+            WHEN token_standard <> 'trc20' THEN CAST(NULL as double)
             WHEN is_trusted_token = true THEN amount_usd
             WHEN (is_trusted_token = false AND amount_usd < 1000000000) THEN amount_usd
             WHEN (is_trusted_token = false AND amount_usd >= 1000000000) THEN CAST(NULL as double) /* ignore inflated outlier prices */


### PR DESCRIPTION
Closes CUR2-4079.

## Problem

Tron's Ethereum JSON-RPC puts the amount of **every** contract type into `transactions.value`, so `tokens_tron_base_transfers` cannot tell a native TRX transfer (`TransferContract`) apart from a TRC10 transfer (`TransferAssetContract`). Both were priced at the TRX price.

Measured over the trailing 30 days on `tokens_tron.transfers`:

| token_standard | transfers | amount_usd |
|---|---:|---:|
| `native` | 162,574,714 | **$52,542,241,008,097,080** |
| `trc20` | 70,243,816 | $713,317,041,568 |

The `native` figure is the bug — it is 99.96% of the whole multichain `tokens.transfers` USD volume, and it is what surfaced as `$52,566.6t` on the customer-facing Token Transfers page.

## Change

Price only `trc20` transfers.

The price join is deliberately kept for all rows: native TRX resolves its `symbol` and `decimals` from the prices table (there is no `tokens.erc20` row for the `0x0` native placeholder), so gating the join would null out `amount` and `symbol` too. Only `price_usd` and `amount_usd` are nulled.

`is_trusted_token` outlier handling is unchanged for `trc20`.

## Scope

`token_standard` on Tron only ever takes the values `native` and `trc20` (verified in prod), so nothing else is affected. USDT and other TRC20s keep their pricing, which is the point — that is the volume worth keeping.

Other Tron models were checked and deliberately left alone: `gas_tron_fees` and the DEX/lending models price genuinely TRX-denominated amounts, where the TRX price is correct. `prices_tron_tokens` is untouched — native TRX pricing stays in the prices tables.

## Follow-up

`tokens_tron.transfers` is incremental, so **a full refresh is needed** for historical rows to pick this up.

## Verification

- `dbt compile` and `dbt parse` clean on the tokens subproject.
- Expected 30d `tokens.transfers` USD volume after this lands: ~$21.8t, down from $52,565t (~$21.07t non-Tron + $0.71t Tron trc20).
