### PR TITLE
feat(dex): add Aquarius Stellar event, pool, trade, and liquidity models

### DIFF
--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/_schema.yml
@@ -241,12 +241,22 @@ models:
         description: "Decoded Soroban event name"
       - name: pool
         description: "Pool contract id"
+      - name: shares_raw
+        description: "Minted or burned shares / liquidity units (first body field on deposit_liquidity and withdraw_liquidity)"
       - name: amount0_raw
-        description: "First decoded i128 from the event body"
+        description: "Token0 amount, or claim_fees amount0 / claim_reward amount"
       - name: amount1_raw
-        description: "Second decoded i128 from the event body"
+        description: "Token1 amount, or claim_fees amount1"
       - name: amount2_raw
-        description: "Third decoded i128 from the event body"
+        description: "Optional token2 amount on classic three-asset pools"
+      - name: tick_lower
+        description: "position_update lower tick"
+      - name: tick_upper
+        description: "position_update upper tick"
+      - name: liquidity_delta
+        description: "position_update liquidity delta"
+      - name: user_address
+        description: "Position owner on position_update, claim_fees, and claim_reward"
 
   - name: aquarius_stellar_router_evt
     meta:
@@ -278,10 +288,30 @@ models:
         description: "Decoded Soroban event name: swap, deposit, withdraw, claim, or config_rewards"
       - name: pool_address
         description: "Pool contract id when present on the router event"
+      - name: token0
+        description: "Sorted pool token0 from event topics"
+      - name: token1
+        description: "Sorted pool token1 from event topics"
       - name: trader
         description: "User address on the router event"
+      - name: token_in
+        description: "Swap input token from the event body"
+      - name: token_out
+        description: "Swap output token from the event body"
+      - name: amount_in_raw
+        description: "Swap input amount (u128)"
+      - name: amount_out_raw
+        description: "Swap output amount (u128)"
+      - name: amount0_raw
+        description: "Deposit or withdraw token0 amount (u128)"
+      - name: amount1_raw
+        description: "Deposit or withdraw token1 amount (u128)"
+      - name: shares_raw
+        description: "Shares minted on deposit or burned on withdraw"
+      - name: reward_token
+        description: "Claimed reward token on claim events"
       - name: reward_amount_raw
-        description: "config_rewards tps / reward amount (u128) when present"
+        description: "Claimed AQUA amount, or config_rewards tps"
       - name: reward_config_time
         description: "config_rewards unix timestamp when present"
 
@@ -315,9 +345,17 @@ models:
       - name: pool
         description: "Pool contract id"
       - name: reserve0_raw
-        description: "First decoded reserve / state i128"
+        description: "update_reserves token0 reserve"
       - name: reserve1_raw
-        description: "Second decoded reserve / state i128"
+        description: "update_reserves token1 reserve"
+      - name: reserve2_raw
+        description: "Optional update_reserves token2 reserve"
+      - name: sqrt_price_x96
+        description: "Concentrated pool_state sqrt price in Q64.96"
+      - name: tick
+        description: "Concentrated pool_state current tick"
+      - name: active_liquidity
+        description: "Concentrated pool_state active liquidity"
 
   - name: aquarius_stellar_base_trades
     meta:
@@ -390,9 +428,11 @@ models:
         description: "deposit_liquidity, withdraw_liquidity, position_update, claim_fees, or claim_reward"
       - name: pool
         description: "Pool contract id"
+      - name: shares_raw
+        description: "Shares or liquidity units from the pool event"
       - name: amount0_raw
-        description: "Signed first token / share amount"
+        description: "Signed token0 amount; withdraws are negative"
       - name: amount1_raw
-        description: "Signed second token amount"
+        description: "Signed token1 amount; withdraws are negative"
       - name: tx_hash
         description: "Transaction hash"

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/_schema.yml
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/_schema.yml
@@ -1,0 +1,398 @@
+version: 2
+
+models:
+  - name: aquarius_stellar_factories
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: aquarius
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'aquarius', 'factories']
+    description: >
+      Canonical Aquarius AMM contract ids on Stellar (router, provider fee factory).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - contract_id
+    columns:
+      - name: blockchain
+        description: "Blockchain the contract is deployed on"
+      - name: project
+        description: "Project name"
+      - name: version
+        description: "Aquarius AMM version"
+      - name: contract_id
+        description: "Stellar contract id (C... strkey)"
+        data_tests:
+          - not_null
+      - name: contract_name
+        description: "Logical contract role (router, provider_fee_factory)"
+
+  - name: aquarius_stellar_evt
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: aquarius
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'aquarius', 'events']
+    description: >
+      Raw index of successful Aquarius Stellar contract events from
+      stellar.history_contract_events. Follows router and fee-factory contracts
+      plus pool addresses seen on router add_pool and init_concentrated_pool
+      events. The only decode is event_name from topics_decoded.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over block date, transaction, operation, contract, event, and raw payload"
+        data_tests:
+          - not_null
+      - name: blockchain
+        description: "Blockchain name"
+      - name: project
+        description: "Project name"
+      - name: version
+        description: "Aquarius AMM version"
+      - name: block_time
+        description: "Ledger close timestamp"
+      - name: ledger_sequence
+        description: "Stellar ledger sequence"
+      - name: tx_hash
+        description: "Transaction hash"
+      - name: transaction_id
+        description: "Transaction identifier (TOID)"
+      - name: operation_id
+        description: "Operation identifier (TOID); nullable on some source rows"
+      - name: contract_id
+        description: "Emitting contract id"
+      - name: event_name
+        description: "Soroban event name from topics_decoded"
+      - name: topics_decoded
+        description: "Raw decoded topics JSON"
+      - name: data_decoded
+        description: "Raw decoded data JSON"
+
+  - name: aquarius_stellar_pool_evt
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: aquarius
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'aquarius', 'pools', 'events']
+    description: >
+      Router pool-registration events decoded from aquarius_stellar_evt.
+      Includes add_pool and init_concentrated_pool.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over block date, transaction, operation, contract, event, and raw payload"
+        data_tests:
+          - not_null
+      - name: event_name
+        description: "Decoded Soroban event name"
+      - name: pool_address
+        description: "Pool contract id from the registration event"
+      - name: pool_type
+        description: "Pool type symbol (constant_product, stable, concentrated)"
+      - name: token0
+        description: "First token contract id"
+      - name: token1
+        description: "Second token contract id"
+      - name: token2
+        description: "Optional third token contract id"
+
+  - name: aquarius_stellar_pools
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: aquarius
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'aquarius', 'pools']
+    description: >
+      Aquarius Stellar pool registry. One row per pool from
+      aquarius_stellar_pool_evt where created_rank = 1.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - pool
+    columns:
+      - name: blockchain
+        description: "Blockchain the DEX is deployed on"
+      - name: project
+        description: "Project name of the DEX"
+      - name: version
+        description: "Aquarius AMM version"
+      - name: pool
+        description: "Pool contract id"
+        data_tests:
+          - not_null
+      - name: pool_type
+        description: "Pool type symbol"
+      - name: token0
+        description: "First token in the pool"
+      - name: token1
+        description: "Second token in the pool"
+      - name: token2
+        description: "Optional third token in the pool"
+      - name: creation_block_time
+        description: "Ledger close time when the pool was created"
+      - name: creation_block_number
+        description: "Ledger sequence when the pool was created"
+      - name: contract_address
+        description: "Router contract that registered the pool"
+      - name: tx_hash
+        description: "Transaction hash of the first registration event"
+
+  - name: aquarius_stellar_trade_evt
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: aquarius
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'aquarius', 'trades', 'events']
+    description: >
+      Pool trade events decoded from aquarius_stellar_evt. Topics are
+      trade, sold asset, bought asset, trader. Body is sold amount,
+      bought amount, fee.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over block date, transaction, operation, contract, event, and raw payload"
+        data_tests:
+          - not_null
+      - name: event_name
+        description: "Decoded Soroban event name (trade)"
+      - name: pool
+        description: "Pool contract id"
+      - name: token_sold_address
+        description: "Sold asset contract id"
+      - name: token_bought_address
+        description: "Bought asset contract id"
+      - name: trader
+        description: "Trader address"
+      - name: token_sold_amount_raw
+        description: "Raw sold amount"
+      - name: token_bought_amount_raw
+        description: "Raw bought amount"
+      - name: fee_raw
+        description: "Raw swap fee"
+
+  - name: aquarius_stellar_liquidity_evt
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: aquarius
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'aquarius', 'liquidity', 'events']
+    description: >
+      Pool liquidity and position events decoded from aquarius_stellar_evt:
+      deposit_liquidity, withdraw_liquidity, position_update, claim_fees,
+      and claim_reward.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over block date, transaction, operation, contract, event, and raw payload"
+        data_tests:
+          - not_null
+      - name: event_name
+        description: "Decoded Soroban event name"
+      - name: pool
+        description: "Pool contract id"
+      - name: amount0_raw
+        description: "First decoded i128 from the event body"
+      - name: amount1_raw
+        description: "Second decoded i128 from the event body"
+      - name: amount2_raw
+        description: "Third decoded i128 from the event body"
+
+  - name: aquarius_stellar_router_evt
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: aquarius
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'aquarius', 'router', 'events']
+    description: >
+      Router swap, deposit, withdraw, claim, and config_rewards events decoded
+      from aquarius_stellar_evt. These sit above pool-level trade and liquidity events.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over block date, transaction, operation, contract, event, and raw payload"
+        data_tests:
+          - not_null
+      - name: event_name
+        description: "Decoded Soroban event name: swap, deposit, withdraw, claim, or config_rewards"
+      - name: pool_address
+        description: "Pool contract id when present on the router event"
+      - name: trader
+        description: "User address on the router event"
+      - name: reward_amount_raw
+        description: "config_rewards tps / reward amount (u128) when present"
+      - name: reward_config_time
+        description: "config_rewards unix timestamp when present"
+
+  - name: aquarius_stellar_pool_state_evt
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: aquarius
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'aquarius', 'reserves', 'events']
+    description: >
+      Pool update_reserves and pool_state events decoded from aquarius_stellar_evt.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over block date, transaction, operation, contract, event, and raw payload"
+        data_tests:
+          - not_null
+      - name: event_name
+        description: "Decoded Soroban event name: update_reserves or pool_state"
+      - name: pool
+        description: "Pool contract id"
+      - name: reserve0_raw
+        description: "First decoded reserve / state i128"
+      - name: reserve1_raw
+        description: "Second decoded reserve / state i128"
+
+  - name: aquarius_stellar_base_trades
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: aquarius
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'aquarius', 'trades']
+    description: >
+      Structured Aquarius Stellar trades from pool trade events. Standalone;
+      not wired into dex.trades.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over the deduplicated trade identity"
+        data_tests:
+          - not_null
+      - name: token_bought_address
+        description: "Bought asset contract id"
+      - name: token_sold_address
+        description: "Sold asset contract id"
+      - name: token_bought_amount_raw
+        description: "Raw bought amount"
+      - name: token_sold_amount_raw
+        description: "Raw sold amount"
+      - name: pool
+        description: "Pool contract id"
+      - name: taker
+        description: "Trader address"
+      - name: tx_hash
+        description: "Transaction hash"
+
+  - name: aquarius_stellar_base_liquidity_events
+    meta:
+      blockchain: stellar
+      sector: dex
+      project: aquarius
+      contributors: ryeblocks
+    config:
+      tags: ['stellar', 'aquarius', 'liquidity']
+    description: >
+      Structured Aquarius Stellar liquidity events. Deposit amounts are positive;
+      withdraw amounts are signed negative.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - block_date
+              - surrogate_key
+    columns:
+      - name: block_date
+        description: "Ledger close date; partition and unique-key column"
+        data_tests:
+          - not_null
+      - name: surrogate_key
+        description: "dbt surrogate key over the deduplicated liquidity event identity"
+        data_tests:
+          - not_null
+      - name: event_type
+        description: "deposit_liquidity, withdraw_liquidity, position_update, claim_fees, or claim_reward"
+      - name: pool
+        description: "Pool contract id"
+      - name: amount0_raw
+        description: "Signed first token / share amount"
+      - name: amount1_raw
+        description: "Signed second token amount"
+      - name: tx_hash
+        description: "Transaction hash"

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_base_liquidity_events.sql
@@ -1,0 +1,70 @@
+{{ config(
+    schema = 'aquarius_stellar'
+    , alias = 'base_liquidity_events'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+-- Structured Aquarius Stellar liquidity events from liquidity_evt.
+-- Twin source rows are already dropped there via operation_id IS NOT NULL.
+-- Deposit amounts stay positive; withdraw amounts are signed negative.
+
+SELECT
+    {{ dbt_utils.generate_surrogate_key([
+        'block_date'
+        , 'to_hex(tx_hash)'
+        , 'transaction_id'
+        , 'contract_id'
+        , 'event_name'
+        , 'topics'
+        , 'data'
+    ]) }} AS surrogate_key
+    , blockchain
+    , project
+    , version
+    , CAST(date_trunc('month', block_time) AS date) AS block_month
+    , block_date
+    , block_time
+    , ledger_sequence AS block_number
+    , event_name AS event_type
+    , pool
+    , pool AS id
+    , pool_type
+    , token0
+    , token1
+    , token2
+    , CASE
+        WHEN event_name = 'withdraw_liquidity' THEN -1 * abs(amount0_raw)
+        ELSE abs(amount0_raw)
+    END AS amount0_raw
+    , CASE
+        WHEN event_name = 'withdraw_liquidity' THEN -1 * abs(amount1_raw)
+        ELSE abs(amount1_raw)
+    END AS amount1_raw
+    , CASE
+        WHEN event_name = 'withdraw_liquidity' THEN -1 * abs(amount2_raw)
+        ELSE amount2_raw
+    END AS amount2_raw
+    , amount3_raw
+    , asset0
+    , asset1
+    , asset2
+    , tx_hash
+    , transaction_id
+    , operation_id
+FROM {{ ref('aquarius_stellar_liquidity_evt') }}
+WHERE event_name IN (
+        'deposit_liquidity'
+        , 'withdraw_liquidity'
+        , 'position_update'
+        , 'claim_fees'
+        , 'claim_reward'
+    )
+    {% if is_incremental() -%}
+    AND {{ incremental_predicate('block_time') }}
+    {% endif -%}

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_base_liquidity_events.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_base_liquidity_events.sql
@@ -38,19 +38,23 @@ SELECT
     , token0
     , token1
     , token2
+    , user_address
+    , shares_raw
     , CASE
         WHEN event_name = 'withdraw_liquidity' THEN -1 * abs(amount0_raw)
-        ELSE abs(amount0_raw)
+        ELSE amount0_raw
     END AS amount0_raw
     , CASE
         WHEN event_name = 'withdraw_liquidity' THEN -1 * abs(amount1_raw)
-        ELSE abs(amount1_raw)
+        ELSE amount1_raw
     END AS amount1_raw
     , CASE
         WHEN event_name = 'withdraw_liquidity' THEN -1 * abs(amount2_raw)
         ELSE amount2_raw
     END AS amount2_raw
-    , amount3_raw
+    , tick_lower
+    , tick_upper
+    , liquidity_delta
     , asset0
     , asset1
     , asset2

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_base_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_base_trades.sql
@@ -1,0 +1,54 @@
+{{ config(
+    schema = 'aquarius_stellar'
+    , alias = 'base_trades'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+-- Structured Aquarius Stellar trades from pool trade_evt.
+-- Twin source rows are already dropped there via operation_id IS NOT NULL.
+-- Not wired into dex.trades.
+
+SELECT
+    {{ dbt_utils.generate_surrogate_key([
+        'block_date'
+        , 'to_hex(tx_hash)'
+        , 'transaction_id'
+        , 'contract_id'
+        , 'topics'
+        , 'data'
+    ]) }} AS surrogate_key
+    , blockchain
+    , project
+    , version
+    , CAST(date_trunc('month', block_time) AS date) AS block_month
+    , block_date
+    , block_time
+    , ledger_sequence AS block_number
+    , abs(token_bought_amount_raw) AS token_bought_amount_raw
+    , abs(token_sold_amount_raw) AS token_sold_amount_raw
+    , token_bought_address
+    , token_sold_address
+    , trader AS taker
+    , pool AS maker
+    , pool AS project_contract_address
+    , trader
+    , pool
+    , pool_type
+    , fee_raw
+    , token0
+    , token1
+    , token2
+    , tx_hash
+    , transaction_id
+    , operation_id
+FROM {{ ref('aquarius_stellar_trade_evt') }}
+WHERE event_name = 'trade'
+    {% if is_incremental() -%}
+    AND {{ incremental_predicate('block_time') }}
+    {% endif -%}

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_evt.sql
@@ -1,0 +1,128 @@
+{{ config(
+    schema = 'aquarius_stellar'
+    , alias = 'evt'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+{% set project_start_date = '2025-01-01' %}
+
+-- Raw index of Aquarius Stellar contract events.
+-- Follows router and fee-factory contracts plus pool addresses seen on
+-- router add_pool / init_concentrated_pool events. The only decode is event_name.
+
+WITH factory AS (
+    SELECT contract_id
+    FROM {{ ref('aquarius_stellar_factories') }}
+    WHERE contract_name = 'router'
+)
+
+, created_pools AS (
+    SELECT DISTINCT
+        json_extract_scalar(TRY(json_parse(e.data_decoded)), '$.vec[0].address') AS pool_address
+    FROM {{ source('stellar', 'history_contract_events') }} e
+    INNER JOIN factory f
+        ON f.contract_id = e.contract_id
+    WHERE e.successful
+        AND e.type_string = 'ContractEventTypeContract'
+        AND json_extract_scalar(TRY(json_parse(e.topics_decoded)), '$[0].symbol') IN (
+            'add_pool'
+            , 'init_concentrated_pool'
+        )
+        {% if is_incremental() -%}
+        AND e.closed_at_date >= date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }})
+        AND {{ incremental_predicate('e.closed_at') }}
+        {% else -%}
+        AND e.closed_at_date >= DATE '{{ project_start_date }}'
+        AND e.closed_at >= TIMESTAMP '{{ project_start_date }}'
+        {% endif -%}
+)
+
+, contracts AS (
+    SELECT contract_id
+    FROM {{ ref('aquarius_stellar_factories') }}
+    UNION
+    SELECT pool_address AS contract_id
+    FROM created_pools
+    WHERE pool_address IS NOT NULL
+    {% if is_incremental() -%}
+    UNION
+    SELECT DISTINCT contract_id
+    FROM {{ this }}
+    {% endif -%}
+)
+
+, events AS (
+    SELECT
+        e.closed_at_date AS block_date
+        , e.closed_at AS block_time
+        , e.ledger_sequence
+        , e.transaction_hash AS tx_hash
+        , e.transaction_id
+        , e.operation_id
+        , e.contract_id
+        , e.successful
+        , e.in_successful_contract_call
+        , e.type
+        , e.type_string
+        , json_extract_scalar(TRY(json_parse(e.topics_decoded)), '$[0].symbol') AS event_name
+        , e.topics
+        , e.topics_decoded
+        , e.data
+        , e.data_decoded
+        , e.contract_event_xdr
+        , e.updated_at
+        , e.ingested_at
+    FROM {{ source('stellar', 'history_contract_events') }} e
+    INNER JOIN contracts c
+        ON c.contract_id = e.contract_id
+    WHERE e.successful
+        AND e.type_string = 'ContractEventTypeContract'
+        {% if is_incremental() -%}
+        AND e.closed_at_date >= date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }})
+        AND {{ incremental_predicate('e.closed_at') }}
+        {% else -%}
+        AND e.closed_at_date >= DATE '{{ project_start_date }}'
+        AND e.closed_at >= TIMESTAMP '{{ project_start_date }}'
+        {% endif -%}
+)
+
+SELECT
+    {{ dbt_utils.generate_surrogate_key([
+        'block_date'
+        , 'to_hex(tx_hash)'
+        , 'transaction_id'
+        , 'operation_id'
+        , 'contract_id'
+        , 'event_name'
+        , 'topics'
+        , 'data'
+    ]) }} AS surrogate_key
+    , CAST('stellar' AS varchar) AS blockchain
+    , CAST('aquarius' AS varchar) AS project
+    , CAST('1' AS varchar) AS version
+    , block_date
+    , block_time
+    , ledger_sequence
+    , tx_hash
+    , transaction_id
+    , operation_id
+    , contract_id
+    , successful
+    , in_successful_contract_call
+    , type
+    , type_string
+    , event_name
+    , topics
+    , topics_decoded
+    , data
+    , data_decoded
+    , contract_event_xdr
+    , updated_at
+    , ingested_at
+FROM events

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_evt.sql
@@ -35,11 +35,9 @@ WITH factory AS (
             , 'init_concentrated_pool'
         )
         {% if is_incremental() -%}
-        AND e.closed_at_date >= date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }})
         AND {{ incremental_predicate('e.closed_at') }}
         {% else -%}
         AND e.closed_at_date >= DATE '{{ project_start_date }}'
-        AND e.closed_at >= TIMESTAMP '{{ project_start_date }}'
         {% endif -%}
 )
 
@@ -84,11 +82,9 @@ WITH factory AS (
     WHERE e.successful
         AND e.type_string = 'ContractEventTypeContract'
         {% if is_incremental() -%}
-        AND e.closed_at_date >= date_trunc('{{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }}', now() - interval '{{ var("DBT_ENV_INCREMENTAL_TIME") }}' {{ var("DBT_ENV_INCREMENTAL_TIME_UNIT") }})
         AND {{ incremental_predicate('e.closed_at') }}
         {% else -%}
         AND e.closed_at_date >= DATE '{{ project_start_date }}'
-        AND e.closed_at >= TIMESTAMP '{{ project_start_date }}'
         {% endif -%}
 )
 

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_evt.sql
@@ -15,6 +15,8 @@
 -- Raw index of Aquarius Stellar contract events.
 -- Follows router and fee-factory contracts plus pool addresses seen on
 -- router add_pool / init_concentrated_pool events. The only decode is event_name.
+-- Keep operation_id IS NOT NULL to drop the Hubble null-TOID twin.
+-- DISTINCT collapses exact source clones (same XDR ingested twice).
 
 WITH factory AS (
     SELECT contract_id
@@ -30,6 +32,7 @@ WITH factory AS (
         ON f.contract_id = e.contract_id
     WHERE e.successful
         AND e.type_string = 'ContractEventTypeContract'
+        AND e.operation_id IS NOT NULL
         AND json_extract_scalar(TRY(json_parse(e.topics_decoded)), '$[0].symbol') IN (
             'add_pool'
             , 'init_concentrated_pool'
@@ -56,7 +59,7 @@ WITH factory AS (
 )
 
 , events AS (
-    SELECT
+    SELECT DISTINCT
         e.closed_at_date AS block_date
         , e.closed_at AS block_time
         , e.ledger_sequence
@@ -81,6 +84,7 @@ WITH factory AS (
         ON c.contract_id = e.contract_id
     WHERE e.successful
         AND e.type_string = 'ContractEventTypeContract'
+        AND e.operation_id IS NOT NULL
         {% if is_incremental() -%}
         AND {{ incremental_predicate('e.closed_at') }}
         {% else -%}

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_factories.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_factories.sql
@@ -1,0 +1,23 @@
+{{ config(
+    schema = 'aquarius_stellar'
+    , alias = 'factories'
+    , materialized = 'view'
+    , tags = ['static']
+    )
+}}
+
+-- Canonical Aquarius AMM contracts on Stellar.
+-- https://docs.aqua.network/developers/reference/addresses-and-networks
+-- ci-stamp: 1
+
+SELECT
+    blockchain
+    , project
+    , version
+    , contract_id
+    , contract_name
+FROM (
+    VALUES
+        ('stellar', 'aquarius', '1', 'CBQDHNBFBZYE4MKPWBSJOPIYLW4SFSXAXUTSXJN76GNKYVYPCKWC6QUK', 'router')
+        , ('stellar', 'aquarius', '1', 'CA4Q2T6FRAFYJYSMDJV7F6B7RL5PS6QS2UOZHBMCT2KSMGQRAAKP2MKO', 'provider_fee_factory')
+) AS t(blockchain, project, version, contract_id, contract_name)

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_liquidity_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_liquidity_evt.sql
@@ -11,9 +11,13 @@
 }}
 
 -- Pool liquidity and position events decoded from the raw Aquarius event index.
--- Covers constant-product / stable deposit_liquidity and withdraw_liquidity plus
--- concentrated position_update, claim_fees, and claim_reward.
--- Twin source rows are dropped via operation_id IS NOT NULL.
+-- Official concentrated-pool event table:
+-- deposit_liquidity / withdraw_liquidity: topics token0, token1; data liquidity, amount0, amount1
+-- position_update: topics user; data tick_lower, tick_upper, liquidity_delta
+-- claim_fees: topics owner, token0, token1; data amount0, amount1
+-- claim_reward: topics reward_token, user; data amount
+-- Classic constant / stable pools use the same deposit/withdraw body:
+-- shares first, then token amounts. Twin rows dropped via operation_id IS NOT NULL.
 
 WITH pools AS (
     SELECT
@@ -53,6 +57,8 @@ WITH pools AS (
         , p.token0
         , p.token1
         , p.token2
+        , TRY(json_parse(e.topics_decoded)) AS topics_json
+        , TRY(json_parse(e.data_decoded)) AS data_json
         , e.updated_at
         , e.ingested_at
     FROM {{ ref('aquarius_stellar_evt') }} e
@@ -98,13 +104,98 @@ SELECT
     , token0
     , token1
     , token2
-    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[1].address') AS asset0
-    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[2].address') AS asset1
-    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[3].address') AS asset2
-    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[0].i128') AS int256) AS amount0_raw
-    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[1].i128') AS int256) AS amount1_raw
-    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[2].i128') AS int256) AS amount2_raw
-    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[3].i128') AS int256) AS amount3_raw
+    , CASE event_name
+        WHEN 'deposit_liquidity' THEN json_extract_scalar(topics_json, '$[1].address')
+        WHEN 'withdraw_liquidity' THEN json_extract_scalar(topics_json, '$[1].address')
+        WHEN 'claim_fees' THEN json_extract_scalar(topics_json, '$[2].address')
+        WHEN 'claim_reward' THEN json_extract_scalar(topics_json, '$[1].address')
+    END AS asset0
+    , CASE event_name
+        WHEN 'deposit_liquidity' THEN json_extract_scalar(topics_json, '$[2].address')
+        WHEN 'withdraw_liquidity' THEN json_extract_scalar(topics_json, '$[2].address')
+        WHEN 'claim_fees' THEN json_extract_scalar(topics_json, '$[3].address')
+    END AS asset1
+    , CASE
+        WHEN event_name IN ('deposit_liquidity', 'withdraw_liquidity')
+            THEN json_extract_scalar(topics_json, '$[3].address')
+    END AS asset2
+    , CASE event_name
+        WHEN 'position_update' THEN json_extract_scalar(topics_json, '$[1].address')
+        WHEN 'claim_fees' THEN json_extract_scalar(topics_json, '$[1].address')
+        WHEN 'claim_reward' THEN json_extract_scalar(topics_json, '$[2].address')
+    END AS user_address
+    , TRY_CAST(
+        CASE
+            WHEN event_name IN ('deposit_liquidity', 'withdraw_liquidity')
+                THEN COALESCE(
+                    json_extract_scalar(data_json, '$.vec[0].i128')
+                    , json_extract_scalar(data_json, '$.vec[0].u128')
+                )
+        END AS int256
+    ) AS shares_raw
+    , TRY_CAST(
+        CASE event_name
+            WHEN 'deposit_liquidity' THEN COALESCE(
+                json_extract_scalar(data_json, '$.vec[1].i128')
+                , json_extract_scalar(data_json, '$.vec[1].u128')
+            )
+            WHEN 'withdraw_liquidity' THEN COALESCE(
+                json_extract_scalar(data_json, '$.vec[1].i128')
+                , json_extract_scalar(data_json, '$.vec[1].u128')
+            )
+            WHEN 'claim_fees' THEN COALESCE(
+                json_extract_scalar(data_json, '$.vec[0].i128')
+                , json_extract_scalar(data_json, '$.vec[0].u128')
+            )
+            WHEN 'claim_reward' THEN COALESCE(
+                json_extract_scalar(data_json, '$.vec[0].i128')
+                , json_extract_scalar(data_json, '$.vec[0].u128')
+            )
+        END AS int256
+    ) AS amount0_raw
+    , TRY_CAST(
+        CASE event_name
+            WHEN 'deposit_liquidity' THEN COALESCE(
+                json_extract_scalar(data_json, '$.vec[2].i128')
+                , json_extract_scalar(data_json, '$.vec[2].u128')
+            )
+            WHEN 'withdraw_liquidity' THEN COALESCE(
+                json_extract_scalar(data_json, '$.vec[2].i128')
+                , json_extract_scalar(data_json, '$.vec[2].u128')
+            )
+            WHEN 'claim_fees' THEN COALESCE(
+                json_extract_scalar(data_json, '$.vec[1].i128')
+                , json_extract_scalar(data_json, '$.vec[1].u128')
+            )
+        END AS int256
+    ) AS amount1_raw
+    , TRY_CAST(
+        CASE
+            WHEN event_name IN ('deposit_liquidity', 'withdraw_liquidity')
+                THEN COALESCE(
+                    json_extract_scalar(data_json, '$.vec[3].i128')
+                    , json_extract_scalar(data_json, '$.vec[3].u128')
+                )
+        END AS int256
+    ) AS amount2_raw
+    , TRY_CAST(
+        CASE
+            WHEN event_name = 'position_update' THEN json_extract_scalar(data_json, '$.vec[0].i32')
+        END AS integer
+    ) AS tick_lower
+    , TRY_CAST(
+        CASE
+            WHEN event_name = 'position_update' THEN json_extract_scalar(data_json, '$.vec[1].i32')
+        END AS integer
+    ) AS tick_upper
+    , TRY_CAST(
+        CASE
+            WHEN event_name = 'position_update' THEN COALESCE(
+                json_extract_scalar(data_json, '$.vec[2].i128')
+                , json_extract_scalar(data_json, '$.vec[2].u128')
+            )
+        END AS int256
+    ) AS liquidity_delta
     , updated_at
     , ingested_at
 FROM events

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_liquidity_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_liquidity_evt.sql
@@ -1,0 +1,110 @@
+{{ config(
+    schema = 'aquarius_stellar'
+    , alias = 'liquidity_evt'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+-- Pool liquidity and position events decoded from the raw Aquarius event index.
+-- Covers constant-product / stable deposit_liquidity and withdraw_liquidity plus
+-- concentrated position_update, claim_fees, and claim_reward.
+-- Twin source rows are dropped via operation_id IS NOT NULL.
+
+WITH pools AS (
+    SELECT
+        pool
+        , pool_type
+        , token0
+        , token1
+        , token2
+    FROM {{ ref('aquarius_stellar_pools') }}
+)
+
+, events AS (
+    SELECT
+        e.surrogate_key
+        , e.blockchain
+        , e.project
+        , e.version
+        , e.block_date
+        , e.block_time
+        , e.ledger_sequence
+        , e.tx_hash
+        , e.transaction_id
+        , e.operation_id
+        , e.contract_id
+        , e.successful
+        , e.in_successful_contract_call
+        , e.type
+        , e.type_string
+        , e.event_name
+        , e.topics
+        , e.topics_decoded
+        , e.data
+        , e.data_decoded
+        , e.contract_event_xdr
+        , p.pool
+        , p.pool_type
+        , p.token0
+        , p.token1
+        , p.token2
+        , e.updated_at
+        , e.ingested_at
+    FROM {{ ref('aquarius_stellar_evt') }} e
+    INNER JOIN pools p
+        ON p.pool = e.contract_id
+    WHERE e.event_name IN (
+        'deposit_liquidity'
+        , 'withdraw_liquidity'
+        , 'position_update'
+        , 'claim_fees'
+        , 'claim_reward'
+    )
+        AND e.operation_id IS NOT NULL
+        {% if is_incremental() -%}
+        AND {{ incremental_predicate('e.block_time') }}
+        {% endif -%}
+)
+
+SELECT
+    surrogate_key
+    , blockchain
+    , project
+    , version
+    , block_date
+    , block_time
+    , ledger_sequence
+    , tx_hash
+    , transaction_id
+    , operation_id
+    , contract_id
+    , successful
+    , in_successful_contract_call
+    , type
+    , type_string
+    , event_name
+    , topics
+    , topics_decoded
+    , data
+    , data_decoded
+    , contract_event_xdr
+    , pool
+    , pool_type
+    , token0
+    , token1
+    , token2
+    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[1].address') AS asset0
+    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[2].address') AS asset1
+    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[3].address') AS asset2
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[0].i128') AS int256) AS amount0_raw
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[1].i128') AS int256) AS amount1_raw
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[2].i128') AS int256) AS amount2_raw
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[3].i128') AS int256) AS amount3_raw
+    , updated_at
+    , ingested_at
+FROM events

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_pool_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_pool_evt.sql
@@ -1,0 +1,82 @@
+{{ config(
+    schema = 'aquarius_stellar'
+    , alias = 'pool_evt'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+-- Router pool-registration events decoded from the raw Aquarius event index.
+-- stellar.history_contract_events stores each Soroban event twice: once with
+-- operation_id and once with a null operation_id. Keep only operation_id IS NOT NULL.
+
+WITH events AS (
+    SELECT
+        e.surrogate_key
+        , e.blockchain
+        , e.project
+        , e.version
+        , e.block_date
+        , e.block_time
+        , e.ledger_sequence
+        , e.tx_hash
+        , e.transaction_id
+        , e.operation_id
+        , e.contract_id
+        , e.successful
+        , e.in_successful_contract_call
+        , e.type
+        , e.type_string
+        , e.event_name
+        , e.topics
+        , e.topics_decoded
+        , e.data
+        , e.data_decoded
+        , e.contract_event_xdr
+        , e.updated_at
+        , e.ingested_at
+    FROM {{ ref('aquarius_stellar_evt') }} e
+    WHERE e.event_name IN (
+        'add_pool'
+        , 'init_concentrated_pool'
+    )
+        AND e.operation_id IS NOT NULL
+        {% if is_incremental() -%}
+        AND {{ incremental_predicate('e.block_time') }}
+        {% endif -%}
+)
+
+SELECT
+    surrogate_key
+    , blockchain
+    , project
+    , version
+    , block_date
+    , block_time
+    , ledger_sequence
+    , tx_hash
+    , transaction_id
+    , operation_id
+    , contract_id
+    , successful
+    , in_successful_contract_call
+    , type
+    , type_string
+    , event_name
+    , topics
+    , topics_decoded
+    , data
+    , data_decoded
+    , contract_event_xdr
+    , json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[0].address') AS pool_address
+    , json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[1].symbol') AS pool_type
+    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[1].vec[0].address') AS token0
+    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[1].vec[1].address') AS token1
+    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[1].vec[2].address') AS token2
+    , updated_at
+    , ingested_at
+FROM events

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_pool_state_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_pool_state_evt.sql
@@ -1,0 +1,102 @@
+{{ config(
+    schema = 'aquarius_stellar'
+    , alias = 'pool_state_evt'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+-- Pool reserve / state snapshots decoded from the raw Aquarius event index.
+-- Constant-product and stable pools emit update_reserves; concentrated also
+-- emits pool_state. Twin source rows are dropped via operation_id IS NOT NULL.
+
+WITH pools AS (
+    SELECT
+        pool
+        , pool_type
+        , token0
+        , token1
+        , token2
+    FROM {{ ref('aquarius_stellar_pools') }}
+)
+
+, events AS (
+    SELECT
+        e.surrogate_key
+        , e.blockchain
+        , e.project
+        , e.version
+        , e.block_date
+        , e.block_time
+        , e.ledger_sequence
+        , e.tx_hash
+        , e.transaction_id
+        , e.operation_id
+        , e.contract_id
+        , e.successful
+        , e.in_successful_contract_call
+        , e.type
+        , e.type_string
+        , e.event_name
+        , e.topics
+        , e.topics_decoded
+        , e.data
+        , e.data_decoded
+        , e.contract_event_xdr
+        , p.pool
+        , p.pool_type
+        , p.token0
+        , p.token1
+        , p.token2
+        , e.updated_at
+        , e.ingested_at
+    FROM {{ ref('aquarius_stellar_evt') }} e
+    INNER JOIN pools p
+        ON p.pool = e.contract_id
+    WHERE e.event_name IN (
+        'update_reserves'
+        , 'pool_state'
+    )
+        AND e.operation_id IS NOT NULL
+        {% if is_incremental() -%}
+        AND {{ incremental_predicate('e.block_time') }}
+        {% endif -%}
+)
+
+SELECT
+    surrogate_key
+    , blockchain
+    , project
+    , version
+    , block_date
+    , block_time
+    , ledger_sequence
+    , tx_hash
+    , transaction_id
+    , operation_id
+    , contract_id
+    , successful
+    , in_successful_contract_call
+    , type
+    , type_string
+    , event_name
+    , topics
+    , topics_decoded
+    , data
+    , data_decoded
+    , contract_event_xdr
+    , pool
+    , pool_type
+    , token0
+    , token1
+    , token2
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[0].i128') AS int256) AS reserve0_raw
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[1].i128') AS int256) AS reserve1_raw
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[2].i128') AS int256) AS reserve2_raw
+    , updated_at
+    , ingested_at
+FROM events

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_pool_state_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_pool_state_evt.sql
@@ -11,8 +11,9 @@
 }}
 
 -- Pool reserve / state snapshots decoded from the raw Aquarius event index.
--- Constant-product and stable pools emit update_reserves; concentrated also
--- emits pool_state. Twin source rows are dropped via operation_id IS NOT NULL.
+-- Official event table: update_reserves data is reserve0, reserve1 [, reserve2].
+-- Concentrated pool_state data is sqrt_price_x96, tick, active_liquidity.
+-- Twin source rows are dropped via operation_id IS NOT NULL.
 
 WITH pools AS (
     SELECT
@@ -52,6 +53,7 @@ WITH pools AS (
         , p.token0
         , p.token1
         , p.token2
+        , TRY(json_parse(e.data_decoded)) AS data_json
         , e.updated_at
         , e.ingested_at
     FROM {{ ref('aquarius_stellar_evt') }} e
@@ -94,9 +96,48 @@ SELECT
     , token0
     , token1
     , token2
-    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[0].i128') AS int256) AS reserve0_raw
-    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[1].i128') AS int256) AS reserve1_raw
-    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[2].i128') AS int256) AS reserve2_raw
+    , TRY_CAST(
+        CASE
+            WHEN event_name = 'update_reserves' THEN COALESCE(
+                json_extract_scalar(data_json, '$.vec[0].i128')
+                , json_extract_scalar(data_json, '$.vec[0].u128')
+            )
+        END AS int256
+    ) AS reserve0_raw
+    , TRY_CAST(
+        CASE
+            WHEN event_name = 'update_reserves' THEN COALESCE(
+                json_extract_scalar(data_json, '$.vec[1].i128')
+                , json_extract_scalar(data_json, '$.vec[1].u128')
+            )
+        END AS int256
+    ) AS reserve1_raw
+    , TRY_CAST(
+        CASE
+            WHEN event_name = 'update_reserves' THEN COALESCE(
+                json_extract_scalar(data_json, '$.vec[2].i128')
+                , json_extract_scalar(data_json, '$.vec[2].u128')
+            )
+        END AS int256
+    ) AS reserve2_raw
+    , TRY_CAST(
+        CASE
+            WHEN event_name = 'pool_state' THEN json_extract_scalar(data_json, '$.vec[0].u256')
+        END AS uint256
+    ) AS sqrt_price_x96
+    , TRY_CAST(
+        CASE
+            WHEN event_name = 'pool_state' THEN json_extract_scalar(data_json, '$.vec[1].i32')
+        END AS integer
+    ) AS tick
+    , TRY_CAST(
+        CASE
+            WHEN event_name = 'pool_state' THEN COALESCE(
+                json_extract_scalar(data_json, '$.vec[2].u128')
+                , json_extract_scalar(data_json, '$.vec[2].i128')
+            )
+        END AS uint256
+    ) AS active_liquidity
     , updated_at
     , ingested_at
 FROM events

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_pools.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_pools.sql
@@ -1,0 +1,52 @@
+{{ config(
+    schema = 'aquarius_stellar'
+    , alias = 'pools'
+    , materialized = 'view'
+    , filtering_columns = ['pool']
+    )
+}}
+
+-- Aquarius Stellar pool registry.
+-- One row per pool from decoded add_pool / init_concentrated_pool events.
+
+WITH created AS (
+    SELECT
+        blockchain
+        , project
+        , version
+        , pool_address AS pool
+        , pool_type
+        , token0
+        , token1
+        , token2
+        , block_time AS creation_block_time
+        , ledger_sequence AS creation_block_number
+        , contract_id AS contract_address
+        , tx_hash
+        , transaction_id
+        , event_name
+        , ROW_NUMBER() OVER (
+            PARTITION BY pool_address
+            ORDER BY block_time, CASE WHEN operation_id IS NOT NULL THEN 0 ELSE 1 END, transaction_id
+        ) AS created_rank
+    FROM {{ ref('aquarius_stellar_pool_evt') }}
+    WHERE pool_address IS NOT NULL
+)
+
+SELECT
+    blockchain
+    , project
+    , version
+    , pool
+    , pool_type
+    , token0
+    , token1
+    , token2
+    , creation_block_time
+    , creation_block_number
+    , contract_address
+    , tx_hash
+    , transaction_id
+    , event_name
+FROM created
+WHERE created_rank = 1

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_pools.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_pools.sql
@@ -1,13 +1,15 @@
 {{ config(
     schema = 'aquarius_stellar'
     , alias = 'pools'
-    , materialized = 'view'
+    , materialized = 'table'
+    , file_format = 'delta'
     , filtering_columns = ['pool']
     )
 }}
 
 -- Aquarius Stellar pool registry.
 -- One row per pool from decoded add_pool / init_concentrated_pool events.
+-- ci-stamp: 1
 
 WITH created AS (
     SELECT

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_router_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_router_evt.sql
@@ -1,0 +1,106 @@
+{{ config(
+    schema = 'aquarius_stellar'
+    , alias = 'router_evt'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+-- Router user-flow events decoded from the raw Aquarius event index.
+-- Router emits swap / deposit / withdraw / claim in addition to pool-level
+-- trade and deposit_liquidity / withdraw_liquidity.
+-- Twin source rows are dropped via operation_id IS NOT NULL.
+
+WITH factory AS (
+    SELECT contract_id
+    FROM {{ ref('aquarius_stellar_factories') }}
+    WHERE contract_name = 'router'
+)
+
+, events AS (
+    SELECT
+        e.surrogate_key
+        , e.blockchain
+        , e.project
+        , e.version
+        , e.block_date
+        , e.block_time
+        , e.ledger_sequence
+        , e.tx_hash
+        , e.transaction_id
+        , e.operation_id
+        , e.contract_id
+        , e.successful
+        , e.in_successful_contract_call
+        , e.type
+        , e.type_string
+        , e.event_name
+        , e.topics
+        , e.topics_decoded
+        , e.data
+        , e.data_decoded
+        , e.contract_event_xdr
+        , e.updated_at
+        , e.ingested_at
+    FROM {{ ref('aquarius_stellar_evt') }} e
+    INNER JOIN factory f
+        ON f.contract_id = e.contract_id
+    WHERE e.event_name IN (
+        'swap'
+        , 'deposit'
+        , 'withdraw'
+        , 'claim'
+        , 'config_rewards'
+    )
+        AND e.operation_id IS NOT NULL
+        {% if is_incremental() -%}
+        AND {{ incremental_predicate('e.block_time') }}
+        {% endif -%}
+)
+
+SELECT
+    surrogate_key
+    , blockchain
+    , project
+    , version
+    , block_date
+    , block_time
+    , ledger_sequence
+    , tx_hash
+    , transaction_id
+    , operation_id
+    , contract_id
+    , successful
+    , in_successful_contract_call
+    , type
+    , type_string
+    , event_name
+    , topics
+    , topics_decoded
+    , data
+    , data_decoded
+    , contract_event_xdr
+    , COALESCE(
+        json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[0].address')
+        , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[1].address')
+    ) AS pool_address
+    , COALESCE(
+        json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[1].address')
+        , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[1].vec[0].address')
+    ) AS token0
+    , COALESCE(
+        json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[2].address')
+        , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[1].vec[1].address')
+    ) AS token1
+    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[2].address') AS trader
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[3].i128') AS int256) AS amount0_raw
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[4].i128') AS int256) AS amount1_raw
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[1].u128') AS uint256) AS reward_amount_raw
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[2].u64') AS bigint) AS reward_config_time
+    , updated_at
+    , ingested_at
+FROM events

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_router_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_router_evt.sql
@@ -11,9 +11,14 @@
 }}
 
 -- Router user-flow events decoded from the raw Aquarius event index.
--- Router emits swap / deposit / withdraw / claim in addition to pool-level
--- trade and deposit_liquidity / withdraw_liquidity.
--- Twin source rows are dropped via operation_id IS NOT NULL.
+-- Official router functions use u128 amounts. Observed event bodies:
+-- swap: pool, token_in, token_out, in_amount, out_amount
+-- deposit: pool, [amount0, amount1, ...], shares
+-- withdraw: pool, shares, [amount0, amount1, ...]
+-- claim: pool, reward_token, amount
+-- config_rewards: pool, tps, unix_ts
+-- Token order on topics is the sorted pool pair. Twin rows dropped via
+-- operation_id IS NOT NULL.
 
 WITH factory AS (
     SELECT contract_id
@@ -44,6 +49,8 @@ WITH factory AS (
         , e.data
         , e.data_decoded
         , e.contract_event_xdr
+        , TRY(json_parse(e.topics_decoded)) AS topics_json
+        , TRY(json_parse(e.data_decoded)) AS data_json
         , e.updated_at
         , e.ingested_at
     FROM {{ ref('aquarius_stellar_evt') }} e
@@ -84,23 +91,53 @@ SELECT
     , data
     , data_decoded
     , contract_event_xdr
-    , COALESCE(
-        json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[0].address')
-        , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[1].address')
-    ) AS pool_address
-    , COALESCE(
-        json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[1].address')
-        , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[1].vec[0].address')
-    ) AS token0
-    , COALESCE(
-        json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[2].address')
-        , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[1].vec[1].address')
-    ) AS token1
-    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[2].address') AS trader
-    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[3].i128') AS int256) AS amount0_raw
-    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[4].i128') AS int256) AS amount1_raw
-    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[1].u128') AS uint256) AS reward_amount_raw
-    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[2].u64') AS bigint) AS reward_config_time
+    , json_extract_scalar(data_json, '$.vec[0].address') AS pool_address
+    , json_extract_scalar(topics_json, '$[1].vec[0].address') AS token0
+    , json_extract_scalar(topics_json, '$[1].vec[1].address') AS token1
+    , json_extract_scalar(topics_json, '$[1].vec[2].address') AS token2
+    , json_extract_scalar(topics_json, '$[2].address') AS trader
+    , json_extract_scalar(data_json, '$.vec[1].address') AS token_in
+    , json_extract_scalar(data_json, '$.vec[2].address') AS token_out
+    , TRY_CAST(json_extract_scalar(data_json, '$.vec[3].u128') AS uint256) AS amount_in_raw
+    , TRY_CAST(json_extract_scalar(data_json, '$.vec[4].u128') AS uint256) AS amount_out_raw
+    , TRY_CAST(
+        COALESCE(
+            json_extract_scalar(data_json, '$.vec[1].vec[0].u128')
+            , json_extract_scalar(data_json, '$.vec[2].vec[0].u128')
+        ) AS uint256
+    ) AS amount0_raw
+    , TRY_CAST(
+        COALESCE(
+            json_extract_scalar(data_json, '$.vec[1].vec[1].u128')
+            , json_extract_scalar(data_json, '$.vec[2].vec[1].u128')
+        ) AS uint256
+    ) AS amount1_raw
+    , TRY_CAST(
+        COALESCE(
+            json_extract_scalar(data_json, '$.vec[1].vec[2].u128')
+            , json_extract_scalar(data_json, '$.vec[2].vec[2].u128')
+        ) AS uint256
+    ) AS amount2_raw
+    , TRY_CAST(
+        CASE event_name
+            WHEN 'deposit' THEN json_extract_scalar(data_json, '$.vec[2].u128')
+            WHEN 'withdraw' THEN json_extract_scalar(data_json, '$.vec[1].u128')
+        END AS uint256
+    ) AS shares_raw
+    , CASE
+        WHEN event_name = 'claim' THEN json_extract_scalar(data_json, '$.vec[1].address')
+    END AS reward_token
+    , TRY_CAST(
+        CASE event_name
+            WHEN 'claim' THEN json_extract_scalar(data_json, '$.vec[2].u128')
+            WHEN 'config_rewards' THEN json_extract_scalar(data_json, '$.vec[1].u128')
+        END AS uint256
+    ) AS reward_amount_raw
+    , TRY_CAST(
+        CASE
+            WHEN event_name = 'config_rewards' THEN json_extract_scalar(data_json, '$.vec[2].u64')
+        END AS bigint
+    ) AS reward_config_time
     , updated_at
     , ingested_at
 FROM events

--- a/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_trade_evt.sql
+++ b/dbt_subprojects/dex/models/_projects/aquarius/stellar/aquarius_stellar_trade_evt.sql
@@ -1,0 +1,102 @@
+{{ config(
+    schema = 'aquarius_stellar'
+    , alias = 'trade_evt'
+    , materialized = 'incremental'
+    , file_format = 'delta'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_date', 'surrogate_key']
+    , partition_by = ['block_date']
+    , incremental_predicates = [incremental_predicate('DBT_INTERNAL_DEST.block_time')]
+    )
+}}
+
+-- Pool trade events decoded from the raw Aquarius event index.
+-- Pool contracts emit trade; the router swap event is decoded separately.
+-- Twin source rows are dropped via operation_id IS NOT NULL.
+
+WITH pools AS (
+    SELECT
+        pool
+        , pool_type
+        , token0
+        , token1
+        , token2
+    FROM {{ ref('aquarius_stellar_pools') }}
+)
+
+, events AS (
+    SELECT
+        e.surrogate_key
+        , e.blockchain
+        , e.project
+        , e.version
+        , e.block_date
+        , e.block_time
+        , e.ledger_sequence
+        , e.tx_hash
+        , e.transaction_id
+        , e.operation_id
+        , e.contract_id
+        , e.successful
+        , e.in_successful_contract_call
+        , e.type
+        , e.type_string
+        , e.event_name
+        , e.topics
+        , e.topics_decoded
+        , e.data
+        , e.data_decoded
+        , e.contract_event_xdr
+        , p.pool
+        , p.pool_type
+        , p.token0
+        , p.token1
+        , p.token2
+        , e.updated_at
+        , e.ingested_at
+    FROM {{ ref('aquarius_stellar_evt') }} e
+    INNER JOIN pools p
+        ON p.pool = e.contract_id
+    WHERE e.event_name = 'trade'
+        AND e.operation_id IS NOT NULL
+        {% if is_incremental() -%}
+        AND {{ incremental_predicate('e.block_time') }}
+        {% endif -%}
+)
+
+SELECT
+    surrogate_key
+    , blockchain
+    , project
+    , version
+    , block_date
+    , block_time
+    , ledger_sequence
+    , tx_hash
+    , transaction_id
+    , operation_id
+    , contract_id
+    , successful
+    , in_successful_contract_call
+    , type
+    , type_string
+    , event_name
+    , topics
+    , topics_decoded
+    , data
+    , data_decoded
+    , contract_event_xdr
+    , pool
+    , pool_type
+    , token0
+    , token1
+    , token2
+    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[1].address') AS token_sold_address
+    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[2].address') AS token_bought_address
+    , json_extract_scalar(TRY(json_parse(topics_decoded)), '$[3].address') AS trader
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[0].i128') AS int256) AS token_sold_amount_raw
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[1].i128') AS int256) AS token_bought_amount_raw
+    , TRY_CAST(json_extract_scalar(TRY(json_parse(data_decoded)), '$.vec[2].i128') AS int256) AS fee_raw
+    , updated_at
+    , ingested_at
+FROM events

--- a/sources/_base_sources/other/stellar_base_sources.yml
+++ b/sources/_base_sources/other/stellar_base_sources.yml
@@ -51,3 +51,42 @@ sources:
             description: "Last update timestamp on the source row"
           - name: ingested_at
             description: "Ingestion timestamp on the source row"
+      - name: history_contract_events
+        description: "Soroban contract events emitted during successful and diagnostic contract execution"
+        columns:
+          - name: closed_at_date
+            description: "Ledger close date; partition column"
+          - name: transaction_hash
+            description: "Transaction hash"
+          - name: transaction_id
+            description: "Transaction identifier (TOID)"
+          - name: successful
+            description: "Whether the enclosing transaction succeeded"
+          - name: in_successful_contract_call
+            description: "Whether the event occurred during a successful contract call"
+          - name: contract_id
+            description: "Contract that emitted the event (C... strkey)"
+          - name: type
+            description: "Numeric contract event type"
+          - name: type_string
+            description: "Contract event type label (Contract, Diagnostic, or System)"
+          - name: topics
+            description: "Encoded event topics"
+          - name: topics_decoded
+            description: "JSON-decoded event topics"
+          - name: data
+            description: "Encoded event data"
+          - name: data_decoded
+            description: "JSON-decoded event data"
+          - name: contract_event_xdr
+            description: "Raw XDR for the contract event"
+          - name: closed_at
+            description: "Ledger close timestamp"
+          - name: ledger_sequence
+            description: "Ledger sequence number"
+          - name: operation_id
+            description: "Operation identifier (TOID); nullable for some Soroban events"
+          - name: updated_at
+            description: "Last update timestamp on the source row"
+          - name: ingested_at
+            description: "Ingestion timestamp on the source row"


### PR DESCRIPTION
## Summary
- Add standalone Aquarius Stellar models: factory registry, raw event index, decoded pool/router/trade/liquidity/state events, pool registry, and structured base trades / liquidity events.
- Decode paths match official Aquarius event tables (u128 router amounts, shares-first liquidity bodies, concentrated pool_state vs update_reserves).
- Materialize `aquarius_stellar.pools` as a Delta table. Register `stellar.history_contract_events`.
- Not wired into `dex.trades`.

## Test plan
- [x] `dbt compile` of the new Aquarius Stellar models
- [x] Small-engine decode probe vs Horizon / Soroban RPC
- [x] Downstream flow checks (swap matches trade, signed withdraws, pool_state not written as reserves)
- [ ] `dbt-ci/dex` green
- [ ] Query CI tables for pool count, trade decode, and leftover `operation_id` twins
- [ ] Sign CLA if asked