### PR TITLE
feat(dex): add Aerodrome Slipstream one-tick liquidity events and volume

### DIFF
--- a/dbt_subprojects/dex/models/_projects/aerodrome/base/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/aerodrome/base/_schema.yml
@@ -279,7 +279,6 @@ models:
       - *id
       - *token0
       - *token1
-      - *fee
       - name: tick_spacing
         description: "Pool tick spacing from CLFactory PoolCreated"
       - name: tick_lower

--- a/dbt_subprojects/dex/models/_projects/aerodrome/base/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/aerodrome/base/_schema.yml
@@ -229,3 +229,121 @@ models:
       - *token1
       - *amount0_raw
       - *amount1_raw
+
+  - name: aerodrome_slipstream_base_one_tick_liquidity_events
+    meta:
+      blockchain: base
+      sector: dex
+      project: aerodrome
+      contributors: ryeblocks
+    config:
+      tags: ['base', 'aerodrome', 'slipstream', 'liquidity', 'one_tick']
+    description: >
+      Aerodrome Slipstream mint and burn events whose position width is exactly
+      one tick (abs(tickLower - tickUpper) = factory tickSpacing). Includes every
+      token pair that uses this methodology, not only stablecoins.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - tx_hash
+              - evt_index
+              - event_type
+    columns:
+      - *blockchain
+      - *project
+      - *version
+      - *block_month
+      - name: block_date
+        description: "UTC event block date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - *block_time
+      - *block_number
+      - name: tx_hash
+        description: "Transaction hash"
+        data_tests:
+          - not_null
+      - *tx_from
+      - name: evt_index
+        description: "Event index within the transaction"
+        data_tests:
+          - not_null
+      - name: event_type
+        description: "mint or burn"
+        data_tests:
+          - not_null
+      - name: pool
+        description: "Slipstream CL pool address"
+      - *id
+      - *token0
+      - *token1
+      - *fee
+      - name: tick_spacing
+        description: "Pool tick spacing from CLFactory PoolCreated"
+      - name: tick_lower
+        description: "Lower tick of the one-tick position"
+      - name: tick_upper
+        description: "Upper tick of the one-tick position"
+      - name: liquidity
+        description: "Liquidity delta from the mint or burn event"
+      - *amount0_raw
+      - *amount1_raw
+      - name: owner
+        description: "Position owner"
+      - name: sender
+        description: "Mint sender, or transaction from-address on burn"
+
+  - name: aerodrome_slipstream_base_one_tick_volume
+    meta:
+      blockchain: base
+      sector: dex
+      project: aerodrome
+      contributors: ryeblocks
+    config:
+      tags: ['base', 'aerodrome', 'slipstream', 'one_tick']
+    description: >
+      Daily token transfer volume on transactions that mint or burn a one-tick
+      Aerodrome Slipstream position. All tokens transferred against the pool are
+      included, not only stablecoins.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - pool
+              - token_contract_address
+    columns:
+      - *blockchain
+      - *project
+      - *version
+      - *block_month
+      - name: pool
+        description: "Slipstream CL pool address"
+        data_tests:
+          - not_null
+      - *block_number
+      - name: block_date
+        description: "UTC transfer date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - *block_time
+      - name: amount
+        description: "Sum of token transfer amounts (decimal-adjusted)"
+      - name: amount_raw
+        description: "Sum of raw token transfer amounts"
+      - name: amount_usd
+        description: "Sum of USD transfer amounts"
+      - name: unique_addresses
+        description: "Distinct transfer senders"
+      - name: total_transfers
+        description: "Transfer row count"
+      - name: total_transactions
+        description: "Distinct transaction count"
+      - name: median_transfer
+        description: "Approximate median transfer amount"
+      - name: token_contract_address
+        description: "Token transferred against the pool"
+        data_tests:
+          - not_null

--- a/dbt_subprojects/dex/models/_projects/aerodrome/base/aerodrome_slipstream_base_one_tick_volume.sql
+++ b/dbt_subprojects/dex/models/_projects/aerodrome/base/aerodrome_slipstream_base_one_tick_volume.sql
@@ -1,0 +1,95 @@
+{{ config(
+    schema = 'aerodrome_base'
+    , alias = 'one_tick_volume'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'pool', 'token_contract_address']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , post_hook='{{ expose_spells(
+        blockchains = \'["base"]\',
+        spell_type = "project",
+        spell_name = "aerodrome",
+        contributors = \'["ryeblocks"]\'
+    ) }}'
+    )
+}}
+
+{% set project_start_date = '2024-04-24' %}
+
+-- Daily token transfer volume on txs that mint or burn a one-tick Aerodrome
+-- Slipstream position. Unlike the sqlmesh stablecoin spam model, this includes
+-- every token transferred against the pool on those txs.
+
+with pool_tx as (
+    select distinct
+        pool
+        , block_date
+        , tx_hash
+        , block_number
+    from {{ ref('aerodrome_slipstream_base_one_tick_liquidity_events') }}
+    {% if is_incremental() -%}
+    where {{ incremental_predicate('block_date') }}
+    {% endif -%}
+)
+
+, daily_transfer_volumes as (
+    select
+        pool_tx.pool
+        , max(transfers.block_number) as block_number
+        , transfers.block_date
+        , max(transfers.block_time) as block_time
+        , sum(coalesce(transfers.amount, 0)) as amount
+        , sum(transfers.amount_raw) as amount_raw
+        , sum(coalesce(transfers.amount_usd, 0)) as amount_usd
+        , count(distinct transfers."from") as unique_addresses
+        , count(transfers.tx_hash) as total_transfers
+        , count(distinct transfers.tx_hash) as total_transactions
+        , approx_percentile(transfers.amount, 0.5) as median_transfer
+        , transfers.contract_address as token_contract_address
+    from {{ source('tokens', 'transfers') }} as transfers
+    inner join pool_tx
+        on transfers.blockchain = 'base'
+        and transfers.block_date = pool_tx.block_date
+        and transfers.tx_hash = pool_tx.tx_hash
+        and transfers.block_number = pool_tx.block_number
+        and (
+            pool_tx.pool = transfers."from"
+            or pool_tx.pool = transfers."to"
+        )
+    where transfers.blockchain = 'base'
+        {% if is_incremental() -%}
+        and {{ incremental_predicate('transfers.block_date') }}
+        {% else -%}
+        and transfers.block_date >= date '{{ project_start_date }}'
+        {% endif -%}
+    group by
+        pool_tx.pool
+        , transfers.contract_address
+        , transfers.block_date
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key([
+        'block_date'
+        , 'to_hex(pool)'
+        , 'to_hex(token_contract_address)'
+    ]) }} as surrogate_key
+    , cast('base' as varchar) as blockchain
+    , cast('aerodrome' as varchar) as project
+    , cast('slipstream' as varchar) as version
+    , cast(date_trunc('month', block_time) as date) as block_month
+    , pool
+    , block_number
+    , block_date
+    , block_time
+    , amount
+    , amount_raw
+    , amount_usd
+    , unique_addresses
+    , total_transfers
+    , total_transactions
+    , median_transfer
+    , token_contract_address
+from daily_transfer_volumes

--- a/dbt_subprojects/dex/models/_projects/aerodrome/base/base_liquidity_events/aerodrome_slipstream_base_one_tick_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/aerodrome/base/base_liquidity_events/aerodrome_slipstream_base_one_tick_liquidity_events.sql
@@ -29,7 +29,6 @@ with pools as (
         , token0
         , token1
         , tickSpacing as tick_spacing
-        , fee
     from {{ source('aerodrome_base', 'CLFactory_evt_PoolCreated') }}
 )
 
@@ -46,7 +45,6 @@ with pools as (
         , mint.contract_address as pool
         , pools.token0
         , pools.token1
-        , pools.fee
         , pools.tick_spacing
         , mint.tickLower as tick_lower
         , mint.tickUpper as tick_upper
@@ -79,7 +77,6 @@ with pools as (
         , burn.contract_address as pool
         , pools.token0
         , pools.token1
-        , pools.fee
         , pools.tick_spacing
         , burn.tickLower as tick_lower
         , burn.tickUpper as tick_upper
@@ -128,7 +125,6 @@ select
     , pool as id
     , token0
     , token1
-    , fee
     , tick_spacing
     , tick_lower
     , tick_upper

--- a/dbt_subprojects/dex/models/_projects/aerodrome/base/base_liquidity_events/aerodrome_slipstream_base_one_tick_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/aerodrome/base/base_liquidity_events/aerodrome_slipstream_base_one_tick_liquidity_events.sql
@@ -1,0 +1,140 @@
+{{ config(
+    schema = 'aerodrome_slipstream_base'
+    , alias = 'one_tick_liquidity_events'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'tx_hash', 'evt_index', 'event_type']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_date')]
+    , post_hook='{{ expose_spells(
+        blockchains = \'["base"]\',
+        spell_type = "project",
+        spell_name = "aerodrome",
+        contributors = \'["ryeblocks"]\'
+    ) }}'
+    )
+}}
+
+{% set project_start_date = '2024-04-24' %}
+
+-- Aerodrome Slipstream positions whose width is exactly one tick:
+-- abs(tickLower - tickUpper) = factory.tickSpacing.
+-- Not limited to stablecoins; every token pair that uses this methodology is included.
+-- Kept out of aerodrome_base_base_liquidity_events so these rows are not double-counted.
+
+with pools as (
+    select
+        pool
+        , token0
+        , token1
+        , tickSpacing as tick_spacing
+        , fee
+    from {{ source('aerodrome_base', 'CLFactory_evt_PoolCreated') }}
+)
+
+, mint as (
+    select
+        mint.evt_block_date as block_date
+        , mint.evt_block_time as block_time
+        , mint.evt_block_number as block_number
+        , mint.evt_tx_hash as tx_hash
+        , mint.evt_tx_from as tx_from
+        , mint.evt_tx_to as tx_to
+        , mint.evt_index
+        , cast('mint' as varchar) as event_type
+        , mint.contract_address as pool
+        , pools.token0
+        , pools.token1
+        , pools.fee
+        , pools.tick_spacing
+        , mint.tickLower as tick_lower
+        , mint.tickUpper as tick_upper
+        , mint.amount as liquidity
+        , mint.amount0 as amount0_raw
+        , mint.amount1 as amount1_raw
+        , mint.owner
+        , mint.sender
+    from {{ source('aerodrome_base', 'CLPool_evt_Mint') }} as mint
+    inner join pools
+        on pools.pool = mint.contract_address
+    where abs(mint.tickLower - mint.tickUpper) = pools.tick_spacing
+        {% if is_incremental() -%}
+        and {{ incremental_predicate('mint.evt_block_date') }}
+        {% else -%}
+        and mint.evt_block_date >= date '{{ project_start_date }}'
+        {% endif -%}
+)
+
+, burn as (
+    select
+        burn.evt_block_date as block_date
+        , burn.evt_block_time as block_time
+        , burn.evt_block_number as block_number
+        , burn.evt_tx_hash as tx_hash
+        , burn.evt_tx_from as tx_from
+        , burn.evt_tx_to as tx_to
+        , burn.evt_index
+        , cast('burn' as varchar) as event_type
+        , burn.contract_address as pool
+        , pools.token0
+        , pools.token1
+        , pools.fee
+        , pools.tick_spacing
+        , burn.tickLower as tick_lower
+        , burn.tickUpper as tick_upper
+        , burn.amount as liquidity
+        , burn.amount0 as amount0_raw
+        , burn.amount1 as amount1_raw
+        , burn.owner
+        , burn.evt_tx_from as sender
+    from {{ source('aerodrome_base', 'CLPool_evt_Burn') }} as burn
+    inner join pools
+        on pools.pool = burn.contract_address
+    where abs(burn.tickLower - burn.tickUpper) = pools.tick_spacing
+        {% if is_incremental() -%}
+        and {{ incremental_predicate('burn.evt_block_date') }}
+        {% else -%}
+        and burn.evt_block_date >= date '{{ project_start_date }}'
+        {% endif -%}
+)
+
+, events as (
+    select * from mint
+    union all
+    select * from burn
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key([
+        'block_date'
+        , 'to_hex(tx_hash)'
+        , 'evt_index'
+        , 'event_type'
+    ]) }} as surrogate_key
+    , cast('base' as varchar) as blockchain
+    , cast('aerodrome' as varchar) as project
+    , cast('slipstream' as varchar) as version
+    , cast(date_trunc('month', block_time) as date) as block_month
+    , block_date
+    , block_time
+    , block_number
+    , tx_hash
+    , tx_from
+    , tx_to
+    , evt_index
+    , event_type
+    , pool
+    , pool as id
+    , token0
+    , token1
+    , fee
+    , tick_spacing
+    , tick_lower
+    , tick_upper
+    , liquidity
+    , amount0_raw
+    , amount1_raw
+    , owner
+    , sender
+from events

--- a/sources/aerodrome/base/aerodrome_base_sources.yml
+++ b/sources/aerodrome/base/aerodrome_base_sources.yml
@@ -5,3 +5,4 @@ sources:
     description: "decoded events and function calls for aerodrome v2 on base"
     tables:
       - name: Voter_evt_GaugeCreated
+      - name: CLPool_evt_Burn


### PR DESCRIPTION
## Summary
- Add `aerodrome_slipstream_base.one_tick_liquidity_events`: Slipstream mint/burn events whose position width is exactly one tick (`abs(tickLower - tickUpper) = tickSpacing`).
- Add `aerodrome_base.one_tick_volume`: daily token transfer volume on those mint/burn transactions.
- Includes every token transferred against the pool, not only stablecoins.
- Not wired into `aerodrome_base_base_liquidity_events`, so existing liquidity event rows are not double-counted.

## Test plan
- [x] `dbt compile` of `aerodrome_slipstream_base_one_tick_liquidity_events` and `aerodrome_slipstream_base_one_tick_volume`
